### PR TITLE
fix(tuffex): enforce accept on drop; single-file uploaders own one slot (#944, #945)

### DIFF
--- a/packages/tuffex/packages/components/src/file-uploader/__tests__/file-uploader.test.ts
+++ b/packages/tuffex/packages/components/src/file-uploader/__tests__/file-uploader.test.ts
@@ -116,4 +116,66 @@ describe('txFileUploader', () => {
     await wrapper.find('.tx-file-uploader__remove').trigger('click')
     expect(wrapper.emitted('remove')).toBeTruthy()
   })
+
+  it('enforces accept on the drop path, not just the picker', async () => {
+    const wrapper = mount(TxFileUploader, {
+      props: { modelValue: [], accept: 'image/png' },
+    })
+
+    const png = new File(['p'], 'shot.png', { type: 'image/png' })
+    const video = new File(['v'], 'clip.mp4', { type: 'video/mp4' })
+    const event = new Event('drop', { bubbles: true, cancelable: true })
+    Object.defineProperty(event, 'dataTransfer', { value: { files: [video, png] } })
+    wrapper.find('.tx-file-uploader').element.dispatchEvent(event)
+    await wrapper.vm.$nextTick()
+
+    // The browser applies `accept` to the picker only; the drop path used to add
+    // anything, so a declared-unacceptable type reached modelValue.
+    const emitted = wrapper.emitted('update:modelValue') as Array<[FileUploaderFile[]]> | undefined
+    expect(emitted?.[0]?.[0]).toHaveLength(1)
+    expect(emitted?.[0]?.[0]?.[0]?.name).toBe('shot.png')
+  })
+
+  it('matches accept by extension and wildcard group', async () => {
+    const wrapper = mount(TxFileUploader, {
+      props: { modelValue: [], accept: '.pdf,image/*' },
+    })
+
+    const pdf = new File(['d'], 'doc.pdf', { type: 'application/pdf' })
+    const jpg = new File(['j'], 'pic.jpg', { type: 'image/jpeg' })
+    const txt = new File(['t'], 'notes.txt', { type: 'text/plain' })
+    const event = new Event('drop', { bubbles: true, cancelable: true })
+    Object.defineProperty(event, 'dataTransfer', { value: { files: [pdf, jpg, txt] } })
+    wrapper.find('.tx-file-uploader').element.dispatchEvent(event)
+    await wrapper.vm.$nextTick()
+
+    const emitted = wrapper.emitted('update:modelValue') as Array<[FileUploaderFile[]]> | undefined
+    expect(emitted?.[0]?.[0]?.map(f => f.name)).toEqual(['doc.pdf', 'pic.jpg'])
+  })
+
+  it('replaces the file instead of accumulating when multiple is false', async () => {
+    const wrapper = mount(TxFileUploader, {
+      props: { modelValue: [], multiple: false },
+    })
+
+    async function pick(name: string) {
+      const input = wrapper.find('input[type="file"]')
+      Object.defineProperty(input.element, 'files', {
+        value: [new File(['x'], name, { type: 'text/plain' })],
+        configurable: true,
+      })
+      await input.trigger('change')
+      const emitted = wrapper.emitted('update:modelValue') as Array<[FileUploaderFile[]]> | undefined
+      const next = emitted?.at(-1)?.[0] ?? []
+      await wrapper.setProps({ modelValue: next })
+      return next
+    }
+
+    await pick('a.pdf')
+    const second = await pick('b.pdf')
+
+    // A single-file uploader owns one slot; it used to grow toward `max`.
+    expect(second).toHaveLength(1)
+    expect(second[0]?.name).toBe('b.pdf')
+  })
 })

--- a/packages/tuffex/packages/components/src/file-uploader/src/TxFileUploader.vue
+++ b/packages/tuffex/packages/components/src/file-uploader/src/TxFileUploader.vue
@@ -45,20 +45,69 @@ function sync(next: FileUploaderFile[]): void {
   emit('change', next)
 }
 
