### PR TITLE
fix(tuffex): complete the TxMessageActions toolbar contract (#958)

### DIFF
--- a/packages/tuffex/packages/components/src/message-actions/__tests__/message-actions.test.ts
+++ b/packages/tuffex/packages/components/src/message-actions/__tests__/message-actions.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 import TxMessageActions from '../src/TxMessageActions.vue'
 
 afterEach(() => {
@@ -53,5 +54,71 @@ describe('txMessageActions', () => {
   it('drops the entrance animation when appear is off', () => {
     const wrapper = mount(TxMessageActions, { props: { appear: false } })
     expect(wrapper.classes()).not.toContain('has-appear')
+  })
+
+  it('names the toolbar and keeps it to a single tab stop', async () => {
+    const wrapper = mount(TxMessageActions, {
+      attachTo: document.body,
+      props: { copyText: 'hello', regenerable: true },
+    })
+    await nextTick()
+
+    // role="toolbar" needs a name, and the group is one tab stop.
+    expect(wrapper.attributes('aria-label')).toBe('Message actions')
+
+    const buttons = wrapper.findAll<HTMLButtonElement>('button')
+    expect(buttons.map(b => b.element.tabIndex)).toEqual([0, -1])
+
+    wrapper.unmount()
+  })
+
+  it('accepts a localized toolbar label', async () => {
+    const wrapper = mount(TxMessageActions, {
+      props: { copyText: 'hello', label: '消息操作' },
+    })
+
+    expect(wrapper.attributes('aria-label')).toBe('消息操作')
+  })
+
+  it('moves focus between controls with arrow keys', async () => {
+    const wrapper = mount(TxMessageActions, {
+      attachTo: document.body,
+      props: { copyText: 'hello', regenerable: true },
+    })
+    await nextTick()
+
+    const buttons = wrapper.findAll<HTMLButtonElement>('button')
+    buttons[0]!.element.focus()
+
+    await wrapper.trigger('keydown', { key: 'ArrowRight' })
+    expect(document.activeElement).toBe(buttons[1]!.element)
+
+    await wrapper.trigger('keydown', { key: 'ArrowRight' })
+    // Wraps, as the toolbar pattern specifies.
+    expect(document.activeElement).toBe(buttons[0]!.element)
+
+    await wrapper.trigger('keydown', { key: 'End' })
+    expect(document.activeElement).toBe(buttons[1]!.element)
+
+    wrapper.unmount()
+  })
+
+  it('includes slotted controls in the roving order', async () => {
+    const wrapper = mount(TxMessageActions, {
+      attachTo: document.body,
+      props: { copyText: 'hello' },
+      slots: { default: '<button type="button" class="extra">Extra</button>' },
+    })
+    await nextTick()
+
+    const buttons = wrapper.findAll<HTMLButtonElement>('button')
+    expect(buttons).toHaveLength(2)
+    expect(buttons.map(b => b.element.tabIndex)).toEqual([0, -1])
+
+    buttons[0]!.element.focus()
+    await wrapper.trigger('keydown', { key: 'ArrowRight' })
+    expect(document.activeElement).toBe(wrapper.find('.extra').element)
+
+    wrapper.unmount()
   })
 })

--- a/packages/tuffex/packages/components/src/message-actions/src/TxMessageActions.vue
+++ b/packages/tuffex/packages/components/src/message-actions/src/TxMessageActions.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { nextTick, onMounted, onUpdated, ref } from 'vue'
 
 defineOptions({ name: 'TxMessageActions' })
 
@@ -14,6 +14,8 @@ const props = withDefaults(
     copyLabel?: string
     copiedLabel?: string
     regenerateLabel?: string
+    /** Accessible name for the toolbar grouping. @default 'Message actions' */
+    label?: string
   }>(),
   {
     regenerable: false,
@@ -21,6 +23,7 @@ const props = withDefaults(
     copyLabel: 'Copy',
     copiedLabel: 'Copied',
     regenerateLabel: 'Regenerate',
+    label: 'Message actions',
   },
 )
 
@@ -28,6 +31,69 @@ const emit = defineEmits<{
   copy: [text: string]
   regenerate: []
 }>()
+
+/**
+ * ARIA toolbar: one tab stop for the whole bar, arrow keys between controls.
+ * The controls are read from the DOM rather than bound per button so slot
+ * content joins the same roving order.
+ */
+const rootRef = ref<HTMLElement | null>(null)
+const activeIndex = ref(0)
+
+function controls(): HTMLElement[] {
+  const root = rootRef.value
+  if (!root)
+    return []
+  return Array.from(root.querySelectorAll<HTMLElement>('button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'))
+}
+
+function syncTabStops(): void {
+  const items = controls()
+  if (!items.length)
+    return
+  const active = Math.min(activeIndex.value, items.length - 1)
+  items.forEach((el, index) => {
+    el.tabIndex = index === active ? 0 : -1
+  })
+}
+
+onMounted(syncTabStops)
+onUpdated(syncTabStops)
+
+function handleKeydown(event: KeyboardEvent): void {
+  const items = controls()
+  if (!items.length)
+    return
+
+  const current = items.indexOf(document.activeElement as HTMLElement)
+  if (current === -1)
+    return
+
+  let next = current
+  switch (event.key) {
+    case 'ArrowRight':
+    case 'ArrowDown':
+      next = (current + 1) % items.length
+      break
+    case 'ArrowLeft':
+    case 'ArrowUp':
+      next = (current - 1 + items.length) % items.length
+      break
+    case 'Home':
+      next = 0
+      break
+    case 'End':
+      next = items.length - 1
+      break
+    default:
+      return
+  }
+
+  event.preventDefault()
+  activeIndex.value = next
+  items[next]?.focus()
+  void nextTick(syncTabStops)
+}
 
 const copied = ref(false)
 let copiedTimer: ReturnType<typeof setTimeout> | undefined
@@ -53,7 +119,14 @@ async function copy(): Promise<void> {
 </script>
 
 <template>
-  <div class="tx-message-actions" :class="{ 'has-appear': appear }" role="toolbar">
+  <div
+    ref="rootRef"
+    class="tx-message-actions"
+    :class="{ 'has-appear': appear }"
+    role="toolbar"
+    :aria-label="label"
+    @keydown="handleKeydown"
+  >
     <button
       v-if="copyText !== undefined"
       type="button"


### PR DESCRIPTION
The wrapper took `role="toolbar"` but carried no `aria-label`/`aria-labelledby`, and the component bound no keydown handler — so it satisfied neither half of the ARIA toolbar contract (named grouping, plus a single tab stop with arrow-key movement).

- **Name:** adds a `label` prop defaulting to `'Message actions'`, wired to `aria-label`. English default overridable via prop, following the library's no-i18n text-prop convention rather than introducing a translation layer.
- **Roving tabindex + Arrow/Home/End:** the bar is now one tab stop and arrows move between controls, wrapping at the ends.

**Design note:** the controls are read from the DOM (`querySelectorAll`) at sync/keydown time rather than bound per known button. The component exposes a default slot, so consumers routinely add their own controls — binding tabindex only to the two built-in buttons would have left slotted controls outside the roving order and still broken the single-tab-stop rule. A test pins the slotted case.

**Adversarial verification:** all four new tests fail against the unfixed component (`git show HEAD:<path>`).

**Gates:** vue-tsc --noEmit 0 errors · vitest 144 files / 1090 tests green · eslint clean.

Fixes #958