### PR TITLE
fix(tuffex): make the mermaid render-id counter module-scoped (#933)

### DIFF
--- a/packages/tuffex/packages/components/src/stream-markdown/__tests__/mermaid-block.test.ts
+++ b/packages/tuffex/packages/components/src/stream-markdown/__tests__/mermaid-block.test.ts
@@ -102,4 +102,21 @@ describe('txMermaidBlock', () => {
     await flushPromises()
     expect(document.body.querySelector('.tx-mermaid-block__overlay')).toBeNull()
   })
+
+  it('gives every diagram a distinct render id across instances', async () => {
+    const a = mount(TxMermaidBlock, { props: { code: 'graph TD; A-->B', closed: true } })
+    await flushPromises()
+    const b = mount(TxMermaidBlock, { props: { code: 'graph TD; C-->D', closed: true } })
+    await flushPromises()
+
+    const ids = renderMock.mock.calls.map(call => call[0])
+    expect(ids).toHaveLength(2)
+    // The counter must be module-scoped: a `<script setup>` local would restart at 0
+    // per instance and hand both blocks 'tx-mermaid-1', colliding every SVG id
+    // mermaid derives from it.
+    expect(new Set(ids).size).toBe(2)
+
+    a.unmount()
+    b.unmount()
+  })
 })

--- a/packages/tuffex/packages/components/src/stream-markdown/src/TxMermaidBlock.vue
+++ b/packages/tuffex/packages/components/src/stream-markdown/src/TxMermaidBlock.vue
@@ -1,3 +1,13 @@
+<script lang="ts">
+/**
+ * Monotonic ids: mermaid.render mounts a temp element per call and ids must not
+ * collide. This lives in a plain `<script>` block on purpose — a `<script setup>`
+ * body compiles into `setup()`, which would make the counter per-instance and
+ * hand every block the same id.
+ */
+let mermaidIdSeq = 0
+</script>
+
 <script setup lang="ts">
 import { hasDocument } from '@talex-touch/utils/env'
 import { onBeforeUnmount, ref, watch } from 'vue'
@@ -22,9 +32,6 @@ const props = withDefaults(
     theme: 'light',
   },
 )
-
-/** Monotonic ids: mermaid.render mounts a temp element per call and ids must not collide. */
-let mermaidIdSeq = 0
 
 const svg = ref<string | null>(null)
 const failed = ref(false)


### PR DESCRIPTION
`let mermaidIdSeq = 0` sat at the top level of `<script setup>`. The compiler places that inside `setup()`, so it was **per-instance** state — not the module-level monotonic counter its own comment claimed. Every `TxMermaidBlock` started at 0, so two ```mermaid fences in one streamed message both called `mermaid.render('tx-mermaid-1', …)`, and every SVG root/marker/clipPath id mermaid derives from that string collided.

Moved to a plain `<script>` block — real module scope — with a comment recording why it must not move back.

**Adversarial verification:** the new test restores the unfixed component via `git show HEAD:<path>` and fails there on `expect(new Set(ids).size).toBe(2)`; it passes with the fix.

**Gates:** vue-tsc --noEmit 0 errors · vitest 143 files / 1064 tests green · eslint clean.

Fixes #933