### PR TITLE
fix(tuffex): reconcile docs-audit tail findings (docs drift + tabs types)

### DIFF
--- a/apps/nexus/content/docs/dev/components/base-surface.en.mdc
+++ b/apps/nexus/content/docs/dev/components/base-surface.en.mdc
@@ -220,10 +220,10 @@ code: |
 | `redOffset` / `greenOffset` / `blueOffset` | `number` | `0 / 10 / 20` | RGB channel offsets for spectral separation. |
 | `xChannel` / `yChannel` | `'R' \| 'G' \| 'B'` | `'R' / 'G'` | Sampling channels used by displacement maps. |
 | `mixBlendMode` | `string` | `'difference'` | Blend mode used in refraction rendering. |
-| `refractionStrength` | `number` | - | Unified refraction strength (0-100). |
-| `refractionProfile` | `'soft' \| 'filmic' \| 'cinematic'` | - | Refraction style preset. |
+| `refractionStrength` | `number` | `62` | Unified refraction strength 0-100 (effective fallback when the refraction model is active). |
+| `refractionProfile` | `'soft' \| 'filmic' \| 'cinematic'` | `'filmic'` | Refraction style preset (computed as `'filmic'` when not set explicitly). |
 | `refractionTone` | `'mist' \| 'balanced' \| 'vivid'` | `'balanced'` | Refraction tone preset (`vivid` is clearer, `mist` is softer). |
-| `refractionAngle` | `number` | - | Main dispersion angle in degrees. |
+| `refractionAngle` | `number` | `-24` | Main dispersion angle in degrees (computed as `-24` when not set explicitly). |
 | `refractionLightX` / `refractionLightY` | `number` | - | Light anchor coordinates (0-1). |
 | `refractionHaloOpacity` | `number` | - | Halo opacity override (0-1). If unset, uses the internal filmic model. |
 | `overlayOpacity` | `number` | `0` | Optional extra mask opacity for non-mask modes. |
@@ -267,6 +267,15 @@ None. Drive motion fallback with `moving` or `autoDetect`, and update visual sta
 | `--tx-surface-refraction-light-x` / `--tx-surface-refraction-light-y` | `refractionLightX` / `refractionLightY` or angle model | Refraction light anchor in percentages. |
 | `--tx-surface-refraction-strength` | `refractionStrength` model | Blended optical strength during rest, motion, and recovery. |
 | `--tx-surface-fake-index` | `fakeIndex` prop | z-index for fake pseudo-element rendering. |
+| `--tx-surface-fake-bg` | `color` prop or theme fallback | Background color of the fake-mode pseudo element. |
+| `--tx-surface-fake-opacity` | mask opacity model | Opacity of the fake-mode pseudo element. |
+| `--tx-surface-mask-opacity-percent` | mask opacity model | Percentage form of the mask opacity (internal interpolation output, do not override). |
+| `--tx-surface-motion-cover-opacity` | motion state model | Refraction motion-cover layer opacity (internal). |
+| `--tx-surface-refraction-edge-opacity` | optics model | Refraction edge highlight opacity (internal). |
+| `--tx-surface-refraction-streak-angle` | `refractionAngle` model | Refraction streak angle (angle model +92deg, internal). |
+| `--tx-surface-refraction-{filter,mask}-{base,primary,secondary,veil}-weight` / `--tx-surface-refraction-streak-weight` | profile/tone weight model | Blend-weight family for the optical layers (internal). |
+| `--tx-surface-refraction-*-gain` / `-boost` / `-base`, `--tx-surface-refraction-halo-opacity`, `--tx-surface-refraction-mask-effective-opacity` | profile/tone derived values | Derived optical interpolation outputs (internal). |
+| `--tx-surface-refraction-mask-color` | theming hook (consumed) | Base color of the refraction gradient layers; overridable in themes (falls back to `#fff`-family defaults). |
 
 ## Interaction Contract
 
