### PR TITLE
docs(nexus): correct dev server port 3000 → 3200 (#623)

### DIFF
--- a/apps/nexus/README.md
+++ b/apps/nexus/README.md
@@ -14,7 +14,7 @@ This is the documentation site for the Tuff project, built with Nuxt and Nuxt Co
 pnpm run dev
 ```
 
-The site will be available at `http://localhost:3000`.
+The site will be available at `http://localhost:3200`.
 
 ## Docs SEO and prerender evidence
 


### PR DESCRIPTION
`apps/nexus/README.md` said the dev site is at `http://localhost:3000`, but every nexus dev script pins `--port 3200` (`apps/nexus/package.json`). Corrected the README.

Docs-only.

Fixes #623

<sub>Automated audit remediation loop · tracker #959</sub>