### PR TITLE
Fix Windows app discovery for WeChat and UWP apps

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.test.ts
@@ -1048,6 +1048,40 @@ describe('appProvider rebuild maintenance', () => {
     ])
   })
 
+  it('indexes Windows Store app keywords by UWP stable id', async () => {
+    const { appProvider } = await loadSubject()
+    const privateProvider = asPrivateProvider(appProvider)
+    const indexItemsMock = vi.fn(async () => undefined)
+    privateProvider.searchIndex = { indexItems: indexItemsMock }
+
+    await privateProvider._syncKeywordsForApp({
+      name: 'Codex',
+      displayName: 'Codex',
+      fileName: 'Codex',
+      bundleId: 'OpenAI.Codex_2p2nqsd0c76g0',
+      path: 'shell:AppsFolder\\OpenAI.Codex_2p2nqsd0c76g0!App',
+      launchKind: 'uwp',
+      launchTarget: 'OpenAI.Codex_2p2nqsd0c76g0!App',
+      stableId: 'uwp:openai.codex_2p2nqsd0c76g0!app',
+      icon: '',
+      lastModified: new Date(0)
+    })
+
+    expect(indexItemsMock).toHaveBeenCalledWith([
+      expect.objectContaining({
+        itemId: 'uwp:openai.codex_2p2nqsd0c76g0!app',
+        extension: '.uwp',
+        path: 'shell:AppsFolder\\OpenAI.Codex_2p2nqsd0c76g0!App',
+        tags: expect.arrayContaining([
+          'OpenAI.Codex_2p2nqsd0c76g0',
+          'uwp:openai.codex_2p2nqsd0c76g0!app',
+          'shell:AppsFolder\\OpenAI.Codex_2p2nqsd0c76g0!App'
+        ]),
+        keywords: expect.arrayContaining([expect.objectContaining({ value: 'codex' })])
+      })
+    ])
+  })
+
   it('does not keep removing retired app item ids during steady-state keyword sync', async () => {
     const { appProvider } = await loadSubject()
     const privateProvider = asPrivateProvider(appProvider)

--- a/apps/core-app/src/main/modules/box-tool/addon/apps/win.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/win.test.ts
@@ -196,6 +196,68 @@ describe('win app scanner', () => {
     })
   })
 
