### PR TITLE
fix(i18n): localize PluginFeatures toasts and preview size label (#702)

### DIFF
--- a/apps/core-app/src/renderer/src/components/plugin/tabs/PluginFeatures.vue
+++ b/apps/core-app/src/renderer/src/components/plugin/tabs/PluginFeatures.vue
@@ -70,7 +70,7 @@ const devDisconnectIssue = computed(() =>
 const devDisconnectMessage = computed(() => {
   const issue = devDisconnectIssue.value
   if (issue?.message) return resolveI18nMessage(issue.message)
-  return 'Dev Server 已断开连接'
+  return t('plugin.devServerDisconnected', 'Dev Server 已断开连接')
 })
 const devDisconnectSuggestion = computed(() => {
   const suggestion = devDisconnectIssue.value?.suggestion
@@ -163,7 +163,10 @@ const previewFrameStorageKey = computed(() => {
 })
 
 const previewSizeOptions = computed(() => {
-  const customLabel = `自定义 ${previewFrameSize.value.width}×${previewFrameSize.value.height}`
+  const customLabel = t('plugin.customPreviewSize', {
+    width: previewFrameSize.value.width,
+    height: previewFrameSize.value.height
+  })
   return [
     ...previewSizePresets,
     {
@@ -319,7 +322,7 @@ const previewWidgetItem = computed<TuffItem | null>(() => {
       mode: 'custom',
       basic: {
         title,
-        subtitle: 'Widget 预览'
+        subtitle: t('plugin.widgetPreview', 'Widget 预览')
       },
       custom: {
         type: 'vue',
@@ -744,7 +747,7 @@ async function reloadPreviewWidget(): Promise<void> {
   }
   const success = await requestWidgetRegister(widgetId, { emitAsUpdate: true, force: true })
   if (!success) {
-    toast.warning('Widget 重新加载失败')
+    toast.warning(t('plugin.widgetReloadFailed', 'Widget 重新加载失败'))
   }
 }
 
@@ -757,7 +760,7 @@ async function reloadAllWidgets(): Promise<void> {
     }
     await requestWidgetRegister(option.value, { emitAsUpdate: true, force: true })
   }
-  toast.success('已触发全部 Widget 重新加载')
+  toast.success(t('plugin.widgetReloadAllTriggered', '已触发全部 Widget 重新加载'))
 }
 
 function handlePreviewRenderError(error: Error): void {

--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -1287,6 +1287,11 @@
     }
   },
   "plugin": {
+    "devServerDisconnected": "Dev Server disconnected",
+    "customPreviewSize": "Custom {width}×{height}",
+    "widgetPreview": "Widget preview",
+    "widgetReloadFailed": "Widget reload failed",
+    "widgetReloadAllTriggered": "Reload triggered for all widgets",
     "perfTrend": "Performance trend",
     "perf": "Performance",
     "add": "Add Plugin",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -1287,6 +1287,11 @@
     }
   },
   "plugin": {
+    "devServerDisconnected": "Dev Server 已断开连接",
+    "customPreviewSize": "自定义 {width}×{height}",
+    "widgetPreview": "Widget 预览",
+    "widgetReloadFailed": "Widget 重新加载失败",
+    "widgetReloadAllTriggered": "已触发全部 Widget 重新加载",
     "perfTrend": "性能趋势",
     "perf": "性能",
     "add": "添加插件",


### PR DESCRIPTION
`PluginFeatures.vue` had five Chinese literals reaching plugin developers: the widget-reload failure and success toasts, the dev-server disconnect status, the widget preview subtitle, and the dynamically composed custom preview-size label. An English-locale developer reloading a widget got a Chinese toast and **couldn't tell success from failure at a glance**.

Added five `plugin.*` keys. The size label became an **interpolation** rather than concatenation:

```ts
// before: `自定义 ${w}×${h}`
t('plugin.customPreviewSize', { width, height })   // "Custom {width}×{height}" / "自定义 {width}×{height}"
```

so a locale can reorder the label relative to the dimensions instead of being locked to prefix position.

Component already had i18n wiring. ESLint clean at `--max-warnings=0`.

Fixes #702

<sub>Automated audit remediation loop · tracker #959</sub>