### PR TITLE
fix(i18n): localize the file index failure dialog (#492)

### DIFF
--- a/apps/core-app/src/renderer/src/components/file-index/FileIndexFailDialog.vue
+++ b/apps/core-app/src/renderer/src/components/file-index/FileIndexFailDialog.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { TxButton } from '@talex-touch/tuffex/button'
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import TBottomDialog from '../base/dialog/TBottomDialog.vue'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   modelValue: boolean
@@ -53,17 +56,19 @@ defineExpose({ updateProgress })
 <template>
   <TBottomDialog
     v-model="visible"
-    title="文件索引初始化失败"
+    :title="t('fileIndex.failTitle', '文件索引初始化失败')"
     class="file-index-fail-dialog"
     :close="handleLater"
   >
     <div class="dialog-content">
       <div class="error-icon">⚠️</div>
 
-      <p class="error-message">文件索引初始化失败，可能导致搜索功能无法正常使用。</p>
+      <p class="error-message">
+        {{ t('fileIndex.failMessage', '文件索引初始化失败，可能导致搜索功能无法正常使用。') }}
+      </p>
 
       <details v-if="errorDetail" class="error-detail">
-        <summary>查看错误详情</summary>
+        <summary>{{ t('fileIndex.viewErrorDetails', '查看错误详情') }}</summary>
         <pre>{{ errorDetail }}</pre>
       </details>
 
@@ -76,14 +81,20 @@ defineExpose({ updateProgress })
 
       <div class="actions">
         <TxButton variant="bare" class="btn-rebuild" :disabled="rebuilding" @click="handleRebuild">
-          {{ rebuilding ? '重建中...' : '重新建立索引' }}
+          {{
+            rebuilding
+              ? t('fileIndex.rebuilding', '重建中...')
+              : t('fileIndex.rebuildIndex', '重新建立索引')
+          }}
         </TxButton>
 
-        <TxButton variant="bare" class="btn-later" @click="handleLater"> 稍后处理 </TxButton>
+        <TxButton variant="bare" class="btn-later" @click="handleLater">
+          {{ t('fileIndex.later', '稍后处理') }}
+        </TxButton>
 
         <label class="checkbox-label">
           <input v-model="dontRemindAgain" type="checkbox" />
-          <span>不再提醒</span>
+          <span>{{ t('fileIndex.dontRemindAgain', '不再提醒') }}</span>
         </label>
       </div>
     </div>

--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -4254,6 +4254,15 @@
       "missingRendererId": "Missing rendererId",
       "renderFailed": "Widget failed to render"
     },
+    "fileIndex": {
+      "failTitle": "File index initialization failed",
+      "failMessage": "The file index failed to initialize, so search may not work correctly.",
+      "viewErrorDetails": "View error details",
+      "rebuilding": "Rebuilding…",
+      "rebuildIndex": "Rebuild index",
+      "later": "Later",
+      "dontRemindAgain": "Don't remind me again"
+    },
   "common": {
     "loadMore": "Load more",
     "copy": "Copy",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -4206,6 +4206,15 @@
       "missingRendererId": "缺少 rendererId",
       "renderFailed": "Widget 渲染失败"
     },
+    "fileIndex": {
+      "failTitle": "文件索引初始化失败",
+      "failMessage": "文件索引初始化失败，可能导致搜索功能无法正常使用。",
+      "viewErrorDetails": "查看错误详情",
+      "rebuilding": "重建中...",
+      "rebuildIndex": "重新建立索引",
+      "later": "稍后处理",
+      "dontRemindAgain": "不再提醒"
+    },
   "common": {
     "loadMore": "加载更多",
     "copy": "复制",


### PR DESCRIPTION
Every user-facing string in `FileIndexFailDialog.vue` was a Chinese literal — there was no `t()` call anywhere in the file. An English-locale user whose file index fails to build got a **fully Chinese modal** explaining that search is broken, and could not tell the *rebuild* button from the *dismiss* button, making them likely to dismiss a recoverable failure.

- Added a `fileIndex` namespace (7 keys) to both locales.
- Routed the dialog title, error message, error-details summary, both action buttons (including the `rebuilding` state) and the "don't remind me again" checkbox through `t('fileIndex.…', '<Chinese literal>')`, keeping the original text as fallback.
- The component had **no i18n wiring**, so `useI18n` + `const { t }` were added.

Verified: no user-facing Chinese literals remain outside `t()` fallbacks, and ESLint passes at `--max-warnings=0`.

Fixes #492

<sub>Automated audit remediation loop · tracker #959</sub>