### PR TITLE
docs(intelligence-uikit): fix second phantom /conversation reference (follow-up to #632)

### DIFF
--- a/packages/intelligence-uikit/README.md
+++ b/packages/intelligence-uikit/README.md
@@ -88,11 +88,11 @@ import { TxAiConversation } from '@talex-touch/intelligence-uikit'
 
 ## AI block mapping 边界
 
-`@talex-touch/intelligence-uikit/conversation` 只提供：
+`@talex-touch/intelligence-uikit` 的对话组件只提供：
 
 - AI block 到 `TxAiRichBlock` 的映射。
 - AI message 到 `TxAiMessageModel` 的映射。
-- `TxAIConversation` / `TxAIMessage` 兼容导出。
+- `TxAiConversation` / `TxAiMessage` 组件导出。
 
 禁止放入：
 


### PR DESCRIPTION
Follow-up completing #632. PR #974 fixed the import example but missed a **second** occurrence in the 'AI block mapping 边界' section, which still referenced the phantom `@talex-touch/intelligence-uikit/conversation` subpath and the mis-cased `TxAIConversation`/`TxAIMessage`. Reworded to the root package and corrected casing to `TxAiConversation`/`TxAiMessage`. Whole-file grep now clean.

Docs-only. Completes #632.

<sub>Automated audit remediation loop · tracker #959</sub>