### PR TITLE
fix(i18n): localize CoreBox preview result card labels (#701)

### DIFF
--- a/apps/core-app/src/renderer/src/components/render/custom/PreviewResultCard.vue
+++ b/apps/core-app/src/renderer/src/components/render/custom/PreviewResultCard.vue
@@ -4,6 +4,9 @@ import type { PreviewCardPayload } from '@talex-touch/utils/core-box'
 import { TxButton } from '@talex-touch/tuffex/button'
 import { hasWindow } from '@talex-touch/utils/env'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   item: TuffItem
@@ -77,18 +80,18 @@ const accentStyle = computed(() => {
       <div class="card-actions">
         <TxButton variant="bare" class="hint" native-type="button" @click="emit('copy-primary')">
           <span class="hint-key">↵</span>
-          复制结果
+          {{ t('previewHistory.copyResult', '复制结果') }}
         </TxButton>
         <TxButton variant="bare" class="hint" native-type="button" @click="emit('show-history')">
           <span class="hint-key">{{ historyVisible ? '⌘→' : '⌘←' }}</span>
-          最近处理
+          {{ t('previewHistory.recentTitle', '最近处理') }}
         </TxButton>
       </div>
     </div>
     <div class="card-body">
       <div class="primary">
         <div class="primary-label">
-          {{ resolvedPayload?.primaryLabel || '结果' }}
+          {{ resolvedPayload?.primaryLabel || t('previewHistory.resultLabel', '结果') }}
         </div>
         <div v-if="qrCodeSrc" class="qr-preview">
           <img :src="qrCodeSrc" alt="QR Code" />

--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -4270,6 +4270,8 @@
       "dontRemindAgain": "Don't remind me again"
     },
     "previewHistory": {
+      "copyResult": "Copy result",
+      "resultLabel": "Result",
       "recentTitle": "Recent",
       "countSummary": "{count} total",
       "noRecords": "No records yet"

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -4222,6 +4222,8 @@
       "dontRemindAgain": "不再提醒"
     },
     "previewHistory": {
+      "copyResult": "复制结果",
+      "resultLabel": "结果",
       "recentTitle": "最近处理",
       "countSummary": "共 {count} 条",
       "noRecords": "暂无记录"


### PR DESCRIPTION
`PreviewResultCard.vue` hardcoded its copy action (`复制结果`), history action (`最近处理`) and — notably — the **JS fallback** used when a plugin's payload omits `primaryLabel`, so any third-party plugin that doesn't set a label got its result section headed `结果` regardless of locale.

- Added `previewHistory.copyResult` and `previewHistory.resultLabel`.
- **Reused `previewHistory.recentTitle`** (added for #494) for the history action instead of creating a duplicate key for the same string.
- Component had no i18n wiring; `useI18n` + `const { t }` added.

ESLint clean at `--max-warnings=0`.

Fixes #701

<sub>Automated audit remediation loop · tracker #959</sub>