### PR TITLE
fix(i18n): add missing settings.window.startSilent keys (#489)

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -4080,7 +4080,9 @@
       "startMinimized": "Start minimized to tray",
       "startMinimizedDesc": "Launch application minimized to system tray",
       "autoStart": "Auto Start on Boot",
-      "autoStartDesc": "Automatically launch app when system starts"
+      "autoStartDesc": "Automatically launch app when system starts",
+      "startSilent": "Start silently",
+      "startSilentDesc": "Launch in the background without showing the main window"
     },
     "setup": {
       "groupTitle": "General Settings",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -4036,7 +4036,9 @@
       "startMinimized": "启动时最小化到托盘",
       "startMinimizedDesc": "应用启动时直接最小化到系统托盘",
       "autoStart": "开机自动启动",
-      "autoStartDesc": "系统启动时自动运行应用"
+      "autoStartDesc": "系统启动时自动运行应用",
+      "startSilent": "静默启动",
+      "startSilentDesc": "在后台启动，不显示主窗口"
     },
     "setup": {
       "groupTitle": "通用配置",


### PR DESCRIPTION
`SettingWindow.vue:163-164` renders `t('settings.window.startSilent')` and `t('settings.window.startSilentDesc')`, but neither key existed in `en-US.json` or `zh-CN.json` — so Settings → Window showed a toggle whose title and description were the raw key strings.

Added both keys to the `settings.window` namespace in both locales. Wording verified against the actual behaviour in `apps/core-app/src/main/core/silent-launch.ts` (launches without showing the main window, paired with `--silent`/`--hidden`), not guessed. Note there are 4 `autoStartDesc` occurrences across these files; the keys were placed in the correct `settings.window` block (verified by parsing, not line number).

Fixes #489

<sub>Automated audit remediation loop · tracker #959</sub>