### PR TITLE
fix(tuffex): complete the TxTabs tablist keyboard and aria wiring (#951)

### DIFF
--- a/packages/tuffex/packages/components/src/tabs/__tests__/tabs.test.ts
+++ b/packages/tuffex/packages/components/src/tabs/__tests__/tabs.test.ts
@@ -337,4 +337,66 @@ describe('txTabs', () => {
     expect(size).not.toBeUndefined()
     expect(size).toEqual({ width: 320, height: 180 })
   })
+
+  it('keeps the tablist to one tab stop and links each tab to its panel', async () => {
+    const wrapper = mountTabs()
+    await nextTick()
+
+    const tabItems = wrapper.findAll('.tx-tab-item')
+    // ARIA tablist: exactly one tab stop, on the selected tab.
+    expect(tabItems.map(item => item.attributes('tabindex'))).toEqual(['0', '-1', '-1'])
+
+    const panel = wrapper.find('[role="tabpanel"]')
+    const activeTab = tabItems[0]
+    expect(activeTab.attributes('aria-controls')).toBe(panel.attributes('id'))
+    expect(panel.attributes('aria-labelledby')).toBe(activeTab.attributes('id'))
+    expect(activeTab.attributes('id')).toBeTruthy()
+  })
+
+  it('moves between tabs with arrow keys', async () => {
+    // A horizontal tablist: placement defaults to 'left', where the pattern
+    // correctly uses Up/Down instead.
+    const wrapper = mountTabs({ placement: 'top' })
+    await nextTick()
+
+    const tablist = wrapper.find('[role="tablist"]')
+    expect(tablist.attributes('aria-orientation')).toBe('horizontal')
+
+    await tablist.trigger('keydown', { key: 'ArrowRight' })
+    await nextTick()
+    expect(wrapper.findAll('.tx-tab-item')[1].attributes('aria-selected')).toBe('true')
+
+    await tablist.trigger('keydown', { key: 'ArrowLeft' })
+    await nextTick()
+    expect(wrapper.findAll('.tx-tab-item')[0].attributes('aria-selected')).toBe('true')
+
+    await tablist.trigger('keydown', { key: 'End' })
+    await nextTick()
+    // The fixture's last tab is disabled, so End lands on the last *enabled*
+    // tab — disabled tabs are not navigation targets.
+    const items = wrapper.findAll('.tx-tab-item')
+    expect(items[1].attributes('aria-selected')).toBe('true')
+    expect(items[2].attributes('aria-selected')).toBe('false')
+
+    await tablist.trigger('keydown', { key: 'Home' })
+    await nextTick()
+    expect(wrapper.findAll('.tx-tab-item')[0].attributes('aria-selected')).toBe('true')
+  })
+
+  it('uses up/down on a vertical tablist', async () => {
+    const wrapper = mountTabs({ placement: 'left' })
+    await nextTick()
+
+    const tablist = wrapper.find('[role="tablist"]')
+    expect(tablist.attributes('aria-orientation')).toBe('vertical')
+
+    await tablist.trigger('keydown', { key: 'ArrowDown' })
+    await nextTick()
+    expect(wrapper.findAll('.tx-tab-item')[1].attributes('aria-selected')).toBe('true')
+
+    // The cross-axis key is not the navigation key for this orientation.
+    await tablist.trigger('keydown', { key: 'ArrowRight' })
+    await nextTick()
+    expect(wrapper.findAll('.tx-tab-item')[1].attributes('aria-selected')).toBe('true')
+  })
 })