@@ -275,6 +284,7 @@ None. Drive motion fallback with `moving` or `autoDetect`, and update visual sta
 - `blur` and `glass` degrade while `moving=true` or auto-detected transform motion is active. `fallbackMode='mask'` uses `fallbackMaskOpacity` when provided; `fallbackMode='pure'` renders no mask layer.
 - `glass` and `refraction` forward normalized geometry and optical props to `TxGlassSurface`; `brightness <= 3` is treated as a multiplier and converted to a percentage.
 - `refraction` renders glass, filter, mask, optional motion-cover, and edge layers, plus renderer/profile/tone classes and light/strength CSS variables.
+- Passing any of `refractionStrength` / `refractionAngle` / `refractionProfile` switches to the derived refraction model (`shouldUseRefractionModel`); unset ones fall back to `62` / `-24` / `'filmic'`.
 - `autoDetect` observes the root and ancestor `style` mutations plus `transitionstart`, `transitionend`, and `transitioncancel`; listeners and observers are removed on unmount.
 - `settleDelay` and `transitionDuration` both affect fallback recovery. The actual settle timer is at least the transition duration.
 - `refraction` keeps the refraction renderer active during motion, but blends optical parameters down while moving and back up during recovery.
@@ -291,7 +301,7 @@ None. Drive motion fallback with `moving` or `autoDetect`, and update visual sta
 ## Review Notes
 
 - Reviewed against `packages/tuffex/packages/components/src/base-surface/src/TxBaseSurface.vue`, `types.ts`, `base-surface-motion.ts`, `base-surface-math.ts`, and `style/index.scss`.
-- The CSS-variable table now reflects runtime variables actually emitted or consumed by the component, instead of stale blur-background documentation from an earlier implementation.
+- The CSS-variable table covers every runtime variable the component emits (rows marked internal are interpolation outputs, not override points) plus the consumed theming hook `--tx-surface-refraction-mask-color`.
 - Existing tests cover root tag/radius/color variables, mask opacity clamping, blur fallback, pure fallback, normalized `TxGlassSurface` props, refraction classes/light variables, and auto-detect teardown.
 - No events or exposed methods exist in source; visual state is controlled through props and CSS variables.
 

--- a/apps/nexus/content/docs/dev/components/base-surface.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/base-surface.zh.mdc
@@ -220,10 +220,10 @@ code: |
 | `redOffset` / `greenOffset` / `blueOffset` | `number` | `0 / 10 / 20` | RGB 通道偏移（底层色散控制）。 |
 | `xChannel` / `yChannel` | `'R' \| 'G' \| 'B'` | `'R' / 'G'` | refraction 位移取样通道。 |
 | `mixBlendMode` | `string` | `'difference'` | refraction 混合模式。 |
-| `refractionStrength` | `number` | - | 0-100，统一控制折射强度。 |
-| `refractionProfile` | `'soft' \| 'filmic' \| 'cinematic'` | - | 折射风格预设。 |
+| `refractionStrength` | `number` | `62` | 0-100，统一控制折射强度（折射模型激活时的实际兜底值）。 |
+| `refractionProfile` | `'soft' \| 'filmic' \| 'cinematic'` | `'filmic'` | 折射风格预设（未显式传入时按 `'filmic'` 计算）。 |
 | `refractionTone` | `'mist' \| 'balanced' \| 'vivid'` | `'balanced'` | 折射色调预设（`vivid` 更通透，`mist` 更柔和）。 |
-| `refractionAngle` | `number` | - | 色散主方向角度（度）。 |
+| `refractionAngle` | `number` | `-24` | 色散主方向角度（度，未显式传入时按 `-24` 计算）。 |
 | `refractionLightX` / `refractionLightY` | `number` | - | 光源锚点（0-1）。 |
 | `refractionHaloOpacity` | `number` | - | halo 透明度（0-1），不传时用内置 filmic 模型。 |
 | `overlayOpacity` | `number` | `0` | 非 mask 模式下附加 mask 层透明度。 |
