### PR TITLE
fix(tuffex): drop the inert --tx-fusion-blur custom property

### DIFF
--- a/packages/tuffex/packages/components/src/fusion/__tests__/fusion.test.ts
+++ b/packages/tuffex/packages/components/src/fusion/__tests__/fusion.test.ts
@@ -28,7 +28,6 @@ describe('txFusion', () => {
     expect(stageStyle).toContain('--tx-fusion-duration: 0ms')
     expect(stageStyle).toContain('--tx-fusion-easing: linear')
     expect(stageStyle).toContain('--tx-fusion-gap: 64px')
-    expect(stageStyle).toContain('--tx-fusion-blur: 12px')
 
     expect(wrapper.find('feGaussianBlur').attributes('stdDeviation')).toBe('12')
     expect(wrapper.find('feColorMatrix').attributes('values')).toContain('31 -8')

--- a/packages/tuffex/packages/components/src/fusion/src/TxFusion.vue
+++ b/packages/tuffex/packages/components/src/fusion/src/TxFusion.vue
@@ -76,7 +76,6 @@ const stageStyle = computed(() => {
     '--tx-fusion-duration': `${d}ms`,
     '--tx-fusion-easing': props.easing,
     '--tx-fusion-gap': `${props.gap}px`,
-    '--tx-fusion-blur': `${props.blur}px`,
   } as Record<string, string>
 })
 


### PR DESCRIPTION
Last finding from the 07-28 tuffex docs audit tail (loop fire 6; tracker #362).

`TxFusion` emitted `--tx-fusion-blur` into the stage's inline style, but nothing consumes it. A repo-wide search finds exactly two references: the write itself and a test asserting the write. Blur reaches the DOM only through the SVG `feGaussianBlur` `stdDeviation` attribute, which a custom property cannot drive — so a consumer overriding `--tx-fusion-blur` to tune blur got no effect, while the sibling variables (`--tx-fusion-duration`/`-easing`/`-gap`) are read by real rules and do work.

Removed the write and the assertion that pinned it. The adjacent test line asserting `stdDeviation === '12'` stays, so blur remains covered by the real mechanism.

The issue's other findings were resolved earlier: d5-bloat (fusion.zh.mdc 1513 → 181 lines), stale inline demo snippets (removed with the doc compression — the page now references 5 registered demos with no inline `Record<Variant, boolean>` scaffolding), and the a11y finding, which the audit's own adversarial review refuted.

**Gates:** vue-tsc --noEmit 0 errors · vitest 1061 tests green · eslint clean.

Fixes #406