### PR TITLE
fix(tuffex): watch tree defaultExpandedKeys by value, not by reference (#943)

### DIFF
--- a/packages/tuffex/packages/components/src/tree/__tests__/tree.test.ts
+++ b/packages/tuffex/packages/components/src/tree/__tests__/tree.test.ts
@@ -141,4 +141,33 @@ describe('txTree', () => {
 
     wrapper.unmount()
   })
+
+  it('keeps user expansion when the parent re-renders an equal defaultExpandedKeys literal', async () => {
+    const wrapper = mount(TxTree, {
+      props: { nodes, defaultExpandedKeys: [] },
+    })
+
+    const alpha = wrapper.findAll<HTMLElement>('[role="treeitem"]')[0]
+    alpha?.element.focus()
+    await alpha?.trigger('keydown', { key: 'ArrowRight' })
+    expect(wrapper.text()).toContain('Alpha-1')
+
+    // An inline `:default-expanded-keys="[]"` literal is a brand-new array on
+    // every parent render; watching by reference collapsed the user's expansion.
+    await wrapper.setProps({ defaultExpandedKeys: [] })
+
+    expect(wrapper.text()).toContain('Alpha-1')
+  })
+
+  it('still applies defaultExpandedKeys when its contents actually change', async () => {
+    const wrapper = mount(TxTree, {
+      props: { nodes, defaultExpandedKeys: [] },
+    })
+
+    expect(wrapper.text()).not.toContain('Alpha-1')
+
+    await wrapper.setProps({ defaultExpandedKeys: ['a'] })
+
+    expect(wrapper.text()).toContain('Alpha-1')
+  })
 })

--- a/packages/tuffex/packages/components/src/tree/src/TxTree.vue
+++ b/packages/tuffex/packages/components/src/tree/src/TxTree.vue
@@ -23,11 +23,15 @@ const emit = defineEmits<TreeEmits>()
 const internalExpanded = ref(new Set<TreeKey>(props.defaultExpandedKeys ?? []))
 
 watch(
-  () => props.defaultExpandedKeys,
-  (next) => {
+  // Track the keys by value, not by array reference. Consumers routinely pass an
+  // inline `:default-expanded-keys="[...]"` literal, so any unrelated parent
+  // re-render produces a brand-new array; a reference watcher would then collapse
+  // whatever the user had expanded. Same hazard TxDataTable guards for defaultSort.
+  () => JSON.stringify(props.defaultExpandedKeys ?? []),
+  () => {
     if (props.expandedKeys !== undefined)
       return
-    internalExpanded.value = new Set(next ?? [])
+    internalExpanded.value = new Set(props.defaultExpandedKeys ?? [])
   },
 )
 


### PR DESCRIPTION
`TxTree` watched `props.defaultExpandedKeys` by reference and overwrote the whole internal expansion set on every fire. An inline `:default-expanded-keys="[...]"` literal produces a new array reference on every parent render, so any unrelated parent state change silently collapsed whatever the user had expanded.

This is the exact hazard `TxDataTable` already guards for `defaultSort`, with a comment explaining it; `TxTree` now watches a value key the same way.

**Two tests, both needed:**
- the regression case (equal-but-new array must not collapse user expansion) — fails against the unfixed component via `git show HEAD:<path>`
- the counter-case (a genuine contents change must still apply) — guards against "fixing" this by simply deleting the watcher

**Gates:** vue-tsc --noEmit 0 errors · vitest 144 files / 1076 tests green · eslint clean.

Fixes #943