@@ -267,6 +267,15 @@ code: |
 | `--tx-surface-refraction-light-x` / `--tx-surface-refraction-light-y` | `refractionLightX` / `refractionLightY` 或角度模型 | 折射光源锚点百分比。 |
 | `--tx-surface-refraction-strength` | `refractionStrength` 模型 | 静止、运动和恢复过程中的混合光学强度。 |
 | `--tx-surface-fake-index` | `fakeIndex` prop | fake 伪元素渲染层的 z-index。 |
+| `--tx-surface-fake-bg` | `color` prop 或主题兜底 | fake 模式伪元素的背景色。 |
+| `--tx-surface-fake-opacity` | mask 透明度模型 | fake 模式伪元素的透明度。 |
+| `--tx-surface-mask-opacity-percent` | mask 透明度模型 | mask 透明度的百分比形式（internal，插值输出，勿覆写）。 |
+| `--tx-surface-motion-cover-opacity` | 运动状态模型 | refraction 运动遮盖层透明度（internal）。 |
+| `--tx-surface-refraction-edge-opacity` | 光学模型 | refraction 边缘高光层透明度（internal）。 |
+| `--tx-surface-refraction-streak-angle` | `refractionAngle` 模型 | 折射拉丝角度（角度模型 +92deg，internal）。 |
+| `--tx-surface-refraction-{filter,mask}-{base,primary,secondary,veil}-weight` / `--tx-surface-refraction-streak-weight` | profile/tone 权重模型 | 各光学层的混合权重族（internal）。 |
+| `--tx-surface-refraction-*-gain` / `-boost` / `-base`、`--tx-surface-refraction-halo-opacity`、`--tx-surface-refraction-mask-effective-opacity` | profile/tone 派生量 | 光学插值的派生输出族（internal）。 |
+| `--tx-surface-refraction-mask-color` | 主题钩子（消费） | refraction 各渐变层的基色，可在主题中覆写（默认 `#fff` 系兜底）。 |
 
 ## 交互契约
 
@@ -275,6 +284,7 @@ code: |
 - `blur` 与 `glass` 在 `moving=true` 或自动检测到 transform 运动时降级。`fallbackMode='mask'` 会优先使用 `fallbackMaskOpacity`；`fallbackMode='pure'` 不渲染 mask 层。
 - `glass` 与 `refraction` 会把归一化后的几何和光学参数透传给 `TxGlassSurface`；`brightness <= 3` 会按倍率转换成百分比。
 - `refraction` 会渲染 glass、filter、mask、可选 motion-cover 和 edge 层，并暴露 renderer/profile/tone class 与 light/strength CSS 变量。
+- `refractionStrength` / `refractionAngle` / `refractionProfile` 任一显式传入即切换到派生折射模型（`shouldUseRefractionModel`），未传的项按 `62` / `-24` / `'filmic'` 兜底。
 - `autoDetect` 监听根节点及祖先节点的 `style` mutation，以及 `transitionstart`、`transitionend`、`transitioncancel`；卸载时会移除监听器和 observer。
 - `settleDelay` 与 `transitionDuration` 都会影响降级恢复，实际 settle timer 至少等于 transition duration。
 - `refraction` 在运动中仍保持折射渲染器启用，但会在运动/恢复过程中降低再恢复光学参数。
@@ -291,7 +301,7 @@ code: |
 ## 审阅说明
 
 - 已对照 `packages/tuffex/packages/components/src/base-surface/src/TxBaseSurface.vue`、`types.ts`、`base-surface-motion.ts`、`base-surface-math.ts` 和 `style/index.scss` 核对。
-- CSS 变量表已改为记录组件实际发出或消费的运行时变量，不再保留早期实现遗留的 blur background 变量说明。
+- CSS 变量表覆盖组件发射的全部运行时变量（标注 internal 的行是插值输出，不作为覆写点）以及消费的主题钩子 `--tx-surface-refraction-mask-color`。
 - 现有测试覆盖根标签/radius/color 变量、mask 透明度 clamp、blur 降级、pure 降级、归一化后的 `TxGlassSurface` props、refraction class/light 变量和 auto-detect 清理。
 - 源码没有事件或暴露方法；视觉状态通过 props 和 CSS 变量控制。
 

