### PR TITLE
Fix Windows app PowerShell scans

### DIFF
--- a/apps/core-app/scripts/windows-capability-evidence.ts
+++ b/apps/core-app/scripts/windows-capability-evidence.ts
@@ -266,7 +266,7 @@ async function collectStartApps(timeoutMs: number) {
     '  [PSCustomObject]@{ Name = [string]$_.Name; AppID = [string]$_.AppId }',
     '}',
     '$apps | ConvertTo-Json -Compress'
-  ].join('; ')
+  ].join('\n')
   const result = await runPowerShell(script, timeoutMs)
   return result.exitCode === 0
     ? parsePowerShellJsonArray(result.stdout, normalizeStartAppRecord)
@@ -276,11 +276,7 @@ async function collectStartApps(timeoutMs: number) {
 async function collectRegistryApps(timeoutMs: number): Promise<WindowsRegistryAppRecord[]> {
   const script = [
     '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8',
-    '$paths = @(',
-    "  'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*',",
-    "  'HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*',",
-    "  'HKLM:\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*'",
-    ')',
+    "$paths = @('HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*', 'HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*', 'HKLM:\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*')",
     '$apps = foreach ($path in $paths) {',
     '  Get-ItemProperty -Path $path -ErrorAction SilentlyContinue | ForEach-Object {',
     '    if (-not $_.DisplayName) { return }',
@@ -296,7 +292,7 @@ async function collectRegistryApps(timeoutMs: number): Promise<WindowsRegistryAp
     '  }',
     '}',
     '$apps | ConvertTo-Json -Compress'
-  ].join('; ')
+  ].join('\n')
   const result = await runPowerShell(script, timeoutMs)
   return result.exitCode === 0
     ? parsePowerShellJsonArray(result.stdout, normalizeRegistryAppRecord)
@@ -327,10 +323,7 @@ function normalizeStartMenuEntry(entry: Record<string, unknown>): WindowsStartMe
 async function collectStartMenuEntries(timeoutMs: number): Promise<WindowsStartMenuEntry[]> {
   const script = [
     '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8',
-    '$roots = @(',
-    "  'C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs',",
-    '  [System.IO.Path]::Combine($env:APPDATA, "Microsoft\\Windows\\Start Menu\\Programs")',
-    ')',
+    '$roots = @(\'C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\', [System.IO.Path]::Combine($env:APPDATA, "Microsoft\\Windows\\Start Menu\\Programs"))',
     '$shell = New-Object -ComObject WScript.Shell',
     '$entries = foreach ($root in $roots) {',
     '  if (-not (Test-Path $root)) { continue }',
@@ -357,7 +350,7 @@ async function collectStartMenuEntries(timeoutMs: number): Promise<WindowsStartM
     '  }',
     '}',
     '$entries | ConvertTo-Json -Compress'
-  ].join('; ')
+  ].join('\n')
   const result = await runPowerShell(script, timeoutMs)
   return result.exitCode === 0
     ? parsePowerShellJsonArray(result.stdout, normalizeStartMenuEntry)

--- a/apps/core-app/src/main/channel/common.ts
+++ b/apps/core-app/src/main/channel/common.ts
@@ -1386,7 +1386,10 @@ export class CommonChannelModule extends BaseModule {
         }
       }),
       transport.on(AppEvents.system.getActiveApp, async (payload) => {
-        return await activeAppService.getActiveApp(Boolean(payload?.forceRefresh))
+        return await activeAppService.getActiveApp({
+          forceRefresh: payload?.forceRefresh === true,
+          includeIcon: payload?.includeIcon === true
+        })
       }),
       transport.on<SecureValueGetRequest, string | null>(
         AppEvents.system.getSecureValue,

--- a/apps/core-app/src/main/modules/box-tool/addon/apps/win.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/win.test.ts
@@ -309,6 +309,32 @@ describe('win app scanner', () => {
     })
   })
 
+  it('keeps Windows PowerShell scan scripts parseable for object literals', async () => {
+    readdirMock.mockResolvedValue([])
+    mockPowerShellOutputs({
+      startApps: [
+        {
+          Name: 'Codex',
+          AppId: 'OpenAI.Codex_2p2nqsd0c76g0!App'
+        }
+      ],
+      registryApps: [
+        {
+          DisplayName: 'Codex',
+          DisplayIcon: 'C:\\Program Files\\Codex\\Codex.exe,0',
+          Publisher: 'OpenAI'
+        }
+      ]
+    })
+
+    const { getApps } = await import('./win')
+    await getApps()
+
+    const scripts = execFileSafeMock.mock.calls.map(([, args]) => args.at(-1))
+    expect(scripts).toEqual(expect.arrayContaining([expect.stringContaining('[PSCustomObject]@{')]))
+    expect(scripts).not.toEqual(expect.arrayContaining([expect.stringContaining('@{;')]))
+  })
+
   it('enriches Windows Store apps with manifest metadata and logo variants', async () => {
     const installLocation = 'C:\\Program Files\\WindowsApps\\Microsoft.WindowsCalculator'
     const manifestPath = `${installLocation}\\AppxManifest.xml`

--- a/apps/core-app/src/main/modules/box-tool/addon/apps/win.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/win.ts
@@ -302,7 +302,7 @@ async function getWindowsStoreRecords(): Promise<StartAppRecord[]> {
       '  }',
       '}',
       '$apps | ConvertTo-Json -Compress'
-    ].join('; ')
+    ].join('\n')
 
     const { stdout } = await execFileSafe(
       'powershell',
@@ -550,7 +550,7 @@ async function getRegistryAppRecords(): Promise<RegistryAppRecord[]> {
       '  }',
       '}',
       '$apps | ConvertTo-Json -Compress'
-    ].join('; ')
+    ].join('\n')
 
     const { stdout } = await execFileSafe(
       'powershell',

--- a/apps/core-app/src/main/modules/box-tool/addon/files/file-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/file-provider.ts
@@ -3362,6 +3362,14 @@ class FileProvider implements ISearchProvider<ProviderContext> {
     )
   }
 
+  public isSearchIndexWorkerBusy(): boolean {
+    return (
+      this.pendingIndexWorkerResults.size > 0 ||
+      this.inflightIndexWorkerResults.size > 0 ||
+      this.searchIndexWorker.hasPendingWork()
+    )
+  }
+
   private scheduleSemanticEnrichment(normalizedQuery: string, candidateCount: number): void {
     const shouldRunSemantic =
       Boolean(this.embeddingService) &&

--- a/apps/core-app/src/main/modules/box-tool/search-engine/workers/search-index-worker-client.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/workers/search-index-worker-client.test.ts
@@ -194,4 +194,23 @@ describe('SearchIndexWorkerClient init gate', () => {
     await vi.advanceTimersByTimeAsync(300)
     expect(worker.terminateCalls).toBe(1)
   })
+
+  it('reports pending work while a worker task is in flight', async () => {
+    const client = new SearchIndexWorkerClient()
+    const initPromise = client.init('/tmp/search-index.db')
+    const worker = workerMock.workers.at(-1)!
+
+    worker.emit('message', { type: 'done', taskId: taskIdOf(worker.messages[0]) })
+    await initPromise
+
+    const removePromise = client.removeItems(['file:/tmp/demo.txt'])
+    await vi.waitFor(() => expect(worker.messages).toHaveLength(2))
+
+    expect(client.hasPendingWork()).toBe(true)
+
+    worker.emit('message', { type: 'done', taskId: taskIdOf(worker.messages[1]) })
+    await removePromise
+
+    expect(client.hasPendingWork()).toBe(false)
+  })
 })

