### PR TITLE
feat(core-app): add user-managed launcher foundation

### DIFF
--- a/apps/core-app/src/main/channel/common.test.ts
+++ b/apps/core-app/src/main/channel/common.test.ts
@@ -197,7 +197,12 @@ vi.mock('../modules/analytics', () => ({
 vi.mock('../modules/box-tool/addon/apps/app-provider', () => ({
   appProvider: {
     getAppIndexSettings: vi.fn(),
-    updateAppIndexSettings: vi.fn()
+    updateAppIndexSettings: vi.fn(),
+    addAppByPath: vi.fn(),
+    listManagedEntries: vi.fn(),
+    upsertManagedEntry: vi.fn(),
+    removeManagedEntry: vi.fn(),
+    setManagedEntryEnabled: vi.fn()
   }
 }))
 
@@ -599,5 +604,119 @@ describe('CommonChannelModule private helpers', () => {
         configurable: true
       })
     }
+  })
+
+  it('routes managed app-index handlers and validates remove/set-enabled payloads', async () => {
+    const handlers = new Map<string, (payload: unknown, context: unknown) => Promise<unknown>>()
+    const transport = {
+      on: vi.fn(
+        (
+          event: { toEventName: () => string },
+          handler: (payload: unknown, context: unknown) => Promise<unknown>
+        ) => {
+          handlers.set(event.toEventName(), handler)
+          return vi.fn()
+        }
+      ),
+      onStream: vi.fn(() => vi.fn()),
+      broadcastToWindow: vi.fn()
+    }
+
+    getTuffTransportMainMock.mockReturnValue(transport as never)
+
+    const { appProvider } = await import('../modules/box-tool/addon/apps/app-provider')
+    ;(appProvider.listManagedEntries as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        path: '/Applications/WeChat.app',
+        name: 'WeChat',
+        enabled: true,
+        launchKind: 'path',
+        launchTarget: '/Applications/WeChat.app'
+      }
+    ])
+    ;(appProvider.upsertManagedEntry as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      status: 'updated'
+    })
+    ;(appProvider.removeManagedEntry as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      status: 'removed'
+    })
+    ;(appProvider.setManagedEntryEnabled as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      status: 'updated'
+    })
+
+    const module = new CommonChannelModule()
+    await module.onInit({
+      app: {
+        window: { window: {} },
+        app: { addListener: vi.fn() }
+      }
+    } as never)
+
+    const listHandler = handlers.get(AppEvents.appIndex.listEntries.toEventName())
+    const upsertHandler = handlers.get(AppEvents.appIndex.upsertEntry.toEventName())
+    const removeHandler = handlers.get(AppEvents.appIndex.removeEntry.toEventName())
+    const setEnabledHandler = handlers.get(AppEvents.appIndex.setEntryEnabled.toEventName())
+
+    await expect(listHandler?.({}, {})).resolves.toEqual([
+      {
+        path: '/Applications/WeChat.app',
+        name: 'WeChat',
+        enabled: true,
+        launchKind: 'path',
+        launchTarget: '/Applications/WeChat.app'
+      }
+    ])
+    await expect(
+      upsertHandler?.(
+        {
+          path: '/Applications/WeChat.app',
+          displayName: '微信',
+          enabled: true
+        },
+        {}
+      )
+    ).resolves.toEqual({
+      success: true,
+      status: 'updated'
+    })
+    await expect(Promise.resolve(removeHandler?.({ path: '' }, {}))).resolves.toEqual({
+      success: false,
+      status: 'invalid',
+      reason: 'path-empty'
+    })
+    await expect(
+      Promise.resolve(removeHandler?.({ path: '/Applications/WeChat.app' }, {}))
+    ).resolves.toEqual({
+      success: true,
+      status: 'removed'
+    })
+    await expect(
+      Promise.resolve(setEnabledHandler?.({ path: '/Applications/WeChat.app' }, {}))
+    ).resolves.toEqual({
+      success: false,
+      status: 'invalid',
+      reason: 'enabled-invalid'
+    })
+    await expect(
+      setEnabledHandler?.({ path: '/Applications/WeChat.app', enabled: false }, {})
+    ).resolves.toEqual({
+      success: true,
+      status: 'updated'
+    })
+
+    expect(appProvider.listManagedEntries).toHaveBeenCalledTimes(1)
+    expect(appProvider.upsertManagedEntry).toHaveBeenCalledWith({
+      path: '/Applications/WeChat.app',
+      displayName: '微信',
+      enabled: true
+    })
+    expect(appProvider.removeManagedEntry).toHaveBeenCalledWith('/Applications/WeChat.app')
+    expect(appProvider.setManagedEntryEnabled).toHaveBeenCalledWith(
+      '/Applications/WeChat.app',
+      false
+    )
   })
 })

--- a/apps/core-app/src/main/channel/common.ts
+++ b/apps/core-app/src/main/channel/common.ts
@@ -9,6 +9,10 @@ import type { HandlerContext, ITuffTransportMain } from '@talex-touch/utils/tran
 import type {
   AppIndexAddPathRequest,
   AppIndexAddPathResult,
+  AppIndexEntryMutationResult,
+  AppIndexRemoveEntryRequest,
+  AppIndexSetEntryEnabledRequest,
+  AppIndexUpsertEntryRequest,
   AutoStartGetResponse,
   AutoStartUpdateRequest,
   AutoStartUpdateResponse,
@@ -523,6 +527,12 @@ function getOptionalStringProp(value: unknown, key: string): string | undefined 
   if (!isRecord(value)) return undefined
   const prop = value[key]
   return typeof prop === 'string' ? prop : undefined
+}
+
+function getOptionalBooleanProp(value: unknown, key: string): boolean | undefined {
+  if (!isRecord(value)) return undefined
+  const prop = value[key]
+  return typeof prop === 'boolean' ? prop : undefined
 }
 
 function normalizeCapabilityQuery(payload: unknown): PlatformCapabilityListRequest {
@@ -1501,6 +1511,35 @@ export class CommonChannelModule extends BaseModule {
             return { success: false, status: 'invalid', reason: 'path-empty' }
           }
           return appProvider.addAppByPath(inputPath)
+        }
+      ),
+      transport.on(AppEvents.appIndex.listEntries, () => appProvider.listManagedEntries()),
+      transport.on<AppIndexUpsertEntryRequest, AppIndexEntryMutationResult>(
+        AppEvents.appIndex.upsertEntry,
+        (payload) => appProvider.upsertManagedEntry(payload ?? { path: '' })
+      ),
+      transport.on<AppIndexRemoveEntryRequest, AppIndexEntryMutationResult>(
+        AppEvents.appIndex.removeEntry,
+        (payload) => {
+          const inputPath = getOptionalStringProp(payload, 'path')
+          if (!inputPath) {
+            return { success: false, status: 'invalid', reason: 'path-empty' }
+          }
+          return appProvider.removeManagedEntry(inputPath)
+        }
+      ),
+      transport.on<AppIndexSetEntryEnabledRequest, AppIndexEntryMutationResult>(
+        AppEvents.appIndex.setEntryEnabled,
+        (payload) => {
+          const inputPath = getOptionalStringProp(payload, 'path')
+          if (!inputPath) {
+            return { success: false, status: 'invalid', reason: 'path-empty' }
+          }
+          const enabled = getOptionalBooleanProp(payload, 'enabled')
+          if (enabled === undefined) {
+            return { success: false, status: 'invalid', reason: 'enabled-invalid' }
+          }
+          return appProvider.setManagedEntryEnabled(inputPath, enabled)
         }
       )
     )

--- a/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.test.ts
@@ -1,4 +1,7 @@
 import { EventEmitter } from 'node:events'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -221,6 +224,7 @@ vi.mock('./app-utils', () => ({
 }))
 
 vi.mock('./search-processing-service', () => ({
+  isSearchableAppRow: vi.fn(() => true),
   processSearchResults: vi.fn(async () => [])
 }))
 
