### PR TITLE
fix(i18n): localize CoreBox preview history panel (#494)

### DIFF
--- a/apps/core-app/src/renderer/src/components/render/custom/PreviewHistoryPanel.vue
+++ b/apps/core-app/src/renderer/src/components/render/custom/PreviewHistoryPanel.vue
@@ -2,6 +2,9 @@
 import type { CalculationHistoryEntry } from '~/modules/box/adapter/hooks/usePreviewHistory'
 import dayjs from 'dayjs'
 import { computed, nextTick, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = withDefaults(
   defineProps<{
@@ -52,13 +55,15 @@ watch(
     <div class="panel">
       <header>
         <div class="title-row">
-          <span class="title">最近处理</span>
-          <span class="count">共 {{ items.length }} 条</span>
+          <span class="title">{{ t('previewHistory.recentTitle', '最近处理') }}</span>
+          <span class="count">{{ t('previewHistory.countSummary', { count: items.length }) }}</span>
         </div>
       </header>
       <div class="panel-body">
-        <div v-if="loading" class="state">加载中...</div>
-        <div v-else-if="!items.length" class="state">暂无记录</div>
+        <div v-if="loading" class="state">{{ t('common.loading', '加载中...') }}</div>
+        <div v-else-if="!items.length" class="state">
+          {{ t('previewHistory.noRecords', '暂无记录') }}
+        </div>
         <ul v-else ref="listRef" class="history-list">
           <li
             v-for="(item, index) in formattedItems"

--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -4263,6 +4263,11 @@
       "later": "Later",
       "dontRemindAgain": "Don't remind me again"
     },
+    "previewHistory": {
+      "recentTitle": "Recent",
+      "countSummary": "{count} total",
+      "noRecords": "No records yet"
+    },
   "common": {
     "loadMore": "Load more",
     "copy": "Copy",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -4215,6 +4215,11 @@
       "later": "稍后处理",
       "dontRemindAgain": "不再提醒"
     },
+    "previewHistory": {
+      "recentTitle": "最近处理",
+      "countSummary": "共 {count} 条",
+      "noRecords": "暂无记录"
+    },
   "common": {
     "loadMore": "加载更多",
     "copy": "复制",


### PR DESCRIPTION
`PreviewHistoryPanel.vue`'s heading, count summary, loading state and empty state were all Chinese literals with no `t()` in the file. An English user opening the CoreBox preview history saw a Chinese heading and, on an empty list, a Chinese empty state (`暂无记录`) indistinguishable from an error.

- Added a `previewHistory` namespace (3 keys) to both locales and **reused the existing `common.loading`** rather than duplicating it.
- The count summary keeps proper interpolation — `t('previewHistory.countSummary', { count: items.length })` with `"{count} total"` / `"共 {count} 条"` — following the repo's existing `{count}` convention, instead of concatenating text around the number (which doesn't translate).
- Component had **no i18n wiring**; `useI18n` + `const { t }` added.

ESLint clean at `--max-warnings=0` (prettier wanted the interpolated span on one line — fixed).

Fixes #494

<sub>Automated audit remediation loop · tracker #959</sub>