--- a/apps/core-app/src/main/modules/box-tool/search-engine/workers/search-index-worker-client.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/workers/search-index-worker-client.ts
@@ -235,6 +235,10 @@ export class SearchIndexWorkerClient {
     }
   }
 
+  hasPendingWork(): boolean {
+    return this.pending.size > 0
+  }
+
   shutdown(): void {
     this.terminateWorker({ keepInitState: false })
   }

--- a/apps/core-app/src/main/modules/database/index.test.ts
+++ b/apps/core-app/src/main/modules/database/index.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { fileProviderBusyMock, dbLogMock } = vi.hoisted(() => ({
+  fileProviderBusyMock: vi.fn(() => false),
+  dbLogMock: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('@libsql/client', () => ({
+  createClient: vi.fn()
+}))
+
+vi.mock('@talex-touch/utils/common/logger', () => ({
+  getLogger: vi.fn(() => dbLogMock)
+}))
+
+vi.mock('@talex-touch/utils/common/utils/polling', () => ({
+  pollingService: {
+    register: vi.fn(),
+    unregister: vi.fn()
+  }
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getAppPath: vi.fn(() => '/tmp/app'),
+    getPath: vi.fn(() => '/tmp/userData')
+  },
+  BrowserWindow: {
+    getFocusedWindow: vi.fn(),
+    getAllWindows: vi.fn(() => [])
+  },
+  dialog: {
+    showMessageBox: vi.fn()
+  }
+}))
+
+vi.mock('../../../../resources/db/locator.json?commonjs-external&asset', () => ({
+  default: '/tmp/resources/db/locator.json'
+}))
+
+vi.mock('../box-tool/addon/files/file-provider', () => ({
+  fileProvider: {
+    isSearchIndexWorkerBusy: fileProviderBusyMock
+  }
+}))
+
+import { dbWriteScheduler } from '../../db/db-write-scheduler'
+import { DatabaseModule } from './index'
+
+function createModule(client: { execute: ReturnType<typeof vi.fn> }): DatabaseModule {
+  const module = new DatabaseModule()
+  ;(module as unknown as { client: typeof client; mainDbPath: string }).client = client
+  ;(module as unknown as { client: typeof client; mainDbPath: string }).mainDbPath =
+    'C:/tmp/database.db'
+  return module
+}
+
+async function runWalCheckpoint(
+  module: DatabaseModule,
+  mode: 'PASSIVE' | 'TRUNCATE'
+): Promise<void> {
+  await (
+    module as unknown as {
+      runWalCheckpoint: (mode: 'PASSIVE' | 'TRUNCATE') => Promise<void>
+    }
+  ).runWalCheckpoint(mode)
+}
+
+describe('DatabaseModule WAL checkpoint maintenance', () => {
+  beforeEach(async () => {
+    await dbWriteScheduler.drain()
+    vi.clearAllMocks()
+    fileProviderBusyMock.mockReturnValue(false)
+  })
+
+  it('skips checkpoint when search index worker is busy', async () => {
+    fileProviderBusyMock.mockReturnValue(true)
+    const client = {
+      execute: vi.fn(async () => ({ rows: [{ busy: 0, log: 1, checkpointed: 1 }] }))
+    }
+    const module = createModule(client)
+
+    await runWalCheckpoint(module, 'PASSIVE')
+
+    expect(client.execute).not.toHaveBeenCalled()
+    expect(dbLogMock.info).toHaveBeenCalledWith(
+      'DB_WAL_CHECKPOINT_SKIPPED_BUSY',
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          mode: 'PASSIVE',
+          reason: 'search-index-worker'
+        })
+      })
+    )
+  })
+
+  it('runs checkpoint through the maintenance queue when idle', async () => {
+    const client = {
+      execute: vi.fn(async () => ({ rows: [{ busy: 0, log: 2, checkpointed: 2 }] }))
+    }
+    const module = createModule(client)
+
+    await runWalCheckpoint(module, 'PASSIVE')
+
+    expect(client.execute).toHaveBeenCalledWith('PRAGMA wal_checkpoint(PASSIVE)')
+    expect(dbLogMock.info).toHaveBeenCalledWith(
+      'WAL checkpoint PASSIVE complete',
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          mode: 'PASSIVE',
+          logFrames: 2,
+          checkpointedFrames: 2
+        })
+      })
+    )
+  })
+})

--- a/apps/core-app/src/main/modules/database/index.ts
+++ b/apps/core-app/src/main/modules/database/index.ts
@@ -20,6 +20,7 @@ import { dbWriteScheduler } from '../../db/db-write-scheduler'
 import { DB_AUX_ENABLED } from '../../db/runtime-flags'
 import { getSqliteBusyRetryCount } from '../../db/sqlite-retry'
 import { BaseModule } from '../abstract-base-module'
+import { fileProvider } from '../box-tool/addon/files/file-provider'
 
 const dbLog = getLogger('database')
 const AUX_MIGRATION_MARKER_KEY = 'db.aux.migration.v1.complete'
@@ -30,6 +31,8 @@ const DB_WAL_PASSIVE_INTERVAL_MS = 5 * 60 * 1000
 const DB_WAL_TRUNCATE_INTERVAL_MS = 30 * 60 * 1000
 const DB_HEALTH_REPORT_INTERVAL_MS = 10 * 60 * 1000
 const DB_WAL_TRUNCATE_MAX_QUEUED_WRITES = 2
