### PR TITLE
fix(i18n): add missing base.details key to both locales (#488)

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -881,6 +881,7 @@
     "description": "Select the window effect that feels comfortable to you."
   },
   "base": {
+    "details": "Details",
     "last_step": "Last Step",
     "step": "Next",
     "touchCaptcha": {

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -881,6 +881,7 @@
     "description": "选择你喜欢的窗口效果。"
   },
   "base": {
+    "details": "详情",
     "last_step": "上一步",
     "step": "下一步",
     "touchCaptcha": {


### PR DESCRIPTION
`PluginCard.vue:30` renders `$t('base.details')`, but `base.details` was missing from **both** `en-US.json` and `zh-CN.json` (the `base` namespace only had `last_step`, `step`, `touchCaptcha`). Result: every plugin card's primary button showed the literal string `base.details`, once per installed plugin.

Added `"details": "Details"` / `"详情"`. Both locale files re-verified as valid JSON and the key confirmed resolvable.

Fixes #488

<sub>Automated audit remediation loop · tracker #959</sub>