### PR TITLE
chore(workflows): update cleanup paths in build-and-release workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -82,17 +82,17 @@ jobs:
 
       - name: Cleanup Artifacts for Windows
         if: matrix.os == 'windows-latest'
-        run: npx rimraf "dist/!(*.exe)"
+        run: npx rimraf "apps/core-app/dist/!(*.exe)"
 
       - name: Cleanup Artifacts for MacOS
         if: matrix.os == 'macos-latest'
-        run: npx rimraf "dist/!(*.dmg)"
+        run: npx rimraf "apps/core-app/dist/!(*.dmg)"
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}
-          path: dist
+          path: apps/core-app/dist
 
   create-release:
     name: Create Release


### PR DESCRIPTION
This commit modifies the GitHub Actions workflow for building and releasing the application. Key changes include:

- Updated the cleanup commands to specify the correct paths for Windows and macOS artifacts, ensuring that only the intended files are removed.
- Adjusted the artifact upload path to reflect the new directory structure.

These updates aim to improve the accuracy of the build process and maintain a cleaner artifact directory.