### PR TITLE
fix(a11y): give TxSwitch an accessible name (#517)

### DIFF
--- a/packages/tuffex/packages/components/src/switch/__tests__/switch.test.ts
+++ b/packages/tuffex/packages/components/src/switch/__tests__/switch.test.ts
@@ -34,6 +34,29 @@ describe('txSwitch', () => {
     expect(wrapper.emitted('change')?.[0]).toEqual([true])
   })
 
+  it('always exposes an accessible name', () => {
+    const wrapper = mount(TxSwitch)
+
+    expect(wrapper.attributes('aria-label')).toBe('Toggle')
+  })
+
+  it('accepts a custom accessible name', () => {
+    const wrapper = mount(TxSwitch, {
+      props: { ariaLabel: 'Enable notifications' },
+    })
+
+    expect(wrapper.attributes('aria-label')).toBe('Enable notifications')
+  })
+
+  it('prefers aria-labelledby over aria-label when a visible label exists', () => {
+    const wrapper = mount(TxSwitch, {
+      props: { ariaLabelledby: 'notifications-label' },
+    })
+
+    expect(wrapper.attributes('aria-labelledby')).toBe('notifications-label')
+    expect(wrapper.attributes('aria-label')).toBeUndefined()
+  })
+
   it('does not emit events when disabled', async () => {
     const wrapper = mount(TxSwitch, {
       props: {

--- a/packages/tuffex/packages/components/src/switch/src/TxSwitch.vue
+++ b/packages/tuffex/packages/components/src/switch/src/TxSwitch.vue
@@ -10,11 +10,17 @@ const props = withDefaults(
     modelValue?: boolean
     disabled?: boolean
     size?: 'small' | 'default' | 'large'
+    /** Accessible name. Prefer `ariaLabelledby` when a visible label already exists. */
+    ariaLabel?: string
+    /** Id of a visible label element that names this switch. */
+    ariaLabelledby?: string
   }>(),
   {
     modelValue: false,
     disabled: false,
     size: 'default',
+    ariaLabel: 'Toggle',
+    ariaLabelledby: undefined,
   },
 )
 
@@ -43,6 +49,8 @@ function toggle() {
     role="switch"
     :aria-checked="isActive"
     :aria-disabled="disabled"
+    :aria-label="ariaLabelledby ? undefined : ariaLabel"
+    :aria-labelledby="ariaLabelledby"
     :disabled="disabled"
     class="tuff-switch" :class="[
       {


### PR DESCRIPTION
`TxSwitch` declared `role="switch"` with `aria-checked`, but rendered only a decorative thumb span — no text, no label prop, no default. Its accessible name was therefore **empty** unless every call site remembered to pass one, so screen readers announced an unnamed switch and users couldn't tell what they were toggling.

- Added `ariaLabel` (defaulting to `'Toggle'`) and `ariaLabelledby` props, following the existing `TxPagination` convention in this package (`ariaLabel?: string` + English default via `withDefaults`) rather than inventing a new pattern.
- **`aria-labelledby` takes precedence** — when a call site points at a visible label, `aria-label` is omitted so the real label wins instead of competing with a generic default. This matches the project's preference for `aria-labelledby` over `aria-label` where a visible label exists.
- A default was chosen over leaving it undefined so the component is *never* nameless; call sites should still pass a specific name, but the failure mode is now "generic" rather than "silent".

**Added three tests** covering the default name, a custom name, and the labelledby precedence. All **6** switch tests pass; ESLint clean at `--max-warnings=0`.

Fixes #517

<sub>Automated audit remediation loop · tracker #959</sub>