### PR TITLE
fix(plugin): harden touch-intelligence runtime client

### DIFF
--- a/packages/test/src/plugins/intelligence.test.ts
+++ b/packages/test/src/plugins/intelligence.test.ts
@@ -71,6 +71,31 @@ describe('intelligence plugin', () => {
     expect(payload.messages[1]?.content).toBe('hello')
   })
 
+  it('loads the intelligence client through the plugin runtime require path', async () => {
+    const send = vi.fn(async () => ({
+      ok: true,
+      result: {
+        result: 'ok',
+      },
+    }))
+    const pluginWithChannel = loadPluginModule(
+      new URL('../../../../plugins/touch-intelligence/index.js', import.meta.url),
+      createPluginGlobals({
+        touchChannel: { send },
+      }),
+    )
+
+    const client = pluginWithChannel.__test.resolveIntelligenceClient()
+    const result = await client.invoke('text.chat', { messages: [] })
+
+    expect(result).toEqual({ result: 'ok' })
+    expect(send).toHaveBeenCalledWith('intelligence:api:invoke', {
+      capabilityId: 'text.chat',
+      payload: { messages: [] },
+      options: undefined,
+    })
+  })
+
   it('builds chat payload with OCR context', () => {
     const payload = intelligenceTest.buildInvokePayload('总结重点', [], {
       ocrText: '第一行\n第二行',

--- a/packages/tuff-intelligence/package.json
+++ b/packages/tuff-intelligence/package.json
@@ -22,6 +22,7 @@
     },
     "./client": {
       "types": "./src/client.ts",
+      "require": "./dist/client.cjs",
       "import": "./src/client.ts",
       "default": "./src/client.ts"
     },
@@ -44,7 +45,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --splitting --clean --target node18 --platform node",
+    "build": "tsup src/index.ts --format esm --dts --splitting --clean --target node18 --platform node && tsup src/client.ts --format cjs --target node18 --platform node",
     "dev": "tsup src/index.ts --format esm --dts --splitting --clean --target node18 --platform node --watch",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",

--- a/plugins/touch-intelligence/README.md
+++ b/plugins/touch-intelligence/README.md
@@ -1,0 +1,23 @@
+# Tuff Intelligence Ask
+
+Tuff Intelligence Ask provides a lightweight AI entry in CoreBox. It lets users ask questions, summarize copied content, and analyze clipboard images through the shared Tuff Intelligence capability layer.
+
+## Capabilities
+
+- Ask questions from CoreBox with `ai`, `@ai`, `/ai`, `智能`, or `问答`.
+- Reuse recent conversation context for follow-up questions.
+- Run OCR on clipboard images before sending the recognized text to `text.chat`.
+- Copy generated answers back to the clipboard after permission approval.
+- Bridge requests into a stable Tuff Intelligence handoff session for later continuation.
+
+## Permissions
+
+- `intelligence.basic`: invoke Tuff Intelligence text chat and OCR capabilities.
+- `clipboard.write`: copy AI answers to the clipboard.
+
+## Release Notes
+
+### 1.0.0
+
+- Initial Nexus release package for the CoreBox AI Ask plugin.
+- Supports text chat, clipboard image OCR, retry, copy answer, and handoff session metadata.

--- a/plugins/touch-intelligence/index.js
+++ b/plugins/touch-intelligence/index.js
@@ -1,4 +1,4 @@
-const { plugin, clipboard, logger, TuffItemBuilder, permission } = globalThis
+const { plugin, clipboard, logger, TuffItemBuilder, permission, touchChannel } = globalThis
 const crypto = require('node:crypto')
 
 const PLUGIN_NAME = 'touch-intelligence'
@@ -30,8 +30,8 @@ const AI_SYSTEM_PROMPT = '你是 Talex Touch 桌面助手里的智能助手，�
 const conversationSessions = new Map()
 
 function resolveIntelligenceClient() {
-  const { createIntelligenceClient } = require('@talex-touch/tuff-intelligence')
-  return createIntelligenceClient()
+  const { createIntelligenceClient } = require('@talex-touch/tuff-intelligence/client')
+  return createIntelligenceClient(touchChannel)
 }
 
 function normalizeText(value) {
@@ -1015,5 +1015,6 @@ module.exports = {
     normalizeInvokeError,
     normalizeLatency,
     normalizePrompt,
+    resolveIntelligenceClient,
   },
 }

--- a/plugins/touch-intelligence/manifest.json
+++ b/plugins/touch-intelligence/manifest.json
@@ -1,16 +1,26 @@
 {
   "id": "com.tuffex.intelligence",
   "name": "touch-intelligence",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "TalexTouch Team",
   "sdkapi": 260428,
-  "category": "utilities",
+  "category": "ai",
   "icon": {
     "type": "file",
     "value": "assets/logo.svg"
   },
   "description": "智能问答：在 CoreBox 里直接提问并复制回答",
   "main": "index.js",
+  "build": {
+    "index": {
+      "entry": "index.js",
+      "format": "cjs",
+      "target": "node18",
+      "external": ["electron"],
+      "minify": true,
+      "sourcemap": false
+    }
+  },
   "permissions": {
     "required": ["intelligence.basic"],
     "optional": ["clipboard.write"]


### PR DESCRIPTION
## Summary
- switch the touch-intelligence plugin runtime to the packaged @talex-touch/tuff-intelligence/client entry
- pass the host-injected touchChannel into the intelligence client
- add plugin package metadata, README, manifest build config, and a runtime require-path regression test

## Verification
- corepack pnpm -C "packages/tuff-intelligence" run build
- corepack pnpm -C "packages/test" exec vitest run "src/plugins/intelligence.test.ts"
- node "scripts/validate-plugins.mjs"
- git diff --cached --check