### PR TITLE
feat(widget): add beta TouchWidget Arrow and WebComponent runtimes

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -56,6 +56,7 @@
     "windows:acceptance:verify": "pnpm exec tsx \"scripts/windows-acceptance-verify.ts\""
   },
   "dependencies": {
+    "@arrow-js/core": "1.0.6",
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@fingerprintjs/fingerprintjs": "^4.6.2",

--- a/apps/core-app/src/main/modules/plugin/widget/processors/script-processor.ts
+++ b/apps/core-app/src/main/modules/plugin/widget/processors/script-processor.ts
@@ -145,6 +145,7 @@ module.exports = __component
 
       return {
         code: wrappedCode,
+        runtime: source.runtime,
         styles: '',
         dependencies: validation.allowedImports
       }

--- a/apps/core-app/src/main/modules/plugin/widget/processors/tsx-processor.ts
+++ b/apps/core-app/src/main/modules/plugin/widget/processors/tsx-processor.ts
@@ -140,6 +140,7 @@ module.exports = __component
 
       return {
         code: wrappedCode,
+        runtime: source.runtime,
         styles: '', // TSX doesn't have embedded styles like Vue SFC
         dependencies: validation.allowedImports
       }

--- a/apps/core-app/src/main/modules/plugin/widget/processors/vue-processor.ts
+++ b/apps/core-app/src/main/modules/plugin/widget/processors/vue-processor.ts
@@ -199,6 +199,7 @@ module.exports = __component
 
       return {
         code: transformed.code,
+        runtime: source.runtime,
         styles,
         dependencies: ensureVueDependency(validation.allowedImports)
       }

--- a/apps/core-app/src/main/modules/plugin/widget/processors/widget-transform-helper.test.ts
+++ b/apps/core-app/src/main/modules/plugin/widget/processors/widget-transform-helper.test.ts
@@ -39,6 +39,7 @@ function createSource(filePath: string, source: string): WidgetSource {
     hash: 'hash',
     loadedAt: Date.now(),
     pluginName: 'test-plugin',
+    runtime: filePath.includes('.arrow.') ? 'arrow' : 'vue',
     source,
     widgetId: 'test-plugin::test.widget'
   }
@@ -65,6 +66,23 @@ describe('widget processors transform helper contract', () => {
         target: 'node18'
       })
     )
