### PR TITLE
fix(a11y,i18n): localize the CoreBox pin control's accessible name (#496)

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -5195,6 +5195,7 @@
     "confirmAndSend": "Authorize and send"
   },
   "corebox": {
+    "pin": "Pin CoreBox",
     "pinned": "Pinned",
     "unpinned": "Unpinned",
     "pinFailed": "Pin failed",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -5147,6 +5147,7 @@
     "confirmAndSend": "授权并发送"
   },
   "corebox": {
+    "pin": "固定 CoreBox",
     "pinned": "已固定",
     "unpinned": "已取消固定",
     "pinFailed": "固定失败",

--- a/apps/core-app/src/renderer/src/views/box/CoreBox.vue
+++ b/apps/core-app/src/renderer/src/views/box/CoreBox.vue
@@ -871,7 +871,12 @@ const customCss = computed(() => {
           >
             <TuffIcon :icon="{ type: 'class', value: 'i-ri-send-plane-2-fill' }" />
           </button>
-          <TuffIcon v-else :icon="pinIcon" alt="固定 CoreBox" @click="handleTogglePin" />
+          <TuffIcon
+            v-else
+            :icon="pinIcon"
+            :alt="t('corebox.pin', '固定 CoreBox')"
+            @click="handleTogglePin"
+          />
         </div>
       </template>
     </div>

--- a/apps/core-app/src/renderer/src/views/box/MainBoxHeader.vue
+++ b/apps/core-app/src/renderer/src/views/box/MainBoxHeader.vue
@@ -3,6 +3,7 @@ import type { IProviderActivate, ITuffIcon } from '@talex-touch/utils'
 import type { IBoxOptions } from '../../modules/box/adapter'
 import type { IClipboardOptions } from '../../modules/box/adapter/hooks/types'
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useTuffTransport } from '@talex-touch/utils/transport'
 import { CoreBoxEvents } from '@talex-touch/utils/transport/events'
 import { TxIcon as TuffIcon } from '@talex-touch/tuffex/icon'
@@ -31,6 +32,7 @@ interface Emits {
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
 const transport = useTuffTransport()
+const { t } = useI18n()
 
 const boxInputRef = ref()
 defineExpose({ boxInputRef })
@@ -90,7 +92,7 @@ function handlePaste(): void {
     <TagSection v-if="!isUIMode" :box-options="boxOptions" :clipboard-options="clipboardOptions" />
 
     <div class="CoreBox-Configure">
-      <TuffIcon :icon="pinIcon" alt="固定 CoreBox" @click="handleTogglePin" />
+      <TuffIcon :icon="pinIcon" :alt="t('corebox.pin', '固定 CoreBox')" @click="handleTogglePin" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
Both CoreBox pin toggles used a hardcoded Chinese `alt="固定 CoreBox"`, so an English screen-reader user tabbing the header heard a Chinese label immediately next to the send button — which is correctly localized via `t('corebox.send', '发送')`.

- Added `corebox.pin` to both locales ("Pin CoreBox" / "固定 CoreBox").
- Bound `:alt="t('corebox.pin', '固定 CoreBox')"` at both call sites (`MainBoxHeader.vue:93`, `CoreBox.vue:874`), matching the adjacent `corebox.send` pattern including its literal fallback.
- **`MainBoxHeader.vue` had no i18n at all** — no `useI18n` import, no `t` in scope — so the naive fix would have thrown `t is not defined` at runtime. Added the import and `const { t } = useI18n()`.

Verified with ESLint (`--max-warnings=0`): **0 errors, 0 warnings**. The initial single-line binding tripped a prettier line-length warning, so the CoreBox.vue attribute list is wrapped.

Fixes #496

<sub>Automated audit remediation loop · tracker #959</sub>