### PR TITLE
fix(tuffex): stop TxRating dropping focus; add the radiogroup keyboard pattern (#949, #950)

### DIFF
--- a/packages/tuffex/packages/components/src/rating/__tests__/rating.test.ts
+++ b/packages/tuffex/packages/components/src/rating/__tests__/rating.test.ts
@@ -196,4 +196,66 @@ describe('txRating', () => {
 
     expect(app.component).toHaveBeenCalledWith('TxRating', RatingInstalled)
   })
+
+  it('keeps keyboard focus on the clicked star', async () => {
+    const wrapper = mount(TxRating, {
+      attachTo: document.body,
+      props: { modelValue: 0, animated: true },
+    })
+
+    const stars = wrapper.findAll<HTMLButtonElement>('.tx-rating__star')
+    stars[2]!.element.focus()
+    await stars[2]!.trigger('click')
+
+    // The pop animation is applied inside requestAnimationFrame; the key only
+    // flips once that runs, so the remount has to be given a chance to happen.
+    flushRaf()
+    await nextTick()
+
+    // The star's :key used to embed the transient animation state, so selecting
+    // it destroyed and recreated the button and the browser dropped focus.
+    expect(document.activeElement).toBe(
+      wrapper.findAll<HTMLButtonElement>('.tx-rating__star')[2]!.element,
+    )
+
+    wrapper.unmount()
+  })
+
+  it('exposes one tab stop and moves the rating with arrow keys', async () => {
+    const wrapper = mount(TxRating, {
+      attachTo: document.body,
+      props: { modelValue: 3 },
+    })
+
+    const tabindexes = wrapper
+      .findAll('.tx-rating__star')
+      .map(star => star.attributes('tabindex'))
+    // ARIA radiogroup: exactly one tab stop, on the checked option.
+    expect(tabindexes).toEqual(['-1', '-1', '0', '-1', '-1'])
+
+    const stars = wrapper.findAll<HTMLButtonElement>('.tx-rating__star')
+    await stars[2]!.trigger('keydown', { key: 'ArrowRight' })
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([4])
+
+    await stars[2]!.trigger('keydown', { key: 'ArrowLeft' })
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([2])
+
+    await stars[2]!.trigger('keydown', { key: 'Home' })
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([1])
+
+    await stars[2]!.trigger('keydown', { key: 'End' })
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([5])
+
+    wrapper.unmount()
+  })
+
+  it('ignores arrow keys when readonly or disabled', async () => {
+    const wrapper = mount(TxRating, {
+      props: { modelValue: 3, readonly: true },
+    })
+
+    await wrapper.findAll('.tx-rating__star')[2]!.trigger('keydown', { key: 'ArrowRight' })
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+  })
 })

--- a/packages/tuffex/packages/components/src/rating/src/TxRating.vue
+++ b/packages/tuffex/packages/components/src/rating/src/TxRating.vue
@@ -77,6 +77,7 @@ const precisionDigits = computed(() => {
 
 const hoverValue = ref<number>(props.modelValue)
 const animatedStar = ref<number | null>(null)
+const starsRef = ref<HTMLElement | null>(null)
 
 // Sync the hover-preview baseline with external value changes so a programmatic
 // modelValue update — or a committed half-star click — renders immediately in
@@ -185,6 +186,51 @@ function handleClick(star: number) {
   emit('change', newValue)
 }
 
+/**
+ * ARIA radiogroup: the group is a single tab stop, and arrow keys move between
+ * options. Without this every star was its own tab stop and the keyboard could
+ * not change the rating at all.
+ */
+const tabbableStar = computed(() => {
+  const checked = Math.ceil(rating.value)
+  if (checked >= 1 && checked <= props.maxStars)
+    return checked
+  return 1
+})
+
+function focusStar(star: number) {
+  const clamped = Math.min(Math.max(star, 1), props.maxStars)
+  const stars = starsRef.value?.querySelectorAll<HTMLButtonElement>('.tx-rating__star')
+  stars?.[clamped - 1]?.focus()
+  return clamped
+}
+
+function handleKeydown(event: KeyboardEvent, star: number) {
+  if (!isInteractive.value)
+    return
+
+  switch (event.key) {
+    case 'ArrowRight':
+    case 'ArrowUp':
+      event.preventDefault()
+      handleClick(focusStar(star + 1))
+      break
+    case 'ArrowLeft':
+    case 'ArrowDown':
+      event.preventDefault()
+      handleClick(focusStar(star - 1))
+      break
+    case 'Home':
+      event.preventDefault()
+      handleClick(focusStar(1))
+      break
+    case 'End':
+      event.preventDefault()
+      handleClick(focusStar(props.maxStars))
+      break
+  }
+}
+
 function handleMouseEnter(star: number) {
   if (!isInteractive.value)
     return
@@ -206,10 +252,10 @@ function handleMouseLeave() {
     :aria-disabled="disabled || undefined"
     :aria-readonly="readonly || undefined"
   >
-    <div class="tx-rating__stars" role="radiogroup">
+    <div ref="starsRef" class="tx-rating__stars" role="radiogroup">
       <button
         v-for="star in maxStars"
-        :key="`${star}-${animatedStar === star ? 'pop' : 'idle'}`"
+        :key="star"
         type="button"
         class="tx-rating__star"
         :class="{
@@ -222,6 +268,8 @@ function handleMouseLeave() {
         :aria-checked="getStarAriaChecked(star)"
         :disabled="disabled || readonly"
         :aria-label="getStarLabel(star)"
+        :tabindex="star === tabbableStar ? 0 : -1"
+        @keydown="handleKeydown($event, star)"
         @click="handleClick(star)"
         @mouseenter="handleMouseEnter(star)"
         @mouseleave="handleMouseLeave"


### PR DESCRIPTION
**#949 — focus was destroyed by the animation key.** The star's `:key` embedded transient animation state (`${star}-${animatedStar === star ? 'pop' : 'idle'}`), so selecting a star changed its key twice. Each change made Vue destroy and recreate the `<button>` rather than patch it, and the browser drops focus when the focused element is removed. The key is now the star index; the `--pop` class already drives the animation, so nothing visual changes.

**#950 — the radiogroup was keyboard-inert.** The stars were declared `role="radiogroup"` / `role="radio"`, but every star was a plain `<button>` with a default tab stop and the component had no keydown handler at all — so it satisfied neither half of the ARIA radio pattern. Adds a roving tabindex (exactly one tab stop, on the checked star) and Arrow/Home/End movement that moves focus and updates the rating.

**Adversarial verification:** both regression tests fail against the unfixed component (`git show HEAD:<path>`). The focus test needed the suite's existing `flushRaf()` helper — my first draft asserted before `requestAnimationFrame` had run, so the key had not flipped yet and it passed on baseline, i.e. it was not a guard. A third test pins that readonly/disabled ratings still ignore arrow keys.

**Gates:** vue-tsc --noEmit 0 errors · vitest 144 files / 1086 tests green · eslint clean.

Fixes #949
Fixes #950