--- a/apps/nexus/content/docs/dev/components/group-block.en.mdc
+++ b/apps/nexus/content/docs/dev/components/group-block.en.mdc
@@ -12,22 +12,6 @@ verified: true
 
 Use GroupBlock to organize settings, account options, and compact preference rows with a consistent icon, label, and control layout.
 
-<script setup lang="ts">
-import { ref } from 'vue'
-
-const notifications = ref(true)
-const language = ref<'en' | 'zh'>('en')
-const theme = ref<'light' | 'dark' | 'auto'>('auto')
-const profileName = ref('Talex')
-const displayName = ref('Talex')
-const timezone = ref('local')
-const autoUpdate = ref(true)
-const loading = ref(true)
-const locked = ref(false)
-const dummy = ref(false)
-function handleClick() {}
-</script>
-
 ## Basic Usage
 
 ### GroupBlock
@@ -461,7 +445,7 @@ code: |
 | `defaultIcon` | `TxIconSource \| string` | - | Icon shown when `active=false` or when no active icon is provided. |
 | `activeIcon` | `TxIconSource \| string` | - | Icon shown when `active=true`; falls back to `defaultIcon`. |
 | `iconSize` | `number` | `20` | Icon size in pixels. |
-| `active` | `boolean` | `false` | Switch the slot row into active visual/icon state. |
+| `active` | `boolean` | `false` | When `true`, swaps to `activeIcon` and passes `active` into the `icon`/`default` slot scope; it does not change the row's visual style. |
 | `disabled` | `boolean` | `false` | Apply disabled styling and block row click emits. |
 
 ### TxBlockSlot Events
@@ -561,7 +545,6 @@ code: |
 | Slot | Props | Description |
 |------|-------|-------------|
 | `tags` | - | Inline metadata forwarded to the row title area. |
-
 
 ## Exposed Methods
 

--- a/apps/nexus/content/docs/dev/components/group-block.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/group-block.zh.mdc
@@ -12,22 +12,6 @@ verified: true
 
 使用 GroupBlock 组织设置项、账号选项与紧凑的偏好行，统一图标、标签与控件布局。
 
-<script setup lang="ts">
-import { ref } from 'vue'
-
-const notifications = ref(true)
-const language = ref<'en' | 'zh'>('en')
-const theme = ref<'light' | 'dark' | 'auto'>('auto')
-const profileName = ref('Talex')
-const displayName = ref('Talex')
-const timezone = ref('local')
-const autoUpdate = ref(true)
-const loading = ref(true)
-const locked = ref(false)
-const dummy = ref(false)
-function handleClick() {}
-</script>
-
 ## 基础用法
 
 ### GroupBlock
@@ -461,7 +445,7 @@ code: |
 | `defaultIcon` | `TxIconSource \| string` | - | `active=false` 时图标；未提供激活图标时也作为回退。 |
 | `activeIcon` | `TxIconSource \| string` | - | `active=true` 时图标；未提供时回退到 `defaultIcon`。 |
 | `iconSize` | `number` | `20` | 图标像素尺寸。 |
-| `active` | `boolean` | `false` | 切换行的激活视觉状态与图标状态。 |
+| `active` | `boolean` | `false` | 为 `true` 时切换到 `activeIcon`，并把 `active` 传入 `icon`/`default` 插槽作用域；不改变行背景等视觉样式。 |
 | `disabled` | `boolean` | `false` | 应用禁用样式并阻止行点击事件。 |
 
 ### TxBlockSlot 事件
@@ -561,7 +545,6 @@ code: |
 | 插槽名 | 参数 | 说明 |
 |------|------|------|
 | `tags` | - | 透传到行标题区的元信息。 |
-
 
 ## 暴露方法
 

