### PR TITLE
fix(tuffex): make the form item required prop actually validate (#937)

### DIFF
--- a/packages/tuffex/packages/components/src/form/__tests__/form.test.ts
+++ b/packages/tuffex/packages/components/src/form/__tests__/form.test.ts
@@ -129,4 +129,54 @@ describe('txForm', () => {
 
     expect((wrapper.vm as any).model.name).toBe('')
   })
+
+  it('enforces the required prop when the item declares no rules', async () => {
+    const wrapper = mount({
+      components: { TxForm, TxFormItem, TuffInput },
+      setup() {
+        const model = reactive({ name: '' })
+        const formRef = ref<any>(null)
+        return { model, formRef }
+      },
+      template: `
+        <TxForm ref="formRef" :model="model">
+          <TxFormItem prop="name" label="Name" required>
+            <TuffInput v-model="model.name" />
+          </TxFormItem>
+        </TxForm>
+      `,
+    })
+
+    // The item renders the required marker, so validate() must not pass on empty.
+    expect(wrapper.find('.tx-form-item').classes()).toContain('is-required')
+
+    const form = (wrapper.vm as any).formRef
+    expect(await form.validate()).toBe(false)
+    expect(wrapper.find('.tx-form-item__error').text()).toBe('Name is required')
+
+    ;(wrapper.vm as any).model.name = 'Alice'
+    await nextTick()
+
+    expect(await form.validate()).toBe(true)
+  })
+
+  it('leaves an optional item with no rules passing', async () => {
+    const wrapper = mount({
+      components: { TxForm, TxFormItem, TuffInput },
+      setup() {
+        const model = reactive({ nickname: '' })
+        const formRef = ref<any>(null)
+        return { model, formRef }
+      },
+      template: `
+        <TxForm ref="formRef" :model="model">
+          <TxFormItem prop="nickname" label="Nickname">
+            <TuffInput v-model="model.nickname" />
+          </TxFormItem>
+        </TxForm>
+      `,
+    })
+
+    expect(await (wrapper.vm as any).formRef.validate()).toBe(true)
+  })
 })

--- a/packages/tuffex/packages/components/src/form/src/TxFormItem.vue
+++ b/packages/tuffex/packages/components/src/form/src/TxFormItem.vue
@@ -36,6 +36,18 @@ const resolvedRules = computed<FormRule[]>(() => {
   return Array.isArray(merged) ? merged : [merged]
 })
 
+/**
+ * `required` is honoured inside runRule, but runRule is only reachable from the
+ * rule loop — so an item declaring `required` with no rules had nothing to
+ * iterate and validated as passing while still rendering the required marker.
+ */
+const effectiveRules = computed<FormRule[]>(() => {
+  const rules = resolvedRules.value
+  if (rules.length === 0 && props.required)
+    return [{ required: true }]
+  return rules
+})
+
 const isRequired = computed(() => {
   if (props.required)
     return true
@@ -82,7 +94,7 @@ async function runRule(rule: FormRule): Promise<string | null> {
 }
 
 async function validate(): Promise<boolean> {
-  for (const rule of resolvedRules.value) {
+  for (const rule of effectiveRules.value) {
     const message = await runRule(rule)
     if (message) {
       errorMessage.value = message


### PR DESCRIPTION
`validate()` only iterated `resolvedRules`. The `required` prop **is** honoured inside `runRule`, but `runRule` is reachable only from that loop — so `<TxFormItem prop="name" required>` with no `rules` (and no matching entry in the form's `rules` map) had an empty rule list: it rendered the required marker and reported the form valid on an empty value.

Synthesises a `{ required: true }` rule when the resolved list is empty, so the marker and the verdict agree. `runRule` already implements the emptiness check, so the message wording and `isEmpty` semantics are unchanged.

**Two tests:** the required case fails against the unfixed component (`git show HEAD:<path>`); the counter-case pins that an *optional* item with no rules still validates as passing, so this cannot regress into requiring everything.

**Note:** my first draft asserted `is-required` on `.tx-form-item__label`; the class is on the item root. Corrected before verification rather than adjusting the component to fit the test.

**Gates:** vue-tsc --noEmit 0 errors · vitest 144 files / 1092 tests green · eslint clean.

Fixes #937