### PR TITLE
fix(a11y,i18n): localize detached CoreBox window control labels (#495)

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -5195,6 +5195,9 @@
     "confirmAndSend": "Authorize and send"
   },
   "corebox": {
+    "opacity": "Opacity",
+    "debug": "Debug",
+    "alwaysOnTop": "Always on top",
     "pin": "Pin CoreBox",
     "pinned": "Pinned",
     "unpinned": "Unpinned",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -5147,6 +5147,9 @@
     "confirmAndSend": "授权并发送"
   },
   "corebox": {
+    "opacity": "透明度",
+    "debug": "调试",
+    "alwaysOnTop": "置顶",
     "pin": "固定 CoreBox",
     "pinned": "已固定",
     "unpinned": "已取消固定",

--- a/apps/core-app/src/renderer/src/views/box/DivisionBoxHeader.vue
+++ b/apps/core-app/src/renderer/src/views/box/DivisionBoxHeader.vue
@@ -4,6 +4,7 @@ import type { IUseSearch } from '~/modules/box/adapter/types'
 import { useTuffTransport } from '@talex-touch/utils/transport'
 import { DivisionBoxEvents } from '@talex-touch/utils/transport/events'
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { TxIcon as TuffIcon } from '@talex-touch/tuffex/icon'
 import { windowState } from '~/modules/hooks/core-box'
 import { useRendererPlatform } from '~/modules/platform/renderer-platform'
@@ -22,6 +23,7 @@ const emit = defineEmits<
 >()
 
 const { isMac } = useRendererPlatform()
+const { t } = useI18n()
 
 interface Props {
   searchVal: string
@@ -108,22 +110,40 @@ async function handleDebug(): Promise<void> {
 
     <!-- Window Controls -->
     <div class="DivisionBox-Controls">
-      <button type="button" class="control-btn" title="透明度" @click="handleOpacity">
-        <TuffIcon :icon="{ type: 'class', value: opacityIcon }" alt="透明度" :size="18" />
+      <button
+        type="button"
+        class="control-btn"
+        :title="t('corebox.opacity', '透明度')"
+        @click="handleOpacity"
+      >
+        <TuffIcon
+          :icon="{ type: 'class', value: opacityIcon }"
+          :alt="t('corebox.opacity', '透明度')"
+          :size="18"
+        />
       </button>
-      <button type="button" class="control-btn" title="调试" @click="handleDebug">
-        <TuffIcon :icon="{ type: 'class', value: 'i-carbon-debug' }" alt="调试" :size="18" />
+      <button
+        type="button"
+        class="control-btn"
+        :title="t('corebox.debug', '调试')"
+        @click="handleDebug"
+      >
+        <TuffIcon
+          :icon="{ type: 'class', value: 'i-carbon-debug' }"
+          :alt="t('corebox.debug', '调试')"
+          :size="18"
+        />
       </button>
       <button
         type="button"
         class="control-btn"
         :class="{ active: pinned }"
-        title="置顶"
+        :title="t('corebox.alwaysOnTop', '置顶')"
         @click="handlePin"
       >
         <TuffIcon
           :icon="{ type: 'class', value: pinned ? 'i-ri-pushpin-2-line' : 'i-ri-pushpin-2-fill' }"
-          alt="置顶"
+          :alt="t('corebox.alwaysOnTop', '置顶')"
           :size="18"
         />
       </button>


### PR DESCRIPTION
The three window controls in the detached CoreBox header (`DivisionBoxHeader.vue`) carried hardcoded Chinese `title` attributes **and** Chinese `TuffIcon` `alt` text — six literals in total. English users saw Chinese tooltips, and since `alt` is the icons' only accessible name, English screen-reader users heard the controls announced as 透明度 / 调试 / 置顶.

- Added `corebox.opacity`, `corebox.debug`, `corebox.alwaysOnTop` to both locales.
- Bound `:title` and `:alt` through `t('corebox.…', '<Chinese literal>')`, keeping the original literal as the fallback (same pattern as the existing `corebox.send` / `corebox.pin` call sites).
- The component had **no i18n wiring**, so `useI18n` and `const { t }` were added — without them the template would throw `t is not defined` (same trap as #496).

Verified: no hardcoded literals remain, and ESLint passes at `--max-warnings=0` (0 errors, 0 warnings).

Fixes #495

<sub>Automated audit remediation loop · tracker #959</sub>