### PR TITLE
fix(i18n): add missing common.loadMore key (#704)

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -4247,6 +4247,7 @@
     }
   },
   "common": {
+    "loadMore": "Load more",
     "copy": "Copy",
     "copied": "Copied",
     "yes": "Yes",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -4199,6 +4199,7 @@
     }
   },
   "common": {
+    "loadMore": "加载更多",
     "copy": "复制",
     "copied": "已复制",
     "yes": "是",


### PR DESCRIPTION
`IntelligenceAuditLogs.vue:548` renders `{{ t('common.loadMore') }}` for its pagination control, but `loadMore` was absent from the `common` namespace in both locales — so users paging through AI audit logs saw a button labelled `common.loadMore` and might not recognise it as a control.

Added "Load more" / "加载更多". Insert-only diff (2 additions, 0 deletions); JSON validity and key resolution verified.

Fixes #704

<sub>Automated audit remediation loop · tracker #959</sub>