### PR TITLE
fix(i18n): localize clipboard and file tag labels (#497)

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -4268,6 +4268,12 @@
       "countSummary": "{count} total",
       "noRecords": "No records yet"
     },
+    "boxTag": {
+      "image": "Image",
+      "imageCount": "{count} images",
+      "charCount": "{count} chars total",
+      "preparingFiles": "Preparing files…"
+    },
   "common": {
     "loadMore": "Load more",
     "copy": "Copy",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -4220,6 +4220,12 @@
       "countSummary": "共 {count} 条",
       "noRecords": "暂无记录"
     },
+    "boxTag": {
+      "image": "图像",
+      "imageCount": "{count} 张图像",
+      "charCount": "共 {count} 字",
+      "preparingFiles": "文件准备中..."
+    },
   "common": {
     "loadMore": "加载更多",
     "copy": "复制",

--- a/apps/core-app/src/renderer/src/views/box/tag/ClipboardImageTag.vue
+++ b/apps/core-app/src/renderer/src/views/box/tag/ClipboardImageTag.vue
@@ -1,5 +1,8 @@
 <script name="ClipboardImageTag" setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   data: { content?: string | string[]; thumbnail?: string | null } // clipboard data
@@ -44,7 +47,9 @@ const stackWidth = computed(() => {
         alt="clipboard image"
       />
     </div>
-    <span class="label">{{ imageCount > 1 ? `${imageCount} 张图像` : '图像' }}</span>
+    <span class="label">{{
+      imageCount > 1 ? t('boxTag.imageCount', { count: imageCount }) : t('boxTag.image', '图像')
+    }}</span>
   </div>
 </template>
 

--- a/apps/core-app/src/renderer/src/views/box/tag/TagSection.vue
+++ b/apps/core-app/src/renderer/src/views/box/tag/TagSection.vue
@@ -48,7 +48,7 @@ const clipboardPreview = computed(() => {
   // If text is too long, truncate and show character count
   const maxLength = 30
   if (totalLength > maxLength) {
-    return `${preview.substring(0, maxLength)}... 共${totalLength}字`
+    return `${preview.substring(0, maxLength)}... ${t('boxTag.charCount', { count: totalLength })}`
   }
   return preview
 })

--- a/apps/core-app/src/renderer/src/views/box/tag/UnifiedFileTag.vue
+++ b/apps/core-app/src/renderer/src/views/box/tag/UnifiedFileTag.vue
@@ -1,10 +1,12 @@
 <script name="UnifiedFileTag" setup lang="ts">
 import path from 'path-browserify'
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { IClipboardItem } from '../../../modules/box/adapter/hooks/types'
 import { createRendererLogger } from '~/utils/renderer-log'
 import { buildTfileUrl } from '~/utils/tfile-url'
 
+const { t } = useI18n()
 const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'svg', 'webp', 'gif', 'bmp', 'ico'])
 const unifiedFileTagLog = createRendererLogger('UnifiedFileTag')
 
@@ -82,7 +84,7 @@ const fileCount = computed(() => filePaths.value.length)
  * First file name for display
  */
 const firstFileName = computed(() => {
-  if (filePaths.value.length === 0) return '文件准备中...'
+  if (filePaths.value.length === 0) return t('boxTag.preparingFiles', '文件准备中...')
   return path.basename(filePaths.value[0])
 })
 


### PR DESCRIPTION
The CoreBox attachment chips built their labels from Chinese literals across three tag components, so an English user pasting an image or files saw `3 张图像` or `文件准备中...`.

Two of these can't be fixed by a plain string swap, as the audit noted:
- `${imageCount} 张图像` uses the Chinese **measure word** 张 — English needs `{count} images`, not a translated measure word.
- `共${totalLength}字` wraps the number on **both sides** — English puts the unit after (`{count} chars total`).

So both became interpolated keys rather than concatenated fragments:

| key | en-US | zh-CN |
|---|---|---|
| `boxTag.image` | Image | 图像 |
| `boxTag.imageCount` | {count} images | {count} 张图像 |
| `boxTag.charCount` | {count} chars total | 共 {count} 字 |
| `boxTag.preparingFiles` | Preparing files… | 文件准备中... |

I used explicit singular/plural **keys** rather than vue-i18n's `|` pipe syntax, because every existing `|` in these locale files is a literal separator (e.g. `"Total: {total} | Built-in: {builtin}"`) — introducing pipe-plurals here would be inconsistent with the repo's convention.

`ClipboardImageTag` and `UnifiedFileTag` had no i18n wiring (`TagSection` already did) — `useI18n` added to both. ESLint clean at `--max-warnings=0` across all three files.

Fixes #497

<sub>Automated audit remediation loop · tracker #959</sub>