### PR TITLE
fix(tuffex): only hand plugin-shaped exports to app.use (#952)

### DIFF
--- a/packages/tuffex/packages/components/src/__tests__/global-install.test.ts
+++ b/packages/tuffex/packages/components/src/__tests__/global-install.test.ts
@@ -1,0 +1,49 @@
+import { createApp } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import install from '../index'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('global install', () => {
+  it('registers components without warning on non-plugin exports', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const app = createApp({ render: () => null })
+
+    app.use(install)
+
+    // The barrel re-exports injection-key symbols alongside components; Vue
+    // warns "A plugin must either be a function or an object with an install
+    // function" for each one that reaches app.use.
+    const pluginWarnings = warn.mock.calls
+      .map(args => String(args[0]))
+      .filter(message => message.includes('plugin must either be a function'))
+    expect(pluginWarnings).toEqual([])
+
+    expect(app.component('TxButton')).toBeTruthy()
+    expect(app.component('TxRating')).toBeTruthy()
+  })
+
+  it('only hands plugin-shaped exports to app.use', () => {
+    const used: unknown[] = []
+    const fakeApp = {
+      use(plugin: unknown) {
+        used.push(plugin)
+        return fakeApp
+      },
+      component: () => undefined,
+    }
+
+    install(fakeApp as never)
+
+    expect(used.length).toBeGreaterThan(0)
+    // Vue treats any function as an install function, so an unfiltered loop
+    // called exported helpers with the App as their first argument (e.g.
+    // createPositionCache(app)) and warned on injection-key symbols.
+    const offenders = used.filter(
+      value => typeof (value as { install?: unknown })?.install !== 'function',
+    )
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/tuffex/packages/components/src/index.ts
+++ b/packages/tuffex/packages/components/src/index.ts
@@ -1,4 +1,4 @@
-import type { App } from 'vue'
+import type { App, Plugin } from 'vue'
 import * as components from './components'
 import '../style/index.scss'
 
@@ -6,8 +6,15 @@ export * from './components'
 export * from './utils'
 
 function install(app: App) {
-  for (const n in components) {
-    app.use((components as any)[n])
+  for (const key in components) {
+    const candidate = (components as Record<string, unknown>)[key] as Plugin | undefined
+    // Only values carrying a runtime `install` are plugins. This barrel is
+    // `export *` over every component index, so it also holds injection-key
+    // symbols (Vue warns on those) and plain helper functions — and Vue treats
+    // any function as an install function, so it would *call* helpers like
+    // createPositionCache with the App instance as their first argument.
+    if (candidate && typeof (candidate as { install?: unknown }).install === 'function')
+      app.use(candidate)
   }
 }
 


### PR DESCRIPTION
`install` iterated the whole `./components` namespace and passed every value to `app.use()`. That namespace is `export * from './<name>/index'` for all components, so it also contains injection-key symbols and plain helper functions.

Result on the documented `app.use(Tuffex)` path: Vue logged *"A plugin must either be a function or an object with an install function"* for each symbol, and — worse — `isFunction(plugin)` is true for exported helpers like `createPositionCache`, `useStickToBottom` and `shouldRenderSvgAsMask`, so Vue **invoked each of them** with the App instance as their first argument.

**Deliberate deviation from the audit's suggested predicate.** It proposed `typeof v === 'function' || v?.install`. That still calls every exported helper, since helpers *are* functions — it would have fixed the warnings and left the worse half of the bug in place. The filter here is a runtime `install` method, which every component carries via `withInstall` and no helper or symbol does.

**Adversarial verification:** two tests, both failing against the unfixed barrel (`git show HEAD:<path>`) — one asserts Vue emits no plugin warnings and components still register, the other calls `install` with a fake app and asserts every value it forwards is plugin-shaped.

**Gates:** vue-tsc --noEmit 0 errors · vitest 145 files / 1096 tests green · eslint clean.

Fixes #952