### PR TITLE
fix(i18n): add missing migration + common yes/no/retry keys (#486)

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -2302,6 +2302,16 @@
     "modifiedAt": "Modified At"
   },
   "download": {
+    "migration": {
+      "title": "Migrating data",
+      "subtitle": "Please keep the app open until the migration finishes.",
+      "tasks": "Tasks",
+      "history": "History",
+      "config": "Config",
+      "duration": "Duration",
+      "errors": "Errors",
+      "pleaseWait": "Please wait…"
+    },
     "error_logs": "Error Logs",
     "no_logs": "No logs yet",
     "load_logs_failed": "Failed to load logs",
@@ -4233,6 +4243,9 @@
     }
   },
   "common": {
+    "yes": "Yes",
+    "no": "No",
+    "retry": "Retry",
     "cancel": "Cancel",
     "save": "Save",
     "confirm": "Confirm",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -2278,6 +2278,16 @@
     "modifiedAt": "修改时间"
   },
   "download": {
+    "migration": {
+      "title": "正在迁移数据",
+      "subtitle": "迁移完成前请保持应用开启。",
+      "tasks": "任务",
+      "history": "历史记录",
+      "config": "配置",
+      "duration": "耗时",
+      "errors": "错误",
+      "pleaseWait": "请稍候…"
+    },
     "error_logs": "错误日志",
     "no_logs": "暂无日志",
     "load_logs_failed": "加载日志失败",
@@ -4189,6 +4199,9 @@
     }
   },
   "common": {
+    "yes": "是",
+    "no": "否",
+    "retry": "重试",
     "cancel": "取消",
     "save": "保存",
     "confirm": "确认",


### PR DESCRIPTION
`MigrationProgress.vue` referenced **11** keys missing from both locales — `common.yes`, `common.no`, `common.retry`, and the entire `download.migration.*` namespace (`title`, `subtitle`, `tasks`, `history`, `config`, `duration`, `errors`, `pleaseWait`).

Impact: a user upgrading the app saw the data-migration dialog with a raw-key heading, raw-key result labels, and boolean rows reading `common.yes`/`common.no` instead of Yes/No — so they could not tell whether their data migrated.

Wording derived from each call site (the dialog is a blocking data-migration progress view). Diff is **insert-only** (26 additions, 0 deletions, no reformatting); both locale files re-parse as valid JSON with all 11 keys resolving.

Fixes #486

<sub>Automated audit remediation loop · tracker #959</sub>