### PR TITLE
docs(contributing): fix invalid commit types + commitlint config filename (#618, #619)

### DIFF
--- a/.github/docs/contribution/CONTRIBUTING.md
+++ b/.github/docs/contribution/CONTRIBUTING.md
@@ -54,10 +54,10 @@ Sorry! We as much as possible the current primary goal is to optimize the progra
    - test(xxx): message
    - build(xxx): message
    - docs(xxx): message
-   - add(xxx): message
-   - upd(xxx): message (Update dependencies versions)
+   - feat(xxx): message
+   - update(xxx): message (e.g. update dependency versions)
    - change(xxx): message (The last one to choose) [Fallback]
-   - More see `commitlint.config.js`
+   - More see `commitlint.config.cts`
 4. The xxx is what you update and a area or a module:
    - Abstract range like PluginModule
    - Specific single file like touch-core.ts

--- a/.github/docs/contribution/CONTRIBUTING_zh.md
+++ b/.github/docs/contribution/CONTRIBUTING_zh.md
@@ -53,10 +53,10 @@
    - test(xxx): message
    - build(xxx): message
    - docs(xxx): message
-   - add(xxx): message
-   - upd(xxx): message (诸如更新dependencies的版本也可)
+   - feat(xxx): message
+   - update(xxx): message (诸如更新 dependencies 的版本也可)
    - change(xxx): message (应当留作备选)
-   - 更多请参考 `commitlint.config.js`
+   - 更多请参考 `commitlint.config.cts`
 4. XXX 是你更新了什么，或者是一个抽象范围、模块:
    - 抽象范围 像是 PluginModule
    - 具体文件 像是 touch-core.ts


### PR DESCRIPTION
`.github/docs/contribution/CONTRIBUTING.md` (+ `_zh`):

- **#618** — the commit-message guide told contributors to use `add(xxx)` and `upd(xxx)`, but `commitlint.config.cts`'s `type-enum` allows neither (no `add`; `upd` is `update`/`upg`), and `.husky/commit-msg` enforces it — so a contributor copying the guide gets their commit rejected. Changed to `feat()` and `update()` (both in the enum).
- **#619** — the guide said *More see `commitlint.config.js`*, but the file is `commitlint.config.cts` (husky runs `--config commitlint.config.cts`). Corrected.

EN + zh. Docs-only.

Fixes #618
Fixes #619

<sub>Automated audit remediation loop · tracker #959</sub>