### PR TITLE
fix(i18n): replace isZh ternary with a real translation key (#500)

### DIFF
--- a/apps/core-app/src/renderer/src/components/store/StorePluginMetaHeader.vue
+++ b/apps/core-app/src/renderer/src/components/store/StorePluginMetaHeader.vue
@@ -11,7 +11,6 @@ const props = defineProps<{
 
 const { t, locale } = useI18n()
 
-const isZh = computed(() => locale.value.startsWith('zh'))
 const isOfficial = computed(
   () => props.plugin.official === true || props.plugin.providerTrustLevel === 'official'
 )
@@ -40,7 +39,7 @@ const metaItems = computed(() => {
     items.push(props.plugin.providerName)
   }
   if (updatedText.value) {
-    items.push(`${isZh.value ? '更新于' : 'Updated'} ${updatedText.value}`)
+    items.push(t('store.updatedAt', { time: updatedText.value }))
   }
   return items
 })

--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -1027,6 +1027,7 @@
     "storeDesc": "Browse, install and manage plugins."
   },
   "store": {
+    "updatedAt": "Updated {time}",
     "title": "Plugin Store",
     "subtitle": "Discover amazing plugins for your workflow",
     "searchPlaceholder": "Search plugins",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -1027,6 +1027,7 @@
     "storeDesc": "浏览、安装与管理插件。"
   },
   "store": {
+    "updatedAt": "更新于 {time}",
     "title": "插件市场",
     "subtitle": "发现适合您工作流程的优秀插件",
     "searchPlaceholder": "搜索插件...",


### PR DESCRIPTION
`StorePluginMetaHeader.vue` built its "Updated <date>" meta chip by inlining **both** language variants and picking with a boolean:

```ts
items.push(`${isZh.value ? '更新于' : 'Updated'} ${updatedText.value}`)
```

That makes the string invisible to the locale files: adding a third locale wouldn't translate it — it would silently fall through to English while the rest of the page translates correctly.

- Added `store.updatedAt` (`"Updated {time}"` / `"更新于 {time}"`) to the existing `store` namespace and replaced the ternary with `t('store.updatedAt', { time: updatedText.value })`. Using interpolation rather than concatenation also lets a locale put the date **before** the label if its grammar requires it.
- Removed the now-unused `isZh` computed.
- **Left `locale` alone** where it feeds `Intl.DateTimeFormat` (line 25) — that's a legitimate locale-dependent formatting choice, not a hardcoded translation.

Verified: no `isZh` references remain, `locale` is still used by the date formatter, ESLint clean at `--max-warnings=0`.

Fixes #500

<sub>Automated audit remediation loop · tracker #959</sub>