-function addFiles(files: File[]) {
-  if (!files.length)
-    return
-  const remain = Math.max(0, (props.max ?? 10) - value.value.length)
-  const take = remain > 0 ? files.slice(0, remain) : []
-  if (!take.length)
-    return
-  const added = take.map(file => ({
+/**
+ * `accept` only reaches the native picker through the input attribute, so the
+ * drop path has to apply the same contract itself. Mirrors the browser's own
+ * matching: `*` / `*&#47;*` wildcards, `type/*` groups, exact MIME types and
+ * `.ext` suffixes, comma separated.
+ */
+function matchesAccept(file: File): boolean {
+  const patterns = (props.accept ?? '')
+    .split(',')
+    .map(pattern => pattern.trim().toLowerCase())
+    .filter(Boolean)
+  if (!patterns.length)
+    return true
+
+  const type = (file.type || '').toLowerCase()
+  const name = file.name.toLowerCase()
+
+  return patterns.some((pattern) => {
+    if (pattern === '*' || pattern === '*/*')
+      return true
+    if (pattern.startsWith('.'))
+      return name.endsWith(pattern)
+    if (pattern.endsWith('/*'))
+      return type.startsWith(pattern.slice(0, -1))
+    return type === pattern
+  })
+}
+
+function toItem(file: File): FileUploaderFile {
+  return {
     id: uid(),
     name: file.name,
     size: file.size,
     type: file.type,
     file,
-  }))
+  }
+}
+
+function addFiles(files: File[]) {
+  if (!files.length)
+    return
+
+  const acceptable = files.filter(matchesAccept)
+  if (!acceptable.length)
+    return
+
+  // A single-file uploader owns one slot: a new pick replaces the previous file
+  // rather than accumulating toward `max`.
+  if (!props.multiple) {
+    const file = acceptable[0]
+    if (!file)
+      return
+    const added = [toItem(file)]
+    emit('add', added)
+    sync(added)
+    return
+  }
+
+  const remain = Math.max(0, (props.max ?? 10) - value.value.length)
+  const take = remain > 0 ? acceptable.slice(0, remain) : []
+  if (!take.length)
+    return
+  const added = take.map(toItem)
   const next = [...value.value, ...added]
   emit('add', added)
   sync(next)

--- a/packages/tuffex/packages/components/src/image-uploader/__tests__/image-uploader.test.ts
+++ b/packages/tuffex/packages/components/src/image-uploader/__tests__/image-uploader.test.ts
@@ -179,4 +179,33 @@ describe('txImageUploader', () => {
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:one.png')
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:two.png')
   })
+
+  it('replaces the image and revokes its url when multiple is false', async () => {
+    const wrapper = mount(TxImageUploader, {
+      props: {
+        modelValue: [],
+        multiple: false,
+      },
+    })
+
+    const input = wrapper.find<HTMLInputElement>('input[type="file"]').element
+    setInputValue(input, 'fake-path')
+    setFiles(input, [createFile('first.png')])
+    await wrapper.find('input[type="file"]').trigger('change')
+
+    const first = wrapper.emitted('update:modelValue')?.at(-1)?.[0] as Array<{ url: string }>
+    await wrapper.setProps({ modelValue: first })
+
+    setInputValue(input, 'fake-path')
+    setFiles(input, [createFile('second.png')])
+    await wrapper.find('input[type="file"]').trigger('change')
+
+    const second = wrapper.emitted('update:modelValue')?.at(-1)?.[0] as Array<{ name: string }>
+
+    // A single-image uploader owns one slot; it used to grow toward `max`.
+    expect(second).toHaveLength(1)
+    expect(second[0]?.name).toBe('second.png')
+    // The replaced preview's object URL must not leak.
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:first.png')
+  })
 })

--- a/packages/tuffex/packages/components/src/image-uploader/src/TxImageUploader.vue
+++ b/packages/tuffex/packages/components/src/image-uploader/src/TxImageUploader.vue
@@ -49,7 +49,12 @@ function onInputChange(e: Event): void {
   if (!files.length)
     return
 
-  const remain = Math.max(0, (props.max ?? 9) - value.value.length)
+  // A single-image uploader owns one slot: a new pick replaces the previous
+  // image (and releases its object URL) rather than accumulating toward `max`.
+  const single = !props.multiple
+  const remain = single
+    ? 1
+    : Math.max(0, (props.max ?? 9) - value.value.length)
   const take = remain > 0 ? files.slice(0, remain) : []
   if (!take.length)
     return
@@ -64,6 +69,17 @@ function onInputChange(e: Event): void {
       file: f,
     }
   })
+
+  if (single) {
+    for (const item of value.value) {
+      if (item.file && item.url && objectUrls.has(item.url)) {
+        URL.revokeObjectURL(item.url)
+        objectUrls.delete(item.url)
+      }
+    }
+    sync(added)
+    return
+  }
 
   sync([...value.value, ...added])
 }


### PR DESCRIPTION
**#944 — `accept` was picker-only.** The browser applies the `accept` attribute to the file picker alone. `onDrop` read `dataTransfer.files` and handed everything to `addFiles`, which did no type check — so `<TxFileUploader accept="image/png" />` accepted a dropped `.mp4` into `modelValue` and emitted `add`/`change` for it, with the mismatch only surfacing server-side.

`addFiles` now filters through a matcher mirroring the browser's own rules: `*` / `*/*` wildcards, `type/*` groups, exact MIME types, and `.ext` suffixes, comma separated. Both the picker and the drop path go through it, so they cannot diverge again.

**#945 — `multiple: false` still accumulated.** `multiple` only reached the `<input multiple>` attribute and the drop-path slice; `addFiles` always appended and was bounded by `max` (10 for files, 9 for images), not by `multiple`. Picking a wrong file then picking another produced `[a.pdf, b.pdf]`. Both uploaders now replace the value when `multiple` is false — `TxImageUploader` additionally revokes the replaced preview's object URL, which would otherwise leak.

**Scope note:** the audit also suggested emitting a rejection event for filtered files. That is a public API addition rather than a defect fix, so it is deliberately not included here — worth a separate decision.

**Adversarial verification:** all four new tests fail against the unfixed components (restored via `git show HEAD:<path>`).

**Gates:** vue-tsc --noEmit 0 errors · vitest 144 files / 1080 tests green · eslint clean. One full run showed a single unrelated failure that did not reproduce on two subsequent full runs or on the isolated uploader suites — the known concurrent-run flake in this repo, reported here rather than quietly re-run.

Fixes #944
Fixes #945