### PR TITLE
fix(tuffex): re-render stream markdown when sanitize flips (#936)

### DIFF
--- a/packages/tuffex/packages/components/src/stream-markdown/__tests__/stream-markdown.test.ts
+++ b/packages/tuffex/packages/components/src/stream-markdown/__tests__/stream-markdown.test.ts
@@ -69,6 +69,24 @@ describe('txStreamMarkdown', () => {
     expect(wrapper.find('strong').text()).toBe('bold')
   })
 
+  it('re-renders when sanitize flips off on settled content', async () => {
+    const wrapper = mount(TxStreamMarkdown, {
+      props: { content: '<script>alert(1)</script>ok', sanitize: true },
+    })
+    await flushSanitizer()
+
+    // The mocked sanitizer strips <script>, so its presence is the discriminator
+    // between HTML produced under sanitize=true and sanitize=false.
+    expect(wrapper.find('.markdown-body').html()).not.toContain('<script>')
+
+    await wrapper.setProps({ sanitize: false })
+    await flushSanitizer()
+
+    // Content and canRender are both unchanged by the flip, so sanitize itself
+    // has to drive the re-render or the stale sanitized HTML stays on screen.
+    expect(wrapper.find('.markdown-body').html()).toContain('<script>')
+  })
+
   it('keeps settled block DOM nodes across streaming updates', async () => {
     const wrapper = mount(TxStreamMarkdown, {
       props: { content: 'First paragraph\n\nTail', streaming: true },

--- a/packages/tuffex/packages/components/src/stream-markdown/src/TxStreamMarkdown.vue
+++ b/packages/tuffex/packages/components/src/stream-markdown/src/TxStreamMarkdown.vue
@@ -64,23 +64,21 @@ const canRender = computed(() => !props.sanitize || (sanitizerReady.value && !!s
 const blocks = shallowRef<StreamBlock[]>([])
 
 watch(
-  () => props.sanitize,
-  () => {
-    // Cached HTML was produced under the other mode — recompute everything.
-    stream.reset()
-  },
-)
-
-watch(
-  [() => props.content, canRender],
-  ([content, ok], previous) => {
+  [() => props.content, canRender, () => props.sanitize],
+  ([content, ok, sanitize], previous) => {
     if (!ok) {
       blocks.value = []
       return
     }
-    // The gate just opened: cached entries predate the sanitizer.
-    if (previous && previous[1] === false)
-      stream.reset()
+    if (previous) {
+      // Either the gate just opened (cached entries predate the sanitizer) or
+      // sanitize flipped (cached HTML was produced under the other mode).
+      // `sanitize` has to be a dependency, not just a separate reset watcher:
+      // flipping it leaves content and canRender untouched, so nothing else
+      // would re-run the render and the stale HTML would stay on screen.
+      if (previous[1] === false || previous[2] !== sanitize)
+        stream.reset()
+    }
     blocks.value = stream.update(content)
   },
   { immediate: true },


### PR DESCRIPTION
The `sanitize` watcher called `stream.reset()` but never re-ran the render — rendering is driven by a separate `[content, canRender]` watcher. On settled content with DOMPurify already loaded, flipping `sanitize` leaves `content` unchanged and `canRender` at `true`, so neither dependency fires: the cache is cleared but `blocks.value` keeps the HTML produced under the previous mode.

Folded `sanitize` into the render watcher's dependency list and dropped the separate reset watcher, so the reset and the re-render happen in the same pass. The existing 'gate just opened' reset path is preserved.

**Adversarial verification:** the regression test flips `sanitize` true→false and asserts the `<script>` the mocked sanitizer strips reappears — the only signal that distinguishes HTML built under the two modes. It fails against the unfixed component (`git show HEAD:<path>`) and passes with the fix. My first draft used a marker the mock does not touch, so it could not have distinguished the two modes; that draft was discarded.

**Gates:** vue-tsc --noEmit 0 errors · vitest 144 files / 1074 tests green · eslint clean.

Fixes #936