### PR TITLE
docs(CLAUDE.md): update drifted technology-stack versions (#626)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,13 +43,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This is a pnpm workspace monorepo with the main application in `apps/core-app/`, utility packages in `packages/`, extracted plugins in `plugins/` (7 independent plugin packages), and documentation in `apps/docs/`.
 
 ### Technology Stack
-- **Electron**: 40.0.0+ with Node.js 22.16.0+
-- **Vue**: 3.5.27+ with Vue Router 4.6.4 and Pinia 3.0.4
+- **Electron**: 41.10.1+ with Node.js 24.15.0+
+- **Vue**: 3.5.39+ with Vue Router 4.6.4 and Pinia 3.0.4
 - **TypeScript**: 5.9.3
-- **Build Tools**: Electron-Vite 4.0.1, Vite 7.3.1, Electron-Builder 26.4.0
-- **UI**: Tuffex, UnoCSS 66.6.0, SASS 1.97.2
-- **Database**: Drizzle ORM 0.44.7 with LibSQL 0.15.15
-- **Utilities**: VueUse 14.1.0, Dayjs 1.11.19, @talex-touch/tuff-native (native OCR), XTerm 5.3.0
+- **Build Tools**: Electron-Vite 4.0.1, Vite 7.3.6, Electron-Builder 26.15.3
+- **UI**: Tuffex, UnoCSS 66.7.5, SASS 1.101.0
+- **Database**: Drizzle ORM 0.45.2 with LibSQL 0.17.4
+- **Utilities**: VueUse 14.3.0, Dayjs 1.11.21, @talex-touch/tuff-native (native OCR), XTerm 5.3.0
 - **Logging**: log4js 6.9.1
 
 ### Core Application Architecture (apps/core-app/)


### PR DESCRIPTION
CLAUDE.md's *Technology Stack* listed versions that had drifted from `package.json`/workspace catalog. Corrected the 8 stale entries (verified against `package.json`, `apps/core-app/package.json`, and `pnpm-workspace.yaml`):

| Item | Was | Now |
|---|---|---|
| Electron | 40.0.0+ | 41.10.1+ |
| Node.js | 22.16.0+ | 24.15.0+ |
| Vue | 3.5.27+ | 3.5.39+ |
| Vite | 7.3.1 | 7.3.6 |
| Electron-Builder | 26.4.0 | 26.15.3 |
| UnoCSS | 66.6.0 | 66.7.5 |
| SASS | 1.97.2 | 1.101.0 |
| Drizzle ORM | 0.44.7 | 0.45.2 |
| LibSQL | 0.15.15 | 0.17.4 |
| Dayjs | 1.11.19 | 1.11.21 |

Docs-only.

Fixes #626

<sub>Automated audit remediation loop · tracker #959</sub>