+  it('treats known-folder Get-StartApps AppId values as desktop apps', async () => {
+    const appPath = 'C:\\Program Files\\Tencent\\Weixin\\Weixin.exe'
+
+    readdirMock.mockResolvedValue([])
+    statMock.mockImplementation(async (target: string) => {
+      if (target === appPath) return createFileStat()
+      throw new Error(`Unexpected stat path: ${target}`)
+    })
+    mockPowerShellOutputs({
+      startApps: [
+        {
+          Name: '微信',
+          AppId: '{6D809377-6AF0-444B-8957-A3773F02200E}\\Tencent\\Weixin\\Weixin.exe'
+        },
+        {
+          Name: '卸载微信',
+          AppId: '{6D809377-6AF0-444B-8957-A3773F02200E}\\Tencent\\Weixin\\Uninstall.exe'
+        }
+      ]
+    })
+
+    const { getApps } = await import('./win')
+    const apps = await getApps()
+
+    expect(apps).toHaveLength(1)
+    expect(apps[0]).toMatchObject({
+      name: 'Weixin',
+      path: appPath,
+      launchKind: 'path',
+      launchTarget: appPath,
+      displayPath: appPath,
+      stableId: 'c:\\program files\\tencent\\weixin\\weixin.exe'
+    })
+  })
+
+  it('keeps Codex as a UWP app from Get-StartApps output', async () => {
+    readdirMock.mockResolvedValue([])
+    mockPowerShellOutputs({
+      startApps: [
+        {
+          Name: 'Codex',
+          AppId: 'OpenAI.Codex_2p2nqsd0c76g0!App',
+          PackageFamilyName: 'OpenAI.Codex_2p2nqsd0c76g0'
+        }
+      ]
+    })
+
+    const { getApps } = await import('./win')
+    const apps = await getApps()
+
+    expect(apps).toHaveLength(1)
+    expect(apps[0]).toMatchObject({
+      name: 'Codex',
+      displayName: 'Codex',
+      path: 'shell:AppsFolder\\OpenAI.Codex_2p2nqsd0c76g0!App',
+      launchKind: 'uwp',
+      launchTarget: 'OpenAI.Codex_2p2nqsd0c76g0!App',
+      bundleId: 'OpenAI.Codex_2p2nqsd0c76g0',
+      stableId: 'uwp:openai.codex_2p2nqsd0c76g0!app'
+    })
+  })
+
   it('enriches Windows Store apps with manifest metadata and logo variants', async () => {
     const installLocation = 'C:\\Program Files\\WindowsApps\\Microsoft.WindowsCalculator'
     const manifestPath = `${installLocation}\\AppxManifest.xml`
@@ -385,6 +447,50 @@ describe('win app scanner', () => {
 
     expect(apps).toHaveLength(0)
     expect(statMock).not.toHaveBeenCalledWith(expect.stringContaining('.exe'))
+  })
+
+  it('prefers Start Menu shortcuts over duplicate Get-StartApps desktop targets', async () => {
+    const startMenuPath = 'C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs'
+    const userStartMenuPath =
+      'C:\\Users\\demo\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs'
+    const shortcutPath = `${startMenuPath}\\微信.lnk`
+    const targetPath = 'C:\\Program Files\\Tencent\\Weixin\\Weixin.exe'
+
+    readdirMock.mockImplementation(async (dir: string) => {
+      if (dir === startMenuPath) return ['微信.lnk']
+      if (dir === userStartMenuPath) return []
+      return []
+    })
+    statMock.mockImplementation(async (target: string) => {
+      if (target === shortcutPath || target === targetPath) return createFileStat()
+      throw new Error(`Unexpected stat path: ${target}`)
+    })
+    readShortcutLinkMock.mockReturnValue({
+      target: targetPath,
+      args: '',
+      cwd: 'C:\\Program Files\\Tencent\\Weixin'
+    })
+    mockPowerShellOutputs({
+      startApps: [
+        {
+          Name: '微信',
+          AppId: '{6D809377-6AF0-444B-8957-A3773F02200E}\\Tencent\\Weixin\\Weixin.exe'
+        }
+      ]
+    })
+
+    const { getApps } = await import('./win')
+    const apps = await getApps()
+
+    expect(apps).toHaveLength(1)
+    expect(apps[0]).toMatchObject({
+      name: '微信',
+      path: shortcutPath,
+      launchKind: 'shortcut',
+      launchTarget: targetPath,
+      workingDirectory: 'C:\\Program Files\\Tencent\\Weixin',
+      stableId: 'shortcut:c:\\program files\\tencent\\weixin\\weixin.exe|'
+    })
   })
 
   it('prefers Start Menu entries over duplicate registry targets', async () => {

--- a/apps/core-app/src/main/modules/box-tool/addon/apps/win.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/win.ts
@@ -37,6 +37,21 @@ export const START_MENU_PATHS = [
 const WINDOWS_STORE_DISPLAY_PATH = 'Windows Store'
 const REGISTRY_DISPLAY_ICON_EXE_PATTERN = /"([^"]+\.exe)"|([^",]+\.exe)/i
 const REGISTRY_EXE_PRIORITY = ['app', 'launcher', 'client', 'desktop']
+const KNOWN_FOLDER_GUID_PATH_PATTERN = /^\{([0-9a-f-]{36})\}[\\/](.+)$/i
+const KNOWN_FOLDER_PATH_RESOLVERS: Record<string, () => string> = {
+  '6d809377-6af0-444b-8957-a3773f02200e': () =>
+    process.env.ProgramW6432 || process.env.ProgramFiles || 'C:\\Program Files',
+  '905e63b6-c1bf-494e-b29c-65b732d3d21a': () =>
+    process.env.ProgramFiles || 'C:\\Program Files',
+  '7c5a40ef-a0fb-4bfc-874a-c0f2e0b9fa8e': () =>
+    process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)',
+  'f1b32785-6fba-4fcf-9d55-7b8e7f157091': () =>
+    process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData\\Local'),
+  '3eb685db-65f9-4cf6-a03a-e3ef65729f3d': () =>
+    process.env.APPDATA || path.join(os.homedir(), 'AppData\\Roaming'),
+  '62ab5d82-fdc1-4dc3-a9dd-070d1d495d97': () =>
+    process.env.ProgramData || 'C:\\ProgramData'
+}
 const UWP_LOGO_ATTRIBUTE_CANDIDATES = [
   'Square44x44Logo',
   'SmallLogo',
@@ -70,6 +85,27 @@ function buildUwpShellPath(appId: string): string {
 
 function isWindowsAbsolutePath(value: string): boolean {
   return /^[a-z]:[\\/]/i.test(value) || value.startsWith('\\\\')
+}
+
+function normalizeWindowsQuotedPath(value?: string): string {
+  return (value || '').trim().replace(/^["']|["']$/g, '')
+}
+
+function resolveKnownFolderGuidPath(value: string): string | null {
+  const match = value.match(KNOWN_FOLDER_GUID_PATH_PATTERN)
+  if (!match) return null
+
+  const resolver = KNOWN_FOLDER_PATH_RESOLVERS[match[1].toLowerCase()]
+  if (!resolver) return null
+
+  return path.join(resolver(), match[2])
+}
+
+function resolveStartAppDesktopPath(appId: string): string | null {
+  const normalized = normalizeWindowsQuotedPath(appId)
+  if (!normalized) return null
+  if (isWindowsAbsolutePath(normalized)) return normalized
+  return resolveKnownFolderGuidPath(normalized)
 }
 
 function buildIconCacheKey(value: string): string {
@@ -381,13 +417,16 @@ async function listWindowsStoreApps(): Promise<AppInfo[]> {
       const name = parseStartAppField(entry, ['name', 'Name'])
       if (!appId || !name) return null
 
-      if (isWindowsAbsolutePath(appId)) {
-        const stats = await fs.stat(appId).catch(() => null)
+      const desktopPath = resolveStartAppDesktopPath(appId)
+      if (desktopPath) {
+        const stats = await fs.stat(desktopPath).catch(() => null)
         if (!stats?.isFile()) {
           return null
         }
-        return await buildDesktopAppInfo(appId, path.basename(appId), stats)
+        return await buildDesktopAppInfo(desktopPath, path.basename(desktopPath), stats)
       }
+
+      if (!appId.includes('!')) return null
 
       return await buildUwpAppInfo(appId, {
         fallbackName: name,
@@ -464,7 +503,9 @@ async function buildRegistryAppInfo(record: RegistryAppRecord): Promise<AppInfo 
   if (record.systemComponent === 1 || record.releaseType || record.parentKeyName) return null
 
   const iconExePath = parseRegistryExePath(record.displayIcon)
-  const installExePath = await findExecutableInInstallLocation(record.installLocation?.trim())
+  const installExePath = await findExecutableInInstallLocation(
+    normalizeWindowsQuotedPath(record.installLocation)
+  )
   const targetPath = iconExePath || installExePath
   if (!targetPath || shouldSkipAppTarget(targetPath)) return null
 
@@ -631,8 +672,13 @@ export async function getApps(): Promise<AppInfo[]> {
 
   for (const app of allApps) {
     const launchTarget = app.launchTarget ? buildPathStableId(app.launchTarget) : ''
+    const isDirectPathDuplicate =
+      app.launchKind === 'path' &&
+      launchTarget &&
+      claimedLaunchTargets.has(launchTarget) &&
+      app.stableId === launchTarget
     if (
-      app.stableId?.startsWith('registry:') &&
+      (app.stableId?.startsWith('registry:') || isDirectPathDuplicate) &&
       launchTarget &&
       claimedLaunchTargets.has(launchTarget)
     ) {
@@ -667,16 +713,17 @@ export async function getAppInfo(filePath: string): Promise<AppInfo | null> {
       })
     }
 
-    const stats = await fs.stat(filePath)
+    const appPath = resolveStartAppDesktopPath(filePath) || filePath
+    const stats = await fs.stat(appPath)
     if (!stats.isFile()) return null
 
-    const fileName = path.basename(filePath)
+    const fileName = path.basename(appPath)
     if (!fileName.endsWith('.lnk') && !fileName.endsWith('.exe')) {
       return null
     }
 
-    const appDetail = fileName.endsWith('.lnk') ? shell.readShortcutLink(filePath) : undefined
-    return await buildDesktopAppInfo(filePath, fileName, stats, appDetail)
+    const appDetail = fileName.endsWith('.lnk') ? shell.readShortcutLink(appPath) : undefined
+    return await buildDesktopAppInfo(appPath, fileName, stats, appDetail)
   } catch (error) {
     windowsAppLog.warn('Failed to get app info', {
       error,

--- a/docs/plan-prd/01-project/CHANGES.md
+++ b/docs/plan-prd/01-project/CHANGES.md
@@ -3,6 +3,17 @@
 > 更新时间: 2026-05-08
 > 说明: 主文件仅保留近 30 天（2026-04-08 ~ 2026-05-08）详细记录；更早历史已按月归档。
 
+## 2026-05-09
+
+### fix(core-app): restore Windows app discovery for WeChat and Codex
+
+- `apps/core-app/src/main/modules/box-tool/addon/apps/win.ts`
+- `apps/core-app/src/main/modules/box-tool/addon/apps/win.test.ts`
+- `apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.test.ts`
+  - Windows `Get-StartApps` desktop AppIDs that use known-folder GUID prefixes now resolve to real filesystem paths before app classification, so WeChat is indexed and launched as a desktop app instead of being misclassified as UWP.
+  - Start Menu shortcuts keep priority over duplicate desktop entries discovered through `Get-StartApps`; registry entries remain fallback-only when a target is already claimed.
+  - Codex/MSIX entries remain UWP apps with stable `uwp:*` identities, `.uwp` search-index extension metadata, and keyword coverage for `codex`.
+
 ## 2026-05-08
 
 ### fix(core-app): hard-cut renderer storage bootstrap warnings


### PR DESCRIPTION
## Summary

This PR restores Windows app discovery/indexing behavior for mixed desktop and UWP/MSIX apps. It specifically fixes WeChat launch discovery from Get-StartApps output while keeping Codex/MSIX entries indexed as UWP apps.

## Background

On Windows, Get-StartApps can return AppID values in more than one shape:

- Desktop apps may be returned as real filesystem paths.
- Some desktop apps, including WeChat, may be returned with Known Folder GUID prefixes, for example {6D809377-6AF0-444B-8957-A3773F02200E}\Tencent\Weixin\Weixin.exe.
- UWP/MSIX apps, such as Codex, are returned as shell app IDs like OpenAI.Codex_2p2nqsd0c76g0!App.

Before this change, Known Folder GUID desktop paths were not resolved before classification, which could cause WeChat to be skipped or misclassified. At the same time, UWP entries need to remain searchable by their stable shell identity instead of being treated like filesystem executables.

## Changes

- Resolve supported Windows Known Folder GUID prefixes from Get-StartApps into real filesystem paths before app classification.
- Treat resolved desktop AppIDs as normal desktop apps only when the resolved target exists as a file.
- Ignore non-shell, non-resolvable AppIDs instead of incorrectly treating them as UWP apps.
- Preserve Codex/MSIX entries as UWP apps with stable uwp:* identities and shell:AppsFolder\... launch paths.
- Strip surrounding quotes from registry InstallLocation values before executable discovery.
- Prefer Start Menu shortcuts over duplicate direct desktop targets discovered via Get-StartApps, while keeping registry entries as fallback-only when another source already claims the same launch target.
- Add regression coverage for WeChat-style Known Folder GUID desktop entries, Codex-style UWP entries, Start Menu priority, and UWP keyword indexing.
- Record the behavior change in docs/plan-prd/01-project/CHANGES.md.

## Validation

- itest run src/main/modules/box-tool/addon/apps/win.test.ts src/main/modules/box-tool/addon/apps/app-provider.test.ts
  - 2 test files passed
  - 35 tests passed
- 	sc --noEmit -p tsconfig.node.json --composite false
  - passed
- git diff --check
  - passed, with CRLF warnings only
- electron-vite dev
  - main/preload/renderer dev build completed successfully
  - Electron startup reached app bootstrap
  - process exited because an existing Tuff instance was already running and the duplicate-process startup guard quit the dev instance

## Notes

pnpm core:dev is still blocked in this environment by an untrusted mise.toml (mise trust required). I did not change system trust configuration. I verified the dev build path directly with the locked local toolchain instead.