### PR TITLE
docs: clarify release metadata resync

### DIFF
--- a/.trellis/tasks/07-27-batch-commit-release-v2-4-14-beta-1/prd.md
+++ b/.trellis/tasks/07-27-batch-commit-release-v2-4-14-beta-1/prd.md
@@ -7,7 +7,7 @@ Coordinate the ordered v2.4.14-beta.1 release batch after its child release work
 ## Requirements
 
 - Keep this parent limited to the batch order and child release gate; it does not authorize publishing while the release child has unresolved acceptance criteria.
-- Use the repository release workflow as the publication mechanism: beta tags are pre-releases, and the workflow builds platform artifacts, creates the release manifest, and synchronizes release metadata only on tag push.
+- Use the repository release workflow as the publication mechanism: beta tags are pre-releases, and the workflow synchronizes release metadata for normal tag pushes or through `workflow_dispatch.sync_tag` when an existing tag needs recovery or resynchronization.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Scope
- Correct the v2.4.14-beta.1 batch-release requirement: normal tag-push metadata synchronization and the explicit `workflow_dispatch.sync_tag` recovery/resynchronization path are both documented.

## Validation
- `node /private/tmp/docs-verify-pr359.mjs`: `docs:verify passed` (0 diagnostics)
- `python3 ./.trellis/scripts/task.py validate .trellis/tasks/07-27-batch-commit-release-v2-4-14-beta-1`
- Focused Markdown validation with MD013 disabled
- `git diff --check --cached`

PR #360 merged before this independent-review correction could be pushed; this successor PR contains only the review fix.