### PR TITLE
docs: fix license badge branch (main→master) + core-app MIT→MPL-2.0 (#616, #617)

### DIFF
--- a/.github/docs/contribution/CONTRIBUTING.md
+++ b/.github/docs/contribution/CONTRIBUTING.md
@@ -5,7 +5,7 @@
   <h1>Tuff</h1>
 
   [![GitHub issues](https://img.shields.io/github/issues/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/issues)
-  [![GitHub license](https://img.shields.io/github/license/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/blob/main/LICENSE)
+  [![GitHub license](https://img.shields.io/github/license/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/blob/master/LICENSE)
   [![GitHub release](https://img.shields.io/github/v/release/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/releases)
   [![Dev version](https://img.shields.io/github/package-json/v/talex-touch/tuff?style=flat-square&label=dev&color=64391A)](https://github.com/talex-touch/tuff/discussions/35)
 

--- a/.github/docs/contribution/CONTRIBUTING_zh.md
+++ b/.github/docs/contribution/CONTRIBUTING_zh.md
@@ -5,7 +5,7 @@
   <h1>Tuff</h1>
 
   [![GitHub issues](https://img.shields.io/github/issues/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/issues)
-  [![GitHub license](https://img.shields.io/github/license/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/blob/main/LICENSE)
+  [![GitHub license](https://img.shields.io/github/license/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/blob/master/LICENSE)
   [![GitHub release](https://img.shields.io/github/v/release/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/releases)
   [![Dev version](https://img.shields.io/github/package-json/v/talex-touch/tuff?style=flat-square&label=dev&color=64391A)](https://github.com/talex-touch/tuff/discussions/35)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ---
 
   [![GitHub issues](https://img.shields.io/github/issues/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/issues)
-  [![GitHub license](https://img.shields.io/github/license/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/blob/main/LICENSE)
+  [![GitHub license](https://img.shields.io/github/license/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/blob/master/LICENSE)
   [![GitHub release](https://img.shields.io/github/v/release/talex-touch/tuff?include_prereleases&style=flat-square)](https://github.com/talex-touch/tuff/releases)
   <br>
   English | [简体中文](./README.zh-CN.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,7 @@
   > 指令中心，为创造者们而重塑。
 
   [![GitHub issues](https://img.shields.io/github/issues/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/issues)
-  [![GitHub license](https://img.shields.io/github/license/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/blob/main/LICENSE)
+  [![GitHub license](https://img.shields.io/github/license/talex-touch/tuff?style=flat-square)](https://github.com/talex-touch/tuff/blob/master/LICENSE)
   [![GitHub release](https://img.shields.io/github/v/release/talex-touch/tuff?include_prereleases&style=flat-square)](https://github.com/talex-touch/tuff/releases)
   <br>
   [English](./README.md) | 简体中文

--- a/apps/core-app/README.md
+++ b/apps/core-app/README.md
@@ -70,4 +70,4 @@ the preload boundary, and use the smallest relevant package checks.
 
 ## License
 
-CoreApp is distributed under the repository [MIT License](../../LICENSE).
+CoreApp is distributed under the repository [Mozilla Public License 2.0 (MPL-2.0)](../../LICENSE).


### PR DESCRIPTION
- **#617** — the GitHub-license badges in `README.md`, `README.zh-CN.md`, and both `.github/docs/contribution/CONTRIBUTING*.md` linked `/blob/main/LICENSE`, but origin has **no `main` branch** (`git ls-remote --heads origin main master` → only `refs/heads/master`; origin/HEAD → master), so every link 404'd. Changed to `/blob/master/LICENSE`. The unrelated `TalexDreamSoul/touchq/blob/main/...` guide links (a different repo) are left untouched.
- **#616** — `apps/core-app/README.md` called the repo LICENSE an *MIT License*; it is **MPL-2.0**. Corrected.

Docs-only.

Fixes #616
Fixes #617

<sub>Automated audit remediation loop · tracker #959</sub>