### PR TITLE
chore(build-macos): integrate external script for package.json prepar…

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -14,6 +14,7 @@
     "start": "electron-vite preview",
     "dev": "electron-vite dev",
     "build": "npm run typecheck && electron-vite build",
+    "postbuild": "node scripts/prepare-out-package-json.js",
     "postinstall": "echo 'Skipping electron-builder install-app-deps - will run during build'",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/apps/core-app/scripts/build-macos.js
+++ b/apps/core-app/scripts/build-macos.js
@@ -24,16 +24,7 @@ try {
   console.log('Step 1: Building application...');
   execSync('npm run build', { stdio: 'inherit' });
 
-  const outPackageJsonPath = path.join(projectRoot, 'out/package.json');
-  const minimalPackageJson = {
-    "name": "@talex-touch/core-app",
-    "version": "2.0.0",
-    "description": "A powerful productivity launcher and automation tool",
-    "main": "./main/index.js",
-    "author": "TalexDreamSoul",
-    "homepage": "https://talex-touch.tagzxia.com"
-  };
-  fs.writeFileSync(outPackageJsonPath, JSON.stringify(minimalPackageJson, null, 2));
+  require(path.join(__dirname, 'prepare-out-package-json.js'));
 
   const distDir = path.join(projectRoot, 'dist');
   if (fs.existsSync(distDir)) {

--- a/apps/core-app/scripts/prepare-out-package-json.js
+++ b/apps/core-app/scripts/prepare-out-package-json.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+const projectRoot = path.join(__dirname, '..');
+const outDir = path.join(projectRoot, 'out');
+const outPackageJsonPath = path.join(outDir, 'package.json');
+
+const minimalPackageJson = {
+  name: '@talex-touch/core-app',
+  version: '2.0.0',
+  description: 'A powerful productivity launcher and automation tool',
+  main: './main/index.js',
+  author: 'TalexDreamSoul',
+  homepage: 'https://talex-touch.tagzxia.com'
+};
+
+fs.mkdirSync(outDir, { recursive: true });
+fs.writeFileSync(outPackageJsonPath, JSON.stringify(minimalPackageJson, null, 2));
+
+console.log('Generated out/package.json for electron-builder');


### PR DESCRIPTION
…ation

This commit adds a new postbuild script in package.json to execute an external script for preparing the output package.json file during the build process. The macOS build script is updated to require this external script, enhancing modularity and maintainability of the build workflow. These changes aim to streamline the build process and ensure consistent package.json generation.