### PR TITLE
fix(tuffex): keep the accordion collapse model a string (#953)

### DIFF
--- a/packages/tuffex/packages/components/src/collapse/__tests__/collapse.test.ts
+++ b/packages/tuffex/packages/components/src/collapse/__tests__/collapse.test.ts
@@ -83,7 +83,8 @@ describe('txCollapse', () => {
     await wrapper.findAll('.tx-collapse-item__header')[1].trigger('click')
 
     expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['second'])
-    expect(wrapper.emitted('update:modelValue')?.[1]).toEqual([[]])
+    // Accordion mode's model is a single name, so collapsing emits '' — not [].
+    expect(wrapper.emitted('update:modelValue')?.[1]).toEqual([''])
   })
 
   it('blocks disabled item activation', async () => {
@@ -164,5 +165,31 @@ describe('txCollapse', () => {
 
     expect(app.component).toHaveBeenCalledWith('TxCollapse', InstalledCollapse)
     expect(app.component).toHaveBeenCalledWith('TxCollapseItem', InstalledCollapseItem)
+  })
+
+  it('emits a string, not an array, when the accordion panel is collapsed', async () => {
+    const wrapper = mount(TxCollapse, {
+      props: {
+        modelValue: 'first',
+        accordion: true,
+      },
+      slots: {
+        default: `
+          <TxCollapseItem title="First" name="first">First content</TxCollapseItem>
+        `,
+      },
+      global: {
+        components: { TxCollapseItem },
+      },
+    })
+
+    // Collapse the only open panel: the model is a single name in accordion
+    // mode, so the emitted value must stay a string rather than becoming [].
+    await wrapper.find('.tx-collapse-item__header').trigger('click')
+
+    const emitted = wrapper.emitted('update:modelValue')?.[0]?.[0]
+    expect(emitted).toBe('')
+    expect(Array.isArray(emitted)).toBe(false)
+    expect(wrapper.emitted('change')?.[0]?.[0]).toBe('')
   })
 })

--- a/packages/tuffex/packages/components/src/collapse/src/TxCollapse.vue
+++ b/packages/tuffex/packages/components/src/collapse/src/TxCollapse.vue
@@ -30,7 +30,9 @@ if (props.modelValue) {
 
 watch(() => props.modelValue, (newValue) => {
   if (newValue !== undefined) {
-    activeNames.value = Array.isArray(newValue) ? newValue : [newValue]
+    activeNames.value = Array.isArray(newValue)
+      ? newValue
+      : (newValue === '' ? [] : [newValue])
   }
 }, { immediate: true })
 
@@ -38,8 +40,11 @@ function setActiveNames(names: string[]) {
   activeNames.value = names
 
   const first = names[0]
+  // Accordion mode's model is a single name, so collapsing the open panel must
+  // emit an empty string — emitting [] would flip the v-model's runtime type
+  // from string to array.
   const emitValue: string | string[] = props.accordion
-    ? (first !== undefined ? first : [])
+    ? (first ?? '')
     : names
 
   emit('update:modelValue', emitValue)


### PR DESCRIPTION
In accordion mode `TxCollapse`'s model is a single panel name, but `setActiveNames` emitted `[]` whenever the active list went empty. Collapsing the open panel therefore flipped the v-model's runtime type from `string` to `array` — a consumer holding `ref('first')` ends up holding `[]`.

Now emits `''`.

**Second-order fix in the same change:** that `''` round-trips back through the `modelValue` watcher, which wrapped any non-array into `[newValue]`. Since `TxCollapseItem`'s `itemName` falls back to `''` when neither `name` nor `title` is set, `['']` would have spuriously opened such an item. The watcher now maps `''` to an empty set.

**Note on the test change:** `collapse.test.ts` asserted `toEqual([[]])` — it encoded the bug. Updated to `['']` with the reason inline. Both accordion tests fail against the unfixed component (verified via `git show HEAD:<path>`).

**Gates:** vue-tsc --noEmit 0 errors · vitest 143 files / 1066 tests green · eslint clean.

Fixes #953