### PR TITLE
fix(tuffex): guard TxIcon svg fetches against a stale response (#957)

### DIFF
--- a/packages/tuffex/packages/components/src/icon/__tests__/icon.test.ts
+++ b/packages/tuffex/packages/components/src/icon/__tests__/icon.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 import TxIcon from '../src/TxIcon.vue'
 import TxStatusIcon from '../src/TxStatusIcon.vue'
 import { TX_ICON_CONFIG_KEY } from '../src/types'
@@ -193,5 +194,43 @@ describe('txIcon', () => {
     expect(wrapper.find('.tx-status-icon__indicator').classes()).toContain('is-success')
     expect(wrapper.attributes('style')).toContain('--tx-status-icon-size: 24px')
     expect(wrapper.attributes('style')).toContain('--tx-status-indicator-size: 8px')
+  })
+
+  it('ignores a slow in-flight svg fetch once the url changes', async () => {
+    const resolvers: Array<(svg: string) => void> = []
+    const svgFetcher = vi.fn(
+      (_url: string) => new Promise<string>((resolve) => {
+        resolvers.push(resolve)
+      }),
+    )
+
+    const wrapper = mount(TxIcon, {
+      props: {
+        icon: { type: 'url', value: '/first.svg' },
+        svgFetcher,
+      },
+    })
+    await nextTick()
+
+    await wrapper.setProps({ icon: { type: 'url', value: '/second.svg' } })
+    await nextTick()
+
+    expect(resolvers).toHaveLength(2)
+
+    // Settle the newer request first, then let the superseded one land late.
+    // The svg reaches the DOM percent-encoded inside the mask url, so these
+    // alphanumeric markers survive verbatim.
+    resolvers[1]!('<svg viewBox="0 0 1 1"><title>SECONDMARK</title></svg>')
+    await vi.waitFor(() => {
+      expect(wrapper.find('.tuff-icon__svg-mask').exists()).toBe(true)
+    })
+
+    resolvers[0]!('<svg viewBox="0 0 1 1"><title>FIRSTMARK</title></svg>')
+    await nextTick()
+    await nextTick()
+
+    const style = wrapper.find('.tuff-icon__svg-mask').attributes('style') ?? ''
+    expect(style).toContain('SECONDMARK')
+    expect(style).not.toContain('FIRSTMARK')
   })
 })

--- a/packages/tuffex/packages/components/src/icon/src/TxIcon.vue
+++ b/packages/tuffex/packages/components/src/icon/src/TxIcon.vue
@@ -179,7 +179,16 @@ function decodeSvgDataUrl(url: string): string | null {
   }
 }
 
+/**
+ * Guards against a stale fetch winning the race: when the url changes while a
+ * request is in flight, only the newest one may assign. Same pattern as
+ * TxCodeBlock and TxMermaidBlock.
+ */
+let fetchToken = 0
+
 async function fetchSvg(url: string) {
+  const token = ++fetchToken
+
   const dataSvg = decodeSvgDataUrl(url)
   if (dataSvg !== null) {
     svgContent.value = dataSvg
@@ -192,10 +201,13 @@ async function fetchSvg(url: string) {
   }
 
   try {
-    svgContent.value = await svgFetcher.value(url)
+    const content = await svgFetcher.value(url)
+    if (token === fetchToken)
+      svgContent.value = content
   }
   catch {
-    svgContent.value = ''
+    if (token === fetchToken)
+      svgContent.value = ''
   }
 }
 


### PR DESCRIPTION
`fetchSvg` awaited the injected fetcher and assigned the result unconditionally. Nothing recorded which request was current, so when the icon url changed while a fetch was in flight, the later-resolving (older) response overwrote the newer icon. Sibling components `TxCodeBlock` and `TxMermaidBlock` both already implement exactly this guard.

Adds the same request token, applied to the success and the catch path.

**Adversarial verification — worth noting.** My first attempt at the regression test passed against the *unfixed* component, i.e. it was not a real guard: the svg reaches the DOM percent-encoded inside a mask `url(...)`, so an assertion written against `wrapper.html()` with quoted attributes could never match. Rewritten to assert on the mask style with alphanumeric markers that survive encoding; it now fails on baseline with the stale icon visible in the received style, and passes with the fix.

**Gates:** vue-tsc --noEmit 0 errors · vitest 143 files / 1067 tests green · eslint clean.

Fixes #957