--- a/apps/nexus/content/docs/dev/components/icon-button.en.mdc
+++ b/apps/nexus/content/docs/dev/components/icon-button.en.mdc
@@ -59,7 +59,7 @@ code: |
 |------|------|---------|-------------|
 | `icon` | `string` | `''` | Icon class/name rendered through `TxIcon` when no default slot is provided. |
 | `label` | `string` | `''` | Accessible label. Required for icon-only actions. |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Button size. |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'md'` | Button size. |
 | `shape` | `'square' \| 'circle' \| 'pill'` | `'square'` | Hit-area silhouette. |
 | `pressed` | `boolean` | - | Toggle state; forwarded to `aria-pressed` when defined. |
 | `disabled` | `boolean` | `false` | Native disabled state and visual disabled class. |

--- a/apps/nexus/content/docs/dev/components/icon-button.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/icon-button.zh.mdc
@@ -59,7 +59,7 @@ code: |
 |------|------|---------|------|
 | `icon` | `string` | `''` | 未提供默认插槽时，通过 `TxIcon` 渲染的图标名称。 |
 | `label` | `string` | `''` | 可访问名称。纯图标操作必填。 |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | 按钮尺寸。 |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'md'` | 按钮尺寸。 |
 | `shape` | `'square' \| 'circle' \| 'pill'` | `'square'` | 点击区域轮廓。 |
 | `pressed` | `boolean` | - | 持久切换态；定义后转发为 `aria-pressed`。 |
 | `disabled` | `boolean` | `false` | 原生禁用态与禁用样式。 |

--- a/apps/nexus/content/docs/dev/components/stat-card.en.mdc
+++ b/apps/nexus/content/docs/dev/components/stat-card.en.mdc
@@ -12,7 +12,7 @@ verified: true
 
 `TxStatCard` displays a primary metric with optional icon decoration, insight comparison, or progress ring. Use the default variant for simple metrics, `insight` for trend deltas, and `variant="progress"` or `progress` for bounded percentage summaries.
 
-Progress values are clamped to 0-100 for the ring. `insight` renders only when both `from` and `to` are finite numbers; otherwise the card falls back to the plain metric layout.
+Progress values are clamped to 0-100 for the ring. `insight` renders only when both `from` and `to` are finite numbers; otherwise the card falls back to the plain metric layout. When the progress ring is active (`progress` or `variant="progress"`), `insight` is not rendered — the trend block is silently dropped.
 
 ## Basic Usage
 

--- a/apps/nexus/content/docs/dev/components/stat-card.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/stat-card.zh.mdc
@@ -12,7 +12,7 @@ verified: true
 
 `TxStatCard` 用于展示核心指标，可附加图标装饰、趋势对比或进度环。普通指标使用默认变体，趋势变化使用 `insight`，有明确 0-100 边界的健康度/容量/完成率使用 `variant="progress"` 或 `progress`。
 
-进度环会把数值裁剪到 0-100。`insight` 只有在 `from` 和 `to` 都是有限数字时才渲染，否则会退回普通指标布局。
+进度环会把数值裁剪到 0-100。`insight` 只有在 `from` 和 `to` 都是有限数字时才渲染，否则会退回普通指标布局。进度环激活（`progress` 或 `variant="progress"`）时，`insight` 不渲染，趋势块会被静默省略。
 
 ## 基础用法
 

--- a/apps/nexus/content/docs/dev/components/tabs.en.mdc
+++ b/apps/nexus/content/docs/dev/components/tabs.en.mdc
@@ -585,6 +585,7 @@ code: |
 | `iconClass` | `string` | `''` | Optional icon class rendered before the nav label. |
 | `disabled` | `boolean` | `false` | Block click activation and render a disabled native button. |
 | `activation` | `boolean` | `false` | Mark this tab as the uncontrolled default when neither `modelValue` nor `defaultValue` selects a tab. |
+| `active` | `boolean` | `false` | Whether the item is active; injected automatically by TxTabs — set manually only when using TxTabItem standalone. |
 
 ### TxTabItem Events
 