+const DB_WAL_CHECKPOINT_MAX_QUEUE_WAIT_MS = 5_000
+const DB_WAL_CHECKPOINT_SKIPPED_BUSY = 'DB_WAL_CHECKPOINT_SKIPPED_BUSY'
 const WAL_WARN_THRESHOLD_BYTES = 512 * 1024 * 1024
 const AUX_COPY_TABLES = [
   'analytics_snapshots',
@@ -239,29 +242,117 @@ export class DatabaseModule extends BaseModule {
     }
   }
 
+  private getDbSchedulerBusyReason():
+    | {
+        reason: 'db-write-scheduler'
+        queued: number
+        processing: boolean
+        currentTaskLabel?: string
+      }
+    | null {
+    const stats = dbWriteScheduler.getStats()
+    this.schedulerQueuePeak = Math.max(this.schedulerQueuePeak, stats.queued)
+    if (stats.queued > 0 || stats.processing) {
+      return {
+        reason: 'db-write-scheduler',
+        queued: stats.queued,
+        processing: stats.processing,
+        currentTaskLabel: stats.currentTaskLabel ?? undefined
+      }
+    }
+    return null
+  }
+
+  private getSearchIndexWorkerBusyReason():
+    | { reason: 'search-index-worker'; queued: number; processing: boolean }
+    | null {
+    try {
+      if (fileProvider.isSearchIndexWorkerBusy()) {
+        return {
+          reason: 'search-index-worker',
+          queued: 0,
+          processing: true
+        }
+      }
+    } catch {
+      return null
+    }
+    return null
+  }
+
+  private getWalCheckpointBusyReason():
+    | {
+        reason: 'db-write-scheduler' | 'search-index-worker'
+        queued: number
+        processing: boolean
+        currentTaskLabel?: string
+      }
+    | null {
+    return this.getDbSchedulerBusyReason() ?? this.getSearchIndexWorkerBusyReason()
+  }
+
+  private logWalCheckpointSkippedBusy(
+    mode: 'PASSIVE' | 'TRUNCATE',
+    busy: NonNullable<ReturnType<DatabaseModule['getWalCheckpointBusyReason']>>
+  ): void {
+    dbLog.info(DB_WAL_CHECKPOINT_SKIPPED_BUSY, {
+      meta: {
+        mode,
+        reason: busy.reason,
+        busyQueueDepth: busy.queued,
+        busyProcessing: busy.processing,
+        currentTaskLabel: busy.currentTaskLabel
+      }
+    })
+  }
+
   private async runWalCheckpoint(mode: 'PASSIVE' | 'TRUNCATE'): Promise<void> {
     if (!this.client) return
 
-    const queueDepth = dbWriteScheduler.getStats().queued
-    this.schedulerQueuePeak = Math.max(this.schedulerQueuePeak, queueDepth)
+    const busyBeforeSchedule = this.getWalCheckpointBusyReason()
+    if (busyBeforeSchedule) {
+      this.logWalCheckpointSkippedBusy(mode, busyBeforeSchedule)
+      return
+    }
 
     try {
-      const result = await this.client.execute(`PRAGMA wal_checkpoint(${mode})`)
-      const parsed = this.parseCheckpointRow(result.rows?.[0])
-      const walSize = await this.getWalSizeBytes()
-      this.walPeakBytes = Math.max(this.walPeakBytes, walSize)
+      await dbWriteScheduler.schedule(
+        `database.wal-checkpoint.${mode.toLowerCase()}`,
+        async () => {
+          const busyBeforeExecute = this.getSearchIndexWorkerBusyReason()
+          if (busyBeforeExecute) {
+            this.logWalCheckpointSkippedBusy(mode, busyBeforeExecute)
+            return
+          }
 
-      dbLog.info(`WAL checkpoint ${mode} complete`, {
-        meta: {
-          busy: parsed.busy,
-          logFrames: parsed.log,
-          checkpointedFrames: parsed.checkpointed,
-          walSizeBytes: walSize,
-          walPeakBytes: this.walPeakBytes,
-          schedulerQueueDepth: queueDepth,
-          schedulerQueuePeak: this.schedulerQueuePeak
+          const checkpointStart = Date.now()
+          dbLog.debug('DB_WAL_CHECKPOINT_START', {
+            meta: { mode }
+          })
+          const result = await this.client!.execute(`PRAGMA wal_checkpoint(${mode})`)
+          const parsed = this.parseCheckpointRow(result.rows?.[0])
+          const walSize = await this.getWalSizeBytes()
+          this.walPeakBytes = Math.max(this.walPeakBytes, walSize)
+
+          dbLog.info(`WAL checkpoint ${mode} complete`, {
+            meta: {
+              mode,
+              busy: parsed.busy,
+              logFrames: parsed.log,
+              checkpointedFrames: parsed.checkpointed,
+              walSizeBytes: walSize,
+              walPeakBytes: this.walPeakBytes,
+              durationMs: Date.now() - checkpointStart,
+              schedulerQueuePeak: this.schedulerQueuePeak
+            }
+          })
+        },
+        {
+          priority: 'best_effort',
+          dropPolicy: 'drop',
+          maxQueueWaitMs: DB_WAL_CHECKPOINT_MAX_QUEUE_WAIT_MS
         }
-      })
+      )
     } catch (error) {
       dbLog.warn(`WAL checkpoint ${mode} failed`, { error })
     }

--- a/apps/core-app/src/main/modules/plugin/adapters/plugin-features-adapter.ts
+++ b/apps/core-app/src/main/modules/plugin/adapters/plugin-features-adapter.ts
@@ -29,6 +29,12 @@ import { buildFeatureSearchTokens } from './feature-search-tokens'
 
 const pluginFeaturesLog = getLogger('plugin-system')
 
+function getErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined
+  const code = (error as { code?: unknown }).code
+  return typeof code === 'string' ? code : undefined
+}
+
 function isCommandMatch(command: IFeatureCommand, queryText: string): boolean {
   if (!command.type) {
     return true
@@ -249,7 +255,13 @@ export class PluginFeaturesAdapter implements ISearchProvider<ProviderContext> {
       }
       searchEngineCore.activateProviders([activation])
 
-      await PluginViewLoader.loadPluginView(plugin as TouchPlugin, feature, query)
+      try {
+        await PluginViewLoader.loadPluginView(plugin as TouchPlugin, feature, query)
+      } catch (error) {
+        pluginFeaturesLog.error('[PluginFeaturesAdapter] webcontent feature execute failed:', error)
+        searchEngineCore.deactivateProvider(`${this.id}:${pluginName}`)
+        return null
+      }
 
       if (
         plugin.issues.some(
@@ -266,6 +278,21 @@ export class PluginFeaturesAdapter implements ISearchProvider<ProviderContext> {
     }
 
     const query: TuffQuery = searchQuery ? { ...searchQuery } : { text: '' }
+    const executeStart = Date.now()
+    const logExecuteBreadcrumb = (
+      stage: string,
+      extra?: { durationMs?: number; errorCode?: string }
+    ) => {
+      pluginFeaturesLog.debug('[Breadcrumb] feature execute adapter', {
+        meta: {
+          pluginName,
+          featureId,
+          stage,
+          durationMs: extra?.durationMs,
+          errorCode: extra?.errorCode
+        }
+      })
+    }
 
     // For push-mode features, pre-activate BEFORE triggering to ensure
     // items pushed during onFeatureTriggered have correct activation state
@@ -289,7 +316,19 @@ export class PluginFeaturesAdapter implements ISearchProvider<ProviderContext> {
       }
       searchEngineCore.activateProviders([activation])
 
-      const shouldActivate = await plugin.triggerFeature(feature, query)
+      logExecuteBreadcrumb('push-trigger-start')
+      let shouldActivate: boolean | void
+      try {
+        shouldActivate = await plugin.triggerFeature(feature, query)
+      } catch (error) {
+        pluginFeaturesLog.error('[PluginFeaturesAdapter] push feature execute failed:', error)
+        logExecuteBreadcrumb('push-trigger-error', {
+          durationMs: Date.now() - executeStart,
+          errorCode: getErrorCode(error)
+        })
+        searchEngineCore.deactivateProvider(`${this.id}:${pluginName}`)
+        return null
+      }
 
       if (typeof shouldActivate === 'boolean' && shouldActivate === false) {
         // Deactivate if feature explicitly returns false
@@ -297,17 +336,30 @@ export class PluginFeaturesAdapter implements ISearchProvider<ProviderContext> {
         return null
       }
 
+      logExecuteBreadcrumb('push-trigger-complete', { durationMs: Date.now() - executeStart })
       return activation
     }
 
     // For non-push features, use original flow
-    const shouldActivate = await plugin.triggerFeature(feature, query)
+    logExecuteBreadcrumb('trigger-start')
+    let shouldActivate: boolean | void
+    try {
+      shouldActivate = await plugin.triggerFeature(feature, query)
+    } catch (error) {
+      pluginFeaturesLog.error('[PluginFeaturesAdapter] feature execute failed:', error)
+      logExecuteBreadcrumb('trigger-error', {
+        durationMs: Date.now() - executeStart,
+        errorCode: getErrorCode(error)
+      })
+      return null
+    }
 
     if (typeof shouldActivate === 'boolean' && shouldActivate === false) {
       return null
     }
 
     if (typeof shouldActivate === 'boolean' && shouldActivate === true) {
+      logExecuteBreadcrumb('trigger-activate', { durationMs: Date.now() - executeStart })
       return {
         id: this.id,
         meta: {
@@ -319,6 +371,7 @@ export class PluginFeaturesAdapter implements ISearchProvider<ProviderContext> {
       }
     }
 
+    logExecuteBreadcrumb('trigger-complete', { durationMs: Date.now() - executeStart })
     return null
   }
 

--- a/apps/core-app/src/main/modules/plugin/plugin-feature.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-feature.ts
@@ -78,9 +78,16 @@ export function loadPluginFeatureContextFromContent(
     vm.runInContext(scriptContent, sandbox)
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
-    throw new Error(`Plugin script execution failed for ${plugin.name}: ${message}`, {
+    const wrapped = new Error(`Plugin script execution failed for ${plugin.name}: ${message}`, {
       cause: err
-    })
+    }) as Error & { code?: string; moduleId?: string; pluginName?: string }
+    if (err && typeof err === 'object') {
+      const cause = err as { code?: unknown; moduleId?: unknown; pluginName?: unknown }
+      if (typeof cause.code === 'string') wrapped.code = cause.code
+      if (typeof cause.moduleId === 'string') wrapped.moduleId = cause.moduleId
+      if (typeof cause.pluginName === 'string') wrapped.pluginName = cause.pluginName
+    }
+    throw wrapped
   }
 
   const exported = sandbox.module.exports

--- a/apps/core-app/src/main/modules/plugin/plugin.test.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin.test.ts
@@ -180,6 +180,47 @@ describe('TouchPlugin.triggerFeature', () => {
       })
     )
   })
+
+  it('converts widget registration throws into a feature failure', async () => {
+    vi.mocked(getCoreBoxWindow).mockReturnValue(undefined)
+    vi.mocked(widgetManager.registerWidget).mockRejectedValue(new Error('missing widget bundle'))
+
+    const transport = {
+      sendToWindow: vi.fn().mockResolvedValue(undefined),
+      invoke: vi.fn().mockResolvedValue({ level: 100, charging: true }),
+      keyManager: {
+        requestKey: vi.fn(),
+        revokeKey: vi.fn()
+      }
+    } as unknown as ITuffTransportMain
+
+    TouchPlugin.setTransport(transport)
+
+    const plugin = new TouchPlugin(
+      'test-plugin',
+      { type: 'class', value: 'i-ri-test-tube-line' },
+      '1.0.0',
+      'desc',
+      '',
+      { enable: true, address: 'http://localhost' },
+      '/tmp',
+      {},
+      { skipDataInit: true }
+    )
+
+    const feature = {
+      id: 'test-feature',
+      name: 'Test Feature',
+      desc: '',
+      interaction: { type: 'widget', path: '/widget.vue' }
+    } as IPluginFeature
+
+    await expect(plugin.triggerFeature(feature, { text: '', inputs: [] })).resolves.toBe(false)
+    expect(plugin.issues.at(-1)).toMatchObject({
+      code: 'RUNTIME_ERROR',
+      source: 'runtime:registerWidget'
+    })
+  })
 })
 
 describe('TouchPlugin.setRuntime', () => {

--- a/apps/core-app/src/main/modules/plugin/plugin.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin.ts
@@ -78,6 +78,46 @@ interface FeatureEventUtil {
   offFeatureLifeCycle: (id: string, callback: ITargetFeatureLifeCycle) => void
 }
 
+type PluginClipboardApi = Pick<
+  Electron.Clipboard,
+  'readText' | 'writeText' | 'readImage' | 'writeImage' | 'clear' | 'has'
+>
+
+function createSafePluginDialogApi() {
+  return {
+    showMessageBox: (...args: Parameters<typeof dialog.showMessageBox>) =>
+      dialog.showMessageBox(...args),
+    showOpenDialog: (...args: Parameters<typeof dialog.showOpenDialog>) =>
+      dialog.showOpenDialog(...args),
+    showSaveDialog: (...args: Parameters<typeof dialog.showSaveDialog>) =>
+      dialog.showSaveDialog(...args)
+  }
+}
+
+function createSafePluginClipboardApi(): PluginClipboardApi {
+  return {
+    readText: (...args) => clipboard.readText(...args),
+    writeText: (...args) => clipboard.writeText(...args),
+    readImage: (...args) => clipboard.readImage(...args),
+    writeImage: (...args) => clipboard.writeImage(...args),
+    clear: (...args) => clipboard.clear(...args),
+    has: (...args) => clipboard.has(...args)
+  }
+}
+
+function createSafePluginOpenUrl(pluginName: string, logger: PluginLogger) {
+  return async (url: string): Promise<void> => {
+    try {
+      await shell.openExternal(url)
+    } catch (error) {
+      logger.warn(`[Plugin ${pluginName}] openUrl failed`, {
+        error: error instanceof Error ? error.message : String(error)
+      })
+      throw error
+    }
+  }
+}
+
 function createRemovedChannelError(capability: 'channel.raw' | 'channel.sendSync'): Error {
   return new Error(
     `[Plugin API] ${capability} was removed by the core-app hard-cut. Migrate this plugin to typed transport send/on APIs.`
@@ -126,6 +166,20 @@ const TRANSIENT_ISSUE_CODES = new Set([
 ])
 const CHANNEL_SOURCE_TRANSPORT = 'transport' as PluginStandardChannelData['header']['type']
 const CHANNEL_SUCCESS_CODE = 200 as PluginStandardChannelData['code']
+
+function getRuntimeErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined
+  const code = (error as { code?: unknown }).code
+  return typeof code === 'string' ? code : undefined
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    value !== null &&
+    (typeof value === 'object' || typeof value === 'function') &&
+    typeof (value as { then?: unknown }).then === 'function'
+  )
+}
 
 export interface TouchPluginRuntimeContext {
   rootPath: string
@@ -486,9 +540,24 @@ export class TouchPlugin implements ITouchPlugin {
     feature: IPluginFeature,
     query: TuffQuery | undefined
   ): Promise<boolean | void> {
+    const executeStart = Date.now()
+    const logFeatureBreadcrumb = (
+      stage: string,
+      extra?: { errorCode?: string; durationMs?: number }
+    ) => {
+      this.logger.debug('[Breadcrumb] feature execute', {
+        pluginName: this.name,
+        featureId: feature.id,
+        stage,
+        durationMs: extra?.durationMs,
+        errorCode: extra?.errorCode
+      })
+    }
+
     this._runtimeStats.requestCount += 1
     this._runtimeStats.lastActiveAt = Date.now()
     this.markActive()
+    logFeatureBreadcrumb('start')
 
     if (this.featureControllers.has(feature.id)) {
       this.featureControllers.get(feature.id)?.abort()
@@ -513,15 +582,39 @@ export class TouchPlugin implements ITouchPlugin {
           `Plugin lifecycle not initialized before triggering feature. This may indicate an issue.`
         )
       }
-      await PluginViewLoader.loadPluginView(this, feature, query)
+      try {
+        await PluginViewLoader.loadPluginView(this, feature, query)
+        logFeatureBreadcrumb('webcontent-ready', { durationMs: Date.now() - executeStart })
+      } catch (error) {
+        logFeatureBreadcrumb('webcontent-failed', {
+          durationMs: Date.now() - executeStart,
+          errorCode: getRuntimeErrorCode(error)
+        })
+        this.handleRuntimeError('loadPluginView', error)
+        return false
+      }
       return true
     }
 
     if (feature.interaction?.type === 'widget') {
       const needsRegistration = Boolean(feature.interaction.path)
       if (needsRegistration) {
-        const registration = await widgetManager.registerWidget(this, feature)
+        logFeatureBreadcrumb('widget-register-start')
+        let registration: Awaited<ReturnType<typeof widgetManager.registerWidget>>
+        try {
+          registration = await widgetManager.registerWidget(this, feature)
+        } catch (error) {
+          logFeatureBreadcrumb('widget-register-error', {
+            durationMs: Date.now() - executeStart,
+            errorCode: getRuntimeErrorCode(error)
+          })
+          this.handleRuntimeError('registerWidget', error)
+          return false
+        }
         if (!registration) {
+          logFeatureBreadcrumb('widget-register-failed', {
+            durationMs: Date.now() - executeStart
+          })
           this.logger.warn(`Widget interaction failed to load for feature: ${feature.id}`)
           const coreBoxWindow = getCoreBoxWindow()
           if (coreBoxWindow && !coreBoxWindow.window.isDestroyed()) {
@@ -545,6 +638,9 @@ export class TouchPlugin implements ITouchPlugin {
           }
           return false
         }
+        logFeatureBreadcrumb('widget-register-ready', {
+          durationMs: Date.now() - executeStart
+        })
         this.logger.info(
           `Widget interaction ready for feature: ${feature.id} (id=${registration.widgetId}, file=${registration.filePath})`
         )
@@ -559,24 +655,39 @@ export class TouchPlugin implements ITouchPlugin {
         feature,
         controller.signal
       )
+      if (isPromiseLike(result)) {
+        result = (await result) as boolean | void
+      }
     } catch (error) {
+      logFeatureBreadcrumb('lifecycle-error', {
+        durationMs: Date.now() - executeStart,
+        errorCode: getRuntimeErrorCode(error)
+      })
       this.handleRuntimeError('onFeatureTriggered', error)
     }
     try {
       this._featureEvent.get(feature.id)?.forEach((fn) => fn.onLaunch?.(feature))
     } catch (error) {
+      logFeatureBreadcrumb('on-launch-error', {
+        durationMs: Date.now() - executeStart,
+        errorCode: getRuntimeErrorCode(error)
+      })
       this.handleRuntimeError('onLaunch', error)
     }
+    logFeatureBreadcrumb('complete', { durationMs: Date.now() - executeStart })
     return result
   }
 
-  triggerInputChanged(feature: IPluginFeature, query: TuffQuery | undefined): void {
+  async triggerInputChanged(feature: IPluginFeature, query: TuffQuery | undefined): Promise<void> {
     this._runtimeStats.requestCount += 1
     this._runtimeStats.lastActiveAt = Date.now()
     this.markActive()
 
     try {
-      this.pluginLifecycle?.onFeatureTriggered(feature.id, query, feature)
+      const result = this.pluginLifecycle?.onFeatureTriggered(feature.id, query, feature)
+      if (isPromiseLike(result)) {
+        await result
+      }
     } catch (error) {
       this.handleRuntimeError('onFeatureTriggered', error)
     }
@@ -738,6 +849,7 @@ export class TouchPlugin implements ITouchPlugin {
    */
   private handleRuntimeError(source: string, error: unknown): void {
     const err = error instanceof Error ? error : new Error(String(error))
+    const errorCode = getRuntimeErrorCode(error) ?? 'RUNTIME_ERROR'
 
     this.logger.error(`[Runtime] ${source} failed: ${err.message}`, err)
 
@@ -745,8 +857,8 @@ export class TouchPlugin implements ITouchPlugin {
       type: 'error',
       message: `Runtime error in ${source}: ${err.message}`,
       source: `runtime:${source}`,
-      code: 'RUNTIME_ERROR',
-      meta: { error: err.stack },
+      code: errorCode,
+      meta: { error: err.stack, code: errorCode },
       timestamp: Date.now()
     })
 
@@ -961,7 +1073,10 @@ export class TouchPlugin implements ITouchPlugin {
     this._runtimeStats.lastActiveAt = now
 
     try {
-      this.pluginLifecycle?.onInit?.()
+      const initResult = this.pluginLifecycle?.onInit?.()
+      if (isPromiseLike(initResult)) {
+        Promise.resolve(initResult).catch((error) => this.handleRuntimeError('onInit', error))
+      }
     } catch (error) {
       this.handleRuntimeError('onInit', error)
     }
@@ -1362,7 +1477,9 @@ export class TouchPlugin implements ITouchPlugin {
 
     const http = createPluginHttpClient()
     const storage = this.createPluginStorageAPI(pluginName)
-    const clipboardUtil = createClipboardManager(clipboard)
+    const clipboardUtil = createClipboardManager(createSafePluginClipboardApi())
+    const dialogUtil = createSafePluginDialogApi()
+    const openUrl = createSafePluginOpenUrl(pluginName, this.logger)
 
     const onTransport = (
       eventName: string,
@@ -1747,10 +1864,10 @@ export class TouchPlugin implements ITouchPlugin {
     }
 
     return {
-      dialog,
+      dialog: dialogUtil,
       logger: this.logger,
       $event: this.getFeatureEventUtil(),
-      openUrl: (url: string) => shell.openExternal(url),
+      openUrl,
       http,
       storage,
       clipboard: clipboardUtil,

--- a/apps/core-app/src/main/modules/plugin/runtime/plugin-require.test.ts
+++ b/apps/core-app/src/main/modules/plugin/runtime/plugin-require.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PLUGIN_RUNTIME_DENIED_MODULE,
+  PluginRuntimeDeniedModuleError,
+  createPluginRequire
+} from './plugin-require'
+import { loadPluginFeatureContextFromContent } from '../plugin-feature'
+
+function expectDenied(operation: () => unknown, moduleId: string): void {
+  expect(operation).toThrow(PluginRuntimeDeniedModuleError)
+  try {
+    operation()
+  } catch (error) {
+    expect(error).toMatchObject({
+      code: PLUGIN_RUNTIME_DENIED_MODULE,
+      pluginName: 'test-plugin',
+      moduleId
+    })
+  }
+}
+
+describe('createPluginRequire', () => {
+  it('denies Electron and native-risk modules', () => {
+    const pluginRequire = createPluginRequire('test-plugin')
+
+    expectDenied(() => pluginRequire('electron'), 'electron')
+    expectDenied(() => pluginRequire('@libsql/client'), '@libsql/client')
+    expectDenied(() => pluginRequire('@libsql/win32-x64-msvc'), '@libsql/win32-x64-msvc')
+    expectDenied(() => pluginRequire('@crosscopy/clipboard'), '@crosscopy/clipboard')
+    expectDenied(() => pluginRequire('extract-file-icon'), 'extract-file-icon')
+    expectDenied(() => pluginRequire('./native-addon.node'), './native-addon.node')
+  })
+
+  it('keeps worker_threads available through the instrumented wrapper', () => {
+    const pluginRequire = createPluginRequire('test-plugin')
+
+    const workerThreads = pluginRequire('node:worker_threads') as typeof import('node:worker_threads')
+
+    expect(workerThreads.Worker).toBeTypeOf('function')
+    expect(workerThreads.isMainThread).toBe(true)
+  })
+
+  it('denies resolving native addons before loading them', () => {
+    const pluginRequire = createPluginRequire('test-plugin')
+
+    expectDenied(() => pluginRequire.resolve('./native-addon.node'), './native-addon.node')
+  })
+
+  it('preserves the denied error code through plugin script loading', () => {
+    expect(() =>
+      loadPluginFeatureContextFromContent(
+        {
+          name: 'test-plugin',
+          pluginPath: '/tmp/test-plugin'
+        } as never,
+        "require('electron')",
+        {}
+      )
+    ).toThrow(expect.objectContaining({ code: PLUGIN_RUNTIME_DENIED_MODULE }))
+  })
+})

--- a/apps/core-app/src/main/modules/plugin/runtime/plugin-require.ts
+++ b/apps/core-app/src/main/modules/plugin/runtime/plugin-require.ts
@@ -2,8 +2,67 @@ import type { Worker as NodeWorker, WorkerOptions } from 'node:worker_threads'
 import { pluginRuntimeTracker } from './plugin-runtime-tracker'
 
 const WORKER_THREAD_MODULE_IDS = new Set(['worker_threads', 'node:worker_threads'])
+export const PLUGIN_RUNTIME_DENIED_MODULE = 'PLUGIN_RUNTIME_DENIED_MODULE'
+
+const DENIED_MODULE_EXACT_IDS = new Set([
+  'electron',
+  'node:electron',
+  '@libsql/client',
+  '@crosscopy/clipboard',
+  'extract-file-icon'
+])
+const DENIED_MODULE_PREFIXES = [
+  'electron/',
+  'node:electron/',
+  '@libsql/',
+  '@crosscopy/clipboard/',
+  'extract-file-icon/'
+]
 
 const instrumentedWorkerThreadsModuleCache = new Map<string, typeof import('node:worker_threads')>()
+
+export class PluginRuntimeDeniedModuleError extends Error {
+  readonly code = PLUGIN_RUNTIME_DENIED_MODULE
+  readonly pluginName: string
+  readonly moduleId: string
+
+  constructor(pluginName: string, moduleId: string) {
+    super(`Plugin runtime denied module "${moduleId}" for plugin "${pluginName}"`)
+    this.name = 'PluginRuntimeDeniedModuleError'
+    this.pluginName = pluginName
+    this.moduleId = moduleId
+  }
+}
+
+function normalizeModuleId(moduleId: string): string {
+  return moduleId.trim().replace(/\\/g, '/')
+}
+
+function stripQueryAndHash(moduleId: string): string {
+  return normalizeModuleId(moduleId).split(/[?#]/, 1)[0].toLowerCase()
+}
+
+function isNativeAddonRequest(moduleId: string): boolean {
+  const normalized = stripQueryAndHash(moduleId)
+  return normalized.endsWith('.node') || normalized.includes('.node/')
+}
+
+function isDeniedModuleId(moduleId: string): boolean {
+  const normalized = normalizeModuleId(moduleId)
+  if (DENIED_MODULE_EXACT_IDS.has(normalized)) {
+    return true
+  }
+  if (DENIED_MODULE_PREFIXES.some((prefix) => normalized.startsWith(prefix))) {
+    return true
+  }
+  return isNativeAddonRequest(normalized)
+}
+
+function assertAllowedPluginModule(pluginName: string, moduleId: string): void {
+  if (isDeniedModuleId(moduleId)) {
+    throw new PluginRuntimeDeniedModuleError(pluginName, moduleId)
+  }
+}
 
 function getInstrumentedWorkerThreadsModule(
   pluginName: string
@@ -36,10 +95,19 @@ export function createPluginRequire(pluginName: string): NodeRequire {
     if (WORKER_THREAD_MODULE_IDS.has(id)) {
       return getInstrumentedWorkerThreadsModule(pluginName)
     }
+    assertAllowedPluginModule(pluginName, id)
     return baseRequire(id)
   }) as unknown as NodeRequire
 
-  pluginRequire.resolve = baseRequire.resolve
+  const resolve = ((id: string, options?: { paths?: string[] }) => {
+    assertAllowedPluginModule(pluginName, id)
+    const resolved = baseRequire.resolve(id, options)
+    assertAllowedPluginModule(pluginName, resolved)
+    return resolved
+  }) as NodeRequire['resolve']
+  resolve.paths = baseRequire.resolve.paths
+
+  pluginRequire.resolve = resolve
   pluginRequire.cache = baseRequire.cache
   pluginRequire.extensions = baseRequire.extensions
   pluginRequire.main = baseRequire.main

--- a/apps/core-app/src/main/modules/system/active-app.test.ts
+++ b/apps/core-app/src/main/modules/system/active-app.test.ts
@@ -124,6 +124,54 @@ describe('active-app resolution', () => {
     })
   })
 
+  it('does not resolve app icons by default', async () => {
+    withOSAdapterMock.mockImplementation(
+      async (options: Record<string, () => Promise<unknown>>) => {
+        return await options.win32()
+      }
+    )
+    mockExecFileSuccess(
+      JSON.stringify({
+        processId: 404,
+        displayName: 'Code',
+        executablePath: 'C:\\Program Files\\Code.exe',
+        windowTitle: 'workspace'
+      })
+    )
+
+    const result = await activeAppService.getActiveApp(true)
+
+    expect(result).toMatchObject({
+      displayName: 'Code',
+      icon: null
+    })
+    expect(getFileIconMock).not.toHaveBeenCalled()
+  })
+
+  it('resolves app icons only when includeIcon is true', async () => {
+    withOSAdapterMock.mockImplementation(
+      async (options: Record<string, () => Promise<unknown>>) => {
+        return await options.win32()
+      }
+    )
+    mockExecFileSuccess(
+      JSON.stringify({
+        processId: 404,
+        displayName: 'Code',
+        executablePath: 'C:\\Program Files\\Code.exe',
+        windowTitle: 'workspace'
+      })
+    )
+
+    const result = await activeAppService.getActiveApp({ forceRefresh: true, includeIcon: true })
+
+    expect(result).toMatchObject({
+      displayName: 'Code',
+      icon: 'data:image/png;base64,icon'
+    })
+    expect(getFileIconMock).toHaveBeenCalledWith('C:\\Program Files\\Code.exe', { size: 'small' })
+  })
+
   it('parses Windows foreground JSON when PowerShell emits warning lines first', async () => {
     withOSAdapterMock.mockImplementation(
       async (options: Record<string, () => Promise<unknown>>) => {

--- a/apps/core-app/src/main/modules/system/active-app.ts
+++ b/apps/core-app/src/main/modules/system/active-app.ts
@@ -469,13 +469,13 @@ try {
     if (typeof forceRefreshOrOptions === 'boolean') {
       return {
         forceRefresh: forceRefreshOrOptions,
-        includeIcon: true
+        includeIcon: false
       }
     }
 
     return {
       forceRefresh: forceRefreshOrOptions.forceRefresh === true,
-      includeIcon: forceRefreshOrOptions.includeIcon !== false
+      includeIcon: forceRefreshOrOptions.includeIcon === true
     }
   }
 

--- a/docs/plan-prd/01-project/CHANGES.md
+++ b/docs/plan-prd/01-project/CHANGES.md
@@ -5,6 +5,15 @@
 
 ## 2026-05-14
 
+### fix(core-app): restore Windows PowerShell app source scans
+
+- `apps/core-app/src/main/modules/box-tool/addon/apps/win.ts`
+- `apps/core-app/src/main/modules/box-tool/addon/apps/win.test.ts`
+- `apps/core-app/scripts/windows-capability-evidence.ts`
+  - Windows app scanner and capability evidence scripts now pass PowerShell object-literal scripts with newline separators instead of semicolon-joining `[PSCustomObject]@{ ... }`, preventing parser failures that silently dropped `Get-StartApps`, registry, and Start Menu evidence.
+  - Real Windows scan smoke now finds Codex as `shell:AppsFolder\OpenAI.Codex_2p2nqsd0c76g0!App` with `launchKind=uwp`; `windows:capability:verify --requireTargets --requireUwp --strict` passes for the Codex target, with only the local `es.exe` Everything warning remaining.
+  - Added regression coverage so Windows PowerShell scan scripts do not reintroduce the invalid `@{;` form that previously caused Codex/UWP apps to miss the app index.
+
 ### fix(core-app): contain prod feature native crash paths
 
 - `apps/core-app/src/main/modules/plugin/runtime/plugin-require.ts`

--- a/docs/plan-prd/01-project/CHANGES.md
+++ b/docs/plan-prd/01-project/CHANGES.md
@@ -3,6 +3,23 @@
 > 更新时间: 2026-05-12
 > 说明: 主文件仅保留近 30 天（2026-04-12 ~ 2026-05-12）详细记录；更早历史已按月归档。
 
+## 2026-05-14
+
+### fix(core-app): contain prod feature native crash paths
+
+- `apps/core-app/src/main/modules/plugin/runtime/plugin-require.ts`
+- `apps/core-app/src/main/modules/plugin/plugin.ts`
+- `apps/core-app/src/main/modules/plugin/adapters/plugin-features-adapter.ts`
+- `apps/core-app/src/main/modules/system/active-app.ts`
+- `apps/core-app/src/main/modules/database/index.ts`
+- `packages/utils/plugin/sdk/system.ts`
+- `packages/utils/transport/events/types/app.ts`
+  - Plugin runtime now denies direct `electron`, `.node`, `@libsql/*`, `@crosscopy/clipboard`, and `extract-file-icon` imports with `PLUGIN_RUNTIME_DENIED_MODULE`, keeping failures scoped to the plugin/feature.
+  - Plugin `dialog`, `openUrl`, and `clipboard` globals remain compatible but now go through narrow main-process wrappers instead of exposing raw Electron objects.
+  - `system.getActiveApp` adds `includeIcon`; plugin transport and main channel default it to `false`, so `app.getFileIcon` only runs for explicit icon requests.
+  - WAL checkpoint now runs through DB maintenance scheduling and skips when the DB write queue or search-index worker is busy, logging `DB_WAL_CHECKPOINT_SKIPPED_BUSY`.
+  - Feature execution, widget registration, plugin lifecycle, and WAL checkpoint paths emit lightweight breadcrumbs without query text, clipboard text, or full file paths.
+
 ## 2026-05-12
 
 ### fix(core-app): skip unresolved optional packaged runtime modules

--- a/packages/utils/__tests__/system-sdk.test.ts
+++ b/packages/utils/__tests__/system-sdk.test.ts
@@ -44,6 +44,7 @@ describe('plugin sdk system.getActiveAppSnapshot', () => {
 
     expect(transport.send).toHaveBeenCalledWith(AppEvents.system.getActiveApp, {
       forceRefresh: true,
+      includeIcon: false,
     })
     expect(channel.send).not.toHaveBeenCalled()
     expect(result).toMatchObject({
@@ -70,6 +71,7 @@ describe('plugin sdk system.getActiveAppSnapshot', () => {
 
     expect(transport.send).toHaveBeenCalledWith(AppEvents.system.getActiveApp, {
       forceRefresh: false,
+      includeIcon: false,
     })
     expect(channel.send).not.toHaveBeenCalled()
   })
@@ -90,7 +92,32 @@ describe('plugin sdk system.getActiveAppSnapshot', () => {
     await expect(getTypedActiveAppSnapshot()).rejects.toThrow('typed unavailable')
     expect(transport.send).toHaveBeenCalledWith(AppEvents.system.getActiveApp, {
       forceRefresh: false,
+      includeIcon: false,
     })
     expect(channel.send).not.toHaveBeenCalled()
+  })
+
+  it('only requests app icon when includeIcon is explicit', async () => {
+    const channel = {
+      send: vi.fn(),
+    }
+    const transport = {
+      send: vi.fn(async () => ({
+        identifier: 'com.demo.app',
+        displayName: 'Demo',
+        platform: 'macos',
+        lastUpdated: 1,
+      })),
+    }
+
+    useChannelMock.mockReturnValue(channel)
+    createPluginTuffTransportMock.mockReturnValue(transport)
+
+    await getActiveAppSnapshot({ includeIcon: true })
+
+    expect(transport.send).toHaveBeenCalledWith(AppEvents.system.getActiveApp, {
+      forceRefresh: false,
+      includeIcon: true,
+    })
   })
 })

--- a/packages/utils/plugin/sdk/system.ts
+++ b/packages/utils/plugin/sdk/system.ts
@@ -35,22 +35,24 @@ function getSystemChannel() {
 async function getTypedActiveAppSnapshotWithChannel(
   channel: ReturnType<typeof getSystemChannel>,
   forceRefresh: boolean,
+  includeIcon: boolean,
 ): Promise<ActiveAppSnapshot | null> {
   const transport = createPluginTuffTransport(channel as any)
-  const typed = await transport.send(AppEvents.system.getActiveApp, { forceRefresh })
+  const typed = await transport.send(AppEvents.system.getActiveApp, { forceRefresh, includeIcon })
   return normalizeActiveAppSnapshot(typed)
 }
 
 export async function getTypedActiveAppSnapshot(
-  options: { forceRefresh?: boolean } = {},
+  options: { forceRefresh?: boolean, includeIcon?: boolean } = {},
 ): Promise<ActiveAppSnapshot | null> {
   const channel = getSystemChannel()
   const forceRefresh = options.forceRefresh === true
-  return await getTypedActiveAppSnapshotWithChannel(channel, forceRefresh)
+  const includeIcon = options.includeIcon === true
+  return await getTypedActiveAppSnapshotWithChannel(channel, forceRefresh, includeIcon)
 }
 
 export async function getActiveAppSnapshot(
-  options: { forceRefresh?: boolean } = {},
+  options: { forceRefresh?: boolean, includeIcon?: boolean } = {},
 ): Promise<ActiveAppSnapshot | null> {
   return await getTypedActiveAppSnapshot(options)
 }

--- a/packages/utils/transport/events/types/app.ts
+++ b/packages/utils/transport/events/types/app.ts
@@ -218,6 +218,12 @@ export interface GetActiveAppRequest {
    * When true, bypasses runtime cache and forces a fresh system query.
    */
   forceRefresh?: boolean
+
+  /**
+   * When true, include the foreground app icon in the response.
+   * Defaults to false because icon resolution may touch native UI APIs.
+   */
+  includeIcon?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix Windows app PowerShell script joining so PSCustomObject blocks stay parseable.
- Restore Windows Store and UWP app discovery, including Codex search results.
- Repair Windows capability evidence scans for registry and Start Menu sources, and document the fix.

## Tests
- Targeted Vitest: win.test.ts and windows-capability-evidence.test.ts
- git diff --check
- windows-capability-verify --requireTargets --requireUwp --strict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Fixed Windows PowerShell app scanning and Start Menu/registry evidence detection
  * Added security denials for risky plugin module imports
  * Improved plugin error logging and handling throughout feature execution

* **Changes**
  * Active app API now excludes icons by default; use `includeIcon: true` to retrieve them

* **Performance**
  * Enhanced search index worker monitoring and WAL checkpoint scheduling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/talex-touch/tuff/pull/265)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->