### PR TITLE
fix(tuffex): observe <body> for auto-theme toggles (#932, #954)

### DIFF
--- a/packages/tuffex/packages/components/src/markdown-view/__tests__/markdown-view.test.ts
+++ b/packages/tuffex/packages/components/src/markdown-view/__tests__/markdown-view.test.ts
@@ -143,6 +143,28 @@ describe('txMarkdownView', () => {
     expect(wrapper.attributes('data-theme')).toBe('light')
   })
 
+  it('tracks auto theme when dark mode is toggled on <body>', async () => {
+    const wrapper = mount(TxMarkdownView, {
+      props: {
+        sanitize: false,
+        theme: 'auto',
+        content: 'auto',
+      },
+    })
+
+    await nextTick()
+    expect(wrapper.classes()).toContain('light')
+
+    // resolveAutoTheme reads <body> too, so the observer has to watch it as well.
+    document.body.classList.add('dark')
+    await nextTick()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await nextTick()
+
+    expect(wrapper.classes()).toContain('dark')
+    expect(wrapper.attributes('data-theme')).toBe('dark')
+  })
+
   it('does not mutate the shared global marked singleton', async () => {
     const setOptionsSpy = vi.spyOn(marked, 'setOptions')
 

--- a/packages/tuffex/packages/components/src/markdown-view/src/TxMarkdownView.vue
+++ b/packages/tuffex/packages/components/src/markdown-view/src/TxMarkdownView.vue
@@ -91,10 +91,15 @@ function setupThemeObserver(): void {
   themeObserver = new MutationObserver(() => {
     syncAutoTheme()
   })
-  themeObserver.observe(root, {
+  const observerInit: MutationObserverInit = {
     attributes: true,
     attributeFilter: ['class', 'data-theme'],
-  })
+  }
+  themeObserver.observe(root, observerInit)
+  // resolveAutoTheme also reads theme signals off <body>, so a body-driven dark-mode
+  // toggle has to be observed too — the read surface and the watched surface must match.
+  if (document.body)
+    themeObserver.observe(document.body, observerInit)
 }
 
 onMounted(() => {

--- a/packages/tuffex/packages/components/src/stream-markdown/__tests__/stream-markdown.test.ts
+++ b/packages/tuffex/packages/components/src/stream-markdown/__tests__/stream-markdown.test.ts
@@ -228,4 +228,23 @@ describe('txStreamMarkdown', () => {
     // Open fence: the skeleton is up and mermaid itself was never imported.
     expect(mermaidBlock.find('.tx-mermaid-block__skeleton').exists()).toBe(true)
   })
+
+  it('tracks auto theme when dark mode is toggled on <body>', async () => {
+    const wrapper = mount(TxStreamMarkdown, {
+      props: { content: 'hello', theme: 'auto' },
+    })
+    await flushSanitizer()
+
+    expect(wrapper.attributes('data-theme')).toBe('light')
+
+    // detect() reads <body> too, so the observer has to watch it as well.
+    document.body.classList.add('dark')
+    await nextTick()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await nextTick()
+
+    expect(wrapper.attributes('data-theme')).toBe('dark')
+
+    document.body.classList.remove('dark')
+  })
 })

--- a/packages/tuffex/packages/components/src/stream-markdown/src/use-auto-theme.ts
+++ b/packages/tuffex/packages/components/src/stream-markdown/src/use-auto-theme.ts
@@ -37,10 +37,15 @@ export function useAutoTheme(theme: () => 'light' | 'dark' | 'auto') {
     observer = new MutationObserver(() => {
       autoTheme.value = detect()
     })
-    observer.observe(document.documentElement, {
+    const observerInit: MutationObserverInit = {
       attributes: true,
       attributeFilter: ['class', 'data-theme'],
-    })
+    }
+    observer.observe(document.documentElement, observerInit)
+    // detect() also reads theme signals off <body>, so a body-driven dark-mode toggle
+    // has to be observed too — the read surface and the watched surface must match.
+    if (document.body)
+      observer.observe(document.body, observerInit)
   }
 
   function disconnect(): void {


### PR DESCRIPTION
`TxStreamMarkdown` (via `use-auto-theme.ts`) and `TxMarkdownView` both resolve `theme="auto"` by reading `data-theme` / `.dark` from **both** `documentElement` and `body`, but each attached its MutationObserver to `documentElement` only, with no `subtree`. Any app that toggles dark mode on `<body>` therefore got a correct first paint followed by a permanently stale theme.

The fix is the pattern `TxMarkdownEditor` already implements and documents in a comment — observe both nodes, because the read surface and the watched surface must match.

**Adversarial verification:** both new regression tests were run against the unmodified sources (restored via `git show HEAD:<path>`) and fail there; they pass with the fix. They are real guards, not tautologies.

**Gates:** vue-tsc --noEmit 0 errors · vitest 143 files / 1063 tests green · eslint clean on changed files.

Fixes #932
Fixes #954