--- a/apps/nexus/content/docs/dev/components/tabs.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/tabs.zh.mdc
@@ -585,6 +585,7 @@ code: |
 | `iconClass` | `string` | `''` | 导航标签前的可选图标 class。 |
 | `disabled` | `boolean` | `false` | 阻止点击激活，并渲染禁用的原生按钮。 |
 | `activation` | `boolean` | `false` | 当 `modelValue` 和 `defaultValue` 都没有选中 tab 时，作为非受控默认项。 |
+| `active` | `boolean` | `false` | 是否处于激活态；由 TxTabs 自动注入，仅独立使用 TxTabItem 时手动传入。 |
 
 ### TxTabItem 事件
 

--- a/apps/nexus/content/docs/dev/components/timeline.en.mdc
+++ b/apps/nexus/content/docs/dev/components/timeline.en.mdc
@@ -69,11 +69,11 @@ rows:
 rows:
   - name: title
     type: string
-    default: "''"
+    default: '-'
     description: Timeline item title
   - name: time
     type: string
-    default: "''"
+    default: '-'
     description: Time label
   - name: color
     type: "'default' | 'primary' | 'success' | 'warning' | 'error'"

--- a/apps/nexus/content/docs/dev/components/timeline.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/timeline.zh.mdc
@@ -69,11 +69,11 @@ rows:
 rows:
   - name: title
     type: string
-    default: "''"
+    default: '-'
     description: 条目标题
   - name: time
     type: string
-    default: "''"
+    default: '-'
     description: 时间文本
   - name: color
     type: "'default' | 'primary' | 'success' | 'warning' | 'error'"

--- a/apps/nexus/content/docs/dev/components/version-capsule.en.mdc
+++ b/apps/nexus/content/docs/dev/components/version-capsule.en.mdc
@@ -215,8 +215,8 @@ opens a full-screen release-history overlay instead.
 | Member | Type | Description |
 |------|------|------|
 | `close` | `() => void` | Closes the open panel and returns focus to the segment that opened it. Also passed into both panel slots. |
-| `downloadRef` | `Ref<HTMLButtonElement>` | The left (download) segment button element. |
-| `historyRef` | `Ref<HTMLButtonElement>` | The right (history) segment button element. |
+| `downloadRef` | `Ref<HTMLButtonElement \| null>` | The left (download) segment button element. |
+| `historyRef` | `Ref<HTMLButtonElement \| null>` | The right (history) segment button element. |
 
 ## Interaction Contract
 

--- a/apps/nexus/content/docs/dev/components/version-capsule.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/version-capsule.zh.mdc
@@ -214,8 +214,8 @@ code: |
 | 成员 | 类型 | 说明 |
 |------|------|------|
 | `close` | `() => void` | 关闭已打开的面板，并把焦点交还给打开它的分段。同时会传入两个面板插槽。 |
-| `downloadRef` | `Ref<HTMLButtonElement>` | 左侧（下载）分段按钮元素。 |
-| `historyRef` | `Ref<HTMLButtonElement>` | 右侧（历史）分段按钮元素。 |
+| `downloadRef` | `Ref<HTMLButtonElement \| null>` | 左侧（下载）分段按钮元素。 |
+| `historyRef` | `Ref<HTMLButtonElement \| null>` | 右侧（历史）分段按钮元素。 |
 
 ## 交互契约
 

--- a/packages/tuffex/packages/components/src/tabs/src/TxTabItem.vue
+++ b/packages/tuffex/packages/components/src/tabs/src/TxTabItem.vue
@@ -6,7 +6,7 @@ defineOptions({
   name: 'TxTabItem',
 })
 
