### PR TITLE
fix(i18n): localize WidgetFrame error and status text (#493)

### DIFF
--- a/apps/core-app/src/renderer/src/components/render/WidgetFrame.vue
+++ b/apps/core-app/src/renderer/src/components/render/WidgetFrame.vue
@@ -13,6 +13,7 @@ import {
   type Component,
   type VNode
 } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { getCustomRenderer, getCustomRendererVersion } from '~/modules/box/custom-render'
 import { useWidgetHostKeyEvent } from '~/modules/plugin/widget-host-key-bridge'
 import {
@@ -45,6 +46,7 @@ const emits = defineEmits<{
   (e: 'render-error', error: Error): void
 }>()
 
+const { t } = useI18n()
 const renderError = ref<Error | null>(null)
 const widgetFrameLog = createRendererLogger('WidgetFrame')
 const rendererState = ref<'loading' | 'ready' | 'missing'>('loading')
@@ -109,14 +111,14 @@ const emptyStateLabel = computed(() => {
   return 'Widget renderer unavailable'
 })
 const emptyStateText = computed(() => {
-  if (widgetFailure.value) return 'Widget 编译失败'
-  if (rendererState.value === 'loading') return 'Widget 加载中'
-  if (!props.rendererId) return 'Widget renderer 缺失'
-  return 'Widget renderer 未注册'
+  if (widgetFailure.value) return t('widgetFrame.compileFailed', 'Widget 编译失败')
+  if (rendererState.value === 'loading') return t('widgetFrame.loading', 'Widget 加载中')
+  if (!props.rendererId) return t('widgetFrame.rendererMissing', 'Widget renderer 缺失')
+  return t('widgetFrame.rendererUnregistered', 'Widget renderer 未注册')
 })
 const emptyStateMessage = computed(() => {
   if (widgetFailure.value) return widgetFailure.value.message
-  if (!props.rendererId) return '缺少 rendererId'
+  if (!props.rendererId) return t('widgetFrame.missingRendererId', '缺少 rendererId')
   if (rendererState.value === 'loading') return ''
   return props.rendererId
 })
@@ -410,7 +412,9 @@ onBeforeUnmount(() => {
     @submit.capture="handleWidgetNavigationEvent"
   >
     <div v-if="renderError" class="WidgetFrame-Error text-xs text-[var(--tx-color-danger)]">
-      <div class="WidgetFrame-ErrorTitle">Widget 渲染失败</div>
+      <div class="WidgetFrame-ErrorTitle">
+        {{ t('widgetFrame.renderFailed', 'Widget 渲染失败') }}
+      </div>
       <div class="WidgetFrame-ErrorMessage">{{ renderError.message }}</div>
     </div>
     <div v-else-if="canRenderShadow" ref="shadowHost" class="WidgetFrame-ShadowHost" />

--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -4246,6 +4246,14 @@
       "unofficial": "Current version has not passed official build verification, may be unsafe"
     }
   },
+    "widgetFrame": {
+      "compileFailed": "Widget compile failed",
+      "loading": "Loading widget",
+      "rendererMissing": "Widget renderer missing",
+      "rendererUnregistered": "Widget renderer not registered",
+      "missingRendererId": "Missing rendererId",
+      "renderFailed": "Widget failed to render"
+    },
   "common": {
     "loadMore": "Load more",
     "copy": "Copy",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -4198,6 +4198,14 @@
       "unofficial": "当前版本未通过官方构建验证，可能不安全"
     }
   },
+    "widgetFrame": {
+      "compileFailed": "Widget 编译失败",
+      "loading": "Widget 加载中",
+      "rendererMissing": "Widget renderer 缺失",
+      "rendererUnregistered": "Widget renderer 未注册",
+      "missingRendererId": "缺少 rendererId",
+      "renderFailed": "Widget 渲染失败"
+    },
   "common": {
     "loadMore": "加载更多",
     "copy": "复制",


### PR DESCRIPTION
`WidgetFrame.vue` returned Chinese string literals from `emptyStateText` / `emptyStateMessage` and hardcoded the error title in the template — six literals — so English users saw Chinese text whenever a widget failed to compile, load, or render.

A telling detail: the computed **immediately above** (lines 106-109) already returns **English** strings for the same four conditions, so these were clearly meant to be localized rather than intentionally Chinese.

- Added a `widgetFrame` namespace (6 keys) to both locales.
- Routed all six literals through `t('widgetFrame.…', '<Chinese literal>')`, keeping the original text as fallback.
- The component had **no i18n wiring**, so `useI18n` + `const { t }` were added (declared well before first use).

Verified: no hardcoded literals remain outside the `t()` fallbacks, and ESLint passes at `--max-warnings=0` (a prettier line-length warning on the template edit was fixed by wrapping).

Fixes #493

<sub>Automated audit remediation loop · tracker #959</sub>