### PR TITLE
fix(tuffex): keep conversation history loading alive across list swaps (#939, #940)

### DIFF
--- a/packages/tuffex/packages/components/src/conversation-stream/__tests__/conversation-stream.test.ts
+++ b/packages/tuffex/packages/components/src/conversation-stream/__tests__/conversation-stream.test.ts
@@ -293,4 +293,47 @@ describe('txConversationStream', () => {
     expect((control.element as any).scrollTop).toBe(500 * 96)
     expect(wrapper.vm.atBottom).toBe(true)
   })
+
+  it('observes the load-older sentinel after items arrive on an empty mount', async () => {
+    const loadOlder = vi.fn(async () => ({ items: [], hasMore: true }))
+    const wrapper = mountStream({ items: [], loadOlder, hasMoreInitial: true })
+    await nextTick()
+
+    // The sentinel lives in the non-empty branch, so an empty mount has none:
+    // the observer used to be built once in onMounted and stay unattached.
+    intersectionCallbacks = []
+
+    await wrapper.setProps({ items: makeMessages(0, 5) })
+    await nextTick()
+    await nextTick()
+
+    fireIntersection()
+    await nextTick()
+
+    expect(loadOlder).toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('revives the history observer when hasMoreInitial is re-supplied', async () => {
+    const loadOlder = vi.fn(async () => ({ items: [], hasMore: false }))
+    const wrapper = mountStream({ items: makeMessages(0, 5), loadOlder, hasMoreInitial: true })
+    await nextTick()
+
+    fireIntersection()
+    await nextTick()
+    await nextTick()
+    expect(loadOlder).toHaveBeenCalledTimes(1)
+
+    // hasMore is now false, which disconnects the observer. Swapping in a
+    // different conversation with hasMoreInitial: true must rebuild it —
+    // hasMore used to be seeded once at setup and never re-synced.
+    intersectionCallbacks = []
+    await wrapper.setProps({ hasMoreInitial: false })
+    await wrapper.setProps({ items: makeMessages(100, 5), hasMoreInitial: true })
+    await nextTick()
+    await nextTick()
+
+    expect(intersectionCallbacks.length).toBeGreaterThan(0)
+    wrapper.unmount()
+  })
 })

--- a/packages/tuffex/packages/components/src/conversation-stream/src/TxConversationStream.vue
+++ b/packages/tuffex/packages/components/src/conversation-stream/src/TxConversationStream.vue
@@ -283,9 +283,55 @@ function retryLoad(): void {
   void triggerLoad()
 }
 
+/**
+ * The sentinel lives inside the `v-else` of `v-if="items.length === 0"`, so a
+ * stream that mounts with an empty list has no sentinel at mount time. Attaching
+ * only in onMounted left history loading permanently dead for that case, so the
+ * observer is (re)built whenever the sentinel or the gating state changes.
+ */
+function setupHistoryObserver(): void {
+  intersectionObserver?.disconnect()
+  intersectionObserver = null
+
+  const scroller = scrollerRef.value
+  const sentinel = sentinelRef.value
+  if (typeof IntersectionObserver === 'undefined')
+    return
+  if (!props.loadOlder || !hasMore.value || !sentinel || !scroller)
+    return
+
+  intersectionObserver = new IntersectionObserver(
+    (entries) => {
+      if (entries.some(entry => entry.isIntersecting))
+        void triggerLoad()
+    },
+    { root: scroller, rootMargin: '200px 0px 0px 0px' },
+  )
+  intersectionObserver.observe(sentinel)
+}
+
+watch(sentinelRef, () => {
+  setupHistoryObserver()
+})
+
+// hasMoreInitial was read once at setup and never re-synced, so re-supplying
+// `true` for a different conversation could not revive history loading.
+watch(
+  () => props.hasMoreInitial,
+  (next) => {
+    if (next === undefined)
+      return
+    hasMore.value = next
+  },
+)
+
 watch(hasMore, (value) => {
-  if (!value)
+  if (!value) {
     intersectionObserver?.disconnect()
+    intersectionObserver = null
+    return
+  }
+  setupHistoryObserver()
 })
 
 // ---------------------------------------------------------------------------
@@ -346,16 +392,7 @@ onMounted(() => {
   if (scroller)
     viewportHeight.value = scroller.clientHeight
 
-  if (typeof IntersectionObserver !== 'undefined' && props.loadOlder && sentinelRef.value && scroller) {
-    intersectionObserver = new IntersectionObserver(
-      (entries) => {
-        if (entries.some(entry => entry.isIntersecting))
-          void triggerLoad()
-      },
-      { root: scroller, rootMargin: '200px 0px 0px 0px' },
-    )
-    intersectionObserver.observe(sentinelRef.value)
-  }
+  setupHistoryObserver()
 
   // A conversation opens at its latest message.
   void nextTick(() => scrollToBottom())


### PR DESCRIPTION
**#939 — the sentinel was never observed on an empty mount.** The IntersectionObserver was created in `onMounted` and required `sentinelRef.value` to already exist, but the sentinel lives inside the `v-else` of `v-if="items.length === 0"`. A stream that mounts with no items has no sentinel at that moment, and nothing re-created or re-observed it when items later arrived.

**#940 — `hasMore` was read once.** It was seeded from `props.hasMoreInitial` at setup and never re-synced, so once it flipped false the `watch(hasMore)` disconnected the observer permanently.

Observer construction is extracted into one function that re-runs when the sentinel appears/changes and when `hasMore` becomes true again; `hasMoreInitial` is now watched.

**Two things I want to flag honestly:**

1. My first draft of the revival test asserted `loadOlder` was called a second time. It failed *with* the fix — blocked by an unrelated and deliberate guard (`autoLoadUsed && !interactedSinceAutoLoad`, which stops an under-filled list chain-loading; jsdom lists are never scrollable). I rewrote it to assert the observer is rebuilt, which is what #940 actually describes, rather than weakening that guard.

2. Re-supplying the *same* `hasMoreInitial: true` value cannot revive loading, because an unchanged prop fires no watcher. The fix makes `hasMoreInitial` a live input — consumers binding `:has-more-initial="conversation.hasMore"` get revival when the value changes. A consumer who keeps it permanently `true` across conversation swaps would still need a `:key` remount; that is a design question about what "initial" means, not something I silently redefined here.

**Adversarial verification:** both tests fail against the unfixed component (`git show HEAD:<path>`).

**Gates:** vue-tsc --noEmit 0 errors · vitest 144 files / 1094 tests green · eslint clean.

Fixes #939
Fixes #940