### PR TITLE
fix(tuffex): honour DialogConfig.priority and run cleanup on unregister (#946)

### DIFF
--- a/packages/tuffex/packages/utils/__tests__/dialog-manager.test.ts
+++ b/packages/tuffex/packages/utils/__tests__/dialog-manager.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest'
+import { DialogManager } from '../dialog-manager'
+
+function makeDialog(id: string, priority?: 'low' | 'normal' | 'high') {
+  const setVisible = vi.fn()
+  const cleanup = vi.fn()
+  const onDestroy = vi.fn()
+  return {
+    config: { id, priority, setVisible, cleanup, onDestroy },
+    setVisible,
+    cleanup,
+    onDestroy,
+  }
+}
+
+describe('dialogManager', () => {
+  it('keeps LIFO order for dialogs of equal priority', () => {
+    const manager = new DialogManager()
+    const first = makeDialog('first')
+    const second = makeDialog('second')
+
+    manager.register(first.config)
+    manager.register(second.config)
+
+    expect(manager.getVisibleDialog()?.id).toBe('second')
+    expect(first.setVisible).toHaveBeenLastCalledWith(false)
+    expect(second.setVisible).toHaveBeenLastCalledWith(true)
+  })
+
+  it('lets a high-priority dialog jump ahead of the visible normal one', () => {
+    const manager = new DialogManager()
+    const normal = makeDialog('normal')
+    const high = makeDialog('high', 'high')
+
+    manager.register(normal.config)
+    manager.register(high.config)
+
+    expect(manager.getVisibleDialog()?.id).toBe('high')
+    expect(manager.getAllDialogs().map(d => d.id)).toEqual(['normal', 'high'])
+  })
+
+  it('queues a low-priority dialog below the visible one instead of stealing focus', () => {
+    const manager = new DialogManager()
+    const high = makeDialog('high', 'high')
+    const low = makeDialog('low', 'low')
+
+    manager.register(high.config)
+    manager.register(low.config)
+
+    // The queued dialog must not become visible, and the incumbent must not be hidden.
+    expect(manager.getVisibleDialog()?.id).toBe('high')
+    expect(manager.getAllDialogs().map(d => d.id)).toEqual(['low', 'high'])
+    expect(low.setVisible).not.toHaveBeenCalledWith(true)
+    expect(high.setVisible).toHaveBeenLastCalledWith(true)
+  })
+
+  it('promotes the queued dialog once the visible one unregisters', () => {
+    const manager = new DialogManager()
+    const high = makeDialog('high', 'high')
+    const low = makeDialog('low', 'low')
+
+    manager.register(high.config)
+    manager.register(low.config)
+    manager.unregister('high')
+
+    expect(manager.getVisibleDialog()?.id).toBe('low')
+    expect(low.setVisible).toHaveBeenLastCalledWith(true)
+  })
+
+  it('runs cleanup on unregister, not only on clearAll', () => {
+    const manager = new DialogManager()
+    const dialog = makeDialog('only')
+
+    manager.register(dialog.config)
+    manager.unregister('only')
+
+    expect(dialog.onDestroy).toHaveBeenCalledTimes(1)
+    // clearAll() runs both hooks; unregister() must not leak what cleanup releases.
+    expect(dialog.cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  it('still runs both hooks on clearAll', () => {
+    const manager = new DialogManager()
+    const a = makeDialog('a')
+    const b = makeDialog('b')
+
+    manager.register(a.config)
+    manager.register(b.config)
+    manager.clearAll()
+
+    expect(manager.getStackSize()).toBe(0)
+    expect(a.cleanup).toHaveBeenCalledTimes(1)
+    expect(b.cleanup).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/tuffex/packages/utils/dialog-manager.ts
+++ b/packages/tuffex/packages/utils/dialog-manager.ts
@@ -14,6 +14,12 @@ export interface DialogConfig extends DialogLifecycleCallbacks {
   cleanup?: () => void
 }
 
+const PRIORITY_WEIGHT: Record<DialogPriority, number> = {
+  low: 0,
+  normal: 1,
+  high: 2,
+}
+
 export class DialogManager {
   private stack: DialogConfig[] = []
 
@@ -23,13 +29,29 @@ export class DialogManager {
       this.unregister(config.id)
     }
 
-    const currentVisible = this.getVisibleDialog()
-    if (currentVisible) {
-      this.hideDialog(currentVisible)
+    // Insert above every dialog of equal or lower priority: a high-priority
+    // dialog jumps ahead of queued lower-priority ones, while dialogs of the
+    // same priority keep plain LIFO order. Callers that pass no priority are
+    // all 'normal', so they land on top exactly as before.
+    const weight = weightOf(config)
+    let index = this.stack.length
+    while (index > 0 && weightOf(this.stack[index - 1]!) > weight) {
+      index--
     }
 
-    this.stack.push(config)
-    this.showDialog(config)
+    const previousVisible = this.getVisibleDialog()
+    this.stack.splice(index, 0, config)
+    const nextVisible = this.getVisibleDialog()
+
+    if (previousVisible === nextVisible)
+      return
+
+    if (previousVisible) {
+      this.hideDialog(previousVisible)
+    }
+    if (nextVisible) {
+      this.showDialog(nextVisible)
+    }
   }
 
   unregister(id: string): void {
@@ -43,6 +65,9 @@ export class DialogManager {
     const wasVisible = index === this.stack.length
 
     dialog.onDestroy?.()
+    // clearAll() runs both hooks; unregister() used to skip cleanup, so a
+    // dialog torn down individually leaked whatever cleanup released.
+    dialog.cleanup?.()
 
     if (wasVisible && this.stack.length > 0) {
       const nextVisible = this.getVisibleDialog()
@@ -95,6 +120,10 @@ export class DialogManager {
 
     dialog.onHide?.()
   }
+}
+
+function weightOf(dialog: DialogConfig): number {
+  return PRIORITY_WEIGHT[dialog.priority ?? 'normal']
 }
 
 let singleton: DialogManager | null = null


### PR DESCRIPTION
Two defects in `packages/tuffex/packages/utils/dialog-manager.ts`.

**1. `priority` was inert public API.** `DialogConfig.priority` and the `DialogPriority` type ship on the `@talex-touch/tuffex/utils` surface, but nothing read them — the stack was pure LIFO.

I chose to **implement** the ordering rather than delete the option, because both language docs already promise it (`utils.en.mdc:68` "Serially manages global dialogs **by priority**", zh:68 "按优先级排队"). Deleting would have meant a breaking type change plus a docs correction; implementing makes the documented contract true.

`register()` now inserts above every dialog of equal or lower priority. Callers that pass no priority are all `'normal'`, so they land on top exactly as before — verified by a LIFO test. A queued lower-priority dialog no longer steals visibility from the incumbent, and is promoted when the visible one unregisters.

**2. `unregister()` skipped `cleanup`.** It called `onDestroy` only, while `clearAll()` called both — so a dialog torn down individually leaked whatever `cleanup` released.

**Tests:** this module had none; added six. Two fail against the unfixed module (verified via `git show HEAD:<path>`): the low-priority queuing case and the cleanup leak. The rest pin behaviour that must not regress.

**Gates:** vue-tsc --noEmit 0 errors · vitest 144 files / 1073 tests green · eslint clean.

Fixes #946