### PR TITLE
fix(i18n): point download history duration at existing common.* time keys (#490)

### DIFF
--- a/apps/core-app/src/renderer/src/components/download/HistoryCard.vue
+++ b/apps/core-app/src/renderer/src/components/download/HistoryCard.vue
@@ -113,15 +113,15 @@ function formatSize(bytes: number): string {
 
 function formatDuration(seconds: number): string {
   if (seconds < 60) {
-    return `${Math.round(seconds)}${t('download.seconds')}`
+    return `${Math.round(seconds)}${t('common.seconds')}`
   } else if (seconds < 3600) {
     const minutes = Math.floor(seconds / 60)
     const secs = Math.round(seconds % 60)
-    return `${minutes}${t('download.minutes')}${secs}${t('download.seconds')}`
+    return `${minutes}${t('common.minutes')}${secs}${t('common.seconds')}`
   } else {
     const hours = Math.floor(seconds / 3600)
     const minutes = Math.floor((seconds % 3600) / 60)
-    return `${hours}${t('download.hours')}${minutes}${t('download.minutes')}`
+    return `${hours}${t('common.hours')}${minutes}${t('common.minutes')}`
   }
 }
 


### PR DESCRIPTION
`HistoryCard.vue`'s `formatDuration` called `t('download.seconds')`, `t('download.minutes')`, `t('download.hours')` — none of which exist in either locale — so every download-history entry rendered its duration as e.g. `42download.seconds` in **all** locales.

The equivalent `common.seconds` / `common.minutes` / `common.hours` already exist in both locales with compact units (`s`/`min`/`hr`, `秒`/`分钟`/`小时`) that suit this no-space template concatenation, so this repoints the three call sites rather than adding duplicate keys — which is what the audit recommended.

The unrelated `download.minutes_ago` / `download.hours_ago` relative-time keys in the same file are **untouched** (verified).

Change is 3 quoted key strings; diff shows no structural edits.

Fixes #490

<sub>Automated audit remediation loop · tracker #959</sub>