### PR TITLE
fix(tuffex): guard the two real unchecked index accesses (#941)

### DIFF
--- a/packages/tuffex/packages/components/src/markdown-editor/src/markdown-serializer.ts
+++ b/packages/tuffex/packages/components/src/markdown-editor/src/markdown-serializer.ts
@@ -60,10 +60,10 @@ function serializeTable(element: HTMLElement): string {
   if (!rows.length)
     return ''
 
-  const header = rows[0]
+  const header = rows[0] ?? []
   const separator = header.map(() => '---')
   const body = rows.slice(1)
-  const lines = [header, separator, ...body].map(row => `| ${row.join(' | ')} |`)
+  const lines = [header, separator, ...body].map(row => `| ${(row ?? []).join(' | ')} |`)
 
   return `${lines.join('\n')}\n\n`
 }

--- a/packages/tuffex/packages/script/build/run.ts
+++ b/packages/tuffex/packages/script/build/run.ts
@@ -49,7 +49,7 @@ const spawnSafe = (
 }
 
 export default async (command: any, path: string) => {
-  const [cmd, ...args] = String(command ?? "").trim().split(" ")
+  const [cmd = "", ...args] = String(command ?? "").trim().split(" ")
   const displayCommand = [cmd, ...args].join(" ")
   console.log(`[build-run] ${displayCommand} (cwd: ${path})`)
   return new Promise((resolve, _reject) => {


### PR DESCRIPTION
Partial, deliberately. Running `vue-tsc --noUncheckedIndexedAccess` (the flag `apps/nexus` already enforces on this same source) surfaces **63 errors**. This PR fixes the 3 that are genuinely ours:

- `markdown-serializer.ts:64,66` — `serializeTable` reads `rows[0]` and maps over `rows` without proving either is present
- `script/build/run.ts:56` — the argv head is passed to `spawn` as `string` when it can be `undefined`

**The flag is not enabled in this PR.** 60 of the 63 errors are in `thinking-orb/src/engine/*`, which is vendored third-party code (`// Vendored from thinking-orbs v0.2.0 (MIT © Jakub Antalik)`). Enabling the flag requires choosing between forking the vendor to satisfy local strictness or exempting it wholesale — and `exclude` does not work here, since TypeScript still checks files reached by import. That is a vendoring-policy decision, so it is left to the maintainer; the analysis with exact counts and options is on #941, which stays open.

**Gates:** vue-tsc --noEmit 0 errors · vitest 145 files / 1096 tests green · eslint clean.

Refs #941