### PR TITLE
docs(CLAUDE.md): fix 4 stale paths in Key File Locations (#624)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,12 +401,12 @@ await accountSDK.hasPrioritySupport()     // Priority support
 ## Key File Locations
 
 - Main entry: [apps/core-app/src/main/index.ts](apps/core-app/src/main/index.ts)
-- Core app logic: [apps/core-app/src/main/core/touch-core.ts](apps/core-app/src/main/core/touch-core.ts)
+- Core app logic: [apps/core-app/src/main/core/touch-app.ts](apps/core-app/src/main/core/touch-app.ts)
 - Module manager: [apps/core-app/src/main/core/module-manager.ts](apps/core-app/src/main/core/module-manager.ts)
-- Plugin system: [apps/core-app/src/main/modules/plugin/plugin-provider.ts](apps/core-app/src/main/modules/plugin/plugin-provider.ts)
-- CoreBox launcher: [apps/core-app/src/main/modules/box-tool/core-box.ts](apps/core-app/src/main/modules/box-tool/core-box.ts)
+- Plugin system: [apps/core-app/src/main/modules/plugin/index.ts](apps/core-app/src/main/modules/plugin/index.ts)
+- CoreBox launcher: [apps/core-app/src/main/modules/box-tool/core-box/index.ts](apps/core-app/src/main/modules/box-tool/core-box/index.ts)
 - Channel system: [apps/core-app/src/main/core/channel-core.ts](apps/core-app/src/main/core/channel-core.ts)
-- Storage module: [apps/core-app/src/main/modules/storage/storage-provider.ts](apps/core-app/src/main/modules/storage/storage-provider.ts)
+- Storage module: [apps/core-app/src/main/modules/storage/index.ts](apps/core-app/src/main/modules/storage/index.ts)
 - Permission module: [apps/core-app/src/main/modules/permission/](apps/core-app/src/main/modules/permission/)
 - Transport SDKs: [packages/utils/transport/](packages/utils/transport/)
 - Extracted plugins: [plugins/](plugins/)


### PR DESCRIPTION
The *Key File Locations* section linked 4 files that have since moved (verified missing at the old paths, present at the new ones):

| Was | Now |
|---|---|
| `core/touch-core.ts` | `core/touch-app.ts` |
| `modules/plugin/plugin-provider.ts` | `modules/plugin/index.ts` |
| `modules/box-tool/core-box.ts` | `modules/box-tool/core-box/index.ts` |
| `modules/storage/storage-provider.ts` | `modules/storage/index.ts` |

Docs-only. Note: the same `core-box`/`plugin-provider` links are also stale in the *Key Modules* section (lines 64-65) — flagged as an adjacent gap, out of this issue's scope.

Fixes #624

<sub>Automated audit remediation loop · tracker #959</sub>