### PR TITLE
fix(i18n): localize plugin performance panel headings (#499)

### DIFF
--- a/apps/core-app/src/renderer/src/components/plugin/runtime/PluginPerfCharts.vue
+++ b/apps/core-app/src/renderer/src/components/plugin/runtime/PluginPerfCharts.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup name="PluginPerfCharts">
 import { TxCard } from '@talex-touch/tuffex/card'
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import {
   formatBytesShort,
   formatCompactNumber,
@@ -14,6 +15,7 @@ const props = defineProps<{
   layout?: 'card' | 'bar'
 }>()
 
+const { t } = useI18n()
 const layoutMode = computed(() => props.layout ?? 'card')
 
 const { stats, history, lastUpdatedAt, error } = usePluginRuntimeStats(
@@ -68,7 +70,7 @@ const lastUpdatedAgeLabel = computed(() => {
         <div class="header">
           <div class="title">
             <i class="i-ri-pulse-line" />
-            <span class="text">性能趋势</span>
+            <span class="text">{{ t('plugin.perfTrend', '性能趋势') }}</span>
             <span class="hint">Up {{ uptimeLabel }}</span>
           </div>
           <div class="meta">

--- a/apps/core-app/src/renderer/src/components/plugin/runtime/PluginPerfStatusBar.vue
+++ b/apps/core-app/src/renderer/src/components/plugin/runtime/PluginPerfStatusBar.vue
@@ -2,8 +2,11 @@
 import type { StatusTone } from '@talex-touch/tuffex/status-badge'
 import { TxStatusBadge } from '@talex-touch/tuffex/status-badge'
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { formatBytesShort } from '~/components/plugin/runtime/format'
 import { usePluginRuntimeStats } from '~/composables/usePluginRuntimeStats'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   pluginName: string
@@ -133,7 +136,7 @@ const health = computed(() => {
     <div class="left">
       <i class="i-ri-pulse-line" />
       <div class="left-title">
-        <span class="title">性能</span>
+        <span class="title">{{ t('plugin.perf', '性能') }}</span>
         <span v-if="error" class="error-text">· {{ error }}</span>
         <span v-else class="hint">Updated {{ lastUpdatedAgeLabel }} ago</span>
       </div>

--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -1287,6 +1287,8 @@
     }
   },
   "plugin": {
+    "perfTrend": "Performance trend",
+    "perf": "Performance",
     "add": "Add Plugin",
     "running": "Running",
     "all": "All",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -1287,6 +1287,8 @@
     }
   },
   "plugin": {
+    "perfTrend": "性能趋势",
+    "perf": "性能",
     "add": "添加插件",
     "running": "运行中",
     "all": "全部",


### PR DESCRIPTION
`PluginPerfCharts.vue` and `PluginPerfStatusBar.vue` hardcoded their section titles (`性能趋势` / `性能`) in the template, so English users saw Chinese headings on the plugin runtime performance panels.

- Added `plugin.perfTrend` and `plugin.perf` to the existing `plugin` namespace in both locales.
- Routed both headings through `t()` with the Chinese text kept as fallback.
- **Neither component had i18n wiring**, so `useI18n` + `const { t }` were added to both (declared before first use).

The audit cited one file; the same heading pattern existed in its sibling status bar, so both are covered here.

ESLint clean at `--max-warnings=0`.

Fixes #499

<sub>Automated audit remediation loop · tracker #959</sub>