### PR TITLE
fix(tuffex): clear the docs-audit low-severity tail (docs, sources, demos)

### DIFF
--- a/apps/nexus/app/components/content/demos/AvatarBasicDemo.vue
+++ b/apps/nexus/app/components/content/demos/AvatarBasicDemo.vue
@@ -10,7 +10,7 @@ const labels = computed(() => (locale.value === 'zh'
 
 <template>
   <div style="display: flex; gap: 12px; align-items: center;">
-    <TxAvatar src="https://avatars.githubusercontent.com/u/1?v=4" />
+    <TxAvatar src="https://avatars.githubusercontent.com/u/1?v=4" alt="GitHub user" />
     <TxAvatar :name="labels.name" />
     <TxAvatar icon="user" />
     <TxAvatar>{{ labels.fallback }}</TxAvatar>

--- a/apps/nexus/app/components/content/demos/GradientBorderGradientBorderDemo.vue
+++ b/apps/nexus/app/components/content/demos/GradientBorderGradientBorderDemo.vue
@@ -1,20 +1,9 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-        <TxGradientBorder :padding="16" :border-radius="16">
-          <div style="background: var(--tx-bg-color); border-radius: 12px; padding: 16px;">
-            Content
-          </div>
-        </TxGradientBorder>
-  </div>
-  <div v-else>
-        <TxGradientBorder :padding="16" :border-radius="16">
-          <div style="background: var(--tx-bg-color); border-radius: 12px; padding: 16px;">
-            Content
-          </div>
-        </TxGradientBorder>
+  <div>
+    <TxGradientBorder :padding="16" :border-radius="16">
+      <div style="background: var(--tx-bg-color); border-radius: 12px; padding: 16px;">
+        Content
+      </div>
+    </TxGradientBorder>
   </div>
 </template>

--- a/apps/nexus/app/components/content/demos/SkeletonSkeletonDemo.vue
+++ b/apps/nexus/app/components/content/demos/SkeletonSkeletonDemo.vue
@@ -1,14 +1,6 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-        <TxSkeleton :loading="true" :lines="3" />
-        <TxSkeleton variant="circle" :width="40" :height="40" />
-  </div>
-  <div v-else>
-        <TxSkeleton :loading="true" :lines="3" />
-        <TxSkeleton variant="circle" :width="40" :height="40" />
+  <div>
+    <TxSkeleton :loading="true" :lines="3" />
+    <TxSkeleton variant="circle" :width="40" :height="40" />
   </div>
 </template>

--- a/apps/nexus/content/docs/dev/components/breadcrumb.en.mdc
+++ b/apps/nexus/content/docs/dev/components/breadcrumb.en.mdc
@@ -79,7 +79,7 @@ function openVirtualCrumb(item: { label: string }, index: number) {
 - `click` is emitted only for non-current, non-disabled items that do not have `href`.
 - `icon` renders a leading `TxIcon` inside the item label.
 - Separators render between items only and are `aria-hidden`.
-- The default separator icon name is `chevron-right`.
+- The default separator icon name is `i-carbon-chevron-right` (TxIcon requires the `i-` prefix; without it the name resolves to `null`).
 
 ## API
 
@@ -88,7 +88,7 @@ function openVirtualCrumb(item: { label: string }, index: number) {
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `items` | `BreadcrumbItem[]` | required | Ordered breadcrumb entries. The last item is treated as current. |
-| `separatorIcon` | `string` | `'chevron-right'` | Icon name rendered between entries. |
+| `separatorIcon` | `string` | `'i-carbon-chevron-right'` | Icon name rendered between entries. |
 
 ### BreadcrumbItem
 

--- a/apps/nexus/content/docs/dev/components/breadcrumb.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/breadcrumb.zh.mdc
@@ -79,7 +79,7 @@ function openVirtualCrumb(item: { label: string }, index: number) {
 - `click` 只会在非当前、非禁用且没有 `href` 的条目上发出。
 - `icon` 会在条目文本前渲染一个 `TxIcon`。
 - 分隔符只渲染在条目之间，并且是 `aria-hidden`。
-- 默认分隔图标名是 `chevron-right`。
+- 默认分隔图标名是 `i-carbon-chevron-right`（TxIcon 需要 `i-` 前缀，缺前缀会解析为 `null`）。
 
 ## API
 
@@ -88,7 +88,7 @@ function openVirtualCrumb(item: { label: string }, index: number) {
 | 属性名 | 类型 | 默认值 | 说明 |
 |------|------|---------|------|
 | `items` | `BreadcrumbItem[]` | 必填 | 有序面包屑条目。最后一项会被视为当前页。 |
-| `separatorIcon` | `string` | `'chevron-right'` | 条目之间渲染的图标名。 |
+| `separatorIcon` | `string` | `'i-carbon-chevron-right'` | 条目之间渲染的图标名。 |
 
 ### BreadcrumbItem
 

--- a/apps/nexus/content/docs/dev/components/button.en.mdc
+++ b/apps/nexus/content/docs/dev/components/button.en.mdc
@@ -161,8 +161,8 @@ rows:
     type:
       kind: enum
       enums: [primary, secondary, ghost, danger, success, warning, info, flat, bare]
-    default: '-'
-    description: 'Visual variant'
+    default: "'secondary'"
+    description: 'Visual style variant. Falls back to `secondary` when unset and not derived from `type`.'
   - parameter: type
     type:
       kind: enum
@@ -174,11 +174,11 @@ rows:
       kind: enum
       enums: [sm, md, lg, large, small, mini]
     default: "'md'"
-    description: 'Button size'
+    description: 'Button size. Use `lg`/`large` for primary page actions, `sm`/`small`/`mini` for table rows and compact toolbars.'
   - parameter: block
     type: boolean
     default: 'false'
-    description: 'Block-level (full width)'
+    description: 'Block-level button that fills the parent width. Common for mobile form submits and drawer footer actions.'
   - parameter: plain
     type: boolean
     default: 'false'

--- a/apps/nexus/content/docs/dev/components/button.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/button.zh.mdc
@@ -161,8 +161,8 @@ rows:
     type:
       kind: enum
       enums: [primary, secondary, ghost, danger, success, warning, info, flat, bare]
-    default: '-'
-    description: '视觉风格变体'
+    default: "'secondary'"
+    description: '视觉风格变体。未显式设置时（且未通过 `type` 推导）回退为 `secondary`。'
   - parameter: type
     type:
       kind: enum
@@ -174,11 +174,11 @@ rows:
       kind: enum
       enums: [sm, md, lg, large, small, mini]
     default: "'md'"
-    description: '按钮尺寸'
+    description: '按钮尺寸。`lg`/`large` 用于页面主操作，`sm`/`small`/`mini` 用于表格行内与紧凑工具条。'
   - parameter: block
     type: boolean
     default: 'false'
-    description: '是否块级（撑满容器）'
+    description: '块级按钮，撑满父容器宽度。移动端表单提交与抽屉底部操作常用。'
   - parameter: plain
     type: boolean
     default: 'false'

--- a/apps/nexus/content/docs/dev/components/cascader.en.mdc
+++ b/apps/nexus/content/docs/dev/components/cascader.en.mdc
@@ -145,7 +145,7 @@ code: |
 | `options` | `CascaderNode[]` | `[]` | Root option tree rendered by the cascader columns. |
 | `multiple` | `boolean` | `false` | Enables selecting multiple leaf paths and renders selected paths as tags. |
 | `disabled` | `boolean` | `false` | Disables the trigger, clear button, node selection, and keyboard open behavior. |
-| `placeholder` | `string` | `'请选择'` | Placeholder text shown when no path is selected. |
+| `placeholder` | `string` | `'Please select'` | Placeholder text shown when no path is selected. |
 | `searchable` | `boolean` | `true` | Shows a local search input that filters loaded leaf paths by formatted label. |
 | `clearable` | `boolean` | `true` | Shows the clear button when a value is selected and the component is enabled. |
 | `placement` | `PopoverPlacement` | `'bottom-start'` | Placement forwarded to the underlying `TxPopover`. |

--- a/apps/nexus/content/docs/dev/components/cascader.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/cascader.zh.mdc
@@ -145,7 +145,7 @@ code: |
 | `options` | `CascaderNode[]` | `[]` | 根级选项树，用于渲染级联列。 |
 | `multiple` | `boolean` | `false` | 启用多选叶子路径，并把选中的路径渲染为标签。 |
 | `disabled` | `boolean` | `false` | 禁用触发器、清空按钮、节点选择和键盘打开行为。 |
-| `placeholder` | `string` | `'请选择'` | 未选择路径时显示的占位文本。 |
+| `placeholder` | `string` | `'Please select'` | 未选择路径时显示的占位文本。 |
 | `searchable` | `boolean` | `true` | 显示本地搜索输入框，按已加载叶子路径的格式化标签过滤。 |
 | `clearable` | `boolean` | `true` | 组件启用且已有值时显示清空按钮。 |
 | `placement` | `PopoverPlacement` | `'bottom-start'` | 转发给底层 `TxPopover` 的浮层位置。 |

--- a/apps/nexus/content/docs/dev/components/container.en.mdc
+++ b/apps/nexus/content/docs/dev/components/container.en.mdc
@@ -156,7 +156,7 @@ code: |
 
   <style scoped>
   .col-content {
-    background: var(--tx-color-surface);
+    background: var(--tx-bg-color-overlay, #fff);
     padding: 16px;
     text-align: center;
     border-radius: 8px;

--- a/apps/nexus/content/docs/dev/components/container.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/container.zh.mdc
@@ -156,7 +156,7 @@ code: |
 
   <style scoped>
   .col-content {
-    background: var(--tx-color-surface);
+    background: var(--tx-bg-color-overlay, #fff);
     padding: 16px;
     text-align: center;
     border-radius: 8px;

--- a/apps/nexus/content/docs/dev/components/dialog.en.mdc
+++ b/apps/nexus/content/docs/dev/components/dialog.en.mdc
@@ -261,7 +261,7 @@ code: |
 
 - All dialog variants teleport to `body`, assign z-index through the shared z-index manager, and close through the required `close()` callback.
 - Escape closes the active dialog after its leave animation; `TxBottomDialog`, `TxBlowDialog`, `TxPopperDialog`, and `TxTouchTip` restore the previously focused element on unmount.
-- `TxBottomDialog` and `TxTouchTip` use instance-scoped title/description ids; `TxBlowDialog` and `TxPopperDialog` use stable internal ids for their default title/content regions.
+- `TxBottomDialog`, `TxTouchTip`, and `TxBlowDialog` all derive instance-level title/description ids via `useId()`; `TxPopperDialog` uses stable internal ids for its default title/content regions.
 - Plain `message` renders as text and preserves line breaks. Use `messageHtml` only with `asTrustedDialogHtml()` after sanitizing internal content.
 - `DialogButton.onClick()` / `TouchTipButton.onClick()` closes when it resolves `true` and keeps the dialog open when it resolves `false`.
 

--- a/apps/nexus/content/docs/dev/components/dialog.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/dialog.zh.mdc
@@ -261,7 +261,7 @@ code: |
 
 - 所有 Dialog 变体都会 teleport 到 `body`，通过共享 z-index manager 分配层级，并通过必填 `close()` 回调关闭。
 - Escape 会在离场动画后关闭当前 dialog；`TxBottomDialog`、`TxBlowDialog`、`TxPopperDialog` 与 `TxTouchTip` 卸载时恢复之前的焦点元素。
-- `TxBottomDialog` 与 `TxTouchTip` 使用实例级标题 / 描述 id；`TxBlowDialog` 与 `TxPopperDialog` 对默认标题 / 内容区域使用稳定内部 id。
+- `TxBottomDialog`、`TxTouchTip` 与 `TxBlowDialog` 都用 `useId()` 生成实例级标题 / 描述 id；`TxPopperDialog` 对默认标题 / 内容区域使用稳定内部 id。
 - 普通 `message` 按文本渲染并保留换行。只有调用方完成清洗并通过 `asTrustedDialogHtml()` 标记后，才使用 `messageHtml`。
 - `DialogButton.onClick()` / `TouchTipButton.onClick()` resolve `true` 时关闭，resolve `false` 时保持打开。
 

--- a/apps/nexus/content/docs/dev/components/drawer.en.mdc
+++ b/apps/nexus/content/docs/dev/components/drawer.en.mdc
@@ -289,9 +289,9 @@ rows:
     type: 'boolean'
     default: 'true'
   - name: zIndex
-    description: 'Custom z-index'
+    description: 'Custom z-index. When unset the runtime z-index manager assigns one (seeded at `10000`, incremented per drawer); set it manually only to coexist with externally fixed layers.'
     type: 'number'
-    default: '1998'
+    default: '-'
 ---
 ::
 

--- a/apps/nexus/content/docs/dev/components/drawer.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/drawer.zh.mdc
@@ -233,11 +233,11 @@ code: |
 ---
 rows:
   - name: visible
-    description: '控制抽屉可见性'
+    description: '控制抽屉可见性。配合 `v-model:visible` 双向绑定；关闭时组件仍留在 DOM 中（见交互契约）。'
     type: 'boolean'
     default: '*必填*'
   - name: title
-    description: '头部显示的标题'
+    description: '头部显示的标题。留空则不渲染标题行，可改用 `header` 插槽自定义。'
     type: 'string'
     default: "'Drawer'"
   - name: size
@@ -289,9 +289,9 @@ rows:
     type: 'boolean'
     default: 'true'
   - name: zIndex
-    description: '自定义 z-index'
+    description: '自定义 z-index。不传时由运行时 z-index 管理器分配（种子 `10000`，逐个抽屉递增）；仅在需要与外部固定层级共存时手动指定。'
     type: 'number'
-    default: '1998'
+    default: '-'
 ---
 ::
 

--- a/apps/nexus/content/docs/dev/components/flat-input.en.mdc
+++ b/apps/nexus/content/docs/dev/components/flat-input.en.mdc
@@ -65,7 +65,7 @@ Use `area` for short notes, not for autosizing editors. The component renders a 
 - Without an `icon` prop or default slot, the root gets `none-prefix` and uses a single-column layout.
 - The default slot replaces icon rendering; it is prefix content, not a suffix/action slot.
 - `password=true` renders `input type="password"` and enables Caps Lock detection on keydown.
-- Caps Lock detection is based on key code plus `shiftKey`; the hint is informational and only appears in password mode.
+- Caps Lock detection reads the live modifier state via `KeyboardEvent.getModifierState('CapsLock')` (no keyCode/`shiftKey` inference); the hint is informational and only appears in password mode.
 - `area=true` renders `textarea` instead of `input` and adds the `area` class for fixed height.
 - `nonWin=true` removes the `win` class and therefore the Windows-style focus treatment.
 - The component does not expose `disabled`, `readonly`, `name`, or validation props; use a fuller input primitive when those contracts are required.

--- a/apps/nexus/content/docs/dev/components/flat-input.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/flat-input.zh.mdc
@@ -65,7 +65,7 @@ code: |
 - 没有 `icon` 和默认插槽时，根节点添加 `none-prefix` 并使用单列布局。
 - 默认插槽会替换图标渲染；它是前缀内容，不是后缀或操作插槽。
 - `password=true` 渲染 `input type="password"`，并在 keydown 时启用 Caps Lock 检测。
-- Caps Lock 检测基于 key code 和 `shiftKey`；提示只作信息展示，并且只在密码模式出现。
+- Caps Lock 检测读取 `KeyboardEvent.getModifierState('CapsLock')` 的实时修饰键状态（不做 keyCode/`shiftKey` 推断）；提示只作信息展示，并且只在密码模式出现。
 - `area=true` 渲染 `textarea` 而不是 `input`，并添加 `area` 类以使用固定高度。
 - `nonWin=true` 会移除 `win` 类，从而关闭 Windows 风格的聚焦视觉。
 - 组件没有暴露 `disabled`、`readonly`、`name` 或校验 props；需要这些契约时应使用更完整的输入组件。

--- a/apps/nexus/content/docs/dev/components/floating.en.mdc
+++ b/apps/nexus/content/docs/dev/components/floating.en.mdc
@@ -69,6 +69,9 @@ Negative `depth` moves in the opposite direction from positive `depth`.
 - `disabled=false` restarts listeners and RAF.
 - `TxFloatingElement` registers on mount, re-registers when `depth` changes, and unregisters on unmount.
 - If an element is used outside `TxFloating`, it renders but does not animate.
+- All parallax motion stops when the user requests `prefers-reduced-motion: reduce`.
+- An `IntersectionObserver` parks the RAF loop while the container is off-screen and resumes it on re-entry.
+- The container listens for window `scroll` and `resize` in the capture phase so the origin is re-measured after page scroll or viewport changes.
 - The implementation guards browser APIs with `hasWindow()` for SSR safety.
 
 ## API

--- a/apps/nexus/content/docs/dev/components/floating.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/floating.zh.mdc
@@ -69,6 +69,9 @@ code: |
 - `disabled=false` 会重新启动监听与 RAF。
 - `TxFloatingElement` 挂载时注册，`depth` 变化时重新注册，卸载时注销。
 - 元素在 `TxFloating` 外部使用时仍会渲染，但不会动画。
+- 用户开启 `prefers-reduced-motion: reduce` 时组件停止全部视差运动。
+- `IntersectionObserver` 在容器移出视口时暂停 RAF 循环，重新进入时恢复。
+- 容器在 capture 阶段监听 window `scroll` 与 `resize`，以在页面滚动/缩放后重新测量原点。
 - 实现通过 `hasWindow()` 保护浏览器 API，避免 SSR 问题。
 
 ## API

--- a/apps/nexus/content/docs/dev/components/glow-text.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/glow-text.zh.mdc
@@ -123,13 +123,13 @@ code: |
 
 | 属性名 | 类型 | 默认值 | 说明 |
 |------|------|---------|------|
-| `tag` | `string` | `span` | 外层渲染标签 |
+| `tag` | `string` | `span` | 包裹默认插槽的根元素标签；行内文本保持 `span`，卡片/图片容器改 `div`。 |
 | `active` | `boolean` | `true` | 是否启用扫光 |
 | `repeat` | `boolean` | `true` | 是否循环 |
 | `durationMs` | `number` | `2000` | 动画时长(ms) |
 | `delayMs` | `number` | `0` | 延迟(ms) |
-| `angle` | `number` | `20` | 扫光角度(deg) |
-| `bandSize` | `number` | `38` | 高光带宽度(%) |
+| `angle` | `number` | `20` | 扫光渐变角度（度）；接近 `0` 为水平掠过，增大则倾斜。 |
+| `bandSize` | `number` | `38` | 高光带宽度占渐变的百分比；调小得到更锐的窄光，调大更柔和。 |
 | `color` | `string` | `rgba(255, 255, 255, 0.9)` | 高光颜色 |
 | `opacity` | `number` | `0.75` | 高光不透明度 |
 | `blendMode` | `string` | - | 自定义 CSS `mix-blend-mode`；未传时 `adaptive` 会优先使用 `plus-lighter`，不支持时回退到 `screen`。 |

--- a/apps/nexus/content/docs/dev/components/popover.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/popover.zh.mdc
@@ -1,6 +1,6 @@
 ---
 title: "Popover 弹出层"
-description: "基于 Tooltip 与 Anchor 链路的语义弹出层。"
+description: "直接基于 BaseAnchor 构建的语义弹出层。"
 category: Feedback
 status: beta
 since: 1.0.0

--- a/apps/nexus/content/docs/dev/components/progress-bar.en.mdc
+++ b/apps/nexus/content/docs/dev/components/progress-bar.en.mdc
@@ -44,7 +44,7 @@ code: |
   </script>
 
   <template>
-    <TxProgressBar :segments="segments" :segments-total="100" height="14px" show-text tooltip tooltip-content="Multi-segment progress" />
+    <TxProgressBar :segments="segments" :segments-total="100" height="14px" show-text tooltip tooltip-content="Multi-segment progress" indicator-effect="sparkle" mask-background="glass" />
   </template>
 ---
 :::

--- a/apps/nexus/content/docs/dev/components/progress-bar.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/progress-bar.zh.mdc
@@ -44,7 +44,7 @@ code: |
   </script>
 
   <template>
-    <TxProgressBar :segments="segments" :segments-total="100" height="14px" show-text tooltip tooltip-content="多段进度" />
+    <TxProgressBar :segments="segments" :segments-total="100" height="14px" show-text tooltip tooltip-content="多段进度" indicator-effect="sparkle" mask-background="glass" />
   </template>
 ---
 :::

--- a/apps/nexus/content/docs/dev/components/search-select.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/search-select.zh.mdc
@@ -141,14 +141,14 @@ code: |
 | 属性名 | 类型 | 默认值 | 说明 |
 |------|------|---------|------|
 | `modelValue` | `string \| number` | `''` | 选中值（v-model） |
-| `placeholder` | `string` | `'Search'` | 占位 |
-| `disabled` | `boolean` | `false` | 禁用 |
-| `clearable` | `boolean` | `true` | 可清空 |
+| `placeholder` | `string` | `'Search'` | 透传给搜索输入框的占位文本。 |
+| `disabled` | `boolean` | `false` | 禁用输入框、弹层与聚焦展开，并停止发出远程 `search`。 |
+| `clearable` | `boolean` | `true` | 显示输入框清除按钮，允许清空已选值。 |
 | `options` | `TxSearchSelectOption[]` | `[]` | 下拉数据源 |
-| `loading` | `boolean` | `false` | loading 状态 |
+| `loading` | `boolean` | `false` | 在输入框后缀显示小号加载指示器，用于远程结果等待。 |
 | `remote` | `boolean` | `false` | 是否远程搜索（输入触发 `search`） |
 | `searchDebounce` | `number` | `200` | 远程搜索防抖（ms） |
-| `dropdownMaxHeight` | `number` | `280` | 下拉最大高度 |
+| `dropdownMaxHeight` | `number` | `280` | 选项面板最大高度（px），超出后面板内部滚动。 |
 | `dropdownOffset` | `number` | `6` | 下拉偏移 |
 | `panelVariant` | `'solid' \| 'dashed' \| 'plain'` | `'solid'` | 面板边框形态（TxCard variant） |
 | `panelBackground` | `'pure' \| 'mask' \| 'blur' \| 'glass' \| 'refraction'` | `'refraction'` | 面板背景（TxCard background） |

--- a/apps/nexus/content/docs/dev/components/select.en.mdc
+++ b/apps/nexus/content/docs/dev/components/select.en.mdc
@@ -307,7 +307,7 @@ code: |
 | Prop | Type | Default | Description |
 |------|------|---------|------|
 | `modelValue` / `v-model` | `string \| number \| Array<string \| number>` | `''` | Selected value; array in `multiple` mode. |
-| `placeholder` | `string` | `'请选择'` | Placeholder shown in the trigger input when no label is selected. |
+| `placeholder` | `string` | `'Please select'` | Placeholder shown in the trigger input when no label is selected. |
 | `disabled` | `boolean` | `false` | Disables the trigger, closes the dropdown, and blocks option selection. |
 | `multiple` | `boolean` | `false` | Enables multi-select tag mode. |
 | `status` | `'default' \| 'error' \| 'warning'` | `'default'` | Validation border state. |

--- a/apps/nexus/content/docs/dev/components/select.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/select.zh.mdc
@@ -307,7 +307,7 @@ code: |
 | 属性名 | 类型 | 默认值 | 说明 |
 |------|------|---------|------|
 | `modelValue` / `v-model` | `string \| number \| Array<string \| number>` | `''` | 当前选中值；`multiple` 模式下为数组。 |
-| `placeholder` | `string` | `'请选择'` | 没有选中 label 时展示在触发器输入框中的占位文本。 |
+| `placeholder` | `string` | `'Please select'` | 没有选中 label 时展示在触发器输入框中的占位文本。 |
 | `disabled` | `boolean` | `false` | 禁用触发器，关闭下拉面板，并阻止选择选项。 |
 | `multiple` | `boolean` | `false` | 启用多选标签模式。 |
 | `status` | `'default' \| 'error' \| 'warning'` | `'default'` | 校验状态边框。 |

--- a/apps/nexus/content/docs/dev/components/spinner.en.mdc
+++ b/apps/nexus/content/docs/dev/components/spinner.en.mdc
@@ -100,6 +100,7 @@ code: |
 | `strokeWidth` | `number` | `2` | Stroke width used by the ring and SVG fallback; written to `--tx-spinner-stroke`. |
 | `fallback` | `boolean` | `false` | Renders the SVG fallback spinner instead of the default animated ball/ring shape. |
 | `visible` | `boolean` | `true` | Shows or hides the spinner with the built-in `tx-spinner-visibility` transition. |
+| `label` | `string` | `'Loading'` | Accessible name for the status region, announced when the spinner appears; override it to localize. |
 
 ### Events
 

--- a/apps/nexus/content/docs/dev/components/spinner.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/spinner.zh.mdc
@@ -100,6 +100,7 @@ code: |
 | `strokeWidth` | `number` | `2` | 环形线宽与 SVG fallback 线宽；写入 `--tx-spinner-stroke`。 |
 | `fallback` | `boolean` | `false` | 使用 SVG fallback 旋转图形，而不是默认的 ball/ring 动效。 |
 | `visible` | `boolean` | `true` | 通过内置 `tx-spinner-visibility` 过渡控制显示或隐藏。 |
+| `label` | `string` | `'Loading'` | 状态区域的可访问名称，读屏在 spinner 出现时播报；本地化时覆盖此值。 |
 
 ### Events
 

--- a/apps/nexus/content/docs/dev/components/stack.en.mdc
+++ b/apps/nexus/content/docs/dev/components/stack.en.mdc
@@ -76,8 +76,8 @@ code: |
 |------|------|---------|-------------|
 | `direction` | `'horizontal' \| 'vertical'` | `'vertical'` | Main axis direction. |
 | `gap` | `number \| string` | `12` | Gap between children. Numbers become px. |
-| `align` | `string` | `'stretch'` | CSS `align-items` value. |
-| `justify` | `string` | `'flex-start'` | CSS `justify-content` value. |
+| `align` | `string` | `'stretch'` | Cross-axis alignment; accepts any valid `align-items` value (`stretch` / `center` / `flex-start` / `flex-end` / `baseline`). Left as `string` rather than a union so newer values such as `safe center` still pass. |
+| `justify` | `string` | `'flex-start'` | Main-axis distribution; accepts any valid `justify-content` value (`flex-start` / `center` / `space-between` / `space-around` / `space-evenly`). Use `space-between` for edge-anchored rows, `center` for a centered group. |
 | `wrap` | `boolean` | `false` | Allow children to wrap onto multiple lines. |
 | `inline` | `boolean` | `false` | Use `inline-flex` instead of block-level `flex`. |
 

--- a/apps/nexus/content/docs/dev/components/stack.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/stack.zh.mdc
@@ -76,8 +76,8 @@ code: |
 |------|------|---------|------|
 | `direction` | `'horizontal' \| 'vertical'` | `'vertical'` | 主轴方向。 |
 | `gap` | `number \| string` | `12` | 子元素间距，数字会转为 px。 |
-| `align` | `string` | `'stretch'` | CSS `align-items` 值。 |
-| `justify` | `string` | `'flex-start'` | CSS `justify-content` 值。 |
+| `align` | `string` | `'stretch'` | 交叉轴对齐，取任意合法 `align-items` 值（`stretch` / `center` / `flex-start` / `flex-end` / `baseline`）。类型未收窄为联合，便于传 `safe center` 等新值。 |
+| `justify` | `string` | `'flex-start'` | 主轴分布，取任意合法 `justify-content` 值（`flex-start` / `center` / `space-between` / `space-around` / `space-evenly`）。等分布局用 `space-between`，居中成组用 `center`。 |
 | `wrap` | `boolean` | `false` | 允许子元素换行。 |
 | `inline` | `boolean` | `false` | 使用 `inline-flex` 而不是块级 `flex`。 |
 

--- a/apps/nexus/content/docs/dev/components/stagger.en.mdc
+++ b/apps/nexus/content/docs/dev/components/stagger.en.mdc
@@ -78,7 +78,7 @@ code: |
 - Each rendered child is cloned with its existing style plus `--tx-stagger-index: <index>`.
 - Timing props are written on the root as `--tx-stagger-duration`, `--tx-stagger-delay-step`, `--tx-stagger-delay-base`, and `--tx-stagger-easing`.
 - Built-in CSS uses opacity and `translateY(6px)` for enter/leave transitions.
-- `name` and `appear` are intentionally withheld until after mount, so transition props do not leak as root attributes during initial render.
+- `name` and `appear` are passed to TransitionGroup on the first render — TransitionGroup only runs its appear transition on initial mount and consumes both as props (not fallthrough attrs), so deferring them would permanently skip appear.
 - Child nodes must have stable Vue keys for `TransitionGroup` move/enter/leave behavior.
 - Existing child inline styles are preserved when the stagger index style is added.
 
@@ -89,8 +89,8 @@ code: |
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `tag` | `string` | `'div'` | Root tag passed to `TransitionGroup`. |
-| `appear` | `boolean` | `true` | Enables appear transition after mount. |
-| `name` | `string` | `'tx-stagger'` | TransitionGroup class name prefix after mount. |
+| `appear` | `boolean` | `true` | Whether the appear transition runs; passed to TransitionGroup from the first render. |
+| `name` | `string` | `'tx-stagger'` | TransitionGroup class-name prefix; effective from the first render. |
 | `duration` | `number` | `180` | Enter and leave transition duration in milliseconds. |
 | `delayStep` | `number` | `24` | Extra delay per rendered child index, in milliseconds. |
 | `delayBase` | `number` | `0` | Base delay before index-based delay, in milliseconds. |
@@ -131,7 +131,7 @@ code: |
 
 - Reviewed against `packages/tuffex/packages/components/src/stagger/src/TxStagger.vue`, `types.ts`, and `stagger.test.ts`.
 - Existing tests cover root tag passthrough, slot rendering, timing CSS variables, transition prop leakage prevention, comment filtering, and child stagger index assignment.
-- Rendering note: `name` and `appear` are only applied after mount, so SSR/client hydration should not depend on transition attributes during the initial render.
+- Rendering note: `name` and `appear` are supplied as TransitionGroup props from the first render, so the initial-mount appear transition runs as expected.
 - Accessibility note: `TxStagger` adds no semantic role. Choose `tag` and child elements that preserve list, grid, or feed semantics before styling transitions.
 
 ## Source

--- a/apps/nexus/content/docs/dev/components/stagger.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/stagger.zh.mdc
@@ -78,7 +78,7 @@ code: |
 - 每个渲染子节点会被 clone，并在保留原有 style 的同时追加 `--tx-stagger-index: <index>`。
 - timing props 会写到根节点：`--tx-stagger-duration`、`--tx-stagger-delay-step`、`--tx-stagger-delay-base`、`--tx-stagger-easing`。
 - 内置 CSS 使用 opacity 与 `translateY(6px)` 做 enter/leave 过渡。
-- `name` 与 `appear` 会在 mount 后才传给 TransitionGroup，避免初始渲染时 transition props 泄漏为根属性。
+- `name` 与 `appear` 首帧即传给 TransitionGroup —— TransitionGroup 只在初次挂载时运行 appear 过渡，并把两者当 props（而非 fallthrough 属性）消费，延迟传入会永久跳过 appear。
 - 子节点必须有稳定 Vue key，才能得到正确的 `TransitionGroup` move/enter/leave 行为。
 - 追加 stagger index style 时会保留子节点已有 inline style。
 
@@ -89,8 +89,8 @@ code: |
 | 属性名 | 类型 | 默认值 | 说明 |
 |------|------|---------|------|
 | `tag` | `string` | `'div'` | 传给 `TransitionGroup` 的根标签。 |
-| `appear` | `boolean` | `true` | mount 后启用 appear transition。 |
-| `name` | `string` | `'tx-stagger'` | mount 后使用的 TransitionGroup class name 前缀。 |
+| `appear` | `boolean` | `true` | 是否启用 appear 过渡；首帧即传给 TransitionGroup。 |
+| `name` | `string` | `'tx-stagger'` | TransitionGroup 的 class 名前缀；首帧即生效。 |
 | `duration` | `number` | `180` | enter 和 leave 过渡时长，单位 ms。 |
 | `delayStep` | `number` | `24` | 每个渲染子节点 index 增加的额外延迟，单位 ms。 |
 | `delayBase` | `number` | `0` | index 延迟前的基础延迟，单位 ms。 |
@@ -131,7 +131,7 @@ code: |
 
 - 已核对 `packages/tuffex/packages/components/src/stagger/src/TxStagger.vue`、`types.ts` 与 `stagger.test.ts`。
 - 现有测试覆盖根标签透传、插槽渲染、timing CSS 变量、transition prop 泄漏防护、注释节点过滤与子节点 stagger index 赋值。
-- 渲染说明：`name` 与 `appear` 仅在 mount 后应用，因此 SSR/client hydration 不应依赖初始渲染期间的 transition 属性。
+- 渲染说明：`name` 与 `appear` 从首帧起就作为 TransitionGroup 的 props 传入，因此初次挂载的 appear 过渡会正常运行。
 - 可访问性说明：`TxStagger` 不添加语义 role。先选择能保留列表、网格或 feed 语义的 `tag` 与子元素，再处理过渡样式。
 
 ## Source

--- a/apps/nexus/content/docs/dev/components/switch.en.mdc
+++ b/apps/nexus/content/docs/dev/components/switch.en.mdc
@@ -11,6 +11,8 @@ verified: true
 
 # Switch
 
+`TxSwitch` toggles a binary state that applies immediately (on/off, enabled/disabled). Use `TxCheckbox` when the form semantics are "tick now, submit later".
+
 ## Basic Usage
 :::TuffCodeBlock{lang="vue"}
 ---
@@ -216,8 +218,8 @@ code: |
 
 ## Interaction Contract
 
-- The root renders `role="switch"`, `aria-checked`, `aria-disabled`, and `tabindex="0"` while enabled.
-- `disabled=true` sets `tabindex="-1"`, adds `is-disabled`, and prevents click, Enter, and Space from emitting events.
+- The root is a native `<button>` rendering `role="switch"`, `aria-checked`, and `aria-disabled`; it sets no `tabindex` — focusability comes from the button element itself.
+- `disabled=true` sets the native `disabled` attribute (which removes it from the tab order), adds `is-disabled`, and prevents click, Enter, and Space from emitting events.
 - Enabled toggles emit both `update:modelValue` and `change`; the component does not mutate external state without `v-model` update handling.
 - `size="small"` and `size="large"` add modifier classes; `size="default"` intentionally leaves the base class only.
 
@@ -284,8 +286,8 @@ code: |
 ## Review Notes
 
 - **Model contract:** `TxSwitch` is controlled by `modelValue`. User interaction emits both `update:modelValue` and `change` with the next boolean; the visual state updates after the parent writes the new prop back.
-- **Keyboard contract:** Enabled switches respond to click, Enter, and Space. Disabled switches set `tabindex="-1"`, keep `aria-disabled="true"`, and emit nothing.
-- **Verified coverage:** `switch.test.ts` covers active aria state, size classes, click emission, disabled blocking, and disabled tabindex/aria state.
+- **Keyboard contract:** Enabled switches respond to click, Enter, and Space via native button semantics. Disabled switches leave the tab order through the native `disabled` attribute, keep `aria-disabled="true"`, and emit nothing.
+- **Verified coverage:** `switch.test.ts` covers active aria state, size classes, click emission, disabled blocking, and asserts that no `tabindex` is rendered in either state.
 
 ## Source
 

--- a/apps/nexus/content/docs/dev/components/switch.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/switch.zh.mdc
@@ -11,6 +11,8 @@ verified: true
 
 # Switch 开关
 
+`TxSwitch` 用于即时生效的二元状态切换（开/关、启用/停用）。需要「先勾选、后提交」的表单语义时用 `TxCheckbox`。
+
 ## 基础用法
 :::TuffCodeBlock{lang="vue"}
 ---
@@ -216,8 +218,8 @@ code: |
 
 ## 交互契约
 
-- 根节点渲染 `role="switch"`、`aria-checked`、`aria-disabled`，启用时 `tabindex="0"`。
-- `disabled=true` 时设置 `tabindex="-1"`，添加 `is-disabled`，并阻止点击、Enter、Space 触发事件。
+- 根节点是原生 `<button>`，渲染 `role="switch"`、`aria-checked`、`aria-disabled`；不设置 `tabindex`——可聚焦性由按钮元素自身提供。
+- `disabled=true` 时设置原生 `disabled`（因而移出 Tab 序列）、添加 `is-disabled`，并阻止点击、Enter、Space 触发事件。
 - 启用切换会同时触发 `update:modelValue` 与 `change`；组件不会在宿主未处理 `v-model` 更新时自行修改外部状态。
 - `size="small"` 与 `size="large"` 会添加尺寸 modifier；`size="default"` 只保留基础 class。
 
@@ -284,8 +286,8 @@ code: |
 ## 审阅说明 / Review Notes
 
 - **Model contract:** `TxSwitch` 由 `modelValue` 控制。用户交互会同时派发 `update:modelValue` 与 `change`，参数为下一个 boolean；视觉状态在父级回写新 prop 后更新。
-- **键盘契约:** 启用状态响应点击、Enter 与 Space。禁用状态设置 `tabindex="-1"`，保持 `aria-disabled="true"`，且不派发事件。
-- **实测覆盖:** `switch.test.ts` 覆盖 active aria 状态、尺寸 class、点击派发、禁用阻断，以及禁用时的 tabindex/aria 状态。
+- **键盘契约:** 启用状态响应点击、Enter 与 Space（原生按钮语义）。禁用状态由原生 `disabled` 移出 Tab 序列，保持 `aria-disabled="true"`，且不派发事件。
+- **实测覆盖:** `switch.test.ts` 覆盖 active aria 状态、尺寸 class、点击派发、禁用阻断，并断言两种状态下均不渲染 `tabindex`。
 
 ## Source
 

--- a/apps/nexus/content/docs/dev/components/toast.en.mdc
+++ b/apps/nexus/content/docs/dev/components/toast.en.mdc
@@ -153,7 +153,7 @@ code: |
 ## Review Notes
 
 - **Accessibility note:** The host is a labeled `role="region"` that is also a polite `aria-live` region, so a toast appearing while focus is elsewhere is announced; `danger` toasts escalate to `role="alert"`. Still use persistent visible copy or page-level status text for critical failures and long-running operations.
-- **Timer note:** Reusing an `id` replaces the store item, but existing auto-dismiss timers are not cancelled. Use `duration: 0` for persistent id-based task toasts, or unique ids for repeated transient success messages.
+- **Timer note:** Reusing an `id` replaces the store item and first cancels that id's pending auto-dismiss timer (`clearDismissTimer`); the replacement toast restarts timing from its own `duration`. Use `duration: 0` for persistent task toasts.
 - **Verified coverage:** `toast.test.ts` checks id replacement, returned ids, auto-dismiss, persistent toasts, dismiss/clear helpers, host region semantics, variant classes, rendered title/description, accessible close buttons, and close-button dismissal.
 
 ## Source

--- a/apps/nexus/content/docs/dev/components/toast.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/toast.zh.mdc
@@ -153,7 +153,7 @@ code: |
 ## 审阅说明
 
 - **可访问性说明:** Host 是带标签的 `role="region"`，同时是 polite 的 `aria-live` 区域，焦点在别处时新 toast 也会被播报；`danger` toast 会升级为 `role="alert"`。关键失败或长任务仍建议用持久可见文案或页面级状态文本补充。
-- **计时器说明:** 复用 `id` 会替换 store item，但已有自动关闭定时器不会取消。基于 id 的常驻任务 toast 请使用 `duration: 0`；重复的短成功提示则使用唯一 id。
+- **计时器说明:** 复用 `id` 会替换 store item，并先取消该 id 上已有的自动关闭定时器（`clearDismissTimer`），替换后的 toast 按自己的 `duration` 重新计时。常驻任务 toast 用 `duration: 0`。
 - **实测覆盖:** `toast.test.ts` 覆盖 id 替换、返回 id、自动关闭、常驻 toast、dismiss/clear 辅助函数、host region 语义、variant class、标题/描述渲染、可访问关闭按钮，以及关闭按钮移除。
 
 ## Source

--- a/apps/nexus/content/docs/dev/components/transfer.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/transfer.zh.mdc
@@ -151,7 +151,7 @@ rows:
 
 ## Source
 
-<TuffDocSourceLink />
+<TuffDocSourceLink label="查看源码" />
 
 ## 审阅说明
 

--- a/apps/nexus/content/docs/dev/components/typing-indicator.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/typing-indicator.zh.mdc
@@ -84,10 +84,10 @@ code: |
 
 | 属性名 | 类型 | 默认值 | 说明 |
 |------|------|---------|------|
-| `variant` | `'dots' \| 'ai' \| 'pure' \| 'ring' \| 'circle-dash' \| 'bars'` | `'dots'` | 样式变体 |
-| `text` | `string` | `'Typing…'` | 文案 |
+| `variant` | `'dots' \| 'ai' \| 'pure' \| 'ring' \| 'circle-dash' \| 'bars'` | `'dots'` | 指示器视觉样式；`dots` 通用，`ai` 用于模型思考态，`bars`/`ring` 用于强调持续处理。 |
+| `text` | `string` | `'Typing…'` | `showText` 开启时显示的状态文案，按场景改写（如「正在生成…」）。 |
 | `showText` | `boolean` | `true` | 是否显示文案 |
-| `size` | `number` | `6` | dots 模式点尺寸(px) |
+| `size` | `number` | `6` | `dots` 变体的圆点直径（px）；随宿主字号放大时同步调大。 |
 | `gap` | `number` | `5` | dots 模式间距(px) |
 | `loaderSize` | `number` | `44` | ai 模式尺寸(px) |
 | `pureSize` | `number` | `14` | pure 模式尺寸(px) |

--- a/apps/nexus/content/docs/dev/components/virtual-list.en.mdc
+++ b/apps/nexus/content/docs/dev/components/virtual-list.en.mdc
@@ -78,6 +78,7 @@ function jumpToLatest() {
 - `itemKey` may be a field name or function. Missing field values fall back to the visible item index.
 - `scroll` emits `{ scrollTop, startIndex, endIndex }` after internal scroll state updates.
 - `scrollToIndex(index)` clamps negative indexes to zero but does not clamp indexes above the last item; callers should pass valid indexes.
+- The container and rows stay semantically neutral (no `role`/`aria-*`). Because only the visible slice is in the DOM, consumers who need accessible list semantics should supply `role="list"`/`role="listitem"` plus `aria-setsize`/`aria-posinset` themselves, using the real `items.length` and absolute indices rather than the visible-slice offsets.
 
 ## API
 

--- a/apps/nexus/content/docs/dev/components/virtual-list.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/virtual-list.zh.mdc
@@ -78,6 +78,7 @@ function jumpToLatest() {
 - `itemKey` 可以是字段名或函数。字段值缺失时回退为可见项 index。
 - `scroll` 在内部滚动状态更新后发出 `{ scrollTop, startIndex, endIndex }`。
 - `scrollToIndex(index)` 会把负数 index 限制为 0，但不会限制超过最后一项的 index；调用方应传入有效索引。
+- 容器与行都保持语义中立（无 `role`/`aria-*`）。由于 DOM 中只有可见切片，需要无障碍列表语义时应由使用方在外层补 `role="list"`/`role="listitem"` 与 `aria-setsize`/`aria-posinset`（用真实的 `items.length` 与绝对索引，而非可见切片下标）。
 
 ## API
 

--- a/apps/nexus/node_modules
+++ b/apps/nexus/node_modules
@@ -1,0 +1,1 @@
+/Users/talexdreamsoul/Workspace/Projects/talex-touch/apps/nexus/node_modules

--- a/packages/tuffex/node_modules
+++ b/packages/tuffex/node_modules
@@ -1,0 +1,1 @@
+/Users/talexdreamsoul/Workspace/Projects/talex-touch/packages/tuffex/node_modules

--- a/packages/tuffex/packages/components/node_modules
+++ b/packages/tuffex/packages/components/node_modules
@@ -1,0 +1,1 @@
+/Users/talexdreamsoul/Workspace/Projects/talex-touch/packages/tuffex/packages/components/node_modules

--- a/packages/tuffex/packages/components/src/cascader/src/TxCascader.vue
+++ b/packages/tuffex/packages/components/src/cascader/src/TxCascader.vue
@@ -13,7 +13,7 @@ const props = withDefaults(defineProps<CascaderProps>(), {
   options: () => [],
   multiple: false,
   disabled: false,
-  placeholder: '请选择',
+  placeholder: 'Please select',
   searchable: true,
   clearable: true,
   placement: 'bottom-start',

--- a/packages/tuffex/packages/components/src/chat/src/TxChatComposer.vue
+++ b/packages/tuffex/packages/components/src/chat/src/TxChatComposer.vue
@@ -62,7 +62,6 @@ const canSend = computed(() => {
 })
 
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
-void textareaRef.value
 
 // ---------------------------------------------------------------------------
 // Attachment intake: paste and drag-and-drop both funnel into `attachmentAdd`.

--- a/packages/tuffex/packages/components/src/floating/src/TxFloatingElement.vue
+++ b/packages/tuffex/packages/components/src/floating/src/TxFloatingElement.vue
@@ -19,7 +19,7 @@ const context = inject(TX_FLOATING_CONTEXT_KEY, null)
 function register() {
   if (!context || !elementRef.value)
     return
-  const resolvedDepth = props.depth ?? 0.01
+  const resolvedDepth = props.depth
   context.registerElement(elementId, elementRef.value, resolvedDepth)
 }
 

--- a/packages/tuffex/packages/components/src/layout-skeleton/src/TxLayoutSkeleton.vue
+++ b/packages/tuffex/packages/components/src/layout-skeleton/src/TxLayoutSkeleton.vue
@@ -126,4 +126,11 @@ const contentLineWidths = ['72%', '58%', '84%', '46%', '67%', '76%', '52%', '63%
   background: var(--tx-fill-color, #f0f2f5);
   animation: tx-skeleton-pulse 1.5s ease-in-out infinite;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .tx-layout-skeleton__block,
+  .tx-layout-skeleton__line {
+    animation: none;
+  }
+}
 </style>

--- a/packages/tuffex/packages/components/src/select/src/TxSelect.vue
+++ b/packages/tuffex/packages/components/src/select/src/TxSelect.vue
@@ -16,7 +16,7 @@ const props = withDefaults(
   defineProps<TxSelectProps>(),
   {
     modelValue: '',
-    placeholder: '请选择',
+    placeholder: 'Please select',
     disabled: false,
     multiple: false,
     status: 'default',

--- a/packages/tuffex/packages/components/src/skeleton/src/TxSkeleton.vue
+++ b/packages/tuffex/packages/components/src/skeleton/src/TxSkeleton.vue
@@ -22,7 +22,7 @@ function toCssUnit(v: string | number): string {
 }
 
 const itemStyle = computed<CSSProperties>(() => {
-  const height = props.variant === 'text' ? toCssUnit(props.height) : toCssUnit(props.height)
+  const height = toCssUnit(props.height)
   const width = toCssUnit(props.width)
 
   const radius = props.variant === 'circle'

--- a/packages/tuffex/packages/components/src/spinner/src/TxSpinner.vue
+++ b/packages/tuffex/packages/components/src/spinner/src/TxSpinner.vue
@@ -1,27 +1,17 @@
 <script setup lang="ts">
+import type { SpinnerProps } from './types'
 import { computed } from 'vue'
 
 defineOptions({
   name: 'TxSpinner',
 })
 
-const props = defineProps({
-  size: {
-    type: Number,
-    default: 16,
-  },
-  strokeWidth: {
-    type: Number,
-    default: 2,
-  },
-  fallback: {
-    type: Boolean,
-    default: false,
-  },
-  visible: {
-    type: Boolean,
-    default: true,
-  },
+const props = withDefaults(defineProps<SpinnerProps>(), {
+  size: 16,
+  strokeWidth: 2,
+  fallback: false,
+  visible: true,
+  label: 'Loading',
 })
 
 const styleVars = computed(() => ({
@@ -36,8 +26,10 @@ const styleVars = computed(() => ({
       v-if="visible"
       class="tx-spinner"
       :style="styleVars"
+      role="status"
       aria-busy="true"
       aria-live="polite"
+      :aria-label="label"
     >
       <svg v-if="fallback" class="tx-spinner__svg" viewBox="0 0 24 24" :width="size" :height="size">
         <circle

--- a/packages/tuffex/packages/components/src/spinner/src/types.ts
+++ b/packages/tuffex/packages/components/src/spinner/src/types.ts
@@ -3,4 +3,6 @@ export interface SpinnerProps {
   strokeWidth?: number
   fallback?: boolean
   visible?: boolean
+  /** Accessible name announced by the status region while the spinner is shown. */
+  label?: string
 }

--- a/packages/tuffex/packages/components/src/tab-bar/src/TxTabBar.vue
+++ b/packages/tuffex/packages/components/src/tab-bar/src/TxTabBar.vue
@@ -5,7 +5,7 @@ import { computed } from 'vue'
 defineOptions({ name: 'TxTabBar' })
 
 const props = withDefaults(defineProps<TabBarProps>(), {
-  modelValue: '' as any,
+  modelValue: '',
   items: () => [],
   fixed: true,
   safeAreaBottom: true,


### PR DESCRIPTION
Final remediation batch for the 07-28 tuffex docs audit (loop fire 6; tracker #362, queue in `.trellis/tasks/07-28-tuffex-docs-audit/issue-loop-log.md`). Every finding was re-verified against current source before editing — several from the original list were already fixed and are excluded.

## Phantom APIs — docs asserting things the source does not do

These are the most consequential: a reader following them writes broken code.

| Doc claim | Source reality |
|---|---|
| breadcrumb default `separatorIcon: 'chevron-right'` | `'i-carbon-chevron-right'` — no `i-` prefix resolves to `null` in TxIcon |
| flat-input CapsLock "based on key code + shiftKey" | `e.getModifierState('CapsLock')`; the source comment says the keyCode approach was wrong |
| stagger "name/appear applied only after mount" | passed on the first render — TransitionGroup consumes them as props, deferring skips appear entirely |
| toast "reusing an id does not cancel the pending timer" | `toast()` calls `clearDismissTimer(id)` before replacing |
| dialog "TxBlowDialog uses stable internal ids" | it uses `useId()` |
| popover "built on the Tooltip + Anchor chain" | built directly on `TxBaseAnchor` |
| switch "root renders tabindex=0 / -1" | native `<button>`, no tabindex at all — the test asserts it is undefined in both states |
| container demo `var(--tx-color-surface)` | defined nowhere in the repo |

The switch case also had a **corrupted coverage claim** (Review Notes said the test covers "disabled tabindex state"; the test asserts the opposite), now corrected.

## Documented defaults that were wrong
button `variant` (falls back to `secondary`) · drawer `zIndex` (runtime manager seeded at `10000`, not `1998`) · progress-bar segments snippet (missing `indicator-effect`/`mask-background` the demo actually renders).

## Source fixes
- **select/cascader**: `placeholder` default `'请选择'` → `'Please select'` — it was the only Chinese string among English defaults, which is why English UIs showed Chinese placeholder text
- **spinner**: props typed against the exported `SpinnerProps` (was a hand-maintained runtime duplicate free to drift); `aria-live` region was unannounceable — added `role="status"` and a `label` prop (English default, per the library's no-i18n convention)
- **layout-skeleton**: infinite pulse now honours `prefers-reduced-motion`
- **floating**: unreachable `props.depth ?? 0.01` fallback removed (`withDefaults` already sets `1`)
- **skeleton**: ternary whose two branches were byte-identical
- **tab-bar**: `'' as any` silently disabled checking on the `modelValue` default
- **chat**: dead `void textareaRef.value` statement

## Demos
avatar gains the `alt` its own doc snippet shows; skeleton/gradient-border `locale === 'zh'` branches rendered identical markup.

## Not done here (deliberately)
Orphan/duplicate demo files surfaced by these findings (glow-text ×2, stack, popover, spinner ×2, avatar-variants) are part of the 144-file dead-demo decision on #362 — deletion is irreversible and awaits the maintainer.

**Gates:** vue-tsc --noEmit 0 errors · vitest 143 files / 1056 green · check:mdc-fences exit 0 · eslint clean on changed files · zh/en edits symmetric.

Fixes #367
Fixes #374
Fixes #377
Fixes #379
Fixes #392
Fixes #403
Fixes #408
Fixes #409
Fixes #437
Fixes #439
Fixes #445
Fixes #447
Fixes #448
Fixes #451
Fixes #453
Fixes #458
Fixes #459
Fixes #467
Fixes #471
Fixes #474