### PR TITLE
fix(tuffex): stop blank select values coercing equal to a zero option (#934)

### DIFF
--- a/packages/tuffex/packages/components/src/select/__tests__/select.test.ts
+++ b/packages/tuffex/packages/components/src/select/__tests__/select.test.ts
@@ -184,6 +184,27 @@ describe('txSelect', () => {
     expect(wrapper.findComponent(TxSelectItem).classes()).toContain('is-selected')
   })
 
+  it('does not mark a zero-valued option selected while nothing is selected', async () => {
+    const wrapper = mount(TxSelect, {
+      props: {
+        modelValue: '',
+      },
+      slots: {
+        default: '<TxSelectItem :value="0" label="Zero" />',
+      },
+      global: {
+        stubs: { TxPopover: PopoverStub },
+        components: { TxSelectItem },
+      },
+    })
+    await nextTick()
+
+    // Number('') is 0, so numeric coercion used to make the unselected empty
+    // default compare equal to an option whose value is 0.
+    expect(wrapper.findComponent(TxSelectItem).classes()).not.toContain('is-selected')
+    expect(wrapper.find('.tuff-select__trigger input').element.value).toBe('')
+  })
+
   it('renders loading and empty states', async () => {
     const wrapper = mount(TxSelect, {
       props: {

--- a/packages/tuffex/packages/components/src/select/src/TxSelect.vue
+++ b/packages/tuffex/packages/components/src/select/src/TxSelect.vue
@@ -241,6 +241,14 @@ function isSelectValueEqual(
     (typeof optionValue === 'string' || typeof optionValue === 'number')
     && (typeof currentValue === 'string' || typeof currentValue === 'number')
   ) {
+    // `Number('')` and `Number('  ')` are 0, so a blank string — which is this
+    // component's own unselected default — would otherwise compare equal to an
+    // option whose value is 0.
+    if (typeof optionValue === 'string' && optionValue.trim() === '')
+      return false
+    if (typeof currentValue === 'string' && currentValue.trim() === '')
+      return false
+
     const optionNumber = Number(optionValue)
     const currentNumber = Number(currentValue)
     if (Number.isFinite(optionNumber) && Number.isFinite(currentNumber)) {


### PR DESCRIPTION
`isSelectValueEqual` fell back to `Number()` coercion whenever both sides were `string | number`. `Number('')` is `0`, and `TxSelect`'s own `modelValue` default is `''` — so the **unselected** state compared equal to any option whose value is `0`. That option rendered `is-selected` and its label populated the trigger input before the user picked anything.

Blank (and whitespace-only) strings now short-circuit to `false` before coercion. The behaviour the coercion exists for — matching `'1'` against `1` — is untouched, and its existing test still passes.

**Adversarial verification:** the new test fails against the unfixed component (restored via `git show HEAD:<path>`) and passes with the fix.

**Gates:** vue-tsc --noEmit 0 errors · vitest 143 files / 1065 tests green · eslint clean.

Fixes #934