### PR TITLE
docs(contributing): fix stale slug, version badges & structure tree (#620, #621)

### DIFF
--- a/.github/docs/contribution/CONTRIBUTING.md
+++ b/.github/docs/contribution/CONTRIBUTING.md
@@ -4,10 +4,10 @@
 
   <h1>Tuff</h1>
 
-  [![GitHub issues](https://img.shields.io/github/issues/talex-touch/talex-touch?style=flat-square)](https://github.com/talex-touch/talex-touch/issues)
-  [![GitHub license](https://img.shields.io/github/license/talex-touch/talex-touch?style=flat-square)](https://github.com/talex-touch/talex-touch/blob/main/LICENSE)
-  [![GitHub release](https://img.shields.io/badge/release-1.2.0-42B883?style=flat-square)](https://github.com/talex-touch/talex-touch/releases)
-  [![GitHub release](https://img.shields.io/badge/dev-2.1.0-64391A?style=flat-square)](https://github.com/talex-touch/talex-touch/discussions/35)
+  [![GitHub issues](https://img.shields.io/github/issues/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/issues)
+  [![GitHub license](https://img.shields.io/github/license/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/blob/main/LICENSE)
+  [![GitHub release](https://img.shields.io/github/v/release/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/releases)
+  [![Dev version](https://img.shields.io/github/package-json/v/talex-touch/tuff?style=flat-square&label=dev&color=64391A)](https://github.com/talex-touch/tuff/discussions/35)
 
   English | [简体中文](./CONTRIBUTING_zh.md)
 </div>
@@ -73,10 +73,10 @@ Sorry! We as much as possible the current primary goal is to optimize the progra
    Tuff tree helper:
  > tuff:
    ├── apps: (Main applications)
-   ├──── core: (Electron application)
-   ├──── docs: (Document application)
+   ├──── core-app: (Electron application)
+   ├──── nexus: (Docs & ecosystem site)
    ├── packages: (Assistant packages)
-   ├──── components: (Tuff components)
+   ├──── tuffex: (Tuff UI components)
    ├──── utils: (Assistant Utils)
    ├── plugins: (Official plugins)
 ```

--- a/.github/docs/contribution/CONTRIBUTING_zh.md
+++ b/.github/docs/contribution/CONTRIBUTING_zh.md
@@ -4,10 +4,10 @@
 
   <h1>Tuff</h1>
 
-  [![GitHub issues](https://img.shields.io/github/issues/talex-touch/talex-touch?style=flat-square)](https://github.com/talex-touch/talex-touch/issues)
-  [![GitHub license](https://img.shields.io/github/license/talex-touch/talex-touch?style=flat-square)](https://github.com/talex-touch/talex-touch/blob/main/LICENSE)
-  [![GitHub release](https://img.shields.io/badge/release-2.1.0-42B883?style=flat-square)](https://github.com/talex-touch/talex-touch/releases)
-  [![GitHub release](https://img.shields.io/badge/dev-2.1.0-64391A?style=flat-square)](https://github.com/talex-touch/talex-touch/discussions/35)
+  [![GitHub issues](https://img.shields.io/github/issues/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/issues)
+  [![GitHub license](https://img.shields.io/github/license/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/blob/main/LICENSE)
+  [![GitHub release](https://img.shields.io/github/v/release/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/releases)
+  [![Dev version](https://img.shields.io/github/package-json/v/talex-touch/tuff?style=flat-square&label=dev&color=64391A)](https://github.com/talex-touch/tuff/discussions/35)
 
   [English](./CONTRIBUTING.md) | 简体中文
 </div>
@@ -72,10 +72,10 @@
    Tuff tree helper:
  > tuff:
    ├── apps: (主要的应用)
-   ├──── core: (Electron 应用)
-   ├──── docs: (文档应用)
+   ├──── core-app: (Electron 应用)
+   ├──── nexus: (文档与生态站点)
    ├── packages: (辅助包)
-   ├──── components: (Tuff 组件)
+   ├──── tuffex: (Tuff UI 组件)
    ├──── utils: (辅助工具)
    ├── plugins: (官方插件)
 ```


### PR DESCRIPTION
`.github/docs/contribution/CONTRIBUTING.md` (+ `_zh` mirror):

**#621** — badges used the pre-rename `talex-touch/talex-touch` slug (repo is now `talex-touch/tuff`) and hardcoded `release-1.2.0`/`dev-2.1.0`. Switched to the correct slug and **dynamic** shields badges (`github/v/release`, `github/package-json/v`) so they no longer drift.

**#620** — the project-structure tree named `apps/core`, `apps/docs`, and `packages/components`, none of which exist. Corrected to `apps/core-app`, `apps/nexus`, `packages/tuffex`.

Both fixes applied to the EN doc and its zh mirror. Docs-only.

Fixes #620
Fixes #621

<sub>Automated audit remediation loop · tracker #959</sub>