### PR TITLE
docs(tuff-native): fix audio.d.ts contract comments (#855, #856)

### DIFF
--- a/packages/tuff-native/audio.d.ts
+++ b/packages/tuff-native/audio.d.ts
@@ -76,8 +76,9 @@ export declare function snapshotCapture(sessionId: string): AudioSnapshot
 /** Returns only the NEW captured PCM since the last drain (raw 16-bit LE mono). Throws `session-not-found: <id>` for an unknown id. */
 export declare function drainCapture(sessionId: string): AudioPcmChunk
 export declare function stopCapture(sessionId: string): AudioCaptureResult
+/** Cancel the capture session and discard its buffered PCM. Throws `session-not-found: <id>` for an unknown id. */
 export declare function cancelCapture(sessionId: string): void
-/** Decode WAV/MP3 bytes and play them through the default output device. Returns immediately; playback continues on a native thread. Throws when the binding is unavailable or the audio can't be decoded. */
+/** Decode WAV/MP3 bytes and play them through the default output device. Returns immediately; playback continues on a native thread. Degrades to a no-op (`{ playbackId: '' }`) when the native binding is unavailable or disabled; throws when the audio can't be decoded. */
 export declare function playAudio(bytes: Buffer): AudioPlaybackStart
 /** Stop one playback by id, or all playbacks when omitted. Unknown/absent id is a no-op. */
 export declare function stopPlayback(playbackId?: string): void


### PR DESCRIPTION
Two contract-comment mismatches in `packages/tuff-native/audio.d.ts` (comment-only, no type/behaviour change):

- **#856** `cancelCapture` was declared with no throw documented, but `audio.js` forwards to the native binding which returns `Err` (throws) for an unknown session id — same as the adjacent `drainCapture`. Added the `session-not-found` throw to its doc.
- **#855** `playAudio`'s comment said it *throws when the binding is unavailable*, but `audio.js:92-99` deliberately degrades to a no-op `{ playbackId: '' }` in that case. Corrected the comment to describe the degradation (it still throws on undecodable audio).

Fixes #855
Fixes #856

<sub>Automated audit remediation loop · tracker #959</sub>