### PR TITLE
docs: fix version sourcing in READMEs & ROADMAP (#628, #629)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Tuff (formerly TalexTouch) is a local-first, AI-native, extensible desktop comma
 
 ## Release and platform status
 
-The repository's stable baseline is `2.4.13`, resolved from the matching [root package manifest](./package.json) and [CoreApp package manifest](./apps/core-app/package.json). Consult [GitHub Releases](https://github.com/talex-touch/tuff/releases) for published artifacts.
+The repository's latest stable release is `2.4.13` (see [GitHub Releases](https://github.com/talex-touch/tuff/releases)); the in-development version declared in the [root package manifest](./package.json) and [CoreApp package manifest](./apps/core-app/package.json) is `2.4.14-beta.2`.
 
 Preview artifacts are produced for macOS, Windows, and Linux. A stable source version does not imply identical capability maturity or complete OTA acceptance across platforms; unsupported or degraded paths must remain explicit and fail closed. See the [current stability plan](./docs/plan-prd/TODO.md) and [cross-platform audit](./.trellis/tasks/07-13-search-crossplatform-audit/prd.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,7 +15,7 @@
 
 ## 📌 发布与平台状态
 
-仓库当前稳定基线为 `2.4.13`，由一致的[根目录 package manifest](./package.json)与 [CoreApp package manifest](./apps/core-app/package.json)确定。已发布制品以 [GitHub Releases](https://github.com/talex-touch/tuff/releases) 为准。
+仓库最新稳定发布为 `2.4.13`（详见 [GitHub Releases](https://github.com/talex-touch/tuff/releases)）；[根目录 package manifest](./package.json)与 [CoreApp package manifest](./apps/core-app/package.json)中声明的开发版本为 `2.4.14-beta.2`。
 
 当前提供 macOS、Windows 和 Linux 预发布构建。稳定源码版本不代表三端能力成熟度一致，也不代表 OTA 验收已经完成；不支持或降级路径必须明确说明并保持 fail-closed。详情见[当前稳定化计划](./docs/plan-prd/TODO.md)与[跨平台审计](./.trellis/tasks/07-13-search-crossplatform-audit/prd.md)。
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,11 +3,11 @@
 > 更新时间：2026-07-31（经全条目事实校准，校准记录见 `.trellis/tasks/07-30-docs-roadmap-consolidation-cleanup/research/`）
 > 定位：项目全貌一览。实时任务优先级见 [`docs/plan-prd/TODO.md`](docs/plan-prd/TODO.md)，任务状态见 [`.trellis/tasks/`](.trellis/tasks/README.md)。本文不复制易漂移细节，只保留稳定入口与高层状态。
 
-## 🎯 当前版本：v2.4.13
+## 🎯 当前版本：v2.4.14-beta.2
 
 | 维度 | 状态 |
 |------|------|
-| CoreApp 版本 | `2.4.13`（`apps/core-app/package.json`） |
+| CoreApp 版本 | `2.4.14-beta.2`（`apps/core-app/package.json`） |
 | Node.js | `>=24.15.0` |
 | pnpm | `10.34.4` |
 | Electron | `^41.10.1`（根 `package.json`） |


### PR DESCRIPTION
Both docs conflated the latest stable release with the manifest (in-dev) version.

- `v2.4.13` is the latest stable release (GitHub Releases marks it Latest).
- `2.4.14-beta.2` is what `package.json` / `apps/core-app/package.json` actually declare.

**#628** - READMEs (EN + zh) said the `2.4.13` baseline was resolved from the package manifests, which is false (they say `2.4.14-beta.2`). Reworded to state both accurately.

**#629** - ROADMAP header and the CoreApp-version row cited `apps/core-app/package.json` but showed `2.4.13`; that file declares `2.4.14-beta.2`. Corrected both rows.

Docs-only.

Fixes #628
Fixes #629

<sub>Automated audit remediation loop · tracker #959</sub>