### PR TITLE
fix(a11y): scope TxPopperDialog aria ids per instance (#955)

### DIFF
--- a/packages/tuffex/packages/components/src/dialog/__tests__/dialog.test.ts
+++ b/packages/tuffex/packages/components/src/dialog/__tests__/dialog.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
 import TxBottomDialog from '../src/TxBottomDialog.vue'
 import TxBlowDialog from '../src/TxBlowDialog.vue'
 import TxPopperDialog from '../src/TxPopperDialog.vue'
@@ -39,6 +40,60 @@ describe('dialog components', () => {
     expect(describedBy).toBeTruthy()
     expect(document.getElementById(labelledBy ?? '')?.textContent).toBe('Confirm')
     expect(document.getElementById(describedBy ?? '')?.textContent).toBe('Continue?')
+
+    wrapper.unmount()
+  })
+
+  it('links PopperDialog title and message with instance-scoped ids', () => {
+    const close = vi.fn()
+    const wrapper = mount(TxPopperDialog, {
+      props: {
+        title: 'Confirm',
+        message: 'Continue?',
+        close,
+      },
+      attachTo: document.body,
+    })
+
+    const dialog = document.body.querySelector<HTMLElement>('.tx-popper-dialog')
+    const labelledBy = dialog?.getAttribute('aria-labelledby')
+    const describedBy = dialog?.getAttribute('aria-describedby')
+
+    expect(labelledBy).toBeTruthy()
+    expect(describedBy).toBeTruthy()
+    expect(document.getElementById(labelledBy ?? '')?.textContent?.trim()).toBe('Confirm')
+    expect(document.getElementById(describedBy ?? '')?.textContent?.trim()).toBe('Continue?')
+
+    wrapper.unmount()
+  })
+
+  it('keeps PopperDialog aria wiring correct when two dialogs coexist', () => {
+    const close = vi.fn()
+    // Both dialogs must live in ONE app: useId() is scoped per app instance, so
+    // two separate mount() calls would each restart the counter and collide for
+    // reasons unrelated to this component.
+    const Host = defineComponent({
+      setup: () => () => [
+        h(TxPopperDialog, { title: 'First', message: 'First body', close }),
+        h(TxPopperDialog, { title: 'Second', message: 'Second body', close }),
+      ],
+    })
+    const wrapper = mount(Host, { attachTo: document.body })
+
+    const dialogs = document.body.querySelectorAll<HTMLElement>('.tx-popper-dialog')
+    expect(dialogs.length).toBe(2)
+
+    const ids = Array.from(dialogs).map((d) => ({
+      labelledBy: d.getAttribute('aria-labelledby') ?? '',
+      describedBy: d.getAttribute('aria-describedby') ?? '',
+    }))
+
+    // Pre-fix both instances emitted the same literal ids, so getElementById
+    // resolved to the first dialog and the second was mislabelled.
+    expect(ids[0].labelledBy).not.toBe(ids[1].labelledBy)
+    expect(ids[0].describedBy).not.toBe(ids[1].describedBy)
+    expect(document.getElementById(ids[0].labelledBy)?.textContent?.trim()).toBe('First')
+    expect(document.getElementById(ids[1].labelledBy)?.textContent?.trim()).toBe('Second')
 
     wrapper.unmount()
   })

--- a/packages/tuffex/packages/components/src/dialog/src/TxPopperDialog.vue
+++ b/packages/tuffex/packages/components/src/dialog/src/TxPopperDialog.vue
@@ -9,6 +9,7 @@ import {
 
   provide,
   ref,
+  useId,
 
 } from 'vue'
 import { getZIndex, nextZIndex } from '../../../../utils/z-index-manager'
@@ -26,6 +27,9 @@ const props = withDefaults(defineProps<PopperDialogProps>(), {
   comp: undefined,
   render: undefined,
 })
+
+const titleId = useId()
+const contentId = useId()
 
 const isClosing = ref(false)
 const renderComp = ref<Component | null>(null)
@@ -77,8 +81,8 @@ provide('destroy', destroy)
       :style="{ zIndex }"
       role="dialog"
       aria-modal="true"
-      :aria-labelledby="title ? 'tx-popper-dialog-title' : undefined"
-      :aria-describedby="message || messageHtml ? 'tx-popper-dialog-content' : undefined"
+      :aria-labelledby="title ? titleId : undefined"
+      :aria-describedby="message || messageHtml ? contentId : undefined"
       @keydown.esc="destroy"
     >
       <div
@@ -88,13 +92,13 @@ provide('destroy', destroy)
         <component :is="renderComp" v-if="renderComp" />
         <component :is="comp" v-else-if="comp" />
         <template v-else>
-          <p v-if="title" id="tx-popper-dialog-title" class="tx-popper-dialog__title">
+          <p v-if="title" :id="titleId" class="tx-popper-dialog__title">
             {{ title }}
           </p>
 
           <div
             v-if="message || messageHtml"
-            id="tx-popper-dialog-content"
+            :id="contentId"
             class="tx-popper-dialog__content"
           >
             <!-- eslint-disable-next-line vue/no-v-html -->


### PR DESCRIPTION
`TxPopperDialog` used the literal ids `tx-popper-dialog-title` / `tx-popper-dialog-content` with `aria-labelledby`/`aria-describedby` pointing at them. With two dialogs open, both emitted the **same ids**, so `getElementById` resolved both references to the first dialog and the second one was announced with the wrong title and description.

Switched to `useId()`, matching the `TxBlowDialog` / `TxTouchTip` pattern already used in this package.

**The added test caught a subtlety worth recording.** My first version asserted uniqueness across two `mount()` calls and **failed** (`expected 'v-0' not to be 'v-0'`). I probed it rather than assuming the fix was wrong: `useId()` is scoped **per app instance**, and each `mount()` creates its own app, so the counter restarts — a test artifact, not a component bug. Within one app the ids are correctly unique (`v-0` / `v-2`). The test now mounts both dialogs inside a single host component, which is how they actually coexist at runtime, and passes.

Also worth flagging: the existing sibling tests only ever assert **single-instance** ids, which is why this whole class of collision went unnoticed across the dialog family.

All **13** dialog tests pass; ESLint clean at `--max-warnings=0`.

Fixes #955

<sub>Automated audit remediation loop · tracker #959</sub>