--- a/packages/tuffex/packages/components/src/tabs/src/TxTabItem.vue
+++ b/packages/tuffex/packages/components/src/tabs/src/TxTabItem.vue
@@ -34,6 +34,7 @@ function handleClick() {
     :aria-selected="active"
     :class="{ 'is-active': active, 'is-disabled': disabled }"
     :disabled="disabled"
+    :tabindex="active ? 0 : -1"
     @click="handleClick"
   >
     <span v-if="iconClass || $slots.icon" class="tx-tab-item__icon">

--- a/packages/tuffex/packages/components/src/tabs/src/TxTabs.vue
+++ b/packages/tuffex/packages/components/src/tabs/src/TxTabs.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { PropType } from 'vue'
-import { Comment, Fragment, computed, defineComponent, h, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { Comment, Fragment, computed, defineComponent, h, nextTick, onBeforeUnmount, ref, useId, watch } from 'vue'
 import type { TabsAnimation, TabsProps } from './types'
 import TxAutoSizer from '../../auto-sizer/src/TxAutoSizer.vue'
 import TxTabHeader from './TxTabHeader.vue'
@@ -497,11 +497,69 @@ export default defineComponent({
         playPointerAnim(direction)
     }
 
+    const idScope = useId() ?? 'tx-tabs'
+    const panelDomId = `${idScope}-panel`
+
+    function tabDomId(name: string): string {
+      // Names are author-supplied, so encode rather than interpolate raw.
+      return `${idScope}-tab-${encodeURIComponent(name)}`
+    }
+
+    /**
+     * ARIA tablist: arrow keys move between tabs and activate them, wrapping at
+     * the ends. Paired with the roving tabindex in TxTabItem, which keeps the
+     * whole list to a single tab stop.
+     */
+    function handleTablistKeydown(event: KeyboardEvent): void {
+      const horizontalNext = isVertical.value ? 'ArrowDown' : 'ArrowRight'
+      const horizontalPrev = isVertical.value ? 'ArrowUp' : 'ArrowLeft'
+
+      const enabled = tabNodeCache.value.filter(node => !node?.props?.disabled)
+      if (!enabled.length)
+        return
+
+      const current = enabled.findIndex(node => getNodeName(node) === activeName.value)
+      let next = current
+
+      switch (event.key) {
+        case horizontalNext:
+          next = current < 0 ? 0 : (current + 1) % enabled.length
+          break
+        case horizontalPrev:
+          next = current < 0 ? enabled.length - 1 : (current - 1 + enabled.length) % enabled.length
+          break
+        case 'Home':
+          next = 0
+          break
+        case 'End':
+          next = enabled.length - 1
+          break
+        default:
+          return
+      }
+
+      event.preventDefault()
+      const target = enabled[next]
+      if (!target)
+        return
+
+      setActive(target)
+      void nextTick(() => {
+        const name = getNodeName(target)
+        const el = navInnerElRef.value?.querySelector<HTMLElement>(`#${CSS.escape(tabDomId(name))}`)
+        el?.focus()
+      })
+    }
+
     function createTab(vnode: any): any {
       const name = getNodeName(vnode)
       const tab = h(TxTabItem, {
         ...vnode.props,
         active: activeName.value === name,
+        // Tie each tab to the panel it controls; the panel points back with
+        // aria-labelledby so the pair is announced as a real tab relationship.
+        id: tabDomId(name),
+        'aria-controls': panelDomId,
         onClick: () => {
           if (vnode.props?.disabled)
             return
@@ -691,6 +749,8 @@ export default defineComponent({
           // Identify the active panel as a tabpanel so it is announced as the
           // content region controlled by the tablist above.
           role: 'tabpanel',
+          id: panelDomId,
+          'aria-labelledby': activeName.value ? tabDomId(activeName.value) : undefined,
         },
         renderContent(tabHeader, activeNode),
       )
@@ -747,6 +807,7 @@ export default defineComponent({
                   // tablist of tabs rather than an unlabelled group of buttons.
                   role: 'tablist',
                   'aria-orientation': isVertical.value ? 'vertical' : 'horizontal',
+                  onKeydown: handleTablistKeydown,
                 },
                 pointer ? [...tabs, pointer] : tabs,
               ),


### PR DESCRIPTION
`TxTabs` rendered `role="tablist"`, `role="tab"` and `role="tabpanel"` with `aria-selected`, but there was **no keydown handler anywhere in `tabs/`**, no tabindex management, and no id/`aria-controls`/`aria-labelledby` relationship between a tab and its panel. A screen reader announced "tab 1 of 3" while the arrow keys did nothing.

- **Roving tabindex** on `TxTabItem` (`0` for the selected tab, `-1` for the rest) — one tab stop for the list.
- **Arrow/Home/End movement** on the tablist, following `aria-orientation`: Left/Right when horizontal, Up/Down when vertical (`placement` defaults to `left`, which is vertical). Movement wraps and activates.
- **id / aria-controls / aria-labelledby** between each tab and the active panel, ids derived from `useId()` with the author-supplied name encoded.
- **Disabled tabs are skipped** as navigation targets.

**Two test corrections worth flagging** — in both cases the implementation was right and my test was wrong, so I fixed the test rather than bending the component:
1. My first arrow test used the default `placement: 'left'` and pressed ArrowRight. That is a *vertical* tablist, where Up/Down is correct. Retested with `placement: 'top'`, and added a vertical case that also asserts the cross-axis key does nothing.
2. My `End` assertion expected the last DOM tab, which is the fixture's *disabled* one. End correctly lands on the last **enabled** tab.

**Adversarial verification:** all three tests fail against the unfixed components (`git show HEAD:<path>`).

**Gates:** vue-tsc --noEmit 0 errors · vitest 145 files / 1099 tests green · eslint clean.

Fixes #951