### PR TITLE
fix(a11y): add missing alt attributes on four images (#514, #515, #516, #518)

### DIFF
--- a/apps/core-app/src/renderer/src/components/render/addon/preview/ImagePreview.vue
+++ b/apps/core-app/src/renderer/src/components/render/addon/preview/ImagePreview.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts" name="ImagePreview">
 import type { TuffItem } from '@talex-touch/utils'
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { buildTfileUrl } from '~/utils/tfile-url'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   item: TuffItem
@@ -31,7 +34,13 @@ function handleLoad() {
       <i class="i-ri-image-line error-icon" />
       <span class="error-text">Failed to load image</span>
     </div>
-    <img v-show="!imageError" :src="imageSrc" @error="handleError" @load="handleLoad" />
+    <img
+      v-show="!imageError"
+      :src="imageSrc"
+      :alt="t('common.imagePreviewAlt', '图片预览')"
+      @error="handleError"
+      @load="handleLoad"
+    />
   </div>
 </template>
 

--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -4288,6 +4288,8 @@
       "preparingFiles": "Preparing files…"
     },
   "common": {
+    "imagePreviewAlt": "Image preview",
+    "wallpaperPreviewAlt": "Custom background preview",
     "loadMore": "Load more",
     "copy": "Copy",
     "copied": "Copied",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -4240,6 +4240,8 @@
       "preparingFiles": "文件准备中..."
     },
   "common": {
+    "imagePreviewAlt": "图片预览",
+    "wallpaperPreviewAlt": "自定义背景预览",
     "loadMore": "加载更多",
     "copy": "复制",
     "copied": "已复制",

--- a/apps/core-app/src/renderer/src/views/base/styles/ThemeStyle.vue
+++ b/apps/core-app/src/renderer/src/views/base/styles/ThemeStyle.vue
@@ -602,6 +602,7 @@ const bgSaving = computed(() => appSettings.savingState?.value ?? false)
           <div v-if="customBgPath" class="theme-style-wallpaper-preview">
             <img
               :src="customBgPreviewUrl"
+              :alt="t('common.wallpaperPreviewAlt', '自定义背景预览')"
               class="h-24 w-full object-cover"
               :style="{
                 filter: `blur(${bgBlur}px) brightness(${bgBrightness}%) contrast(${bgContrast}%) saturate(${bgSaturate}%)`,

--- a/apps/core-app/src/renderer/src/views/box/PrefixIcon.vue
+++ b/apps/core-app/src/renderer/src/views/box/PrefixIcon.vue
@@ -32,7 +32,7 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="PrefixIcon transition-cubic">
-    <img class="transition-cubic" :src="AppIcon" />
+    <img class="transition-cubic" :src="AppIcon" alt="" />
     <svg
       v-if="isIndexing"
       class="ProgressRing op-50"

--- a/apps/nexus/app/components/content/demos/TxOutlineBorderDemo.vue
+++ b/apps/nexus/app/components/content/demos/TxOutlineBorderDemo.vue
@@ -12,7 +12,7 @@ const { locale } = useI18n()
         clip-mode="mask"
         clip-shape="hexagon"
       >
-        <img src="https://avatars.githubusercontent.com/u/3?v=4" style="width:48px;height:48px;object-fit:cover;">
+        <img src="https://avatars.githubusercontent.com/u/3?v=4" alt="Example user avatar" style="width:48px;height:48px;object-fit:cover;">
       </TxOutlineBorder>
     </div>
   </div>
@@ -25,7 +25,7 @@ const { locale } = useI18n()
         clip-mode="mask"
         clip-shape="hexagon"
       >
-        <img src="https://avatars.githubusercontent.com/u/3?v=4" style="width:48px;height:48px;object-fit:cover;">
+        <img src="https://avatars.githubusercontent.com/u/3?v=4" alt="Example user avatar" style="width:48px;height:48px;object-fit:cover;">
       </TxOutlineBorder>
     </div>
   </div>


### PR DESCRIPTION
Four `<img>` elements had no `alt`, so assistive technology announced the `src` URL or filename instead of a name.

I applied the standard decorative-vs-content distinction rather than blanket-labelling everything:

| # | Element | Treatment | Why |
|---|---|---|---|
| #515 | CoreBox prefix app icon | `alt=""` | Purely decorative — the adjacent input already conveys context, so it should be **hidden** from AT, not announced |
| #514 | Image preview | `t('common.imagePreviewAlt')` | Content — it *is* the thing being previewed |
| #516 | Custom background preview | `t('common.wallpaperPreviewAlt')` | Content — conveys the chosen wallpaper |
| #518 | Nexus demo avatars (×2) | `alt="Example user avatar"` | A published doc example; leaving it unlabelled means readers copy an inaccessible pattern |

Two new localized keys (`common.imagePreviewAlt`, `common.wallpaperPreviewAlt`) in both locales. `ImagePreview.vue` had no i18n wiring — `useI18n` added. The nexus demo is plain HTML in a docs demo, so a literal alt is correct there (no i18n system on that surface for this string).

ESLint clean at `--max-warnings=0` for both the core-app files and the nexus file (checked with each app's own config).

Fixes #514
Fixes #515
Fixes #516
Fixes #518

<sub>Automated audit remediation loop · tracker #959</sub>