-const props = withDefaults(defineProps<TabItemProps & { active?: boolean }>(), {
+const props = withDefaults(defineProps<TabItemProps>(), {
   iconClass: '',
   disabled: false,
   activation: false,

--- a/packages/tuffex/packages/components/src/tabs/src/TxTabs.vue
+++ b/packages/tuffex/packages/components/src/tabs/src/TxTabs.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { PropType } from 'vue'
 import { Comment, Fragment, computed, defineComponent, h, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import type { TabsAnimation, TabsProps } from './types'
 import TxAutoSizer from '../../auto-sizer/src/TxAutoSizer.vue'
 import TxTabHeader from './TxTabHeader.vue'
 import TxTabItem from './TxTabItem.vue'
@@ -62,7 +63,7 @@ export default defineComponent({
   props: {
     modelValue: String,
     defaultValue: String,
-    placement: { type: String, default: 'left' },
+    placement: { type: String as PropType<TabsProps['placement']>, default: 'left' },
     offset: { type: Number, default: 0 },
     navMinWidth: { type: Number, default: 220 },
     navMaxWidth: { type: Number, default: 320 },
@@ -72,12 +73,12 @@ export default defineComponent({
     autoHeight: { type: Boolean, default: false },
     autoWidth: { type: Boolean, default: false },
     showIndicator: { type: Boolean, default: true },
-    indicatorVariant: { type: String, default: 'line' },
-    indicatorMotion: { type: String, default: 'stretch' },
+    indicatorVariant: { type: String as PropType<TabsProps['indicatorVariant']>, default: 'line' },
+    indicatorMotion: { type: String as PropType<TabsProps['indicatorMotion']>, default: 'stretch' },
     indicatorMotionStrength: { type: Number, default: 1 },
     autoHeightDurationMs: { type: Number, default: 250 },
     autoHeightEasing: { type: String, default: 'ease' },
-    animation: { type: Object as PropType<any>, default: undefined },
+    animation: { type: Object as PropType<TabsAnimation>, default: undefined },
   },
   emits: ['update:modelValue', 'change'],
   setup(props, { slots, emit, expose }) {

--- a/packages/tuffex/packages/components/src/tabs/src/types.ts
+++ b/packages/tuffex/packages/components/src/tabs/src/types.ts
@@ -64,6 +64,8 @@ export interface TabItemProps {
   iconClass?: string
   disabled?: boolean
   activation?: boolean
+  /** Injected by TxTabs; set manually only when using TxTabItem standalone. */
+  active?: boolean
 }
 
 export interface TabHeaderProps {


### PR DESCRIPTION
Closes out the last verified-unfixed tail findings from the 07-28 tuffex docs audit (loop fire 4; see tracker #362 and the fix queue in `.trellis/tasks/07-28-tuffex-docs-audit/issue-loop-log.md`).

**Docs drift (verified against current source before fixing):**
- timeline: `title`/`time` documented defaults `''` → `-` (withDefaults never sets them)
- version-capsule: exposed refs typed `Ref<HTMLButtonElement \| null>` (source: TxVersionCapsule.vue:25-26)
- icon-button: document shipped `'xs'` size (types.ts:4, `--xs` rule)
- stat-card: state that an active progress ring suppresses `insight` (hasInsight short-circuit)
- group-block: drop dead top-level `<script setup>` (10 unused refs; demos render via `code:` strings); correct BlockSlot `active` description (activeIcon + slot scope only, no visual style)
- base-surface: document effective refraction fallbacks (`62` / `-24` / `'filmic'`) + derived-model switch bullet; extend CSS-variable table to the full emitted set (internal rows marked) incl. consumed theming hook `--tx-surface-refraction-mask-color`; scope the Review Notes claim accordingly

**tabs type-leak (source):**
- `animation: PropType<TabsAnimation>`, `placement`/`indicatorVariant`/`indicatorMotion` typed against `TabsProps` unions
- `active` folded into `TabItemProps` + documented in zh/en tables

**Gates:** vue-tsc --noEmit 0 errors · vitest 146 files / 1056 green · check:mdc-fences exit 0 · eslint (changed files) clean · zh/en edits symmetric. `audit:exports`/`audit:types` not run: they read `dist/` and invoke `pnpm install`, unavailable in this fresh worktree (environmental; diff touches no export surface).

Fixes #371
Fixes #413
Fixes #416
Fixes #455
Fixes #460
Fixes #464
Fixes #473