### PR TITLE
fix(tuffex): accept an inbound query prop on the command palette (#947)

### DIFF
--- a/packages/tuffex/packages/components/src/command-palette/__tests__/command-palette.test.ts
+++ b/packages/tuffex/packages/components/src/command-palette/__tests__/command-palette.test.ts
@@ -198,4 +198,48 @@ describe('txCommandPalette', () => {
     // The combobox points at the highlighted option while focus stays in the input.
     expect(input.attributes('aria-activedescendant')).toBe(options[0].attributes('id'))
   })
+
+  it('accepts an inbound query prop, completing the v-model:query pair', async () => {
+    const wrapper = mount(TxCommandPalette, {
+      props: {
+        modelValue: true,
+        query: 'open',
+        commands: [
+          { id: 'open', title: 'Open File' },
+          { id: 'close', title: 'Close File' },
+        ],
+      },
+      global: { stubs: { Teleport: true } },
+    })
+
+    // update:query was emitted with no matching prop, so a parent could push
+    // changes out but never feed one in.
+    expect(wrapper.find('input').element.value).toBe('open')
+    expect(wrapper.text()).toContain('Open File')
+    expect(wrapper.text()).not.toContain('Close File')
+
+    await wrapper.setProps({ query: 'close' })
+
+    expect(wrapper.find('input').element.value).toBe('close')
+    expect(wrapper.text()).toContain('Close File')
+    expect(wrapper.text()).not.toContain('Open File')
+  })
+
+  it('stays uncontrolled when no query prop is supplied', async () => {
+    const wrapper = mount(TxCommandPalette, {
+      props: {
+        modelValue: true,
+        commands: [
+          { id: 'open', title: 'Open File' },
+          { id: 'close', title: 'Close File' },
+        ],
+      },
+      global: { stubs: { Teleport: true } },
+    })
+
+    await wrapper.find('input').setValue('close')
+
+    expect(wrapper.text()).toContain('Close File')
+    expect(wrapper.emitted('update:query')?.at(-1)).toEqual(['close'])
+  })
 })

--- a/packages/tuffex/packages/components/src/command-palette/src/TxCommandPalette.vue
+++ b/packages/tuffex/packages/components/src/command-palette/src/TxCommandPalette.vue
@@ -20,7 +20,18 @@ const props = withDefaults(defineProps<CommandPaletteProps>(), {
 const emit = defineEmits<CommandPaletteEmits>()
 
 const inputRef = ref<HTMLInputElement | null>(null)
-const query = ref('')
+const query = ref(props.query ?? '')
+
+// `update:query` was emitted with no matching prop, so v-model:query could only
+// ever be write-only. Accepting the prop closes the pair; leaving it undefined
+// keeps the palette uncontrolled.
+watch(
+  () => props.query,
+  (next) => {
+    if (next !== undefined && next !== query.value)
+      query.value = next
+  },
+)
 const activeIndex = ref(0)
 const zIndex = ref(getZIndex())
 const composing = ref(false)

--- a/packages/tuffex/packages/components/src/command-palette/src/types.ts
+++ b/packages/tuffex/packages/components/src/command-palette/src/types.ts
@@ -22,6 +22,8 @@ export interface CommandPaletteProps {
   closeOnSelect?: boolean
   overlayClass?: CommandPaletteClassValue
   panelClass?: CommandPaletteClassValue
+  /** Search text. Completes the `v-model:query` pair; omit to leave the palette uncontrolled. */
+  query?: string
   /** Accessible name for the palette's `role="dialog"` and command listbox. @default 'Command palette' */
   ariaLabel?: string
 }


### PR DESCRIPTION
`CommandPaletteEmits` declared `update:query` and the component emitted it from both `onInput` and the close reset, but `CommandPaletteProps` had no `query` member. The v-model pair was half-implemented: the palette pushed changes out and could never accept one in, so `v-model:query` silently did nothing in the inbound direction.

Adds `query?: string` and syncs the internal ref from it. Leaving the prop undefined keeps the palette uncontrolled — pinned by a second test so this cannot regress into forcing controlled usage.

**Adversarial verification:** the controlled test fails against the unfixed component (`git show HEAD:<path>`); the uncontrolled test passes on both, which is the point — it guards existing behaviour.

**Gates:** vue-tsc --noEmit 0 errors · vitest 144 files / 1083 tests green · eslint clean.

Fixes #947