+  })
+
+  it('allows ArrowJS core imports for beta TouchWidget runtime', async () => {
+    const processor = new WidgetScriptProcessor()
+
+    const compiled = await processor.compile(
+      createSource(
+        '/plugin/widgets/panel.arrow.ts',
+        'import { html } from "@arrow-js/core"; export default () => html`<div />`'
+      ),
+      createContext()
+    )
+
+    expect(compiled).toMatchObject({
+      dependencies: ['@arrow-js/core'],
+      runtime: 'arrow'
+    })
   })
 
   it('keeps precompiled cjs widgets out of esbuild', async () => {

--- a/apps/core-app/src/main/modules/plugin/widget/widget-compiler.ts
+++ b/apps/core-app/src/main/modules/plugin/widget/widget-compiler.ts
@@ -12,6 +12,11 @@ widgetProcessorRegistry.register(new WidgetVueProcessor())
 widgetProcessorRegistry.register(new WidgetTsxProcessor())
 widgetProcessorRegistry.register(new WidgetScriptProcessor())
 
+function resolveWidgetSourceExtension(filePath: string): string {
+  const normalized = filePath.split('?')[0]?.split('#')[0] ?? filePath
+  return path.extname(normalized)
+}
+
 /**
  * Compile widget source using the processor registry
  * 使用处理器注册表编译 widget 源码
@@ -23,7 +28,7 @@ export async function compileWidgetSource(
   source: WidgetSource,
   context: WidgetCompilationContext
 ): Promise<CompiledWidget | null> {
-  const ext = path.extname(source.filePath)
+  const ext = resolveWidgetSourceExtension(source.filePath)
 
   const processor = widgetProcessorRegistry.getProcessor(ext)
 

--- a/apps/core-app/src/main/modules/plugin/widget/widget-loader.ts
+++ b/apps/core-app/src/main/modules/plugin/widget/widget-loader.ts
@@ -1,7 +1,8 @@
 import type { IPluginFeature, ITouchPlugin } from '@talex-touch/utils/plugin'
+import type { WidgetRuntime } from '@talex-touch/utils/plugin/widget'
 import crypto from 'node:crypto'
 import path from 'node:path'
-import { makeWidgetId } from '@talex-touch/utils/plugin/widget'
+import { makeWidgetId, resolveWidgetRuntime } from '@talex-touch/utils/plugin/widget'
 import fse from 'fs-extra'
 import { getNetworkService } from '../../network'
 import { pushWidgetFeatureIssue } from './widget-issue'
@@ -10,6 +11,7 @@ export interface WidgetSource {
   widgetId: string
   pluginName: string
   featureId: string
+  runtime: WidgetRuntime
   source: string
   filePath: string
   hash: string
@@ -17,6 +19,7 @@ export interface WidgetSource {
 }
 
 const WIDGET_ROOT = 'widgets'
+const ARROW_WIDGET_SOURCE_PATTERN = /\.arrow\.(ts|js)$/i
 
 export function resolveWidgetFilePath(pluginPath: string, rawPath: string): string | null {
   const widgetsDir = path.resolve(pluginPath, WIDGET_ROOT)
@@ -33,6 +36,14 @@ export function resolveWidgetFilePath(pluginPath: string, rawPath: string): stri
   }
 
   return path.extname(candidate) ? candidate : `${candidate}.vue`
+}
+
+export function resolveWidgetRuntimeFromFeature(feature: IPluginFeature): WidgetRuntime {
+  const declared = resolveWidgetRuntime(feature.interaction?.runtime)
+  if (declared !== 'vue') {
+    return declared
+  }
+  return ARROW_WIDGET_SOURCE_PATTERN.test(feature.interaction?.path ?? '') ? 'arrow' : 'vue'
 }
 
 export class WidgetLoader {
@@ -94,6 +105,7 @@ export class WidgetLoader {
         widgetId,
         pluginName: plugin.name,
         featureId: feature.id,
+        runtime: resolveWidgetRuntimeFromFeature(feature),
         source,
         filePath: widgetFile,
         hash,
@@ -163,6 +175,7 @@ export class WidgetLoader {
         widgetId,
         pluginName: plugin.name,
         featureId: feature.id,
+        runtime: resolveWidgetRuntimeFromFeature(feature),
         source,
         filePath: widgetUrl,
         hash,

--- a/apps/core-app/src/main/modules/plugin/widget/widget-manager.test.ts
+++ b/apps/core-app/src/main/modules/plugin/widget/widget-manager.test.ts
@@ -59,6 +59,11 @@ vi.mock('./widget-loader', () => ({
   pluginWidgetLoader: {
     loadWidget: mocks.loadWidget
   },
+  resolveWidgetRuntimeFromFeature: vi.fn((feature: IPluginFeature) => {
+    const runtime = feature.interaction?.runtime
+    if (runtime === 'arrow' || runtime === 'webcomponent') return runtime
+    return feature.interaction?.path?.includes('.arrow.') ? 'arrow' : 'vue'
+  }),
   resolveWidgetFilePath: vi.fn((pluginPath: string, rawPath: string) => {
     const normalized = rawPath.replace(/\\/g, '/')
     const resolvedPath = `${pluginPath}/widgets/${normalized}`
@@ -104,6 +109,7 @@ function createSource(): WidgetSource {
     hash: 'same-source-hash',
     loadedAt: Date.now(),
     pluginName: 'test-plugin',
+    runtime: 'vue',
     source: 'export default {}',
     widgetId: 'test-plugin::test.widget'
   }
@@ -133,6 +139,8 @@ describe('WidgetManager failure cache', () => {
       featureId: 'test.widget',
       hash: 'same-source-hash',
       pluginName: 'test-plugin',
+      runtime: 'vue',
+      runtimeStage: 'stable',
       widgetId: 'test-plugin::test.widget'
     })
     expect(plugin.issues).toHaveLength(1)
@@ -202,7 +210,79 @@ describe('WidgetManager precompiled widgets', () => {
           dependencies: ['vue'],
           featureId: 'test.widget',
           hash: 'same-source-hash',
+          runtime: 'vue',
+          runtimeStage: 'stable',
           styles: '.panel{}',
+          widgetId: 'test-plugin::test.widget'
+        })
+      )
+    } finally {
+      await fs.remove(root)
+    }
+  })
+
+  it('preserves beta arrow runtime from precompiled metadata', async () => {
+    const root = await createPackagedPluginRoot()
+    try {
+      const manager = new WidgetManager()
+      const plugin = {
+        ...createPlugin(),
+        dev: { enable: false, address: '', source: false },
+        pluginPath: root,
+        build: {
+          widgets: [
+            {
+              compiledAt: Date.now(),
+              compiledPath: 'widgets/.compiled/test-plugin__test.widget.cjs',
+              dependencies: ['@arrow-js/core'],
+              featureId: 'test.widget',
+              hash: 'same-source-hash',
+              metaPath: 'widgets/.compiled/test-plugin__test.widget.meta.json',
+              runtime: 'arrow',
+              runtimeStage: 'beta',
+              sourcePath: 'widgets/panel.arrow.ts',
+              styles: '.panel{}',
+              widgetId: 'test-plugin::test.widget'
+            }
+          ]
+        }
+      } as ITouchPlugin
+      const feature = {
+        ...createFeature(),
+        interaction: {
+          path: 'panel.arrow.ts',
+          runtime: 'arrow',
+          type: 'widget'
+        }
+      } as IPluginFeature
+      const compiledPath = path.join(root, 'widgets', '.compiled', 'test-plugin__test.widget.cjs')
+      const metaPath = path.join(root, 'widgets', '.compiled', 'test-plugin__test.widget.meta.json')
+
+      await fs.ensureDir(path.dirname(compiledPath))
+      await fs.writeFile(compiledPath, 'module.exports = {}', 'utf-8')
+      await fs.writeJson(metaPath, {
+        compiledAt: Date.now(),
+        compiledPath: 'widgets/.compiled/test-plugin__test.widget.cjs',
+        dependencies: ['@arrow-js/core'],
+        featureId: 'test.widget',
+        hash: 'same-source-hash',
+        runtime: 'arrow',
+        runtimeStage: 'beta',
+        sourcePath: 'widgets/panel.arrow.ts',
+        styles: '.panel{}',
+        widgetId: 'test-plugin::test.widget'
+      })
+
+      await manager.registerWidget(plugin, feature)
+
+      expect(mocks.compileWidgetSource).not.toHaveBeenCalled()
+      expect(mocks.broadcastToWindow).toHaveBeenCalledWith(
+        11,
+        expect.anything(),
+        expect.objectContaining({
+          dependencies: ['@arrow-js/core'],
+          runtime: 'arrow',
+          runtimeStage: 'beta',
           widgetId: 'test-plugin::test.widget'
         })
       )
@@ -227,6 +307,32 @@ describe('WidgetManager precompiled widgets', () => {
       code: 'WIDGET_PRECOMPILED_MISSING',
       featureId: 'test.widget',
       pluginName: 'test-plugin',
+      widgetId: 'test-plugin::test.widget'
+    })
+  })
+
+  it('marks .arrow source-path fallback failures as beta arrow runtime', async () => {
+    const manager = new WidgetManager()
+    const plugin = {
+      ...createPlugin(),
+      dev: { enable: false, address: '', source: false }
+    } as ITouchPlugin
+    const feature = {
+      ...createFeature(),
+      interaction: {
+        path: 'panel.arrow.ts',
+        type: 'widget'
+      }
+    } as IPluginFeature
+
+    await manager.registerWidget(plugin, feature)
+
+    expect(mocks.loadWidget).not.toHaveBeenCalled()
+    expect(mocks.compileWidgetSource).not.toHaveBeenCalled()
+    expect(mocks.broadcastToWindow.mock.calls[0]?.[2]).toMatchObject({
+      code: 'WIDGET_PRECOMPILED_MISSING',
+      runtime: 'arrow',
+      runtimeStage: 'beta',
       widgetId: 'test-plugin::test.widget'
     })
   })
@@ -329,6 +435,8 @@ describe('WidgetManager precompiled widgets', () => {
           dependencies: ['vue'],
           featureId: 'test.widget',
           hash: 'cache-hash',
+          runtime: 'vue',
+          runtimeStage: 'stable',
           styles: '.cached{}',
           widgetId: 'test-plugin::test.widget'
         })

--- a/apps/core-app/src/main/modules/plugin/widget/widget-manager.ts
+++ b/apps/core-app/src/main/modules/plugin/widget/widget-manager.ts
@@ -3,11 +3,18 @@ import type {
   WidgetPrecompiledManifestEntry,
   WidgetPrecompiledMeta,
   WidgetFailurePayload,
-  WidgetRegistrationPayload
+  WidgetRegistrationPayload,
+  WidgetRuntime,
+  WidgetRuntimeStage
 } from '@talex-touch/utils/plugin/widget'
 import type { FSWatcher } from 'chokidar'
 import type { WidgetCompilationContext } from './widget-processor'
-import { WIDGET_RUNTIME_COMPILE_ENV, makeWidgetId } from '@talex-touch/utils/plugin/widget'
+import {
+  WIDGET_RUNTIME_COMPILE_ENV,
+  makeWidgetId,
+  resolveWidgetRuntime,
+  resolveWidgetRuntimeStage
+} from '@talex-touch/utils/plugin/widget'
 import { getTuffTransportMain } from '@talex-touch/utils/transport/main'
 import { PluginEvents } from '@talex-touch/utils/transport/events'
 import crypto from 'node:crypto'
@@ -19,7 +26,11 @@ import { getRegisteredMainRuntime } from '../../../core/runtime-accessor'
 import { getCoreBoxWindow } from '../../box-tool/core-box/window'
 import { compileWidgetSource } from './widget-compiler'
 import { pushWidgetFeatureIssue } from './widget-issue'
-import { pluginWidgetLoader, resolveWidgetFilePath } from './widget-loader'
+import {
+  pluginWidgetLoader,
+  resolveWidgetFilePath,
+  resolveWidgetRuntimeFromFeature
+} from './widget-loader'
 import { classifyWidgetCompileError, resolveWidgetCompileCauseCode } from './widget-transform'
 
 type WidgetEvent = 'register' | 'update'
@@ -29,6 +40,8 @@ const WIDGET_FAILURE_CACHE_TTL_MS = 30_000
 type WidgetCompiledMeta = {
   hash: string
   styles: string
+  runtime?: WidgetRuntime
+  runtimeStage?: WidgetRuntimeStage
   dependencies?: string[]
   filePath?: string
   compiledAt?: number
@@ -44,6 +57,8 @@ type WidgetSourceHint = {
 type WidgetCompiledCache = {
   code: string
   styles: string
+  runtime?: WidgetRuntime
+  runtimeStage?: WidgetRuntimeStage
   dependencies: string[]
   filePath: string
   hash: string
@@ -57,6 +72,8 @@ type WidgetPrecompiledLoadFailure = {
   code: string
   message: string
   fromManifestEntry: boolean
+  runtime?: WidgetRuntime
+  runtimeStage?: WidgetRuntimeStage
   filePath?: string | null
   hash?: string
   cause?: string
@@ -65,6 +82,10 @@ type WidgetPrecompiledLoadFailure = {
 type WidgetCompileFailureCache = {
   expiresAt: number
   payload: WidgetFailurePayload
+}
+
+function resolveFeatureWidgetRuntime(feature: IPluginFeature): WidgetRuntime {
+  return resolveWidgetRuntimeFromFeature(feature)
 }
 
 function resolveWidgetCompiledOutputPath(plugin: ITouchPlugin, widgetId: string): string | null {
@@ -133,6 +154,7 @@ async function loadPrecompiledWidget(
   cache: WidgetPrecompiledCache | null
   failure?: WidgetPrecompiledLoadFailure
 }> {
+  const featureRuntime = resolveFeatureWidgetRuntime(feature)
   const entry = findPrecompiledWidgetEntry(plugin, feature, widgetId)
   if (!entry) {
     return {
@@ -140,10 +162,14 @@ async function loadPrecompiledWidget(
       failure: {
         code: 'WIDGET_PRECOMPILED_MISSING',
         message: `Precompiled widget is missing for feature "${feature.id}". Rebuild the plugin with the latest tuff builder.`,
-        fromManifestEntry: false
+        fromManifestEntry: false,
+        runtime: featureRuntime,
+        runtimeStage: resolveWidgetRuntimeStage(featureRuntime)
       }
     }
   }
+  const entryRuntime = resolveWidgetRuntime(entry.runtime ?? featureRuntime)
+  const entryRuntimeStage = entry.runtimeStage ?? resolveWidgetRuntimeStage(entryRuntime)
 
   const compiledPath = resolvePackagedWidgetPackagePath(plugin, entry.compiledPath)
   if (!compiledPath) {
@@ -153,6 +179,8 @@ async function loadPrecompiledWidget(
         code: 'WIDGET_PRECOMPILED_MISSING',
         message: `Precompiled widget path is invalid or outside plugin package: ${entry.compiledPath}`,
         fromManifestEntry: true,
+        runtime: entryRuntime,
+        runtimeStage: entryRuntimeStage,
         filePath: entry.compiledPath,
         hash: entry.hash
       }
@@ -166,6 +194,8 @@ async function loadPrecompiledWidget(
         code: 'WIDGET_PRECOMPILED_MISSING',
         message: `Precompiled widget output does not exist: ${entry.compiledPath}`,
         fromManifestEntry: true,
+        runtime: entryRuntime,
+        runtimeStage: entryRuntimeStage,
         filePath: compiledPath,
         hash: entry.hash
       }
@@ -184,6 +214,8 @@ async function loadPrecompiledWidget(
             code: 'WIDGET_PRECOMPILED_STALE',
             message: `Precompiled widget is stale for feature "${feature.id}". Rebuild the plugin package.`,
             fromManifestEntry: true,
+            runtime: entryRuntime,
+            runtimeStage: entryRuntimeStage,
             filePath: compiledPath,
             hash: entry.hash,
             cause: sourceHash
@@ -214,6 +246,8 @@ async function loadPrecompiledWidget(
           code: 'WIDGET_PRECOMPILED_MISSING',
           message: `Precompiled widget meta path is invalid or outside plugin package: ${entry.metaPath}`,
           fromManifestEntry: true,
+          runtime: entryRuntime,
+          runtimeStage: entryRuntimeStage,
           filePath: entry.metaPath,
           hash: entry.hash
         }
@@ -232,10 +266,13 @@ async function loadPrecompiledWidget(
   }
 
   const code = await fse.readFile(compiledPath, 'utf-8')
+  const runtime = resolveWidgetRuntime(meta?.runtime ?? entry.runtime ?? featureRuntime)
   return {
     cache: {
       code,
       styles: typeof meta?.styles === 'string' ? meta.styles : entry.styles,
+      runtime,
+      runtimeStage: meta?.runtimeStage ?? entry.runtimeStage ?? resolveWidgetRuntimeStage(runtime),
       dependencies: Array.isArray(meta?.dependencies)
         ? meta.dependencies
         : Array.isArray(entry.dependencies)
@@ -328,6 +365,9 @@ async function loadCompiledWidgetCache(
     return {
       code,
       styles,
+      runtime: resolveWidgetRuntime(meta.runtime),
+      runtimeStage:
+        meta.runtimeStage ?? resolveWidgetRuntimeStage(resolveWidgetRuntime(meta.runtime)),
       dependencies,
       filePath: meta.filePath,
       hash: meta.hash
@@ -386,6 +426,10 @@ export class WidgetManager {
       pluginName: plugin.name,
       featureId: feature.id,
       filePath: compiledCache.filePath,
+      runtime: compiledCache.runtime ?? resolveFeatureWidgetRuntime(feature),
+      runtimeStage:
+        compiledCache.runtimeStage ??
+        resolveWidgetRuntimeStage(compiledCache.runtime ?? resolveFeatureWidgetRuntime(feature)),
       hash: compiledCache.hash,
       code: compiledCache.code,
       styles: compiledCache.styles,
@@ -542,6 +586,10 @@ export class WidgetManager {
         pluginName: source.pluginName,
         featureId: source.featureId,
         filePath: compiledCache.filePath,
+        runtime: compiledCache.runtime ?? source.runtime,
+        runtimeStage:
+          compiledCache.runtimeStage ??
+          resolveWidgetRuntimeStage(compiledCache.runtime ?? source.runtime),
         hash: compiledCache.hash,
         code: compiledCache.code,
         styles: compiledCache.styles,
@@ -685,6 +733,8 @@ export class WidgetManager {
           const meta: WidgetCompiledMeta = {
             hash: source.hash,
             styles: compiled.styles,
+            runtime: compiled.runtime ?? source.runtime,
+            runtimeStage: resolveWidgetRuntimeStage(compiled.runtime ?? source.runtime),
             dependencies: compiled.dependencies || [],
             filePath: source.filePath,
             compiledAt: Date.now(),
@@ -705,6 +755,8 @@ export class WidgetManager {
       pluginName: source.pluginName,
       featureId: source.featureId,
       filePath: source.filePath,
+      runtime: compiled.runtime ?? source.runtime,
+      runtimeStage: resolveWidgetRuntimeStage(compiled.runtime ?? source.runtime),
       hash: source.hash,
       code: compiled.code,
       styles: compiled.styles,
@@ -829,6 +881,8 @@ export class WidgetManager {
       widgetId: failure.widgetId,
       pluginName: plugin.name,
       featureId: feature.id,
+      runtime: resolveFeatureWidgetRuntime(feature),
+      runtimeStage: resolveWidgetRuntimeStage(resolveFeatureWidgetRuntime(feature)),
       code: failure.code,
       message: failure.message,
       filePath: failure.filePath ?? undefined,
@@ -871,6 +925,8 @@ export class WidgetManager {
         pluginName: failure.pluginName,
         featureId: failure.featureId,
         widgetId: failure.widgetId,
+        runtime: failure.runtime,
+        runtimeStage: failure.runtimeStage,
         filePath: failure.filePath,
         hash: failure.hash,
         causeCode: failure.cause

--- a/apps/core-app/src/main/modules/plugin/widget/widget-processor.ts
+++ b/apps/core-app/src/main/modules/plugin/widget/widget-processor.ts
@@ -1,4 +1,5 @@
 import type { IPluginFeature, ITouchPlugin } from '@talex-touch/utils/plugin'
+import type { WidgetRuntime } from '@talex-touch/utils/plugin/widget'
 import type { WidgetSource } from './widget-loader'
 
 /**
@@ -8,6 +9,8 @@ import type { WidgetSource } from './widget-loader'
 export interface CompiledWidget {
   /** Compiled JavaScript code | 编译后的 JavaScript 代码 */
   code: string
+  /** Widget runtime | Widget 运行时 */
+  runtime?: WidgetRuntime
   /** Extracted CSS styles | 提取的 CSS 样式 */
   styles: string
   /** List of allowed dependencies | 允许的依赖列表 */

--- a/apps/core-app/src/renderer/src/components/render/CoreBoxRender.vue
+++ b/apps/core-app/src/renderer/src/components/render/CoreBoxRender.vue
@@ -32,7 +32,7 @@ const quickKey = computed(() => {
 const customRendererId = computed(() => {
   if (render.value?.mode !== 'custom') return null
   const custom = render.value?.custom
-  if (!custom || custom.type !== 'vue') return null
+  if (!custom || !['vue', 'webcomponent', 'arrow'].includes(custom.type)) return null
   return custom.content
 })
 

--- a/apps/core-app/src/renderer/src/modules/plugin/widget-registry.test.ts
+++ b/apps/core-app/src/renderer/src/modules/plugin/widget-registry.test.ts
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+import type { Component } from 'vue'
+import { createApp, h, nextTick, ref } from 'vue'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const transportState = vi.hoisted(() => ({
+  handlers: new Map<string, Function>(),
+  renderers: new Map<string, Component>(),
+  secureValues: new Map<string, string | null>()
+}))
+let handleWidgetRegister: typeof import('./widget-registry').handleWidgetRegister
+
+vi.mock('@talex-touch/utils/transport', () => ({
+  useTuffTransport: () => ({
+    on: (event: string, handler: Function) => {
+      transportState.handlers.set(event, handler)
+      return () => transportState.handlers.delete(event)
+    },
+    send: vi.fn(async (event: string, payload: { key?: string; value?: string | null }) => {
+      if (event === 'app:system:get-secure-value') {
+        return payload.key ? transportState.secureValues.get(payload.key) : null
+      }
+      if (event === 'app:system:set-secure-value' && payload.key) {
+        transportState.secureValues.set(payload.key, payload.value ?? null)
+      }
+      return null
+    })
+  })
+}))
+
+vi.mock('../box/custom-render', () => ({
+  registerCustomRenderer: (name: string, component: Component) => {
+    transportState.renderers.set(name, component)
+  },
+  unregisterCustomRenderer: (name: string) => {
+    transportState.renderers.delete(name)
+  }
+}))
+
+vi.mock('../../utils/dev-log', () => ({
+  devLog: vi.fn()
+}))
+
+vi.mock('../../utils/renderer-log', () => ({
+  createRendererLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn()
+  })
+}))
+
+function makePayload(runtime: 'vue' | 'webcomponent' | 'arrow', code: string) {
+  return {
+    code,
+    dependencies: runtime === 'arrow' ? ['@arrow-js/core'] : runtime === 'vue' ? ['vue'] : [],
+    featureId: `${runtime}.feature`,
+    filePath: `/plugin/widgets/${runtime}.js`,
+    hash: `${runtime}-hash`,
+    pluginName: 'test-plugin',
+    runtime,
+    runtimeStage: runtime === 'vue' ? 'stable' : 'beta',
+    styles: '',
+    widgetId: `test-plugin::${runtime}`
+  } as const
+}
+
+async function register(runtime: 'vue' | 'webcomponent' | 'arrow', code: string) {
+  const payload = makePayload(runtime, code)
+  await handleWidgetRegister(payload)
+  return payload
+}
+
+async function getRenderer(widgetId: string): Promise<Component> {
+  return transportState.renderers.get(widgetId) as Component
+}
+
+async function mountFactory(render: () => ReturnType<typeof h>) {
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  const app = createApp(() => render())
+  app.mount(root)
+  await nextTick()
+  return { app, root }
+}
+
+async function mountRenderer(component: Component, props: Record<string, unknown> = {}) {
+  return mountFactory(() => h(component, props))
+}
+
+describe('widget-registry runtime hosts', () => {
+  beforeAll(async () => {
+    ;({ handleWidgetRegister } = await import('./widget-registry'))
+  }, 10000)
+
+  beforeEach(() => {
+    transportState.handlers.clear()
+    transportState.renderers.clear()
+    transportState.secureValues.clear()
+    document.body.replaceChildren()
+    document.head.querySelectorAll('style[data-widget-id]').forEach((node) => node.remove())
+  })
+
+  afterEach(() => {
+    document.body.replaceChildren()
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('registers Vue widgets without changing the existing renderer path', async () => {
+    const payload = await register(
+      'vue',
+      [
+        'const { h } = require("vue")',
+        'module.exports = {',
+        '  name: "VueWidget",',
+        '  setup() {',
+        '    return () => h("strong", "Vue ok")',
+        '  }',
+        '}'
+      ].join('\n')
+    )
+
+    const renderer = await getRenderer(payload.widgetId)
+    expect(renderer).toBeDefined()
+    expect(renderer).toMatchObject({ name: 'VueWidget' })
+  })
+
+  it('passes host props to WebComponent widgets as DOM properties and cleans up on unmount', async () => {
+    const payload = await register(
+      'webcomponent',
+      [
+        'class DemoTouchWidget extends HTMLElement {',
+        '  set payload(value) { this._payload = value; this.textContent = value?.title || "" }',
+        '  get payload() { return this._payload }',
+        '}',
+        'module.exports = DemoTouchWidget'
+      ].join('\n')
+    )
+
+    const renderer = await getRenderer(payload.widgetId)
+    expect(renderer).toBeDefined()
+
+    const { root, app } = await mountRenderer(renderer, {
+      payload: { title: 'WebComponent ok' },
+      widgetId: payload.widgetId
+    })
+    const element = root.querySelector('tuff-widget-demo-touch-widget') as HTMLElement & {
+      payload?: { title: string }
+      widgetId?: string
+    }
+
+    expect(element).toBeTruthy()
+    expect(element.payload?.title).toBe('WebComponent ok')
+    expect(element.widgetId).toBe(payload.widgetId)
+    expect(root.textContent).toContain('WebComponent ok')
+
+    app.unmount()
+    expect(root.querySelector('tuff-widget-demo-touch-widget')).toBeNull()
+  })
+
+  it('mounts Arrow widgets, reacts to payload changes, and runs Arrow cleanup on unmount', async () => {
+    const cleanup = vi.fn()
+    vi.stubGlobal('__arrowWidgetCleanup', cleanup)
+    const payload = await register(
+      'arrow',
+      [
+        'const { component, html, onCleanup } = require("@arrow-js/core")',
+        'module.exports = component((props) => {',
+        '  onCleanup(() => window.__arrowWidgetCleanup())',
+        '  return html`<span>${() => props.payload?.title || "Arrow"}</span>`',
+        '})'
+      ].join('\n')
+    )
+
+    const renderer = await getRenderer(payload.widgetId)
+    expect(renderer).toBeDefined()
+
+    const title = ref('Arrow ok')
+    const { root, app } = await mountFactory(() =>
+      h(renderer, { payload: { title: title.value }, widgetId: payload.widgetId })
+    )
+
+    await nextTick()
+    expect(root.textContent).toContain('Arrow ok')
+    title.value = 'Arrow updated'
+    await nextTick()
+    await Promise.resolve()
+    expect(root.textContent).toContain('Arrow updated')
+
+    app.unmount()
+    await nextTick()
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/core-app/src/renderer/src/modules/plugin/widget-registry.ts
+++ b/apps/core-app/src/renderer/src/modules/plugin/widget-registry.ts
@@ -1,9 +1,11 @@
 import type {
   WidgetFailurePayload,
-  WidgetRegistrationPayload
+  WidgetRegistrationPayload,
+  WidgetRuntime
 } from '@talex-touch/utils/plugin/widget'
 import type { Component, ComponentPublicInstance, SetupContext } from 'vue'
-import { WIDGET_ALLOWED_PACKAGES } from '@talex-touch/utils/plugin/widget'
+import { WIDGET_ALLOWED_PACKAGES, WIDGET_RUNTIMES } from '@talex-touch/utils/plugin/widget'
+import * as ArrowCore from '@arrow-js/core'
 import * as TalexUtils from '@talex-touch/utils'
 import * as TalexUtilsCommon from '@talex-touch/utils/common'
 import * as TalexUtilsCoreBox from '@talex-touch/utils/core-box'
@@ -15,9 +17,9 @@ import { useTuffTransport } from '@talex-touch/utils/transport'
 import { AppEvents, PluginEvents } from '@talex-touch/utils/transport/events'
 import * as TalexUtilsTypes from '@talex-touch/utils/types'
 import * as Vue from 'vue'
-import { registerCustomRenderer, unregisterCustomRenderer } from '~/modules/box/custom-render'
-import { devLog } from '~/utils/dev-log'
-import { createRendererLogger } from '~/utils/renderer-log'
+import { registerCustomRenderer, unregisterCustomRenderer } from '../box/custom-render'
+import { devLog } from '../../utils/dev-log'
+import { createRendererLogger } from '../../utils/renderer-log'
 import {
   cacheWidgetRuntimeSource,
   clearWidgetFailure,
@@ -589,6 +591,7 @@ const ALLOWED_PACKAGES: readonly string[] = WIDGET_ALLOWED_PACKAGES
 
 // Pre-loaded module cache using ES imports
 const preloadedModuleCache: Record<string, unknown> = {
+  '@arrow-js/core': ArrowCore,
   vue: Vue,
   '@talex-touch/utils': TalexUtils,
   '@talex-touch/utils/plugin': TalexUtilsPlugin,
@@ -610,6 +613,29 @@ type WidgetComponent = {
 } & Record<string, unknown>
 
 type WidgetFunctionalComponent = (props: Record<string, unknown>, ctx: SetupContext) => unknown
+type WidgetHostProps = {
+  item?: unknown
+  payload?: unknown
+  preview?: boolean
+  widgetId?: string
+  hostKeyEvent?: unknown
+}
+type ArrowHostState = WidgetHostProps & {
+  mounted: boolean
+}
+type ArrowPrimitiveRenderable = string | number | boolean | null | undefined
+type ArrowTemplateLike = ((parent?: Node | DocumentFragment) => unknown) & { isT?: boolean }
+type ArrowComponentCallLike = {
+  h: (...args: unknown[]) => unknown
+  p?: unknown
+  e?: unknown
+  k?: unknown
+}
+type CustomElementDefinitionExport = {
+  tagName?: string
+  define?: () => void
+  element?: typeof HTMLElement
+}
 
 function isObjectLike(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
@@ -661,6 +687,44 @@ function normalizeWidgetExport(exported: unknown, renderExport?: unknown): unkno
     ...(target as Record<string, unknown>),
     render: renderExport
   })
+}
+
+function resolveComponentExport(moduleExports: unknown): {
+  defaultExport: unknown
+  renderExport: unknown
+  exported: unknown
+} {
+  const defaultExport =
+    isObjectLike(moduleExports) && 'default' in moduleExports
+      ? (moduleExports as { default?: unknown }).default
+      : undefined
+  const renderExport =
+    isObjectLike(moduleExports) && 'render' in moduleExports
+      ? (moduleExports as { render?: unknown }).render
+      : undefined
+
+  const hasSetup = (value: unknown): boolean =>
+    Boolean(value && (typeof value === 'object' || typeof value === 'function') && 'setup' in value)
+  const hasRender = (value: unknown): boolean =>
+    Boolean(
+      value && (typeof value === 'object' || typeof value === 'function') && 'render' in value
+    )
+
+  let exported =
+    (hasSetup(defaultExport) ? defaultExport : undefined) ??
+    (hasSetup(moduleExports) ? moduleExports : undefined) ??
+    (hasRender(defaultExport) ? defaultExport : undefined) ??
+    (hasRender(moduleExports) ? moduleExports : undefined) ??
+    defaultExport ??
+    moduleExports
+
+  exported = normalizeWidgetExport(exported, renderExport)
+  if (renderExport && exported && typeof exported === 'object' && !hasRender(exported)) {
+    const target = exported as { render?: unknown }
+    target.render = renderExport
+  }
+
+  return { defaultExport, renderExport, exported }
 }
 
 function copyEnumerableRenderContext(
@@ -831,6 +895,255 @@ function attachPluginInfoToComponent(
   return component
 }
 
+function syncHostElementProps(element: HTMLElement, props: WidgetHostProps): void {
+  Object.assign(element, {
+    item: props.item,
+    payload: props.payload,
+    preview: props.preview,
+    widgetId: props.widgetId,
+    hostKeyEvent: props.hostKeyEvent
+  })
+}
+
+function isHTMLElementConstructor(value: unknown): value is typeof HTMLElement {
+  return (
+    typeof value === 'function' &&
+    typeof HTMLElement !== 'undefined' &&
+    (value === HTMLElement || value.prototype instanceof HTMLElement)
+  )
+}
+
+function makeWebComponentTagName(name: string): string {
+  const normalized = name
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-z0-9]+/gi, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+  return `tuff-widget-${normalized || 'element'}`
+}
+
+function resolveWebComponentDefinition(exported: unknown): {
+  tagName: string
+  define?: () => void
+} {
+  if (typeof exported === 'string' && exported.includes('-')) {
+    return { tagName: exported }
+  }
+
+  if (isHTMLElementConstructor(exported)) {
+    const tagName = makeWebComponentTagName(exported.name)
+    return {
+      tagName,
+      define: () => {
+        if (!customElements.get(tagName)) {
+          customElements.define(tagName, exported)
+        }
+      }
+    }
+  }
+
+  if (isObjectLike(exported)) {
+    const definition = exported as CustomElementDefinitionExport
+    if (typeof definition.tagName === 'string' && definition.tagName.includes('-')) {
+      return {
+        tagName: definition.tagName,
+        define: definition.define
+      }
+    }
+    if (typeof definition.define === 'function') {
+      throw new Error('[WidgetRegistry] WebComponent widget define() requires a tagName')
+    }
+    if (isHTMLElementConstructor(definition.element)) {
+      const tagName = makeWebComponentTagName(definition.element.name)
+      return {
+        tagName,
+        define: () => {
+          if (!customElements.get(tagName)) {
+            customElements.define(tagName, definition.element!)
+          }
+        }
+      }
+    }
+  }
+
+  throw new Error(
+    '[WidgetRegistry] WebComponent widget must export a tag name, HTMLElement class, or { tagName, define }'
+  )
+}
+
+function createWebComponentHost(exported: unknown): Component {
+  const definition = resolveWebComponentDefinition(exported)
+  if (!customElements.get(definition.tagName) && !definition.define) {
+    throw new Error(
+      `[WidgetRegistry] WebComponent widget tag "${definition.tagName}" is not defined`
+    )
+  }
+  if (!customElements.get(definition.tagName)) {
+    definition.define?.()
+  }
+  if (!customElements.get(definition.tagName)) {
+    throw new Error(`[WidgetRegistry] WebComponent widget failed to define "${definition.tagName}"`)
+  }
+
+  return Vue.defineComponent({
+    name: 'TouchWidgetWebComponentHost',
+    props: ['item', 'payload', 'preview', 'widgetId', 'hostKeyEvent'],
+    setup(props) {
+      const host = Vue.ref<HTMLElement | null>(null)
+      let element: HTMLElement | null = null
+
+      const sync = () => {
+        if (!element) return
+        syncHostElementProps(element, props as WidgetHostProps)
+      }
+
+      Vue.onMounted(() => {
+        if (!host.value) return
+        element = document.createElement(definition.tagName)
+        element.dataset.widgetRuntime = WIDGET_RUNTIMES.WEBCOMPONENT
+        sync()
+        host.value.replaceChildren(element)
+      })
+
+      Vue.watch(
+        () => [props.item, props.payload, props.preview, props.widgetId, props.hostKeyEvent],
+        sync,
+        { deep: true }
+      )
+
+      Vue.onBeforeUnmount(() => {
+        element?.remove()
+        element = null
+      })
+
+      return () => Vue.h('div', { ref: host, class: 'TouchWidgetWebComponentHost' })
+    }
+  })
+}
+
+function isArrowTemplate(value: unknown): value is ArrowTemplateLike {
+  return typeof value === 'function' && (value as ArrowTemplateLike).isT === true
+}
+
+function isArrowComponentCall(value: unknown): value is ArrowComponentCallLike {
+  return Boolean(value && typeof value === 'object' && 'h' in value)
+}
+
+function isArrowPrimitiveRenderable(value: unknown): value is ArrowPrimitiveRenderable {
+  return (
+    value === null ||
+    value === undefined ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  )
+}
+
+function isArrowRenderable(value: unknown): boolean {
+  if (isArrowPrimitiveRenderable(value) || isArrowTemplate(value) || isArrowComponentCall(value)) {
+    return true
+  }
+  return Array.isArray(value) && value.every(isArrowRenderable)
+}
+
+function resolveArrowRenderable(exported: unknown, props: ArrowHostState): unknown {
+  if (isArrowTemplate(exported) || isArrowComponentCall(exported)) {
+    return exported
+  }
+  return (exported as (props: WidgetHostProps) => unknown)(props)
+}
+
+function createArrowHost(exported: unknown): Component {
+  if (
+    typeof exported !== 'function' &&
+    !isArrowTemplate(exported) &&
+    !isArrowComponentCall(exported)
+  ) {
+    throw new Error(
+      '[WidgetRegistry] Arrow widget must export an Arrow component or template factory'
+    )
+  }
+
+  return Vue.defineComponent({
+    name: 'TouchWidgetArrowHost',
+    props: ['item', 'payload', 'preview', 'widgetId', 'hostKeyEvent'],
+    setup(props) {
+      const host = Vue.ref<HTMLElement | null>(null)
+      let state: ArrowHostState | null = null
+
+      const syncState = () => {
+        if (!state) return
+        state.item = props.item
+        state.payload = props.payload
+        state.preview = props.preview
+        state.widgetId = props.widgetId
+        state.hostKeyEvent = props.hostKeyEvent
+      }
+
+      const mountArrow = () => {
+        if (!host.value) return
+        state = ArrowCore.reactive({
+          mounted: true,
+          item: props.item,
+          payload: props.payload,
+          preview: props.preview,
+          widgetId: props.widgetId,
+          hostKeyEvent: props.hostKeyEvent
+        }) as ArrowHostState
+
+        const root = ArrowCore.html`${() => {
+          if (!state?.mounted) {
+            return ''
+          }
+          const renderable = resolveArrowRenderable(exported, state)
+          if (isArrowRenderable(renderable)) {
+            return renderable
+          }
+          throw new Error(
+            '[WidgetRegistry] Arrow widget render did not return an Arrow template or component'
+          )
+        }}`
+
+        host.value.replaceChildren()
+        root(host.value)
+      }
+
+      const unmountArrow = () => {
+        const target = host.value
+        if (!state) {
+          target?.replaceChildren()
+          return
+        }
+        state.mounted = false
+        state = null
+        void ArrowCore.nextTick(() => {
+          target?.replaceChildren()
+        })
+      }
+
+      Vue.onMounted(mountArrow)
+      Vue.watch(
+        () => [props.item, props.payload, props.preview, props.widgetId, props.hostKeyEvent],
+        syncState,
+        { deep: true }
+      )
+      Vue.onBeforeUnmount(unmountArrow)
+
+      return () => Vue.h('div', { ref: host, class: 'TouchWidgetArrowHost' })
+    }
+  })
+}
+
+function resolveWidgetComponent(exported: unknown, runtime?: WidgetRuntime): Component {
+  if (runtime === WIDGET_RUNTIMES.WEBCOMPONENT) {
+    return createWebComponentHost(exported)
+  }
+  if (runtime === WIDGET_RUNTIMES.ARROW) {
+    return createArrowHost(exported)
+  }
+  return exported as Component
+}
+
 /**
  * Create a sandboxed require function for widgets
  * 为 widget 创建沙箱化的 require 函数
@@ -881,7 +1194,7 @@ function evaluateWidgetComponent(
   dependencies: string[] = [],
   debugLabel?: string,
   sandbox?: WidgetSandboxContext
-): Component {
+): unknown {
   if (!sandbox) {
     throw new Error('[WidgetRegistry] Widget sandbox is required to evaluate component')
   }
@@ -934,35 +1247,7 @@ function evaluateWidgetComponent(
   }
 
   const moduleExports = module.exports
-  const defaultExport =
-    isObjectLike(moduleExports) && 'default' in moduleExports
-      ? (moduleExports as { default?: unknown }).default
-      : undefined
-  const renderExport =
-    isObjectLike(moduleExports) && 'render' in moduleExports
-      ? (moduleExports as { render?: unknown }).render
-      : undefined
-
-  const hasSetup = (value: unknown): boolean =>
-    Boolean(value && (typeof value === 'object' || typeof value === 'function') && 'setup' in value)
-  const hasRender = (value: unknown): boolean =>
-    Boolean(
-      value && (typeof value === 'object' || typeof value === 'function') && 'render' in value
-    )
-
-  let exported =
-    (hasSetup(defaultExport) ? defaultExport : undefined) ??
-    (hasSetup(moduleExports) ? moduleExports : undefined) ??
-    (hasRender(defaultExport) ? defaultExport : undefined) ??
-    (hasRender(moduleExports) ? moduleExports : undefined) ??
-    defaultExport ??
-    moduleExports
-
-  exported = normalizeWidgetExport(exported, renderExport)
-  if (renderExport && exported && typeof exported === 'object' && !hasRender(exported)) {
-    const target = exported as { render?: unknown }
-    target.render = renderExport
-  }
+  const { defaultExport, renderExport, exported } = resolveComponentExport(moduleExports)
 
   if (isDev) {
     devLog('[WidgetRegistry] export resolution', {
@@ -978,7 +1263,7 @@ function evaluateWidgetComponent(
     throw new Error('Widget component did not export a value')
   }
 
-  return exported as Component
+  return exported
 }
 
 function injectStyles(widgetId: string, styles: string): void {
@@ -997,7 +1282,7 @@ function injectStyles(widgetId: string, styles: string): void {
   injectedStyles.set(widgetId, style)
 }
 
-async function handleWidgetRegister(payload: WidgetRegistrationPayload): Promise<void> {
+export async function handleWidgetRegister(payload: WidgetRegistrationPayload): Promise<void> {
   try {
     clearWidgetFailure(payload.widgetId)
     if (isDev) {
@@ -1015,10 +1300,20 @@ async function handleWidgetRegister(payload: WidgetRegistrationPayload): Promise
       }
     }
     const sandbox = await createWidgetSandbox(payload.pluginName, payload.widgetId)
-    const component = attachPluginInfoToComponent(
-      evaluateWidgetComponent(payload.code, payload.dependencies || [], payload.widgetId, sandbox),
-      { name: payload.pluginName, featureId: payload.featureId }
+    const exported = evaluateWidgetComponent(
+      payload.code,
+      payload.dependencies || [],
+      payload.widgetId,
+      sandbox
     )
+    const runtimeComponent = resolveWidgetComponent(exported, payload.runtime)
+    const component =
+      payload.runtime === WIDGET_RUNTIMES.VUE || !payload.runtime
+        ? attachPluginInfoToComponent(runtimeComponent, {
+            name: payload.pluginName,
+            featureId: payload.featureId
+          })
+        : runtimeComponent
     registerCustomRenderer(payload.widgetId, component)
     injectStyles(payload.widgetId, payload.styles)
     if (isDev) {
@@ -1034,7 +1329,7 @@ async function handleWidgetRegister(payload: WidgetRegistrationPayload): Promise
   }
 }
 
-async function handleWidgetUpdate(payload: WidgetRegistrationPayload): Promise<void> {
+export async function handleWidgetUpdate(payload: WidgetRegistrationPayload): Promise<void> {
   try {
     clearWidgetFailure(payload.widgetId)
     if (isDev) {
@@ -1052,10 +1347,20 @@ async function handleWidgetUpdate(payload: WidgetRegistrationPayload): Promise<v
       }
     }
     const sandbox = await createWidgetSandbox(payload.pluginName, payload.widgetId)
-    const component = attachPluginInfoToComponent(
-      evaluateWidgetComponent(payload.code, payload.dependencies || [], payload.widgetId, sandbox),
-      { name: payload.pluginName, featureId: payload.featureId }
+    const exported = evaluateWidgetComponent(
+      payload.code,
+      payload.dependencies || [],
+      payload.widgetId,
+      sandbox
     )
+    const runtimeComponent = resolveWidgetComponent(exported, payload.runtime)
+    const component =
+      payload.runtime === WIDGET_RUNTIMES.VUE || !payload.runtime
+        ? attachPluginInfoToComponent(runtimeComponent, {
+            name: payload.pluginName,
+            featureId: payload.featureId
+          })
+        : runtimeComponent
     registerCustomRenderer(payload.widgetId, component)
     injectStyles(payload.widgetId, payload.styles)
     if (isDev) {
@@ -1071,7 +1376,7 @@ async function handleWidgetUpdate(payload: WidgetRegistrationPayload): Promise<v
   }
 }
 
-function handleWidgetUnregister({ widgetId }: { widgetId: string }): void {
+export function handleWidgetUnregister({ widgetId }: { widgetId: string }): void {
   try {
     if (isDev) {
       devLog(`[WidgetRegistry] unregister widget ${widgetId}`)
@@ -1090,7 +1395,7 @@ function handleWidgetUnregister({ widgetId }: { widgetId: string }): void {
   }
 }
 
-function handleWidgetFailed(payload: WidgetFailurePayload): void {
+export function handleWidgetFailed(payload: WidgetFailurePayload): void {
   recordWidgetFailure(payload)
   clearWidgetRuntimeSource(payload.widgetId)
   unregisterCustomRenderer(payload.widgetId)

--- a/apps/core-app/src/renderer/src/views/box/CoreBox.vue
+++ b/apps/core-app/src/renderer/src/views/box/CoreBox.vue
@@ -104,7 +104,9 @@ const widgetRenderItem = computed(() => {
   const render = item?.render
   if (render?.mode !== 'custom') return null
   const custom = render.custom
-  if (!custom || custom.type !== 'vue' || !custom.content) return null
+  if (!custom || !['vue', 'webcomponent', 'arrow'].includes(custom.type) || !custom.content) {
+    return null
+  }
   if (isDefaultWidgetRenderer(custom.content)) return null
   if (!getCustomRenderer(custom.content)) return null
   return item

--- a/apps/nexus/content/docs/dev/api/widget.en.mdc
+++ b/apps/nexus/content/docs/dev/api/widget.en.mdc
@@ -16,6 +16,8 @@ Declare widgets in the manifest, then provide the renderer entry in your plugin 
 | `.ts` | Plain TypeScript | WidgetScriptProcessor |
 | `.js` | Plain JavaScript | WidgetScriptProcessor |
 | `.cjs` | Precompiled CommonJS | WidgetScriptProcessor |
+| `.arrow.ts` | TouchWidget ArrowJS beta | WidgetScriptProcessor |
+| `.arrow.js` | TouchWidget ArrowJS beta | WidgetScriptProcessor |
 
 ## Widget Types
 
@@ -79,6 +81,62 @@ code: |
 
 Remote widgets are fetched on each trigger; local file watching only applies to local sources.
 
+## TouchWidget Beta: ArrowJS
+
+The `arrow` runtime is the new recommended TouchWidget beta entry. Widget paths without an extension still default to `.vue`; ArrowJS widgets should explicitly use `.arrow.ts` or `.arrow.js` and declare `runtime: "arrow"`.
+
+:::TuffCodeBlock{lang="json"}
+---
+code: |
+  {
+    "type": "widget",
+    "id": "todo.arrow",
+    "title": "Arrow Task Panel",
+    "interaction": {
+      "type": "widget",
+      "runtime": "arrow",
+      "path": "todo-panel.arrow.ts"
+    }
+  }
+---
+:::
+
+`widgets/todo-panel.arrow.ts`
+:::TuffCodeBlock{lang="ts"}
+---
+code: |
+  import { component, html, reactive } from '@arrow-js/core'
+
+  export default component((props) => {
+    const state = reactive({ count: 0 })
+
+    return html`<button @click="${() => state.count++}">
+      ${() => props.payload?.title || 'TouchWidget'} ${() => state.count}
+    </button>`
+  })
+---
+:::
+
+## TouchWidget Beta: WebComponent
+
+The `webcomponent` runtime is also beta. The default export may be a defined tag name, an `HTMLElement` subclass, or `{ tagName, define }`. The host passes `item`, `payload`, `preview`, `widgetId`, and `hostKeyEvent` as DOM properties.
+
+:::TuffCodeBlock{lang="json"}
+---
+code: |
+  {
+    "type": "widget",
+    "id": "todo.webcomponent",
+    "title": "WebComponent Panel",
+    "interaction": {
+      "type": "widget",
+      "runtime": "webcomponent",
+      "path": "todo-card.ts"
+    }
+  }
+---
+:::
+
 ## Vue Widget Example
 
 `widgets/todo-panel.vue`
@@ -137,6 +195,7 @@ code: |
 Widgets run in a sandboxed environment. Only these packages are allowed:
 
 - `vue`
+- `@arrow-js/core` (TouchWidget ArrowJS beta)
 - `@talex-touch/utils`
 - `@talex-touch/utils/plugin`
 - `@talex-touch/utils/plugin/sdk`

--- a/apps/nexus/content/docs/dev/api/widget.zh.mdc
+++ b/apps/nexus/content/docs/dev/api/widget.zh.mdc
@@ -16,6 +16,8 @@ Widgets 是插件在 CoreBox 或 DivisionBox 中渲染的轻量 UI 组件。
 | `.ts` | 纯 TypeScript | WidgetScriptProcessor |
 | `.js` | 纯 JavaScript | WidgetScriptProcessor |
 | `.cjs` | 预编译 CommonJS | WidgetScriptProcessor |
+| `.arrow.ts` | TouchWidget ArrowJS beta | WidgetScriptProcessor |
+| `.arrow.js` | TouchWidget ArrowJS beta | WidgetScriptProcessor |
 
 ## Widget 类型
 | 类型 | 使用场景 |
@@ -37,6 +39,62 @@ code: |
     "interaction": {
       "type": "widget",
       "path": "todo-panel.vue"
+    }
+  }
+---
+:::
+
+## TouchWidget beta：ArrowJS
+
+`arrow` runtime 是新的推荐 TouchWidget beta 入口。`interaction.path` 未带扩展名时仍默认 `.vue`；ArrowJS Widget 需要显式写 `.arrow.ts` 或 `.arrow.js`，并标记 `runtime: "arrow"`。
+
+:::TuffCodeBlock{lang="json"}
+---
+code: |
+  {
+    "type": "widget",
+    "id": "todo.arrow",
+    "title": "Arrow 任务面板",
+    "interaction": {
+      "type": "widget",
+      "runtime": "arrow",
+      "path": "todo-panel.arrow.ts"
+    }
+  }
+---
+:::
+
+`widgets/todo-panel.arrow.ts`
+:::TuffCodeBlock{lang="ts"}
+---
+code: |
+  import { component, html, reactive } from '@arrow-js/core'
+
+  export default component((props) => {
+    const state = reactive({ count: 0 })
+
+    return html`<button @click="${() => state.count++}">
+      ${() => props.payload?.title || 'TouchWidget'} ${() => state.count}
+    </button>`
+  })
+---
+:::
+
+## TouchWidget beta：WebComponent
+
+`webcomponent` runtime 也是 beta。默认导出可以是已定义的 tag name、`HTMLElement` 子类，或 `{ tagName, define }`。宿主通过 DOM property 传入 `item`、`payload`、`preview`、`widgetId` 与 `hostKeyEvent`。
+
+:::TuffCodeBlock{lang="json"}
+---
+code: |
+  {
+    "type": "widget",
+    "id": "todo.webcomponent",
+    "title": "WebComponent 面板",
+    "interaction": {
+      "type": "widget",
+      "runtime": "webcomponent",
+      "path": "todo-card.ts"
     }
   }
 ---
@@ -115,6 +173,7 @@ code: |
 Widgets 运行在受控环境，仅允许以下包：
 
 - `vue`
+- `@arrow-js/core`（TouchWidget ArrowJS beta）
 - `@talex-touch/utils`
 - `@talex-touch/utils/plugin`
 - `@talex-touch/utils/plugin/sdk`

--- a/docs/plan-prd/01-project/CHANGES.md
+++ b/docs/plan-prd/01-project/CHANGES.md
@@ -1,6 +1,6 @@
 # 变更日志
 
-> 更新时间：2026-05-16
+> 更新时间：2026-05-17
 > 说明：主文件只保留近 30 天重点索引与后续新增变更；压缩前完整快照见 `./archive/changes/CHANGES-pre-doc-compression-2026-05-14.md`。更早历史继续按月归档在 `./archive/changes/`。
 
 ## 历史归档
@@ -10,6 +10,19 @@
 - [2026-02 历史归档](./archive/changes/CHANGES-2026-02.md)
 - [2025-11 历史归档](./archive/changes/CHANGES-2025-11.md)
 - [Legacy full snapshot](./archive/changes/CHANGES-legacy-full-2026-03-16.md)
+
+## 2026-05-17
+
+### feat(widget): add TouchWidget Arrow and WebComponent beta runtimes
+
+- `packages/utils/plugin/widget.ts`
+- `apps/core-app/src/main/modules/plugin/widget/**`
+- `apps/core-app/src/renderer/src/modules/plugin/widget-registry.ts`
+- `packages/tuff-cli-core/src/exporter.ts`
+- `apps/nexus/content/docs/dev/api/widget.{zh,en}.mdc`
+  - 新增 `arrow` 与 `webcomponent` Widget runtime，统一标记为 beta；现有 Vue Widget 仍保持默认 stable 路径。
+  - `@arrow-js/core@1.0.6` 进入受控依赖白名单，支持 `.arrow.ts` / `.arrow.js` TouchWidget 推荐入口。
+  - 预编译 manifest 与 runtime payload 记录 `runtime` / `runtimeStage`，renderer 通过轻量 host wrapper 挂载 ArrowJS 与 WebComponent。
 
 ## 2026-05-16
 

--- a/docs/plan-prd/01-project/CHANGES.md
+++ b/docs/plan-prd/01-project/CHANGES.md
@@ -13,6 +13,12 @@
 
 ## 2026-05-17
 
+### fix(plugin): keep touch-intelligence CoreBox session visible
+
+- `plugins/touch-intelligence/index.js`
+  - Intelligence 推送的 placeholder、send、pending、ready、error 项统一标记 `keepCoreBoxOpen`，避免发送 AI 请求、等待响应或展示回答/错误时被 CoreBox auto-hide 提前隐藏。
+  - 复用现有 CoreBox keep-open 语义，不改变普通搜索结果和其他插件 item 的执行流程。
+
 ### feat(widget): add TouchWidget Arrow and WebComponent beta runtimes
 
 - `packages/utils/plugin/widget.ts`

--- a/docs/plan-prd/TODO.md
+++ b/docs/plan-prd/TODO.md
@@ -1,6 +1,6 @@
 # Tuff TODO
 
-> 更新时间：2026-05-15
+> 更新时间：2026-05-17
 > 定位：当前 2 周执行清单。历史完整清单已归档到 `docs/plan-prd/docs/archive/TODO-pre-compression-2026-05-14.md`；长期债务见 `docs/plan-prd/docs/TODO-BACKLOG-LONG-TERM.md`。
 
 ## 当前执行窗口
@@ -38,6 +38,7 @@
 
 | ID | 事项 | 状态 | 验收/证据 |
 | --- | --- | --- | --- |
+| P2-TOUCH-WIDGET | TouchWidget Arrow/WebComponent beta | 进行中 | `arrow` 与 `webcomponent` runtime 以 beta 标记接入 Widget pipeline；保持 `.vue` 默认兼容。后续补真实示例插件、packaged/dev source 手动验收与 `@arrow-js/sandbox` 单独安全评估。 |
 | P2-AI-250 | Tuff 2.5.0 AI 桌面入口 | 进行中 | CoreBox AI Ask、handoff session、Nexus invoke credits 扣减、CoreApp credits summary、Tuff-native Tool Kit foundation、OmniPanel Writing Tools MVP、Workflow `Use Model` 最小节点、Workflow 页面本地 Review Queue MVP 与 3 个 P0 模板已进入 dev 切片；2026-05-15 Review Queue 状态已写回 workflow run metadata 并可从持久化历史恢复，Use Model 步骤补 `inputSources` / `output` 合同与页面 JSON 编辑入口；本地 AI 环境扫描已接 typed `intelligence:api:local-environment`，只读展示 Codex / Claude、项目指令与 Codex skills provider 摘要，后续补 provider / scene / skill 权限门控与执行策略；继续推进跨入口 Review Queue、单步骤重跑/跳过、TTS 队列/播放服务与持久缓存评估。Stable 只承诺文本 + OCR。 |
 | P2-PROVIDER | Nexus Provider Registry / Scene 编排 | 进行中 | 已有 D1 secure store、Scene run、Dashboard dry-run/execute、AI mirror、health/usage ledger 与最小策略路由；后续补旧 `intelligence_providers` 表退场、user-scope OCR 自动绑定、success rate/配额/dynamic pricingRef。 |
 | P2-NATIVE | Native transport V1 真机 smoke | 待执行 | 补 macOS 屏幕录制授权、Windows 多屏、Linux X11/Wayland best-effort；打包预览确认 `sharp` 与 ffmpeg/ffprobe 可执行。 |

--- a/packages/test/src/plugins/intelligence.test.ts
+++ b/packages/test/src/plugins/intelligence.test.ts
@@ -18,6 +18,31 @@ describe('intelligence plugin', () => {
     expect(payload.messages[1]?.content).toBe('hello')
   })
 
+  it('loads the intelligence client through the plugin runtime require path', async () => {
+    const send = vi.fn(async () => ({
+      ok: true,
+      result: {
+        result: 'ok',
+      },
+    }))
+    const pluginWithChannel = loadPluginModule(
+      new URL('../../../../plugins/touch-intelligence/index.js', import.meta.url),
+      createPluginGlobals({
+        touchChannel: { send },
+      }),
+    )
+
+    const client = pluginWithChannel.__test.resolveIntelligenceClient()
+    const result = await client.invoke('text.chat', { messages: [] })
+
+    expect(result).toEqual({ result: 'ok' })
+    expect(send).toHaveBeenCalledWith('intelligence:api:invoke', {
+      capabilityId: 'text.chat',
+      payload: { messages: [] },
+      options: undefined,
+    })
+  })
+
   it('builds chat payload with OCR context', () => {
     const payload = intelligenceTest.buildInvokePayload('总结重点', [], {
       ocrText: '第一行\n第二行',

--- a/packages/tuff-cli-core/package.json
+++ b/packages/tuff-cli-core/package.json
@@ -29,6 +29,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
+    "@arrow-js/core": "1.0.6",
     "@talex-touch/utils": "workspace:*",
     "@vue/compiler-sfc": "^3.5.33",
     "chalk": "^5.6.0",

--- a/packages/tuff-cli-core/src/__tests__/builder-widgets.test.ts
+++ b/packages/tuff-cli-core/src/__tests__/builder-widgets.test.ts
@@ -156,6 +156,46 @@ describe('builder widget precompile', () => {
     })
   })
 
+  it('precompiles beta Arrow TouchWidget entries with runtime metadata', async () => {
+    await withPluginFixture(async (root) => {
+      const manifest = await readManifest(root)
+      manifest.features[0].interaction = {
+        type: 'widget',
+        path: 'panel.arrow.ts',
+        runtime: 'arrow',
+      }
+      await writeManifest(root, manifest)
+      await fs.writeFile(
+        path.join(root, 'widgets', 'panel.arrow.ts'),
+        [
+          'import { component, html } from "@arrow-js/core"',
+          'export default component((props) => html`<section class="arrow-panel">${() => props.payload?.title || "Arrow"}</section>`)',
+        ].join('\n'),
+      )
+
+      await build({
+        root,
+        outDir: 'dist',
+        versionSync: { enabled: false },
+      })
+
+      const packagedManifest = await fs.readJson(path.join(root, 'dist', 'build', 'manifest.json'))
+      const widget = packagedManifest.build.widgets[0]
+
+      expect(widget).toMatchObject({
+        dependencies: ['@arrow-js/core'],
+        featureId: 'translate',
+        runtime: 'arrow',
+        runtimeStage: 'beta',
+        sourcePath: 'widgets/panel.arrow.ts',
+        widgetId: 'demo-plugin::translate',
+      })
+      await expect(
+        fs.pathExists(path.join(root, 'dist', 'build', widget.compiledPath)),
+      ).resolves.toBe(true)
+    })
+  })
+
   it('fails when a widget relative import escapes widgets directory', async () => {
     await withPluginFixture(async (root) => {
       await fs.writeFile(

--- a/packages/tuff-cli-core/src/exporter.ts
+++ b/packages/tuff-cli-core/src/exporter.ts
@@ -1,5 +1,9 @@
 /* eslint-disable no-console */
-import type { WidgetPrecompiledManifestEntry, WidgetPrecompiledMeta } from '@talex-touch/utils/plugin/widget'
+import type {
+  WidgetPrecompiledManifestEntry,
+  WidgetPrecompiledMeta,
+  WidgetRuntime,
+} from '@talex-touch/utils/plugin/widget'
 import type { Plugin as EsbuildPlugin } from 'esbuild'
 import type { Options } from './types'
 import crypto from 'node:crypto'
@@ -12,6 +16,9 @@ import {
   makeWidgetId,
   WIDGET_ALLOWED_PACKAGES,
   WIDGET_COMPILED_DIR,
+  WIDGET_RUNTIMES,
+  resolveWidgetRuntime,
+  resolveWidgetRuntimeStage,
 } from '@talex-touch/utils/plugin/widget'
 import { compileScript, compileTemplate, parse } from '@vue/compiler-sfc'
 import cliProgress from 'cli-progress'
@@ -56,6 +63,7 @@ interface WidgetFeatureManifest {
   interaction?: {
     type?: string
     path?: string
+    runtime?: WidgetRuntime
   }
 }
 
@@ -74,6 +82,7 @@ interface WidgetCompileTarget {
 }
 
 const WIDGET_SUPPORTED_EXTENSIONS = new Set(['.vue', '.ts', '.js', '.cjs', '.tsx', '.jsx'])
+const ARROW_WIDGET_SOURCE_PATTERN = /\.arrow\.(ts|js)$/i
 
 function normalizeIndexConfig(source: unknown, label: string): IndexConfigOverride | null {
   if (!source || typeof source !== 'object')
@@ -332,6 +341,16 @@ function withWidgetExtension(rawPath: string): string {
   return path.extname(rawPath) ? rawPath : `${rawPath}.vue`
 }
 
+function resolveWidgetRuntimeFromPath(feature: WidgetFeatureManifest, sourcePath?: string): WidgetRuntime {
+  const declared = resolveWidgetRuntime(feature.interaction?.runtime)
+  if (declared !== WIDGET_RUNTIMES.VUE) {
+    return declared
+  }
+  return ARROW_WIDGET_SOURCE_PATTERN.test(sourcePath ?? '')
+    ? WIDGET_RUNTIMES.ARROW
+    : WIDGET_RUNTIMES.VUE
+}
+
 function toPosixPath(value: string): string {
   return value.split(path.sep).join('/')
 }
@@ -569,6 +588,8 @@ async function compileWidgetForPackage(
   const ext = path.extname(sourcePath).toLowerCase()
   const baseDependencies = validateWidgetDependencies(context.feature.id, source)
   const dependencies = ext === '.vue' ? ensureVueDependency(baseDependencies) : baseDependencies
+  const runtime = resolveWidgetRuntimeFromPath(context.feature, sourceRelativePath)
+  const runtimeStage = resolveWidgetRuntimeStage(runtime)
   const widgetId = makeWidgetId(context.pluginName, context.feature.id)
   const safeId = makeSafeWidgetFileId(widgetId)
   const compiledRelativePath = posixPath.join('widgets', WIDGET_COMPILED_DIR, `${safeId}.cjs`)
@@ -586,6 +607,8 @@ async function compileWidgetForPackage(
       widgetId,
       sourcePath: sourceRelativePath,
       compiledPath: compiledRelativePath,
+      runtime,
+      runtimeStage,
       hash,
       styles: '',
       dependencies: Array.from(bundledDependencies),
@@ -640,6 +663,8 @@ module.exports = __component
     widgetId,
     sourcePath: sourceRelativePath,
     compiledPath: compiledRelativePath,
+    runtime,
+    runtimeStage,
     hash,
     styles,
     dependencies: Array.from(bundledDependencies),

--- a/packages/tuff-intelligence/package.json
+++ b/packages/tuff-intelligence/package.json
@@ -22,6 +22,7 @@
     },
     "./client": {
       "types": "./src/client.ts",
+      "require": "./dist/client.cjs",
       "import": "./src/client.ts",
       "default": "./src/client.ts"
     },
@@ -44,7 +45,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --splitting --clean --target node18 --platform node",
+    "build": "tsup src/index.ts --format esm --dts --splitting --clean --target node18 --platform node && tsup src/client.ts --format cjs --target node18 --platform node",
     "dev": "tsup src/index.ts --format esm --dts --splitting --clean --target node18 --platform node --watch",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",

--- a/packages/utils/core-box/builder/tuff-builder.ts
+++ b/packages/utils/core-box/builder/tuff-builder.ts
@@ -40,6 +40,8 @@ import type {
   TuffTag,
 } from '../tuff/tuff-dsl'
 
+type TuffCustomRenderType = TuffCustomRender['type']
+
 // ==================== Builder 类 ====================
 
 /**
@@ -240,7 +242,7 @@ class TuffItemBuilder {
    * @returns 当前构建器实例，用于链式调用
    */
   setCustomRender(
-    type: 'html' | 'vue' | 'react' | 'markdown',
+    type: TuffCustomRenderType,
     content: string,
     data?: Record<string, any>,
     styles?: string[],

--- a/packages/utils/core-box/tuff/tuff-dsl.ts
+++ b/packages/utils/core-box/tuff/tuff-dsl.ts
@@ -350,7 +350,7 @@ export interface TuffCustomRender {
    * @description 指定使用哪种技术进行渲染
    * @required
    */
-  type: 'html' | 'vue' | 'react' | 'markdown'
+  type: 'html' | 'vue' | 'react' | 'markdown' | 'webcomponent' | 'arrow'
 
   /**
    * 渲染内容

--- a/packages/utils/plugin/index.ts
+++ b/packages/utils/plugin/index.ts
@@ -7,7 +7,7 @@ import type { ITuffIcon } from '../types/icon'
 import type { Arch, SupportOS } from './../base/index'
 
 import type { IPluginLogger } from './log/types'
-import type { WidgetPrecompiledManifestEntry } from './widget'
+import type { WidgetPrecompiledManifestEntry, WidgetRuntime } from './widget'
 
 import type {
   PluginInstallRequest,
@@ -287,6 +287,10 @@ export interface IPluginFeature {
 
 export interface IFeatureInteraction {
   type: 'webcontent' | 'widget'
+  /**
+   * Widget renderer runtime. `arrow` and `webcomponent` are beta runtimes.
+   */
+  runtime?: WidgetRuntime
   /**
    * The relative path to the html file from the plugin root.
    */

--- a/packages/utils/plugin/widget.ts
+++ b/packages/utils/plugin/widget.ts
@@ -3,9 +3,31 @@ export const DEFAULT_WIDGET_RENDERERS = {
   CORE_INTELLIGENCE_ANSWER: 'core-intelligence-answer',
 } as const
 
+export const WIDGET_RUNTIME_BETA = 'beta' as const
+export const TOUCH_WIDGET_RECOMMENDED_RUNTIME = 'arrow' as const
+
+export const WIDGET_RUNTIMES = {
+  VUE: 'vue',
+  WEBCOMPONENT: 'webcomponent',
+  ARROW: TOUCH_WIDGET_RECOMMENDED_RUNTIME,
+} as const
+
+export type WidgetRuntime = (typeof WIDGET_RUNTIMES)[keyof typeof WIDGET_RUNTIMES]
+export type WidgetRuntimeStage = typeof WIDGET_RUNTIME_BETA | 'stable'
+
+export const WIDGET_BETA_RUNTIMES = [
+  WIDGET_RUNTIMES.WEBCOMPONENT,
+  WIDGET_RUNTIMES.ARROW,
+] as const
+
+export function isBetaWidgetRuntime(runtime: WidgetRuntime | undefined): boolean {
+  return runtime === WIDGET_RUNTIMES.WEBCOMPONENT || runtime === WIDGET_RUNTIMES.ARROW
+}
+
 export const WIDGET_COMPILED_DIR = '.compiled'
 export const WIDGET_RUNTIME_COMPILE_ENV = 'TUFF_WIDGET_RUNTIME_COMPILE'
 export const WIDGET_ALLOWED_PACKAGES = [
+  '@arrow-js/core',
   'vue',
   '@talex-touch/utils',
   '@talex-touch/utils/plugin',
@@ -24,6 +46,8 @@ export interface WidgetPrecompiledManifestEntry {
   sourcePath: string
   compiledPath: string
   metaPath?: string
+  runtime?: WidgetRuntime
+  runtimeStage?: WidgetRuntimeStage
   hash: string
   styles: string
   dependencies?: string[]
@@ -35,6 +59,8 @@ export interface WidgetPrecompiledMeta {
   widgetId: string
   sourcePath: string
   compiledPath: string
+  runtime?: WidgetRuntime
+  runtimeStage?: WidgetRuntimeStage
   hash: string
   styles: string
   dependencies?: string[]
@@ -53,6 +79,8 @@ export interface WidgetRegistrationPayload {
   pluginName: string
   featureId: string
   filePath: string
+  runtime?: WidgetRuntime
+  runtimeStage?: WidgetRuntimeStage
   code: string
   styles: string
   hash: string
@@ -67,6 +95,8 @@ export interface WidgetFailurePayload {
   widgetId: string
   pluginName: string
   featureId: string
+  runtime?: WidgetRuntime
+  runtimeStage?: WidgetRuntimeStage
   code: string
   message: string
   filePath?: string
@@ -76,6 +106,17 @@ export interface WidgetFailurePayload {
 
 export function makeWidgetId(pluginName: string, featureId: string): string {
   return `${pluginName}::${featureId}`
+}
+
+export function resolveWidgetRuntime(runtime: unknown): WidgetRuntime {
+  if (runtime === WIDGET_RUNTIMES.WEBCOMPONENT || runtime === WIDGET_RUNTIMES.ARROW) {
+    return runtime
+  }
+  return WIDGET_RUNTIMES.VUE
+}
+
+export function resolveWidgetRuntimeStage(runtime: WidgetRuntime | undefined): WidgetRuntimeStage {
+  return isBetaWidgetRuntime(runtime) ? WIDGET_RUNTIME_BETA : 'stable'
 }
 
 export function makeSafeWidgetFileId(widgetId: string): string {
@@ -89,4 +130,17 @@ export function isAllowedWidgetModule(moduleName: string): boolean {
   }
 
   return WIDGET_ALLOWED_PACKAGES.includes(normalized as WidgetAllowedPackage)
+}
+
+export interface TouchWidgetDefinition<TProps = Record<string, unknown>> {
+  runtime?: WidgetRuntime
+  render?: unknown
+  setup?: (props: TProps) => unknown
+  tagName?: string
+  define?: () => void
+  [key: string]: unknown
+}
+
+export function defineTouchWidget<T extends TouchWidgetDefinition | Function>(widget: T): T {
+  return widget
 }

--- a/plugins/touch-intelligence/README.md
+++ b/plugins/touch-intelligence/README.md
@@ -1,0 +1,23 @@
+# Tuff Intelligence Ask
+
+Tuff Intelligence Ask provides a lightweight AI entry in CoreBox. It lets users ask questions, summarize copied content, and analyze clipboard images through the shared Tuff Intelligence capability layer.
+
+## Capabilities
+
+- Ask questions from CoreBox with `ai`, `@ai`, `/ai`, `智能`, or `问答`.
+- Reuse recent conversation context for follow-up questions.
+- Run OCR on clipboard images before sending the recognized text to `text.chat`.
+- Copy generated answers back to the clipboard after permission approval.
+- Bridge requests into a stable Tuff Intelligence handoff session for later continuation.
+
+## Permissions
+
+- `intelligence.basic`: invoke Tuff Intelligence text chat and OCR capabilities.
+- `clipboard.write`: copy AI answers to the clipboard.
+
+## Release Notes
+
+### 1.0.0
+
+- Initial Nexus release package for the CoreBox AI Ask plugin.
+- Supports text chat, clipboard image OCR, retry, copy answer, and handoff session metadata.

--- a/plugins/touch-intelligence/index.js
+++ b/plugins/touch-intelligence/index.js
@@ -1,4 +1,4 @@
-const { plugin, clipboard, logger, TuffItemBuilder, permission } = globalThis
+const { plugin, clipboard, logger, TuffItemBuilder, permission, touchChannel } = globalThis
 const crypto = require('node:crypto')
 
 const PLUGIN_NAME = 'touch-intelligence'
@@ -30,8 +30,8 @@ const AI_SYSTEM_PROMPT = '你是 Talex Touch 桌面助手里的智能助手，�
 const conversationSessions = new Map()
 
 function resolveIntelligenceClient() {
-  const { createIntelligenceClient } = require('@talex-touch/tuff-intelligence')
-  return createIntelligenceClient()
+  const { createIntelligenceClient } = require('@talex-touch/tuff-intelligence/client')
+  return createIntelligenceClient(touchChannel)
 }
 
 function normalizeText(value) {
@@ -862,5 +862,6 @@ module.exports = {
     mapInvokeResult,
     normalizeInvokeError,
     normalizePrompt,
+    resolveIntelligenceClient,
   },
 }

--- a/plugins/touch-intelligence/index.js
+++ b/plugins/touch-intelligence/index.js
@@ -391,6 +391,7 @@ function buildInfoItem({
     pluginName: PLUGIN_NAME,
     featureId,
     status,
+    keepCoreBoxOpen: true,
   }
 
   if (handoffSessionId) {

--- a/plugins/touch-intelligence/manifest.json
+++ b/plugins/touch-intelligence/manifest.json
@@ -1,16 +1,26 @@
 {
   "id": "com.tuffex.intelligence",
   "name": "touch-intelligence",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "TalexTouch Team",
   "sdkapi": 260428,
-  "category": "utilities",
+  "category": "ai",
   "icon": {
     "type": "file",
     "value": "assets/logo.svg"
   },
   "description": "智能问答：在 CoreBox 里直接提问并复制回答",
   "main": "index.js",
+  "build": {
+    "index": {
+      "entry": "index.js",
+      "format": "cjs",
+      "target": "node18",
+      "external": ["electron"],
+      "minify": true,
+      "sourcemap": false
+    }
+  },
   "permissions": {
     "required": ["intelligence.basic"],
     "optional": ["clipboard.write"]

--- a/plugins/touch-intelligence/package.json
+++ b/plugins/touch-intelligence/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@talex-touch/touch-intelligence-plugin",
+  "private": true,
+  "version": "1.0.1",
+  "packageManager": "pnpm@10.32.1",
+  "scripts": {
+    "build": "node ../../packages/tuff-cli/bin/tuff.js builder",
+    "publish:nexus": "node ../../packages/tuff-cli/bin/tuff.js publish --channel RELEASE"
+  },
+  "dependencies": {
+    "@talex-touch/tuff-intelligence": "workspace:^"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1289,6 +1289,12 @@ importers:
         specifier: ^3.2.7
         version: 3.2.7(typescript@5.9.3)
 
+  plugins/touch-intelligence:
+    dependencies:
+      '@talex-touch/tuff-intelligence':
+        specifier: workspace:^
+        version: link:../../packages/tuff-intelligence
+
   plugins/touch-music:
     dependencies:
       '@milkdown/theme-nord':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
 
   apps/core-app:
     dependencies:
+      '@arrow-js/core':
+        specifier: 1.0.6
+        version: 1.0.6
       '@electron-toolkit/preload':
         specifier: ^3.0.2
         version: 3.0.2(electron@41.3.0)
@@ -857,6 +860,9 @@ importers:
 
   packages/tuff-cli-core:
     dependencies:
+      '@arrow-js/core':
+        specifier: 1.0.6
+        version: 1.0.6
       '@talex-touch/utils':
         specifier: workspace:*
         version: link:../utils
@@ -1606,6 +1612,10 @@ packages:
     engines: {node: '>= 20'}
     peerDependencies:
       '@types/json-schema': ^7.0.15
+
+  '@arrow-js/core@1.0.6':
+    resolution: {integrity: sha512-75f4N0iHtHTwgxf9XS8a1vtfGZZmCvqT0Ix+ScDLclNuR9Fqp2yOIK1u8vmN1BPsS4aRfMVTdSFSmgGCqkJSCg==}
+    engines: {node: '>=20.19.0 || >=22.12.0'}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -15382,6 +15392,8 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.1
+
+  '@arrow-js/core@1.0.6': {}
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:


### PR DESCRIPTION
## Summary
- Mark TouchWidget Arrow/WebComponent runtimes as beta across contracts, runtime registration, CLI precompile, and docs.
- Add beta runtime support for `vue`, `webcomponent`, and `arrow` while keeping existing Vue widget behavior compatible.
- Add `@arrow-js/core@1.0.6` as the beta Arrow runtime dependency; `@arrow-js/sandbox` is intentionally not included.

## Changes
- Extend widget runtime/type contracts and dependency allowlist.
- Register beta WebComponent and Arrow widgets through Vue host wrappers in core-app.
- Teach tuff-cli-core to precompile explicit `.arrow.ts` / `.arrow.js` widgets and preserve runtime metadata.
- Update Nexus/widget docs and plan-prd docs for the beta TouchWidget developer model.

## Tests
- `corepack pnpm -C "/root/Workspace/tuff/apps/core-app" exec vitest run "src/main/modules/plugin/widget" "src/renderer/src/modules/plugin"`
- `corepack pnpm -C "/root/Workspace/tuff/packages/tuff-cli-core" exec vitest run "src/__tests__/builder-widgets.test.ts"`
- targeted ESLint checks
- `git diff --check`

## Notes
- Existing unrelated dirty worktree changes were not staged or included in these commits.
- Local validation emitted a Node engine warning because the current shell uses Node v20.19.2 while this repo requires Node >=22.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Beta Arrow and WebComponent widget runtimes with .arrow file support and runtime metadata propagated through compile/register flows
  * Extended custom render types to include webcomponent and arrow

* **Documentation**
  * Widget API docs updated with Arrow/WebComponent runtime specs, examples, and allowed dependency note

* **Tests**
  * Added tests for Arrow/WebComponent widget flows and precompile metadata

* **Chores**
  * Added `@arrow-js/core` to controlled dependencies; updated touch-intelligence plugin and builds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/talex-touch/tuff/pull/270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->