### PR TITLE
chore(build): add manual tag push step in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -462,6 +462,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout Repository (for manual tag push)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Create Git Tag (for manual trigger)
         if: github.event_name == 'workflow_dispatch'
         run: |


### PR DESCRIPTION
This commit introduces a new step in the GitHub Actions workflow to checkout the repository for manual tag pushes, enhancing the flexibility of the release process. The addition allows for a complete repository context during manual triggers, ensuring that tags can be created accurately and efficiently. This change aims to improve the overall build and release workflow.