### PR TITLE
fix(tuffex): surface rejected cascader loads instead of leaking them (#948)

### DIFF
--- a/packages/tuffex/packages/components/src/cascader/__tests__/cascader.test.ts
+++ b/packages/tuffex/packages/components/src/cascader/__tests__/cascader.test.ts
@@ -115,6 +115,41 @@ describe('txCascader', () => {
     expect(wrapper.emitted('update:modelValue')?.[0][0]).toEqual(['a', 'a-1'])
   })
 
+  it('surfaces a rejected load instead of leaving an unhandled rejection', async () => {
+    const failure = new Error('offline')
+    const load = vi.fn(async () => {
+      throw failure
+    })
+    const onUnhandled = vi.fn()
+    process.on('unhandledRejection', onUnhandled)
+
+    const wrapper = mount(TxCascader, {
+      props: {
+        options: [{ value: 'a', label: 'Alpha' }],
+        load,
+        expandTrigger: 'click',
+      },
+      global: { stubs: { TxPopover: PopoverStub } },
+    })
+
+    await wrapper.find('.tx-cascader__item').trigger('click')
+    await nextTick()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    process.off('unhandledRejection', onUnhandled)
+
+    expect(onUnhandled).not.toHaveBeenCalled()
+    expect(wrapper.emitted('load-error')?.[0]?.[0]).toMatchObject({
+      path: ['a'],
+      error: failure,
+    })
+
+    // Nothing is cached for a failed path, so expanding again retries.
+    await wrapper.find('.tx-cascader__item').trigger('click')
+    await nextTick()
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+
   it('exposes open, close, toggle, clear, setValue and getValue helpers', async () => {
     const wrapper = mount(TxCascader, {
       props: {

--- a/packages/tuffex/packages/components/src/cascader/src/TxCascader.vue
+++ b/packages/tuffex/packages/components/src/cascader/src/TxCascader.vue
@@ -81,6 +81,13 @@ async function ensureChildren(node: CascaderNode | null, path: CascaderPath, lev
     const children = await props.load(node, level)
     loadedChildren.value.set(k, children)
   }
+  catch (error) {
+    // Callers wire ensureChildren straight to @mouseenter/@click, so a rejected
+    // loader would surface as an unhandled rejection and the column would just
+    // render empty — indistinguishable from a node with no children.
+    // Nothing is cached for a failed path, so expanding again retries.
+    emit('load-error', { path, error })
+  }
   finally {
     loadingKeys.value.delete(k)
   }

--- a/packages/tuffex/packages/components/src/cascader/src/types.ts
+++ b/packages/tuffex/packages/components/src/cascader/src/types.ts
@@ -34,4 +34,6 @@ export interface CascaderEmits {
   (e: 'change', v: CascaderValue): void
   (e: 'open'): void
   (e: 'close'): void
+  /** A `load` call rejected; `path` identifies the node whose children failed. */
+  (e: 'load-error', payload: { path: CascaderPath, error: unknown }): void
 }


### PR DESCRIPTION
`ensureChildren` awaited `props.load(...)` with only a `finally` block — no `catch`. Its callers `onHoverItem`/`onPick` are `async` functions wired straight to `@mouseenter`/`@click`, so a rejected loader produced an unhandled promise rejection, while the child column rendered as an empty list — indistinguishable from a node that genuinely has no children.

Adds the catch plus a `load-error` emit carrying `{ path, error }` so consumers can surface a retry affordance. Additive to `CascaderEmits`; no existing behaviour changes.

**Deliberate deviation from the audit's suggestion.** It also proposed recording per-path error state. I implemented that first and then removed it: nothing renders it, so it would have been dead state — the same defect shape as #946's inert `priority` option, which I fixed in this same sweep. Retry already works because a failed path caches nothing, and the test pins that.

**Adversarial verification:** the test registers an `unhandledRejection` listener and asserts it never fires, plus asserts the emit payload and that a second expand re-invokes the loader. It fails against the unfixed component (`git show HEAD:<path>`).

**Gates:** vue-tsc --noEmit 0 errors · vitest 144 files / 1081 tests green · eslint clean.

Fixes #948