### PR TITLE
docs(CLAUDE.md): fix nonexistent storage channels + required manifest fields (#613, #614)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,8 @@ Plugins are loaded from the user data directory at runtime, not bundled with the
   "id": "com.example.plugin",
   "name": "plugin-name",
   "version": "1.0.0",
+  "sdkapi": 260713,
+  "category": "utilities",
   "features": [
     {
       "id": "feature-id",
@@ -300,8 +302,8 @@ Modules subscribe to events: `touchEventBus.on(TalexEvents.ALL_MODULES_LOADED, (
 - Update broadcast system for reactive UI updates across windows
 
 **Channel Integration:**
-- Main process: `storage:get`, `storage:save`, `storage:delete`
-- Plugin process: `plugin:storage:get-item`, `plugin:storage:set-item`
+- Main process: `storage:sqlite:query`, `storage:plugin:file`, `storage:plugin:secret`
+- Plugin process: `plugin:storage:get-file`, `plugin:storage:set-file`, `plugin:storage:get-secret`, `plugin:storage:set-secret`
 
 ### Shared Utilities Package
 


### PR DESCRIPTION
- **#613** — the *Channel Integration* block documented storage IPC channels (`storage:get`/`save`/`delete`, `plugin:storage:get-item`/`set-item`) that exist nowhere in the source. Replaced with the real ones: `storage:sqlite:query`, `storage:plugin:file`, `storage:plugin:secret` (main) and `plugin:storage:get-file`/`set-file`/`get-secret`/`set-secret` (plugin).
- **#614** — the Plugin Manifest Example omitted `sdkapi` and `category`. `sdkapi-hard-cut-gate.ts` blocks a manifest with undefined `sdkapi` (`missing-sdkapi` → `load_failed`), and `category` is mandatory for `sdkapi >= 260114` — so a copied example never loads. Added `"sdkapi": 260713` + `"category": "utilities"` (both valid, per real plugin manifests).

Docs-only.

Fixes #613
Fixes #614

<sub>Automated audit remediation loop · tracker #959</sub>