### PR TITLE
fix(i18n): localize capability test result metric labels (#498)

### DIFF
--- a/apps/core-app/src/renderer/src/components/intelligence/capabilities/CapabilityTestResult.vue
+++ b/apps/core-app/src/renderer/src/components/intelligence/capabilities/CapabilityTestResult.vue
@@ -62,7 +62,7 @@ const stabilityClass = computed(() => {
           <span class="test-result__meta-value">{{ result.model }}</span>
         </div>
         <div v-if="result.latency" class="test-result__meta-item">
-          <span class="test-result__meta-label">耗时</span>
+          <span class="test-result__meta-label">{{ t('settings.intelligence.testLatency') }}</span>
           <span class="test-result__meta-value">{{ result.latency }}ms</span>
         </div>
         <div v-if="result.usage" class="test-result__meta-item">
@@ -78,14 +78,18 @@ const stabilityClass = computed(() => {
           <span class="test-result__meta-value">{{ result.usage.totalTokens }}</span>
         </div>
         <div v-if="result.tokensPerSecond" class="test-result__meta-item">
-          <span class="test-result__meta-label">Token 速度</span>
+          <span class="test-result__meta-label">{{
+            t('settings.intelligence.testTokenSpeed')
+          }}</span>
           <span class="test-result__meta-value">{{ result.tokensPerSecond }}/s</span>
         </div>
       </div>
     </div>
 
     <div v-if="result.stability" class="test-result__section">
-      <div class="test-result__preview-label">稳定性分析</div>
+      <div class="test-result__preview-label">
+        {{ t('settings.intelligence.testStabilityAnalysis') }}
+      </div>
       <div class="test-result__stability" :class="stabilityClass">
         <div class="test-result__stability-head">
           <span class="test-result__stability-status">{{ result.stability.status }}</span>

--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -3487,6 +3487,9 @@
       "evidenceSaved": "Everything diagnostic evidence saved"
     },
     "intelligence": {
+      "testLatency": "Latency",
+      "testTokenSpeed": "Token speed",
+      "testStabilityAnalysis": "Stability analysis",
       "userMessageLabel": "User message",
       "userMessagePlaceholder": "Hello, can you summarize this...",
       "promptVariablesLabel": "Prompt variables (JSON)",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -3459,6 +3459,9 @@
       "evidenceSaved": "Everything 诊断证据已保存"
     },
     "intelligence": {
+      "testLatency": "耗时",
+      "testTokenSpeed": "Token 速度",
+      "testStabilityAnalysis": "稳定性分析",
       "pageTitle": "塔塔智能",
       "pageDesc": "通过塔塔智能，你可以优雅调度每条渠道，编排专属能力，并在一块打磨精致的控制面板中掌控全程。",
       "channelsSection": "渠道",


### PR DESCRIPTION
`CapabilityTestResult.vue` labelled its latency metric, token-speed metric and stability section with Chinese literals, even though sibling components in the same directory already use `t('settings.intelligence.*')` — so an English user running an AI capability test saw Chinese labels next to correctly-translated ones.

Added three keys to the **same** `settings.intelligence` namespace the siblings use (rather than inventing a new one) and routed all three labels through `t()`:

| key | en-US | zh-CN |
|---|---|---|
| `testLatency` | Latency | 耗时 |
| `testTokenSpeed` | Token speed | Token 速度 |
| `testStabilityAnalysis` | Stability analysis | 稳定性分析 |

The audit cited **two** literals; there were actually **three** — `Token 速度` (line 81) was also hardcoded and is now covered.

The insertion point was located by parsing the JSON (several `"intelligence": {` blocks exist in these files), not by line number. The component already had i18n wiring. ESLint clean at `--max-warnings=0`.

Fixes #498

<sub>Automated audit remediation loop · tracker #959</sub>