### PR TITLE
feat: route update checks to Nexus and refine updates page

### DIFF
--- a/apps/core-app/src/main/modules/update/UpdateService.ts
+++ b/apps/core-app/src/main/modules/update/UpdateService.ts
@@ -1416,15 +1416,7 @@ export class UpdateServiceModule extends BaseModule<TalexEvents> {
     options?: { force?: boolean }
   ): Promise<UpdateFetchResult> {
     if (this.settings.source?.type === UpdateProviderType.OFFICIAL) {
-      try {
-        const officialResult = await this.fetchLatestReleaseFromOfficial(channel, options)
-        if (officialResult.result.hasUpdate || !officialResult.result.error) {
-          return officialResult
-        }
-      } catch (error) {
-        updateLog.warn('Official update source failed, falling back to GitHub', { error })
-      }
-      return this.fetchLatestReleaseFromGitHub(channel, options)
+      return this.fetchLatestReleaseFromOfficial(channel, options)
     }
 
     return this.fetchLatestReleaseFromGitHub(channel, options)
@@ -2049,9 +2041,9 @@ export class UpdateServiceModule extends BaseModule<TalexEvents> {
       enabled: true,
       frequency: 'everyday',
       source: {
-        type: UpdateProviderType.GITHUB,
-        name: 'GitHub Releases',
-        url: UPDATE_GITHUB_RELEASES_API,
+        type: UpdateProviderType.OFFICIAL,
+        name: 'Nexus Releases',
+        url: getTuffBaseUrl(),
         enabled: true,
         priority: 1
       },

--- a/apps/nexus/app/pages/updates.vue
+++ b/apps/nexus/app/pages/updates.vue
@@ -156,8 +156,11 @@ const latestReleaseNotes = computed(() => {
 })
 
 const updateItems = computed(() => updatesPayload.value?.updates ?? [])
-const updateList = computed(() => updateItems.value.slice(0, 6))
-const hasUpdateList = computed(() => updateList.value.length > 0)
+const selectedNewsTab = ref<'release' | 'announcement'>('release')
+const releaseUpdates = computed(() => updateItems.value.filter(update => update.type !== 'announcement').slice(0, 6))
+const announcementUpdates = computed(() => updateItems.value.filter(update => update.type === 'announcement').slice(0, 6))
+const activeNewsList = computed(() => selectedNewsTab.value === 'announcement' ? announcementUpdates.value : releaseUpdates.value)
+const hasUpdateList = computed(() => activeNewsList.value.length > 0)
 const isZh = computed(() => locale.value.startsWith('zh'))
 const UPDATE_RELEASE_TAG_COLOR = 'var(--tx-color-primary)'
 const UPDATE_NEWS_TAG_COLOR = 'var(--tx-text-color-secondary)'
@@ -269,7 +272,16 @@ function getDownloadLabel(asset: { platform: string, arch: string }) {
       </p>
     </header>
 
-    <section class="mx-auto max-w-4xl w-full animate-fade-in-up" style="animation-delay: 60ms;">
+    <div class="mx-auto max-w-2xl w-full animate-fade-in-up" style="animation-delay: 60ms;">
+      <div class="flex gap-2 rounded-xl bg-gray-100 p-1.5 dark:bg-gray-800/80">
+        <TxButton v-for="option in channelOptions" :key="option.id" variant="bare" native-type="button" class="channel-tab flex-1 flex items-center justify-center gap-2 rounded-lg text-sm font-medium transition-all duration-300" :class="selectedChannel === option.id ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'" @click="selectedChannel = option.id">
+          <span :class="option.icon" class="text-base" />
+          <span>{{ option.badge }}</span>
+        </TxButton>
+      </div>
+    </div>
+
+    <section class="mx-auto max-w-4xl w-full animate-fade-in-up" style="animation-delay: 100ms;">
       <div class="UpdateNewsSection">
         <div class="flex flex-wrap items-center justify-between gap-3">
           <div>
@@ -285,9 +297,18 @@ function getDownloadLabel(asset: { platform: string, arch: string }) {
           </span>
         </div>
 
+        <div class="mt-3 flex items-center gap-2">
+          <TxButton variant="bare" native-type="button" class="news-tab-btn" :class="{ 'news-tab-btn--active': selectedNewsTab === 'release' }" @click="selectedNewsTab = 'release'">
+            {{ t('updates.news.typeNews') }}
+          </TxButton>
+          <TxButton variant="bare" native-type="button" class="news-tab-btn" :class="{ 'news-tab-btn--active': selectedNewsTab === 'announcement' }" @click="selectedNewsTab = 'announcement'">
+            {{ t('updates.news.typeAnnouncement') }}
+          </TxButton>
+        </div>
+
         <div v-if="hasUpdateList" class="UpdateNewsList mt-4">
           <TxCardItem
-            v-for="update in updateList"
+            v-for="update in activeNewsList"
             :key="update.id"
             class="UpdateNewsItem"
             :title="resolveUpdateText(update.title)"
@@ -328,16 +349,6 @@ function getDownloadLabel(asset: { platform: string, arch: string }) {
         />
       </div>
     </section>
-
-    <!-- Channel Selector -->
-    <div class="mx-auto max-w-2xl w-full animate-fade-in-up" style="animation-delay: 100ms;">
-      <div class="flex gap-2 rounded-xl bg-gray-100 p-1.5 dark:bg-gray-800/80">
-        <TxButton v-for="option in channelOptions" :key="option.id" variant="bare" native-type="button" class="channel-tab flex-1 flex items-center justify-center gap-2 rounded-lg text-sm font-medium transition-all duration-300" :class="selectedChannel === option.id ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'" @click="selectedChannel = option.id">
-          <span :class="option.icon" class="text-base" />
-          <span>{{ option.badge }}</span>
-        </TxButton>
-      </div>
-    </div>
 
     <!-- Loading State -->
     <Transition name="fade" mode="out-in">
@@ -637,6 +648,19 @@ function getDownloadLabel(asset: { platform: string, arch: string }) {
 /* Channel tab indicator animation */
 .channel-tab {
   position: relative;
+}
+.news-tab-btn {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  color: var(--tx-text-color-secondary, rgb(107, 114, 128));
+  font-size: 12px;
+  font-weight: 600;
+  padding: 4px 10px;
+}
+.news-tab-btn--active {
+  background: color-mix(in srgb, var(--tx-color-primary, rgb(59, 130, 246)) 14%, transparent);
+  border-color: color-mix(in srgb, var(--tx-color-primary, rgb(59, 130, 246)) 32%, transparent);
+  color: var(--tx-color-primary, rgb(59, 130, 246));
 }
 
 /* Release card hover effect */

--- a/docs/plan-prd/01-project/CHANGES.md
+++ b/docs/plan-prd/01-project/CHANGES.md
@@ -3,6 +3,15 @@
 > 更新时间: 2026-05-04
 > 说明: 主文件仅保留近 30 天（2026-04-04 ~ 2026-05-04）详细记录；更早历史已按月归档。
 
+## 2026-05-06
+
+### feat(core-app/nexus): 更新检查统一走 Nexus 与 updates 信息架构调整
+
+- `apps/core-app/src/main/modules/update/UpdateService.ts`
+- `apps/nexus/app/pages/updates.vue`
+  - UpdateService 默认 source 从 GitHub Releases 切换为 Nexus Official（`getTuffBaseUrl()`），且官方源检查失败时不再回落到 GitHub，后续版本监测统一请求 Nexus。
+  - Nexus `updates` 页面将版本 channel 选择上移至要闻区之前；要闻区新增“更新 / 公告”tabs，公告改为单独分栏展示，并统一使用 `TxButton` 交互样式保持按钮规范一致。
+
 ## 2026-05-04
 
 ### ref(core-app): 清理残留兼容运行面


### PR DESCRIPTION
### Motivation
- 统一版本监测入口为 Nexus 官方源，避免同时依赖 GitHub 导致的多源不一致和回落策略复杂化。 
- 优化 `updates` 页面信息架构，使“版本更新”优先可见并把“公告”独立成 tab，提升内容可读性与运营灵活性。 
- 规范交互样式，确保页面中使用的按钮与项目标准 `TxButton` 风格一致，减少视觉/交互差异。 

### Description
- 将更新检查默认 source 从 GitHub 切为 Nexus 官方（`getTuffBaseUrl()`），并在 `UpdateService.fetchLatestRelease` 中当 `source.type === UpdateProviderType.OFFICIAL` 时直接调用 `fetchLatestReleaseFromOfficial`，不再回落到 GitHub；变更文件为 `apps/core-app/src/main/modules/update/UpdateService.ts`。 
- 在 `apps/nexus/app/pages/updates.vue` 中将版本 channel 选择器上移到要闻区之前，新增 `release` / `announcement` 的 tabs（通过 `selectedNewsTab`、`activeNewsList` 等 `computed` 实现），并把公告列表改为独立 tab 渲染，循环列表从 `updateList` 改为 `activeNewsList`。 
- 统一交互控件使用 `TxButton`，并新增样式类 `news-tab-btn` / `news-tab-btn--active` 以匹配标准按钮视觉语言；同时对相关 DOM 结构做适配（移位、样式调整与动画时机微调）。 
- 更新发布说明文档 `docs/plan-prd/01-project/CHANGES.md`，记录此次行为与页面结构调整。 

### Testing
- 已对修改的前端文件运行 ESLint 检查：`pnpm -C "apps/nexus" exec eslint "app/pages/updates.vue"`，检查通过。 
- 已对修改的主进程文件运行 ESLint 检查：`pnpm -C "apps/core-app" exec eslint "src/main/modules/update/UpdateService.ts"`，检查通过。 
- 本次变更在提交时触发的 `lint-staged` 钩子（包含上述 eslint --fix 任务）已执行并通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab74bae7c8322b7cfcb7ec360cd2d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tabs to filter updates by type: Release News and Announcements
  * Channel selection now available on the Updates page

* **Improvements**
  * Updated default update source to Official Nexus Releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->