### PR TITLE
chore(workflows): update build-and-release workflow for Tuff App

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -64,14 +64,18 @@ jobs:
             echo "tag=v${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build Electron App
+      - name: Build Tuff App
         run: |
-          if [ "${{ steps.release-type.outputs.type }}" = "beta" ]; then
-            pnpm -F core run build:beta
-          elif [ "${{ steps.release-type.outputs.type }}" = "snapshot" ]; then
-            pnpm -F core run build:snapshot
+          if [ "${{ steps.release-type.outputs.type }}" = "snapshot" ]; then
+            if [ "${{ matrix.os }}" = "windows-latest" ]; then
+              pnpm core:build:snapshot:win
+            elif [ "${{ matrix.os }}" = "macos-latest" ]; then
+              pnpm core:build:snapshot:mac
+            else
+              pnpm core:build:snapshot:linux
+            fi
           else
-            pnpm -F core run build:release
+            pnpm core:build
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
This commit modifies the GitHub Actions workflow for building and releasing the Tuff application. Key changes include:

- Renamed the build step from "Build Electron App" to "Build Tuff App" for clarity.
- Adjusted the build process to handle snapshot builds for different operating systems (Windows, macOS, Linux) specifically.
- Streamlined the build command for the release process to use `pnpm core:build`.

These updates aim to enhance the clarity and functionality of the CI/CD pipeline for the Tuff application.