### PR TITLE
chore(build-macos): update electron-builder configuration and enhance…

### DIFF
--- a/apps/core-app/electron-builder.yml
+++ b/apps/core-app/electron-builder.yml
@@ -61,6 +61,11 @@ mac:
   category: public.app-category.productivity
   # 强制重新构建
   forceCodeSigning: false
+  # 完全禁用代码签名
+  identity: null
+  hardenedRuntime: false
+  # 确保路径正确
+  artifactName: ${name}-${version}-${arch}.${ext}
 linux:
   target:
     - AppImage

--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -5,6 +5,11 @@
   "main": "./out/main/index.js",
   "author": "TalexDreamSoul",
   "homepage": "https://talex-touch.tagzxia.com",
+  "build": {
+    "directories": {
+      "app": "out"
+    }
+  },
   "scripts": {
     "format": "prettier --write .",
     "lint": "eslint --cache .",


### PR DESCRIPTION
… build script

This commit modifies the electron-builder configuration for macOS by disabling code signing and ensuring correct artifact naming. Additionally, the build script is enhanced with detailed logging for file structure and environment variable checks, improving the reliability and visibility of the build process. These changes aim to streamline the macOS build workflow and facilitate easier debugging.