### PR TITLE
chore: clean up electron-builder configuration and improve icon gener…

### DIFF
--- a/apps/core-app/build/generate-icons.sh
+++ b/apps/core-app/build/generate-icons.sh
@@ -28,10 +28,10 @@ sizes=(16 32 48 64 128 256 512 1024)
 for size in "${sizes[@]}"; do
     output_file="$OUTPUT_DIR/icon-${size}x${size}.png"
     echo "生成 ${size}x${size} 图标..."
-    
+
     # 使用 sips 转换
     sips -s format png -z $size $size "$SVG_FILE" --out "$output_file"
-    
+
     if [ $? -eq 0 ]; then
         echo "✓ 成功生成 $output_file"
     else
@@ -43,5 +43,6 @@ echo ""
 echo "所有图标已生成到 $OUTPUT_DIR 目录"
 echo "文件列表:"
 ls -la "$OUTPUT_DIR"
+
 
 

--- a/apps/core-app/electron-builder.yml
+++ b/apps/core-app/electron-builder.yml
@@ -59,7 +59,6 @@ linux:
   maintainer: tagzxia.com
   category: Utility
 snap:
-  executable: "talex-touch"
   confinement: strict
   grade: stable
   summary: "A powerful productivity launcher and automation tool"


### PR DESCRIPTION
…ation script

This commit removes the `executable` field from the `snap` section in `electron-builder.yml` to streamline the build configuration. Additionally, it cleans up the `generate-icons.sh` script by removing unnecessary line breaks, enhancing readability and maintainability. These changes aim to simplify the build process and improve script clarity.