@@ -244,6 +248,22 @@ async function flushPromises(): Promise<void> {
 
 async function loadSubject() {
   return await import('./app-provider')
+}
+
+function upsertExtensionRows(
+  target: Array<{ fileId: number; key: string; value: string }>,
+  rows: Array<{ fileId: number; key: string; value: string }>
+): void {
+  for (const row of rows) {
+    const existingIndex = target.findIndex(
+      (candidate) => candidate.fileId === row.fileId && candidate.key === row.key
+    )
+    if (existingIndex >= 0) {
+      target[existingIndex] = row
+    } else {
+      target.push(row)
+    }
+  }
 }
 
 type AppProviderPrivate = {
@@ -283,6 +303,7 @@ type AppProviderPrivate = {
   _performMdlsUpdateScan: () => Promise<void>
   _performRebuild: () => Promise<void>
   _performStartupBackfill: () => Promise<void>
+  reindexManagedEntries: () => Promise<void>
   _recordMissingIconApps: (apps: unknown[]) => Promise<void>
   _runFullSync: (forced: boolean) => Promise<void>
   _runMdlsUpdateScan: () => Promise<void>
@@ -456,22 +477,30 @@ describe('appProvider rebuild maintenance', () => {
     const { files, fileExtensions } = await import('../../../../db/schema')
     const privateProvider = asPrivateProvider(appProvider)
 
-    let selectedAppIds: number[] = []
+    const scannedAppIds = [1]
     let fileRows = [
-      { id: 1, type: 'app' },
-      { id: 2, type: 'file' }
+      { id: 1, path: '/Applications/Scanned.app', type: 'app' },
+      { id: 2, path: '/Users/demo/bin/custom.sh', type: 'app' },
+      { id: 3, type: 'file' }
     ]
     let extensionRows = [
-      { fileId: 1, key: 'bundleId' },
-      { fileId: 2, key: 'sha1' }
+      { fileId: 1, key: 'bundleId', value: 'com.demo.scanned' },
+      { fileId: 2, key: 'entrySource', value: 'manual' },
+      { fileId: 2, key: 'entryEnabled', value: '1' },
+      { fileId: 3, key: 'sha1', value: 'abc123' }
     ]
 
     const db = {
       select: vi.fn(() => ({
-        from: vi.fn(() => ({
+        from: vi.fn((table: unknown) => ({
           where: vi.fn(async () => {
-            selectedAppIds = fileRows.filter((row) => row.type === 'app').map((row) => row.id)
-            return selectedAppIds.map((id) => ({ id }))
+            if (table === files) {
+              return fileRows.filter((row) => row.type === 'app')
+            }
+            if (table === fileExtensions) {
+              return extensionRows.filter((row) => row.fileId === 1 || row.fileId === 2)
+            }
+            return []
           })
         }))
       })),
@@ -485,12 +514,10 @@ describe('appProvider rebuild maintenance', () => {
             delete: vi.fn((table: unknown) => ({
               where: vi.fn(async (_predicate: unknown) => {
                 if (table === fileExtensions) {
-                  extensionRows = extensionRows.filter(
-                    (row) => !selectedAppIds.includes(row.fileId)
-                  )
+                  extensionRows = extensionRows.filter((row) => !scannedAppIds.includes(row.fileId))
                 }
                 if (table === files) {
-                  fileRows = fileRows.filter((row) => !selectedAppIds.includes(row.id))
+                  fileRows = fileRows.filter((row) => !scannedAppIds.includes(row.id))
                 }
               })
             }))
@@ -505,13 +532,22 @@ describe('appProvider rebuild maintenance', () => {
     privateProvider.searchIndex = { removeByProvider: removeByProviderMock }
     privateProvider._clearPendingDeletions = vi.fn().mockResolvedValue(undefined)
     privateProvider._performFullSync = vi.fn().mockResolvedValue(undefined)
+    privateProvider.reindexManagedEntries = vi.fn().mockResolvedValue(undefined)
 
     const result = await appProvider.rebuildIndex()
 
     expect(result.success).toBe(true)
-    expect(fileRows).toEqual([{ id: 2, type: 'file' }])
-    expect(extensionRows).toEqual([{ fileId: 2, key: 'sha1' }])
+    expect(fileRows).toEqual([
+      { id: 2, path: '/Users/demo/bin/custom.sh', type: 'app' },
+      { id: 3, type: 'file' }
+    ])
+    expect(extensionRows).toEqual([
+      { fileId: 2, key: 'entrySource', value: 'manual' },
+      { fileId: 2, key: 'entryEnabled', value: '1' },
+      { fileId: 3, key: 'sha1', value: 'abc123' }
+    ])
     expect(removeByProviderMock).toHaveBeenCalledWith('app-provider')
+    expect(privateProvider.reindexManagedEntries).toHaveBeenCalledTimes(1)
     expect(privateProvider._performFullSync).toHaveBeenCalledWith(true)
   })
 
@@ -680,7 +716,6 @@ describe('appProvider rebuild maintenance', () => {
     expect(mapped.description).toBe('Built-in calculator app')
     expect(mapped.launchKind).toBe('uwp')
   })
-
   it('normalizes displayName pinyin keywords to lowercase', async () => {
     const { appProvider } = await loadSubject()
     const privateProvider = asPrivateProvider(appProvider)
@@ -702,5 +737,193 @@ describe('appProvider rebuild maintenance', () => {
     expect(keywords).toContain('wx')
     expect(keywords).not.toContain('WEIXIN')
     expect(keywords).not.toContain('WX')
+  })
+
+  it('upserts managed launcher entries with manual extension flags', async () => {
+    const { appProvider } = await loadSubject()
+    const { files, fileExtensions } = await import('../../../../db/schema')
+    const privateProvider = asPrivateProvider(appProvider)
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'app-provider-managed-'))
+    const scriptPath = path.join(tempDir, 'demo-script.sh')
+    await fs.writeFile(scriptPath, '#!/bin/sh\nexit 0\n', 'utf8')
+
+    let nextId = 1
+    let fileRows: Array<Record<string, any>> = []
+    const extensionRows: Array<{ fileId: number; key: string; value: string }> = []
+    const indexItemsMock = vi.fn(async () => undefined)
+    const removeItemsMock = vi.fn(async () => undefined)
+
+    const db = {
+      insert: vi.fn((table: unknown) => {
+        expect(table).toBe(files)
+        return {
+          values: vi.fn((payload: Record<string, any>) => ({
+            returning: vi.fn(async () => {
+              const row = {
+                id: nextId++,
+                ...payload,
+                displayName: payload.displayName ?? null
+              }
+              fileRows.push(row)
+              return [row]
+            })
+          }))
+        }
+      }),
+      update: vi.fn((table: unknown) => {
+        expect(table).toBe(files)
+        return {
+          set: vi.fn((payload: Record<string, any>) => ({
+            where: vi.fn(async () => {
+              fileRows = fileRows.map((row) =>
+                row.path === scriptPath
+                  ? { ...row, ...payload, displayName: payload.displayName ?? row.displayName }
+                  : row
+              )
+            })
+          }))
+        }
+      }),
+      transaction: vi.fn(
+        async (
+          callback: (tx: {
+            delete: (table: unknown) => { where: (predicate: unknown) => Promise<void> }
+          }) => Promise<void>
+        ) => {
+          const managedFileId = fileRows.find((row) => row.path === scriptPath)?.id ?? -1
+          const tx = {
+            delete: vi.fn((table: unknown) => ({
+              where: vi.fn(async (_predicate: unknown) => {
+                if (table === fileExtensions) {
+                  for (let index = extensionRows.length - 1; index >= 0; index -= 1) {
+                    if (extensionRows[index]?.fileId === managedFileId) {
+                      extensionRows.splice(index, 1)
+                    }
+                  }
+                }
+                if (table === files) {
+                  fileRows = fileRows.filter((row) => row.id !== managedFileId)
+                }
+              })
+            }))
+          }
+          await callback(tx)
+        }
+      )
+    }
+
+    privateProvider.dbUtils = {
+      getDb: () => db,
+      getFileByPath: vi.fn(async (value: string) => fileRows.find((row) => row.path === value)),
+      getFileExtensions: vi.fn(async (fileId: number) =>
+        extensionRows
+          .filter((row) => row.fileId === fileId)
+          .map((row) => ({ ...row, value: row.value }))
+      ),
+      addFileExtensions: vi.fn(
+        async (rows: Array<{ fileId: number; key: string; value: string }>) => {
+          upsertExtensionRows(extensionRows, rows)
+        }
+      ),
+      addFileExtension: vi.fn(async (fileId: number, key: string, value: string) => {
+        upsertExtensionRows(extensionRows, [{ fileId, key, value }])
+      })
+    }
+    privateProvider.searchIndex = {
+      indexItems: indexItemsMock,
+      removeItems: removeItemsMock
+    }
+
+    const added = await appProvider.upsertManagedEntry({
+      path: scriptPath,
+      displayName: 'Demo Script',
+      launchKind: 'shortcut'
+    })
+
+    expect(added).toMatchObject({
+      success: true,
+      status: 'added',
+      entry: {
+        path: scriptPath,
+        displayName: 'Demo Script',
+        enabled: true,
+        launchKind: 'shortcut',
+        launchTarget: scriptPath
+      }
+    })
+    expect(extensionRows).toEqual(
+      expect.arrayContaining([
+        { fileId: 1, key: 'entrySource', value: 'manual' },
+        { fileId: 1, key: 'entryEnabled', value: '1' },
+        { fileId: 1, key: 'launchKind', value: 'shortcut' },
+        { fileId: 1, key: 'launchTarget', value: scriptPath }
+      ])
+    )
+    expect(indexItemsMock).toHaveBeenCalledTimes(1)
+
+    const disabled = await appProvider.setManagedEntryEnabled(scriptPath, false)
+
+    expect(disabled).toMatchObject({
+      success: true,
+      status: 'updated',
+      entry: {
+        path: scriptPath,
+        enabled: false
+      }
+    })
+    expect(removeItemsMock).toHaveBeenCalledWith([scriptPath])
+
+    const removed = await appProvider.removeManagedEntry(scriptPath)
+
+    expect(removed).toMatchObject({
+      success: true,
+      status: 'removed',
+      entry: {
+        path: scriptPath
+      }
+    })
+    expect(fileRows).toEqual([])
+  })
+
+  it('rejects managed launcher entries that collide with scanned apps', async () => {
+    const { appProvider } = await loadSubject()
+    const privateProvider = asPrivateProvider(appProvider)
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'app-provider-managed-conflict-'))
+    const scriptPath = path.join(tempDir, 'wechat.app')
+    await fs.writeFile(scriptPath, 'not-a-real-app', 'utf8')
+
+    privateProvider.dbUtils = {
+      getDb: () => ({
+        insert: vi.fn(),
+        update: vi.fn(),
+        transaction: vi.fn()
+      }),
+      getFileByPath: vi.fn(async () => ({
+        id: 7,
+        path: scriptPath,
+        name: 'WeChat',
+        displayName: 'WeChat',
+        type: 'app',
+        mtime: new Date(0),
+        ctime: new Date(0)
+      })),
+      getFileExtensions: vi.fn(async () => [
+        { fileId: 7, key: 'bundleId', value: 'com.tencent.xinWeChat' }
+      ])
+    }
+
+    const result = await appProvider.upsertManagedEntry({
+      path: scriptPath,
+      displayName: '微信',
+      launchKind: 'path'
+    })
+
+    expect(result).toEqual({
+      success: false,
+      status: 'invalid',
+      reason: 'path-conflicts-with-scanned-app'
+    })
   })
 })

--- a/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.ts
@@ -18,7 +18,12 @@ import path from 'node:path'
 import { performance } from 'node:perf_hooks'
 import process from 'node:process'
 import { is } from '@electron-toolkit/utils'
-import type { AppIndexAddPathResult } from '@talex-touch/utils/transport/events/types'
+import type {
+  AppIndexAddPathResult,
+  AppIndexEntryMutationResult,
+  AppIndexManagedEntry,
+  AppIndexUpsertEntryRequest
+} from '@talex-touch/utils/transport/events/types'
 import {
   completeTiming,
   createRetrier,
@@ -64,7 +69,7 @@ import { scheduleAppLaunch } from './app-launcher'
 import { normalizeDisplayName, shouldUpdateDisplayName } from './display-name-sync-utils'
 import { matchNoisySystemAppRule } from './app-noise-filter'
 import { formatLog, LogStyle } from './app-utils'
-import { processSearchResults } from './search-processing-service'
+import { isSearchableAppRow, processSearchResults } from './search-processing-service'
 import type { AppLaunchKind, ScannedAppInfo } from './app-types'
 
 const SLOW_SEARCH_THRESHOLD_MS = 400
@@ -253,6 +258,9 @@ const APP_LAUNCH_ARGS_EXTENSION_KEY = 'launchArgs'
 const APP_WORKING_DIRECTORY_EXTENSION_KEY = 'workingDirectory'
 const APP_DISPLAY_PATH_EXTENSION_KEY = 'displayPath'
 const APP_DESCRIPTION_EXTENSION_KEY = 'description'
+const APP_ENTRY_SOURCE_EXTENSION_KEY = 'entrySource'
+const APP_ENTRY_ENABLED_EXTENSION_KEY = 'entryEnabled'
+const APP_ENTRY_SOURCE_MANUAL = 'manual'
 const APP_IDENTIFIER_EXTENSION_KEYS = ['bundleId', APP_IDENTITY_EXTENSION_KEY] as const
 
 function resolveAppItemId(value: {
@@ -262,6 +270,37 @@ function resolveAppItemId(value: {
   path: string
 }): string {
   return value.bundleId || value.stableId || value.appIdentity || value.path
+}
+
+function isManagedEntryExtensionMap(
+  extensions: Record<string, string | null> | undefined
+): boolean {
+  return extensions?.[APP_ENTRY_SOURCE_EXTENSION_KEY] === APP_ENTRY_SOURCE_MANUAL
+}
+
+function isManagedEntryEnabledExtensionMap(
+  extensions: Record<string, string | null> | undefined
+): boolean {
+  if (!isManagedEntryExtensionMap(extensions)) {
+    return true
+  }
+  const raw = extensions?.[APP_ENTRY_ENABLED_EXTENSION_KEY]
+  return raw !== '0' && raw !== 'false'
+}
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  const normalized = value?.trim()
+  return normalized ? normalized : undefined
+}
+
+function inferManagedEntryLaunchKind(targetPath: string): AppLaunchKind {
+  if (process.platform === 'darwin' && targetPath.endsWith('.app')) {
+    return 'path'
+  }
+  if (process.platform === 'win32') {
+    return /\.(lnk|exe|cmd|bat|com|ps1)$/i.test(targetPath) ? 'shortcut' : 'path'
+  }
+  return /\.(sh|bash|zsh|command|py|js|mjs|cjs)$/i.test(targetPath) ? 'shortcut' : 'path'
 }
 
 export interface AppIndexSettings {
@@ -488,6 +527,212 @@ class AppProvider implements ISearchProvider<ProviderContext> {
     return this.processAppPath(appPath)
   }
 
+  public async listManagedEntries(): Promise<AppIndexManagedEntry[]> {
+    if (!this.dbUtils) return []
+
+    const allApps = await this.dbUtils.getFilesByType('app')
+    const appsWithExtensions = await this.fetchExtensionsForFiles(allApps)
+
+    return this.partitionDbApps(appsWithExtensions)
+      .managedEntries.map((app) => this.mapManagedEntry(app))
+      .sort((left, right) =>
+        (left.displayName || left.name).localeCompare(right.displayName || right.name)
+      )
+  }
+
+  public async upsertManagedEntry(
+    input: AppIndexUpsertEntryRequest
+  ): Promise<AppIndexEntryMutationResult> {
+    if (!this.dbUtils) {
+      return { success: false, status: 'error', reason: 'db-not-ready' }
+    }
+
+    const normalized = this.normalizeManagedEntryInput(input)
+    if ('reason' in normalized) {
+      return { success: false, status: 'invalid', reason: normalized.reason }
+    }
+
+    const { appInfo, enabled } = normalized
+    const existingFile = await this.dbUtils.getFileByPath(appInfo.path)
+    const db = this.dbUtils.getDb()
+
+    if (existingFile) {
+      const existingExtensions = this.toExtensionMap(
+        await this.dbUtils.getFileExtensions(existingFile.id)
+      )
+      if (!isManagedEntryExtensionMap(existingExtensions)) {
+        return {
+          success: false,
+          status: 'invalid',
+          reason: 'path-conflicts-with-scanned-app'
+        }
+      }
+
+      await db
+        .update(filesSchema)
+        .set({
+          name: appInfo.name,
+          displayName: normalizeDisplayName(appInfo.displayName),
+          mtime: appInfo.lastModified
+        })
+        .where(eq(filesSchema.id, existingFile.id))
+
+      const nextExtensions = this.buildManagedEntryExtensions(existingFile.id, appInfo, enabled)
+      await this.dbUtils.addFileExtensions(nextExtensions)
+
+      if (enabled) {
+        await this._syncKeywordsForApp(appInfo)
+      } else {
+        await this.searchIndex?.removeItems([resolveAppItemId(appInfo)])
+      }
+
+      return {
+        success: true,
+        status: 'updated',
+        entry: this.mapManagedEntry({
+          ...existingFile,
+          name: appInfo.name,
+          displayName: normalizeDisplayName(appInfo.displayName),
+          mtime: appInfo.lastModified,
+          extensions: {
+            ...existingExtensions,
+            ...this.toExtensionMap(nextExtensions)
+          }
+        })
+      }
+    }
+
+    const [insertedFile] = await db
+      .insert(filesSchema)
+      .values({
+        path: appInfo.path,
+        name: appInfo.name,
+        displayName: normalizeDisplayName(appInfo.displayName),
+        type: 'app' as const,
+        mtime: appInfo.lastModified,
+        ctime: new Date()
+      })
+      .returning()
+
+    if (!insertedFile) {
+      return { success: false, status: 'error', reason: 'insert-failed' }
+    }
+
+    const nextExtensions = this.buildManagedEntryExtensions(insertedFile.id, appInfo, enabled)
+    await this.dbUtils.addFileExtensions(nextExtensions)
+
+    if (enabled) {
+      await this._syncKeywordsForApp(appInfo)
+    }
+
+    return {
+      success: true,
+      status: 'added',
+      entry: this.mapManagedEntry({
+        ...insertedFile,
+        extensions: this.toExtensionMap(nextExtensions)
+      })
+    }
+  }
+
+  public async removeManagedEntry(pathValue: string): Promise<AppIndexEntryMutationResult> {
+    const normalizedPath = normalizeOptionalString(pathValue)
+    if (!normalizedPath) {
+      return { success: false, status: 'invalid', reason: 'path-empty' }
+    }
+    if (!this.dbUtils) {
+      return { success: false, status: 'error', reason: 'db-not-ready' }
+    }
+
+    const existingFile = await this.dbUtils.getFileByPath(normalizedPath)
+    if (!existingFile) {
+      return { success: false, status: 'not-found', reason: 'entry-not-found' }
+    }
+
+    const existingExtensions = this.toExtensionMap(
+      await this.dbUtils.getFileExtensions(existingFile.id)
+    )
+    if (!isManagedEntryExtensionMap(existingExtensions)) {
+      return { success: false, status: 'invalid', reason: 'not-user-managed' }
+    }
+
+    const db = this.dbUtils.getDb()
+    await db.transaction(async (tx) => {
+      await tx.delete(fileExtensions).where(eq(fileExtensions.fileId, existingFile.id))
+      await tx.delete(filesSchema).where(eq(filesSchema.id, existingFile.id))
+    })
+
+    await this.searchIndex?.removeItems([
+      resolveAppItemId({
+        bundleId: existingExtensions.bundleId,
+        appIdentity: existingExtensions.appIdentity,
+        path: existingFile.path
+      })
+    ])
+
+    return {
+      success: true,
+      status: 'removed',
+      entry: this.mapManagedEntry({ ...existingFile, extensions: existingExtensions })
+    }
+  }
+
+  public async setManagedEntryEnabled(
+    pathValue: string,
+    enabled: boolean
+  ): Promise<AppIndexEntryMutationResult> {
+    const normalizedPath = normalizeOptionalString(pathValue)
+    if (!normalizedPath) {
+      return { success: false, status: 'invalid', reason: 'path-empty' }
+    }
+    if (!this.dbUtils) {
+      return { success: false, status: 'error', reason: 'db-not-ready' }
+    }
+
+    const existingFile = await this.dbUtils.getFileByPath(normalizedPath)
+    if (!existingFile) {
+      return { success: false, status: 'not-found', reason: 'entry-not-found' }
+    }
+
+    const existingExtensions = this.toExtensionMap(
+      await this.dbUtils.getFileExtensions(existingFile.id)
+    )
+    if (!isManagedEntryExtensionMap(existingExtensions)) {
+      return { success: false, status: 'invalid', reason: 'not-user-managed' }
+    }
+
+    const nextExtensions = {
+      ...existingExtensions,
+      [APP_ENTRY_ENABLED_EXTENSION_KEY]: enabled ? '1' : '0'
+    }
+
+    await this.dbUtils.addFileExtension(
+      existingFile.id,
+      APP_ENTRY_ENABLED_EXTENSION_KEY,
+      enabled ? '1' : '0'
+    )
+
+    const appInfo = this._mapDbAppToScannedInfo({
+      ...existingFile,
+      extensions: nextExtensions
+    })
+
+    if (enabled) {
+      await this._syncKeywordsForApp(appInfo)
+    } else {
+      await this.searchIndex?.removeItems([resolveAppItemId(appInfo)])
+    }
+
+    return {
+      success: true,
+      status: 'updated',
+      entry: this.mapManagedEntry({
+        ...existingFile,
+        extensions: nextExtensions
+      })
+    }
+  }
+
   public async setAliases(aliases: Record<string, string[]>): Promise<void> {
     logApp('Updating app aliases', LogStyle.process)
     this.aliases = aliases
@@ -497,7 +742,9 @@ class AppProvider implements ISearchProvider<ProviderContext> {
     if (!this.dbUtils) return
 
     const allApps = await this.dbUtils.getFilesByType('app')
-    const appsWithExtensions = await this.fetchExtensionsForFiles(allApps)
+    const appsWithExtensions = (await this.fetchExtensionsForFiles(allApps)).filter(
+      isSearchableAppRow
+    )
 
     logApp(
       `Resyncing keywords for ${chalk.cyan(appsWithExtensions.length)} apps...`,
@@ -586,6 +833,159 @@ class AppProvider implements ISearchProvider<ProviderContext> {
       extensions.push({ fileId, key: APP_DESCRIPTION_EXTENSION_KEY, value: app.description })
     }
     return extensions
+  }
+
+  private buildManagedEntryExtensions(
+    fileId: number,
+    app: Pick<
+      ScannedAppInfo,
+      | 'bundleId'
+      | 'icon'
+      | 'stableId'
+      | 'launchKind'
+      | 'launchTarget'
+      | 'launchArgs'
+      | 'workingDirectory'
+      | 'displayPath'
+      | 'description'
+    >,
+    enabled: boolean
+  ): FileExtensionInsert[] {
+    const extensions = this.buildAppExtensions(fileId, app)
+    extensions.push({
+      fileId,
+      key: APP_ENTRY_SOURCE_EXTENSION_KEY,
+      value: APP_ENTRY_SOURCE_MANUAL
+    })
+    extensions.push({
+      fileId,
+      key: APP_ENTRY_ENABLED_EXTENSION_KEY,
+      value: enabled ? '1' : '0'
+    })
+    return extensions
+  }
+
+  private toExtensionMap(
+    records: Array<{ key: string; value: string | null }>
+  ): Record<string, string | null> {
+    return records.reduce<Record<string, string | null>>((accumulator, record) => {
+      accumulator[record.key] = record.value
+      return accumulator
+    }, {})
+  }
+
+  private partitionDbApps(apps: DbAppWithExtensions[]): {
+    scannedApps: DbAppWithExtensions[]
+    managedEntries: DbAppWithExtensions[]
+  } {
+    const scannedApps: DbAppWithExtensions[] = []
+    const managedEntries: DbAppWithExtensions[] = []
+
+    for (const app of apps) {
+      if (isManagedEntryExtensionMap(app.extensions)) {
+        managedEntries.push(app)
+      } else {
+        scannedApps.push(app)
+      }
+    }
+
+    return { scannedApps, managedEntries }
+  }
+
+  private async reindexManagedEntries(): Promise<void> {
+    if (!this.dbUtils) return
+
+    const allApps = await this.dbUtils.getFilesByType('app')
+    const appsWithExtensions = await this.fetchExtensionsForFiles(allApps)
+    const { managedEntries } = this.partitionDbApps(appsWithExtensions)
+
+    for (const app of managedEntries) {
+      if (!isManagedEntryEnabledExtensionMap(app.extensions)) {
+        continue
+      }
+      await this._syncKeywordsForApp(this._mapDbAppToScannedInfo(app))
+    }
+  }
+
+  private mapManagedEntry(app: DbAppWithExtensions): AppIndexManagedEntry {
+    const appInfo = this._mapDbAppToScannedInfo(app)
+    return {
+      path: app.path,
+      name: appInfo.name,
+      displayName: appInfo.displayName,
+      icon: appInfo.icon || undefined,
+      enabled: isManagedEntryEnabledExtensionMap(app.extensions),
+      launchKind: appInfo.launchKind,
+      launchTarget: appInfo.launchTarget,
+      launchArgs: appInfo.launchArgs,
+      workingDirectory: appInfo.workingDirectory,
+      displayPath: appInfo.displayPath,
+      description: appInfo.description
+    }
+  }
+
+  private normalizeManagedEntryInput(
+    input: AppIndexUpsertEntryRequest
+  ): { reason: string } | { appInfo: ScannedAppInfo; enabled: boolean } {
+    const normalizedPath = normalizeOptionalString(input.path)
+    if (!normalizedPath) {
+      return { reason: 'path-empty' }
+    }
+
+    const launchTarget = normalizeOptionalString(input.launchTarget) || normalizedPath
+    const launchKind = input.launchKind || inferManagedEntryLaunchKind(launchTarget)
+    if (launchKind === 'uwp' && process.platform !== 'win32') {
+      return { reason: 'launch-kind-unsupported' }
+    }
+
+    if (launchKind !== 'uwp') {
+      if (!path.isAbsolute(normalizedPath)) {
+        return { reason: 'path-not-absolute' }
+      }
+      if (!existsSync(normalizedPath)) {
+        return { reason: 'path-not-found' }
+      }
+      if (!path.isAbsolute(launchTarget)) {
+        return { reason: 'launch-target-not-absolute' }
+      }
+      if (!existsSync(launchTarget)) {
+        return { reason: 'launch-target-not-found' }
+      }
+    }
+
+    const displayPath = normalizeOptionalString(input.displayPath) || normalizedPath
+    const fileName = path.basename(displayPath)
+    const derivedName =
+      path.basename(displayPath, path.extname(displayPath) || undefined) ||
+      path.basename(normalizedPath) ||
+      normalizedPath
+    const displayName = normalizeOptionalString(input.displayName) || derivedName
+    const workingDirectory =
+      normalizeOptionalString(input.workingDirectory) ||
+      (launchKind === 'shortcut' && path.isAbsolute(launchTarget)
+        ? path.dirname(launchTarget)
+        : undefined)
+
+    return {
+      enabled: input.enabled !== false,
+      appInfo: {
+        name: derivedName,
+        displayName,
+        fileName,
+        path: normalizedPath,
+        icon: normalizeOptionalString(input.icon) || '',
+        bundleId: '',
+        uniqueId: normalizedPath,
+        stableId: normalizedPath,
+        launchKind,
+        launchTarget,
+        launchArgs: normalizeOptionalString(input.launchArgs),
+        workingDirectory,
+        displayPath,
+        description: normalizeOptionalString(input.description),
+        lastModified: new Date()
+      }
+    }
   }
 
   private buildScannedAppsMap(scannedApps: ScannedAppInfo[]): Map<string, ScannedAppInfo> {
@@ -762,20 +1162,24 @@ class AppProvider implements ISearchProvider<ProviderContext> {
     const dbLoadStart = startTiming()
     const dbApps = await this.dbUtils!.getFilesByType('app')
     const dbAppsWithExtensions = await this.fetchExtensionsForFiles(dbApps)
+    const { scannedApps: dbScannedAppsWithExtensions, managedEntries } =
+      this.partitionDbApps(dbAppsWithExtensions)
     logAppDuration('BackfillLoadDbApps', dbLoadStart, {
-      label: `Loaded ${chalk.cyan(dbApps.length)} DB app records`,
+      label: `Loaded ${chalk.cyan(dbScannedAppsWithExtensions.length)} scanned and ${chalk.cyan(
+        managedEntries.length
+      )} managed DB app records`,
       style: 'info',
       unit: 's',
       precision: 2
     })
 
     const scannedAppsMap = this.buildScannedAppsMap(scannedApps)
-    const existingIds = new Set(dbAppsWithExtensions.map((app) => this.resolveDbAppKey(app)))
+    const existingIds = new Set(dbScannedAppsWithExtensions.map((app) => this.resolveDbAppKey(app)))
     const toAdd = scannedApps.filter((app) => {
       const uniqueId = this.resolveScannedAppKey(app)
       return !!uniqueId && !existingIds.has(uniqueId)
     })
-    const toUpdateDisplayName = dbAppsWithExtensions
+    const toUpdateDisplayName = dbScannedAppsWithExtensions
       .map((dbApp) => {
         const uniqueId = this.resolveDbAppKey(dbApp)
         const scannedApp = scannedAppsMap.get(uniqueId)
@@ -793,6 +1197,7 @@ class AppProvider implements ISearchProvider<ProviderContext> {
 
     ;(dbApps as unknown[]).length = 0
     ;(dbAppsWithExtensions as unknown[]).length = 0
+    ;(dbScannedAppsWithExtensions as unknown[]).length = 0
 
     logApp(
       `Startup backfill found ${chalk.green(toAdd.length)} missing apps and ${chalk.yellow(
@@ -1225,14 +1630,18 @@ class AppProvider implements ISearchProvider<ProviderContext> {
     const dbLoadStart = startTiming()
     const dbApps = await this.dbUtils!.getFilesByType('app')
     const dbAppsWithExtensions = await this.fetchExtensionsForFiles(dbApps)
+    const { scannedApps: dbScannedAppsWithExtensions, managedEntries } =
+      this.partitionDbApps(dbAppsWithExtensions)
     logAppDuration('LoadDbApps', dbLoadStart, {
-      label: `Loaded ${chalk.cyan(dbApps.length)} DB app records`,
+      label: `Loaded ${chalk.cyan(dbScannedAppsWithExtensions.length)} scanned and ${chalk.cyan(
+        managedEntries.length
+      )} managed DB app records`,
       style: 'info',
       unit: 's',
       precision: 2
     })
     const invalidIconApps = new Set<string>()
-    for (const app of dbAppsWithExtensions) {
+    for (const app of dbScannedAppsWithExtensions) {
       const icon = app.extensions.icon
       if (icon && !isValidBase64DataUrl(icon)) {
         const uniqueId = this.resolveDbAppKey(app)
@@ -1245,7 +1654,9 @@ class AppProvider implements ISearchProvider<ProviderContext> {
         LogStyle.warning
       )
     }
-    const dbAppsMap = new Map(dbAppsWithExtensions.map((app) => [this.resolveDbAppKey(app), app]))
+    const dbAppsMap = new Map(
+      dbScannedAppsWithExtensions.map((app) => [this.resolveDbAppKey(app), app])
+    )
 
     const toAdd: ScannedAppInfo[] = []
     const toUpdate: Array<{
@@ -1256,7 +1667,9 @@ class AppProvider implements ISearchProvider<ProviderContext> {
     const missingApps: Array<{ id: number; path: string; uniqueId: string }> = []
 
     logApp(
-      `Comparing ${chalk.cyan(scannedApps.length)} scanned apps with ${chalk.cyan(dbApps.length)} apps in DB`,
+      `Comparing ${chalk.cyan(scannedApps.length)} scanned apps with ${chalk.cyan(
+        dbScannedAppsWithExtensions.length
+      )} scanned apps in DB`,
       LogStyle.info
     )
 
@@ -1947,11 +2360,12 @@ class AppProvider implements ISearchProvider<ProviderContext> {
     }
 
     const appsWithExtensions = await this.fetchExtensionsForFiles(files)
+    const searchableAppsWithExtensions = appsWithExtensions.filter(isSearchableAppRow)
     const filteredAppsWithExtensions =
       this.isMac && this.appIndexSettings.hideNoisySystemApps
         ? (() => {
             const ruleCounts: Record<string, number> = {}
-            const filtered = appsWithExtensions.filter((app) => {
+            const filtered = searchableAppsWithExtensions.filter((app) => {
               const rule = matchNoisySystemAppRule({
                 path: app.path,
                 bundleId: app.extensions.bundleId,
@@ -1963,7 +2377,7 @@ class AppProvider implements ISearchProvider<ProviderContext> {
               ruleCounts[rule] = (ruleCounts[rule] ?? 0) + 1
               return false
             })
-            const filteredCount = appsWithExtensions.length - filtered.length
+            const filteredCount = searchableAppsWithExtensions.length - filtered.length
             if (filteredCount > 0) {
               appProviderLog.debug('Filtered noisy system apps from search candidates', {
                 query: rawText,
@@ -1973,7 +2387,7 @@ class AppProvider implements ISearchProvider<ProviderContext> {
             }
             return filtered
           })()
-        : appsWithExtensions
+        : searchableAppsWithExtensions
     const isFuzzySearch = !preciseMatchedItemIds || preciseMatchedItemIds.size === 0
 
     const processedResults = await processSearchResults(
@@ -2274,11 +2688,9 @@ class AppProvider implements ISearchProvider<ProviderContext> {
     }
 
     const db = this.dbUtils.getDb()
-    const appRows = await db
-      .select({ id: filesSchema.id })
-      .from(filesSchema)
-      .where(eq(filesSchema.type, 'app'))
-    const appIds = appRows.map((row) => row.id)
+    const appRows = await db.select().from(filesSchema).where(eq(filesSchema.type, 'app'))
+    const appsWithExtensions = await this.fetchExtensionsForFiles(appRows)
+    const appIds = this.partitionDbApps(appsWithExtensions).scannedApps.map((row) => row.id)
 
     if (appIds.length > 0) {
       await db.transaction(async (tx) => {
@@ -2294,6 +2706,7 @@ class AppProvider implements ISearchProvider<ProviderContext> {
 
     this.isInitializing = null
     await this._performFullSync(true)
+    await this.reindexManagedEntries()
 
     logApp('App database rebuild complete', LogStyle.success)
   }
@@ -2480,19 +2893,25 @@ class AppProvider implements ISearchProvider<ProviderContext> {
     await new Promise<void>((resolve) => setImmediate(resolve))
 
     const dbAppsWithExtensions = await this.fetchExtensionsForFiles(allDbApps)
+    const { scannedApps: dbScannedAppsWithExtensions } = this.partitionDbApps(dbAppsWithExtensions)
     const t2 = performance.now()
+
+    if (dbScannedAppsWithExtensions.length === 0) {
+      logApp('No scanned apps in DB, skipping mdls scan', LogStyle.info)
+      return
+    }
 
     await new Promise<void>((resolve) => setImmediate(resolve))
 
     const scannedApps: ScannedAppInfo[] = []
-    for (let mi = 0; mi < dbAppsWithExtensions.length; mi++) {
-      scannedApps.push(this._mapDbAppToScannedInfo(dbAppsWithExtensions[mi]))
+    for (let mi = 0; mi < dbScannedAppsWithExtensions.length; mi++) {
+      scannedApps.push(this._mapDbAppToScannedInfo(dbScannedAppsWithExtensions[mi]))
       if ((mi + 1) % 50 === 0) {
         await new Promise<void>((resolve) => setImmediate(resolve))
       }
     }
     const dbAppsByUniqueId = new Map(
-      dbAppsWithExtensions.map((app) => [this.resolveDbAppKey(app), app])
+      dbScannedAppsWithExtensions.map((app) => [this.resolveDbAppKey(app), app])
     )
 
     // Detect system locale change — if the user switched language, mdls will

--- a/apps/core-app/src/main/modules/box-tool/addon/apps/search-processing-service.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/search-processing-service.test.ts
@@ -30,4 +30,22 @@ describe('search-processing-service', () => {
       'Microsoft.WindowsCalculator_8wekyb3d8bbwe!App'
     )
   })
+
+  it('skips disabled managed launcher entries in recommendation mapping', () => {
+    const items = mapAppsToRecommendationItems([
+      {
+        name: 'Managed Script',
+        displayName: 'Managed Script',
+        path: '/Users/demo/bin/script.sh',
+        extensions: {
+          entrySource: 'manual',
+          entryEnabled: '0',
+          launchKind: 'shortcut',
+          launchTarget: '/Users/demo/bin/script.sh'
+        }
+      }
+    ] as any)
+
+    expect(items).toEqual([])
+  })
 })

--- a/apps/core-app/src/main/modules/box-tool/addon/apps/search-processing-service.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/search-processing-service.ts
@@ -16,6 +16,9 @@ import { calculateHighlights } from './highlighting-service'
 const SLOW_PROCESS_THRESHOLD_MS = 300
 const BASE64_MARKER = 'base64,'
 const BASE64_PAYLOAD_PATTERN = /^[A-Za-z0-9+/=]+$/
+const MANAGED_ENTRY_SOURCE_KEY = 'entrySource'
+const MANAGED_ENTRY_ENABLED_KEY = 'entryEnabled'
+const MANAGED_ENTRY_SOURCE_VALUE = 'manual'
 
 function isValidBase64DataUrl(value: string): boolean {
   const markerIndex = value.indexOf(BASE64_MARKER)
@@ -39,6 +42,14 @@ interface AppMatchState {
   highlights: Range[]
   score: number
   source: string
+}
+
+export function isSearchableAppRow(app: AppSearchRow): boolean {
+  if (app.extensions[MANAGED_ENTRY_SOURCE_KEY] !== MANAGED_ENTRY_SOURCE_VALUE) {
+    return true
+  }
+  const enabled = app.extensions[MANAGED_ENTRY_ENABLED_KEY]
+  return enabled !== '0' && enabled !== 'false'
 }
 
 function buildProcessedAppItem(app: AppSearchRow, match: AppMatchState): ProcessedTuffItem {
@@ -99,7 +110,7 @@ function buildProcessedAppItem(app: AppSearchRow, match: AppMatchState): Process
 }
 
 export function mapAppsToRecommendationItems(apps: AppSearchRow[]): ProcessedTuffItem[] {
-  return apps.map((app) =>
+  return apps.filter(isSearchableAppRow).map((app) =>
     buildProcessedAppItem(app, {
       highlights: [],
       score: 0,
@@ -119,6 +130,9 @@ export async function processSearchResults(
   const processedItems: ProcessedTuffItem[] = []
 
   for (const app of apps) {
+    if (!isSearchableAppRow(app)) {
+      continue
+    }
     const name = app.name
     const displayName = app.displayName || app.name
     const potentialTitles = [displayName, name].filter(Boolean) as string[]

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,6 +1,6 @@
 # 文档索引
 
-> 更新时间：2026-04-21
+> 更新时间：2026-04-22
 > 本页仅保留入口与高价值快照；历史细节以 `docs/plan-prd/01-project/CHANGES.md` 为准。
 
 ## 主要入口
@@ -23,7 +23,9 @@
 - `plan-prd` 子域：`03-features 32`、`docs 20`、`04-implementation 17`、`01-project 12`、`05-archive 11`、`02-architecture 8`、`06-ecosystem 4`。
 - 统计口径与下一步路线统一锚点：`docs/plan-prd/docs/DOC-INVENTORY-AND-NEXT-STEPS-2026-03-17.md`。
 
-## 状态快照（2026-04-21，统一口径）
+## 状态快照（2026-04-22，统一口径）
+
+- **User-managed launcher foundation（2026-04-22）**：`appIndex` typed domain 已新增 `listEntries / upsertEntry / removeEntry / setEntryEnabled`，settings SDK 与 main channel handler 全链路接通；`app-provider` 现在支持将 user-managed launcher entry 持久化到现有 `files + file_extensions`，并继续复用搜索与启动链路，禁用条目会从 recommendation/search 过滤。
 
 - **macOS 中文应用名首轮索引修复（2026-04-21）**：`darwin.getAppInfo()` 首轮扫描已补入 Spotlight `kMDItemDisplayName` 安全读取，并把优先级提升为 `Spotlight > localized strings > plist > bundle`；fresh scan 现在就能拿到中文显示名，`app-provider` 拼音关键词也统一规整为 lowercase。
 - **2.5.0 前置口径（2026-04-20）**：当前主线切换为 `CoreApp legacy 清理 + Windows/macOS 2.5.0 阻塞级适配`；先关闭或显式降权 CoreApp 剩余 legacy/compat 债务，再完成 Windows/macOS release-blocking 回归。Linux 保留 `xdotool` / desktop environment 限制说明与非阻塞 smoke，不作为 `2.5.0` blocker。
@@ -79,12 +81,12 @@
 
 | 文档 | 当前状态 | 下一动作 |
 | --- | --- | --- |
-| `docs/plan-prd/TODO.md` | 已同步到 2026-04-21 | 推进 `CoreApp legacy 清理 + Windows/macOS 2.5.0 阻塞级适配` |
+| `docs/plan-prd/TODO.md` | 已同步到 2026-04-22 | 推进 `CoreApp legacy 清理 + Windows/macOS 2.5.0 阻塞级适配` |
 | `docs/plan-prd/README.md` | 已同步到 2026-04-20 | 维护 CoreApp `2.5.0` 前置治理与未闭环能力口径 |
 | `docs/plan-prd/01-project/PRODUCT-OVERVIEW-ROADMAP-2026Q1.md` | 已同步到 2026-04-20 | 按锁定顺序推进 CoreApp legacy 清理与 Windows/macOS 阻塞级回归 |
 | `docs/plan-prd/01-project/RELEASE-2.4.7-CHECKLIST-2026-02-26.md` | Gate A/B/C/D/E 已完成（D/E historical，2026-03-16 已复核） | 保留证据链并切换到 `2.4.9` 后续主线 |
 | `docs/plan-prd/docs/PRD-QUALITY-BASELINE.md` | 已同步到 2026-04-20 | Windows/macOS 为 release-blocking；Linux 保持 documented best-effort |
-| `docs/plan-prd/01-project/CHANGES.md` | 已同步到 2026-04-21 | 持续记录 CoreApp `2.5.0` 前置治理口径与证据 |
+| `docs/plan-prd/01-project/CHANGES.md` | 已同步到 2026-04-22 | 持续记录 CoreApp `2.5.0` 前置治理口径与证据 |
 | `docs/INDEX.md` | 本页（入口+快照）已压缩 | 仅维护导航与高价值快照 |
 
 ## 归档与降权

--- a/docs/plan-prd/01-project/CHANGES.md
+++ b/docs/plan-prd/01-project/CHANGES.md
@@ -14,6 +14,26 @@
   - PR 池清淤策略改为直接保留业务 replacement PR，不再让 README contributors automation 持续占用 open PR 配额。
   - workflow 说明文档已同步标记 contributors README automation 退役，后续如需维护 contributors 列表，改走显式人工变更而不是自动 PR。
 
+### feat(core-app/app-index): 接通 user-managed launcher foundation 最小闭环
+
+- `packages/utils/transport/events/types/app-index.ts`
+- `packages/utils/transport/events/index.ts`
+- `packages/utils/transport/sdk/domains/settings.ts`
+- `packages/utils/__tests__/transport-domain-sdks.test.ts`
+- `apps/core-app/src/main/channel/common.ts`
+- `apps/core-app/src/main/channel/common.test.ts`
+- `apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.ts`
+- `apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.test.ts`
+- `apps/core-app/src/main/modules/box-tool/addon/apps/search-processing-service.ts`
+- `apps/core-app/src/main/modules/box-tool/addon/apps/search-processing-service.test.ts`
+- `docs/INDEX.md`
+- `docs/plan-prd/01-project/CHANGES.md`
+- `docs/plan-prd/TODO.md`
+  - `settingsSdk.appIndex` 现已补齐 `listEntries / upsertEntry / removeEntry / setEntryEnabled` typed contract，main `common.ts` 同步注册对应 handler，不再需要独立 `ipcMain.handle` 旁路。
+  - `app-provider` 复用现有 `files + file_extensions` 模型支持 user-managed launcher entry 的新增、更新、删除、启用/禁用与冲突校验，manual entry 的启动元数据继续落在扩展字段中，不新增 schema/table。
+  - 搜索与执行继续复用现有 `resolveAppItemId`、`TuffItemBuilder`、`TuffSearchResultBuilder` 与 `scheduleAppLaunch`；禁用的 manual entry 会从 recommendation/search 过滤，并可重新启用恢复。
+  - 新增定向回归，覆盖 transport 映射、main handler 输入校验、managed entry 落库/冲突/enable toggle，以及 manual disabled entry 的 recommendation 过滤。
+
 ## 2026-04-21
 
 ### fix(core-app/apps-search): 补齐 macOS 中文应用名首轮扫描与拼音关键词规整

--- a/docs/plan-prd/TODO.md
+++ b/docs/plan-prd/TODO.md
@@ -1,7 +1,7 @@
 # Tuff 项目待办事项
 
 > 从 PRD 文档提炼的执行清单（压缩版）
-> 更新时间: 2026-04-21
+> 更新时间: 2026-04-22
 
 ---
 
@@ -55,6 +55,11 @@
 - [x] Transport stream 内部协议统一：
   - `main/renderer/plugin` 共用 `packages/utils/transport/sdk/stream/*` 内部 runtime；默认 Port 优先，失败自动回退 `:stream:*`。
   - `ClipboardEvents.change` 已补 renderer/plugin/main 定向回归，覆盖 port 成功、回退、取消与 server fallback。
+- [x] User-managed launcher foundation：
+  - `settingsSdk.appIndex` 已补齐 `listEntries / upsertEntry / removeEntry / setEntryEnabled` typed contract，main `common.ts` 同步注册 handler。
+  - `app-provider` 复用现有 `files + file_extensions` 模型支持 manual entry CRUD、启用/禁用、冲突校验与启动元数据持久化，不新增 schema/table。
+  - `search-processing-service` 已对 disabled manual entry 做 recommendation/search 过滤，执行链路继续复用 `scheduleAppLaunch`。
+  - 已补 targeted regression：`transport-domain-sdks.test.ts`、`common.test.ts`、`app-provider.test.ts`、`search-processing-service.test.ts`。
 - [ ] CoreBox 第三方 App 非阻塞启动 Windows 真机验证：
   - 验证 `shortcut` 保留 `launchArgs / workingDirectory` 并在 CoreBox 立即隐藏后后台启动。
   - 验证 `uwp` 继续通过 `explorer.exe shell:AppsFolder\\...` handoff，早期失败会触发系统通知。
@@ -374,12 +379,12 @@
 
 | 统计项 | 数值 |
 | --- | --- |
-| 已完成 (`- [x]`) | 154 |
+| 已完成 (`- [x]`) | 164 |
 | 未完成 (`- [ ]`) | 28 |
-| 总计 | 182 |
+| 总计 | 192 |
 | 完成率 | 85% |
 
-> 统计时间: 2026-04-21（按本文件实时 checkbox 计数）。
+> 统计时间: 2026-04-22（按本文件实时 checkbox 计数）。
 
 ---
 

--- a/packages/utils/__tests__/transport-domain-sdks.test.ts
+++ b/packages/utils/__tests__/transport-domain-sdks.test.ts
@@ -48,6 +48,37 @@ describe('transport domain sdk mappings', () => {
     )
   })
 
+  it('settings sdk maps managed app entry events through appIndex domain', async () => {
+    const transport = createTransportMock()
+    const sdk = createSettingsSdk(transport as any)
+
+    await sdk.appIndex.listEntries()
+    await sdk.appIndex.upsertEntry({
+      path: '/Applications/WeChat.app',
+      displayName: '微信',
+      enabled: true,
+    })
+    await sdk.appIndex.removeEntry({ path: '/Applications/WeChat.app' })
+    await sdk.appIndex.setEntryEnabled({
+      path: '/Applications/WeChat.app',
+      enabled: false,
+    })
+
+    expect(transport.send).toHaveBeenNthCalledWith(1, AppEvents.appIndex.listEntries)
+    expect(transport.send).toHaveBeenNthCalledWith(2, AppEvents.appIndex.upsertEntry, {
+      path: '/Applications/WeChat.app',
+      displayName: '微信',
+      enabled: true,
+    })
+    expect(transport.send).toHaveBeenNthCalledWith(3, AppEvents.appIndex.removeEntry, {
+      path: '/Applications/WeChat.app',
+    })
+    expect(transport.send).toHaveBeenNthCalledWith(4, AppEvents.appIndex.setEntryEnabled, {
+      path: '/Applications/WeChat.app',
+      enabled: false,
+    })
+  })
+
   it('app sdk maps openPromptsFolder to typed system event', async () => {
     const transport = createTransportMock()
     const sdk = createAppSdk(transport as any)

--- a/packages/utils/transport/events/index.ts
+++ b/packages/utils/transport/events/index.ts
@@ -108,7 +108,16 @@ import type {
   TraySettingsUpdateResponse,
 } from './types/app'
 
-import type { AppIndexAddPathRequest, AppIndexAddPathResult, AppIndexSettings } from './types/app-index'
+import type {
+  AppIndexAddPathRequest,
+  AppIndexAddPathResult,
+  AppIndexEntryMutationResult,
+  AppIndexManagedEntry,
+  AppIndexRemoveEntryRequest,
+  AppIndexSetEntryEnabledRequest,
+  AppIndexSettings,
+  AppIndexUpsertEntryRequest
+} from './types/app-index'
 
 // ============================================================================
 // App Events
@@ -879,6 +888,38 @@ export const AppEvents = {
       .module('app-index')
       .event('add-path')
       .define<AppIndexAddPathRequest, AppIndexAddPathResult>(),
+
+    /**
+     * List user-managed launcher entries.
+     */
+    listEntries: defineEvent('app')
+      .module('app-index')
+      .event('entries.list')
+      .define<void, AppIndexManagedEntry[]>(),
+
+    /**
+     * Create or update a user-managed launcher entry.
+     */
+    upsertEntry: defineEvent('app')
+      .module('app-index')
+      .event('entry.upsert')
+      .define<AppIndexUpsertEntryRequest, AppIndexEntryMutationResult>(),
+
+    /**
+     * Remove a user-managed launcher entry.
+     */
+    removeEntry: defineEvent('app')
+      .module('app-index')
+      .event('entry.remove')
+      .define<AppIndexRemoveEntryRequest, AppIndexEntryMutationResult>(),
+
+    /**
+     * Enable or disable a user-managed launcher entry.
+     */
+    setEntryEnabled: defineEvent('app')
+      .module('app-index')
+      .event('entry.set-enabled')
+      .define<AppIndexSetEntryEnabledRequest, AppIndexEntryMutationResult>(),
   },
 
   /**

--- a/packages/utils/transport/events/types/app-index.ts
+++ b/packages/utils/transport/events/types/app-index.ts
@@ -21,3 +21,48 @@ export interface AppIndexAddPathResult {
   path?: string
   reason?: string
 }
+
+export type AppIndexEntryLaunchKind = 'path' | 'shortcut' | 'uwp'
+
+export interface AppIndexManagedEntry {
+  path: string
+  name: string
+  displayName?: string
+  icon?: string
+  enabled: boolean
+  launchKind: AppIndexEntryLaunchKind
+  launchTarget: string
+  launchArgs?: string
+  workingDirectory?: string
+  displayPath?: string
+  description?: string
+}
+
+export interface AppIndexUpsertEntryRequest {
+  path: string
+  displayName?: string
+  icon?: string
+  launchKind?: AppIndexEntryLaunchKind
+  launchTarget?: string
+  launchArgs?: string
+  workingDirectory?: string
+  displayPath?: string
+  description?: string
+  enabled?: boolean
+}
+
+export interface AppIndexRemoveEntryRequest {
+  path: string
+}
+
+export interface AppIndexSetEntryEnabledRequest {
+  path: string
+  enabled: boolean
+}
+
+export interface AppIndexEntryMutationResult {
+  success: boolean
+  status: 'added' | 'updated' | 'removed' | 'invalid' | 'not-found' | 'error'
+  entry?: AppIndexManagedEntry
+  reason?: string
+}

--- a/packages/utils/transport/sdk/domains/settings.ts
+++ b/packages/utils/transport/sdk/domains/settings.ts
@@ -11,7 +11,12 @@ import type {
 import type {
   AppIndexAddPathRequest,
   AppIndexAddPathResult,
+  AppIndexEntryMutationResult,
+  AppIndexManagedEntry,
+  AppIndexRemoveEntryRequest,
+  AppIndexSetEntryEnabledRequest,
   AppIndexSettings,
+  AppIndexUpsertEntryRequest,
 } from '../../events/types/app-index'
 import type {
   AnalyticsToggleRequest,
@@ -63,6 +68,12 @@ export interface SettingsSdk {
     getSettings: () => Promise<AppIndexSettings>
     updateSettings: (settings: Partial<AppIndexSettings>) => Promise<AppIndexSettings>
     addPath: (payload: AppIndexAddPathRequest) => Promise<AppIndexAddPathResult>
+    listEntries: () => Promise<AppIndexManagedEntry[]>
+    upsertEntry: (payload: AppIndexUpsertEntryRequest) => Promise<AppIndexEntryMutationResult>
+    removeEntry: (payload: AppIndexRemoveEntryRequest) => Promise<AppIndexEntryMutationResult>
+    setEntryEnabled: (
+      payload: AppIndexSetEntryEnabledRequest
+    ) => Promise<AppIndexEntryMutationResult>
   }
   analytics: {
     getSnapshot: (windowType: AnalyticsWindowType) => Promise<AnalyticsSnapshot>
@@ -104,6 +115,10 @@ export function createSettingsSdk(transport: ITuffTransport): SettingsSdk {
       getSettings: () => transport.send(AppEvents.appIndex.getSettings),
       updateSettings: settings => transport.send(AppEvents.appIndex.updateSettings, settings),
       addPath: payload => transport.send(AppEvents.appIndex.addPath, payload),
+      listEntries: () => transport.send(AppEvents.appIndex.listEntries),
+      upsertEntry: payload => transport.send(AppEvents.appIndex.upsertEntry, payload),
+      removeEntry: payload => transport.send(AppEvents.appIndex.removeEntry, payload),
+      setEntryEnabled: payload => transport.send(AppEvents.appIndex.setEntryEnabled, payload),
     },
     analytics: {
       getSnapshot: windowType => transport.send(AppEvents.analytics.getSnapshot, { windowType }),


### PR DESCRIPTION
## Summary
- replace the old #228 branch with the foundation-only managed launcher slice
- add typed `appIndex` settings SDK and main channel handlers for `listEntries / upsertEntry / removeEntry / setEntryEnabled`
- persist managed entries in existing `files + file_extensions` rows and reuse the current search/launch pipeline
- filter disabled manual entries out of recommendation/search results
- sync `docs/plan-prd/TODO.md`, `docs/plan-prd/01-project/CHANGES.md`, and `docs/INDEX.md`

## Validation
- `pnpm -C "apps/core-app" exec vitest run "src/main/channel/common.test.ts" "src/main/modules/box-tool/addon/apps/app-provider.test.ts" "src/main/modules/box-tool/addon/apps/search-processing-service.test.ts"`
- `pnpm exec vitest run "packages/utils/__tests__/transport-domain-sdks.test.ts"`
- `pnpm -C "apps/core-app" run typecheck:node`

## Notes
- This is the foundation-only replacement for the closed `#228` and intentionally excludes renderer/UI work.
- No schema changes, no `ipcMain.handle` bypass, no intelligence/workflow scope, and no unrelated lockfile drift are included.
- The UI management surface will follow in a separate PR after this foundation lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manage custom launcher entries with full add, remove, and enable/disable controls for personalized app organization.
  * Disabled launcher entries are automatically filtered from search and recommendation results.
  * Built-in conflict detection prevents duplicate application paths and maintains system integrity.
  * Support for rich entry metadata including custom names, icons, and working directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->