### PR TITLE
Fix: Improve Chinese app name indexing and search

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.ts
@@ -819,7 +819,8 @@ class AppProvider implements ISearchProvider<ProviderContext> {
 
   private async _generateKeywordsForApp(appInfo: ScannedAppInfo): Promise<Set<string>> {
     const generatedKeywords = new Set<string>()
-    const names = [appInfo.name, appInfo.displayName, appInfo.fileName].filter(Boolean) as string[]
+    // Prioritize displayName as it may contain localized (e.g., Chinese) names
+    const names = [appInfo.displayName, appInfo.name, appInfo.fileName].filter(Boolean) as string[]
     const CHINESE_REGEX = /[\u4E00-\u9FA5]/
     const INVALID_KEYWORD_REGEX = /[^a-z0-9\u4E00-\u9FA5]/i
 
@@ -838,12 +839,11 @@ class AppProvider implements ISearchProvider<ProviderContext> {
       if (CHINESE_REGEX.test(name)) {
         try {
           const { pinyin } = await import('pinyin-pro')
-          const pinyinFull = pinyin(name, { toneType: 'none' }).replace(/\s/g, '')
+          const pinyinFull = pinyin(name, { toneType: 'none' }).replace(/\s/g, '').toLowerCase()
           generatedKeywords.add(pinyinFull)
-          const pinyinFirst = pinyin(name, { pattern: 'first', toneType: 'none' }).replace(
-            /\s/g,
-            ''
-          )
+          const pinyinFirst = pinyin(name, { pattern: 'first', toneType: 'none' })
+            .replace(/\s/g, '')
+            .toLowerCase()
           generatedKeywords.add(pinyinFirst)
         } catch {
           logApp(`Failed to get pinyin for: ${name}`, LogStyle.warning)

--- a/apps/nexus/nuxt.config.ts
+++ b/apps/nexus/nuxt.config.ts
@@ -62,7 +62,7 @@ export default defineNuxtConfig({
 
   content: {
     experimental: {
-      nativeSqlite: true,
+      nativeSqlite: false,
     },
     build: {
       markdown: {

--- a/apps/nexus/nuxt.config.ts
+++ b/apps/nexus/nuxt.config.ts
@@ -136,7 +136,7 @@ export default defineNuxtConfig({
     prerender: {
       crawlLinks: false,
       routes: ['/'],
-      ignore: ['/hi'],
+      ignore: ['/hi', '/__nuxt_content/**'],
     },
   },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ catalogs:
     typeit:
       specifier: ^8.8.7
       version: 8.8.7
+    vue-sonner:
+      specifier: ^2.0.9
+      version: 2.0.9
   dev:
     '@antfu/eslint-config':
       specifier: ^4.17.0
@@ -504,43 +507,6 @@ importers:
         specifier: ^6.0.6
         version: 6.0.6
 
-  apps/core-app/out:
-    dependencies:
-      '@libsql/client':
-        specifier: ^0.15.15
-        version: 0.15.15(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@libsql/core':
-        specifier: ^0.15.15
-        version: 0.15.15
-      '@libsql/darwin-arm64':
-        specifier: ^0.5.22
-        version: 0.5.22
-      '@libsql/hrana-client':
-        specifier: ^0.7.0
-        version: 0.7.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@libsql/isomorphic-fetch':
-        specifier: ^0.3.1
-        version: 0.3.1
-      '@neon-rs/load':
-        specifier: ^0.0.4
-        version: 0.0.4
-      detect-libc:
-        specifier: ^2.1.2
-        version: 2.1.2
-      fs-extra:
-        specifier: ^11.3.3
-        version: 11.3.3
-      libsql:
-        specifier: ^0.5.22
-        version: 0.5.22
-      marked:
-        specifier: ^17.0.1
-        version: 17.0.1
-    devDependencies:
-      '@sentry/vite-plugin':
-        specifier: ^4.7.0
-        version: 4.7.0(encoding@0.1.13)
-
   apps/nexus:
     dependencies:
       '@clerk/nuxt':
@@ -583,7 +549,7 @@ importers:
         specifier: 'catalog:'
         version: 8.8.7
       vue-sonner:
-        specifier: ^2.0.9
+        specifier: 'catalog:'
         version: 2.0.9(@nuxt/kit@4.2.1(magicast@0.5.1))(@nuxt/schema@4.2.1)(nuxt@4.2.1(@libsql/client@0.15.15(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@parcel/watcher@2.5.1)(@types/node@24.1.0)(@vue/compiler-sfc@3.5.27)(bufferutil@4.1.0)(db0@0.3.4(@libsql/client@0.15.15(bufferutil@4.1.0)(utf-8-validate@6.0.6))(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20251128.0)(@libsql/client@0.15.15(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)))(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20251128.0)(@libsql/client@0.15.15(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@opentelemetry/api@1.9.0)(@types/pg@8.15.6))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(idb-keyval@6.2.2)(ioredis@5.8.2)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.53.2)(sass@1.94.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(vite@7.0.6(@types/node@24.1.0)(jiti@2.6.1)(sass@1.94.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))(vue-tsc@3.1.3(typescript@5.9.3))(yaml@2.8.1))
     devDependencies:
       '@antfu/eslint-config':
@@ -17459,7 +17425,8 @@ snapshots:
     dependencies:
       js-base64: 3.7.8
 
-  '@libsql/darwin-arm64@0.5.22': {}
+  '@libsql/darwin-arm64@0.5.22':
+    optional: true
 
   '@libsql/darwin-x64@0.5.22':
     optional: true


### PR DESCRIPTION
## Problem

Chinese application names were not properly indexed and could not be searched using pinyin input. This affected the user experience for Chinese-speaking users who rely on pinyin search to find applications.

## Root Cause Analysis

1. **Encoding Issue**: `InfoPlist.strings` files often use UTF-16 encoding, but the code was reading them as UTF-8, causing localized names to fail parsing
2. **Missed Spotlight Metadata**: macOS Spotlight's `kMDItemDisplayName` provides the most reliable localized app names, but was only used during update scans, not initial scans
3. **Incorrect Priority**: The keyword generation prioritized `name` over `displayName`, missing Chinese names for pinyin conversion

## Solution

### 1. Add Spotlight Metadata Query
- Query `kMDItemDisplayName` from Spotlight during initial app scan
- Use it as the primary source for display names (most reliable)
- Fallback to other methods if Spotlight query fails

### 2. Support Multiple Encodings
- Detect file encoding by BOM (Byte Order Mark)
- Support UTF-16 LE, UTF-16 BE, and UTF-8
- Use `iconv-lite` for UTF-16 BE decoding when available

### 3. Prioritize displayName in Keyword Generation
- Reorder the names array to prioritize `displayName`
- Ensure Chinese names are used for pinyin keyword generation
- Convert pinyin to lowercase for consistent matching

### 4. Ensure displayName Quality
- Trim whitespace from display names
- Convert empty strings to `undefined` to avoid invalid entries

## Changes

### `darwin.ts`
- Modified `getLocalizedDisplayName()` to support multiple encodings
- Modified `getAppInfoUnstable()` to query Spotlight metadata
- Updated display name priority: Spotlight > localized > plist > bundle name
- Added proper trimming for display names

### `app-provider.ts`
- Reordered names array to prioritize `displayName`
- Ensured pinyin conversion uses lowercase

## Testing

The fix should be tested with:
1. Chinese applications (e.g., 微信 WeChat, 钉钉 DingTalk)
2. Pinyin search: `weixin`, `wx` should find 微信
3. Chinese search: `微信` should find 微信
4. Mixed language apps should work correctly

## Impact

- ✅ Improves Chinese app name detection
- ✅ Enables pinyin search for Chinese apps
- ✅ More reliable localized name handling
- ✅ Better user experience for Chinese-speaking users
- ⚠️ Requires re-scanning apps to rebuild index (existing users)

## Related Issues

This PR addresses the Chinese app name indexing problem reported by users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS app name and localized string handling so app names display correctly.
  * Normalized keyword generation to reduce case-sensitivity and improve search consistency.

* **Improvements**
  * Prefer native system metadata (Spotlight) for more reliable app name resolution and discovery.
  * Updated prerender exclusions and adjusted content storage behavior to align with deployment needs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->