### PR TITLE
docs(intelligence-uikit): fix broken import example in README (#632)

### DIFF
--- a/packages/intelligence-uikit/README.md
+++ b/packages/intelligence-uikit/README.md
@@ -21,13 +21,10 @@ import {
 import '@talex-touch/intelligence-uikit/style.css'
 ```
 
-AI block 兼容入口：
+AI 对话组件（从包根导入，注意 `TxAiConversation` 的大小写）：
 
 ```ts
-import {
-  mapAIChatBlocksToAiBlocks,
-  TxAIConversation,
-} from '@talex-touch/intelligence-uikit/conversation'
+import { TxAiConversation } from '@talex-touch/intelligence-uikit'
 ```
 
 ## 组件矩阵
@@ -55,7 +52,7 @@ import {
 ### Phase 1：落地包结构
 
 - 新增 `packages/intelligence-uikit`。
-- 提供 `@talex-touch/intelligence-uikit`、`@talex-touch/intelligence-uikit/conversation`、`@talex-touch/intelligence-uikit/style.css`。
+- 提供 `@talex-touch/intelligence-uikit`、`@talex-touch/intelligence-uikit/style.css`。
 - README 固化组件矩阵、迁移策略、动效扩展规范。
 - 只提供组件骨架和稳定扩展点。
 


### PR DESCRIPTION
`packages/intelligence-uikit/README.md` documented an import that fails:

```ts
import { mapAIChatBlocksToAiBlocks, TxAIConversation } from '@talex-touch/intelligence-uikit/conversation'
```

- `./conversation` is **not** in the exports map (only `.` and `./style.css`) → `ERR_PACKAGE_PATH_NOT_EXPORTED`.
- `mapAIChatBlocksToAiBlocks` is not exported (only appears in a playground sample).
- `TxAIConversation` is mis-cased; the real component is `TxAiConversation`.

Replaced with the working root import (verified reachable via `src/index.ts` → `components.ts` → `components/conversation/index.ts`) and removed the phantom `/conversation` subpath from the 'provides' list.

Docs-only.

Fixes #632

<sub>Automated audit remediation loop · tracker #959</sub>