### PR TITLE
fix(i18n): add missing corebox.actionUnsupported key (#703)

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -5195,6 +5195,7 @@
     "confirmAndSend": "Authorize and send"
   },
   "corebox": {
+    "actionUnsupported": "This action isn't supported yet",
     "opacity": "Opacity",
     "debug": "Debug",
     "alwaysOnTop": "Always on top",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -5147,6 +5147,7 @@
     "confirmAndSend": "授权并发送"
   },
   "corebox": {
+    "actionUnsupported": "暂不支持该操作",
     "opacity": "透明度",
     "debug": "调试",
     "alwaysOnTop": "置顶",


### PR DESCRIPTION
`useActionPanel.ts` calls `t('corebox.actionUnsupported', '暂不支持该操作')` at **two** sites (lines 95 and 221 — the audit cited one), but the key resolved in neither locale, so the Chinese literal fallback was what *every* user saw. An English user triggering an unsupported CoreBox action got a Chinese error toast and couldn't tell whether the action failed or is simply unavailable.

Added the key to both locales ("This action isn't supported yet" / "暂不支持该操作"). **No code change needed** — the call sites already use the correct `t(key, fallback)` pattern; only the key was missing.

Insert-only diff (2 additions, 0 deletions); both files re-parse as valid JSON with the key resolving.

Fixes #703

<sub>Automated audit remediation loop · tracker #959</sub>