### PR TITLE
fix(tuffex): trap Tab in the command palette; keep options off the tab order (#942)

### DIFF
--- a/packages/tuffex/packages/components/src/command-palette/__tests__/command-palette.test.ts
+++ b/packages/tuffex/packages/components/src/command-palette/__tests__/command-palette.test.ts
@@ -1,6 +1,7 @@
 import type { CommandPaletteItem } from '../src/types'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
 import TxCommandPalette from '../src/TxCommandPalette.vue'
 
 describe('txCommandPalette', () => {
@@ -148,10 +149,12 @@ describe('txCommandPalette', () => {
     })
 
     const options = wrapper.findAll('.tx-command-palette__item')
-    // The disabled option is out of the tab order and announced as disabled.
     expect(options[1].attributes('aria-disabled')).toBe('true')
+    // Every option is out of the tab order: the ARIA combobox contract drives
+    // them through aria-activedescendant from the input, so making enabled
+    // options tab stops put DOM focus somewhere the pattern never expects.
+    expect(options[0].attributes('tabindex')).toBe('-1')
     expect(options[1].attributes('tabindex')).toBe('-1')
-    expect(options[0].attributes('tabindex')).toBe('0')
 
     const input = wrapper.find('input')
     // ArrowDown from the first row skips the disabled second row onto the third.
@@ -241,5 +244,34 @@ describe('txCommandPalette', () => {
 
     expect(wrapper.text()).toContain('Close File')
     expect(wrapper.emitted('update:query')?.at(-1)).toEqual(['close'])
+  })
+
+  it('traps Tab inside the dialog it declares modal', async () => {
+    const wrapper = mount(TxCommandPalette, {
+      attachTo: document.body,
+      props: {
+        modelValue: true,
+        commands: [{ id: 'open', title: 'Open File' }],
+      },
+      slots: { footer: '<button type="button" class="footer-action">Docs</button>' },
+      global: { stubs: { Teleport: true } },
+    })
+    await nextTick()
+
+    const overlay = wrapper.find('[role="dialog"]')
+    const input = wrapper.find('input').element
+    const footerButton = wrapper.find('.footer-action').element as HTMLElement
+
+    // Tab from the last tabbable element must wrap to the first rather than
+    // escaping to the page behind, which aria-modal="true" declares inert.
+    footerButton.focus()
+    await overlay.trigger('keydown', { key: 'Tab' })
+    expect(document.activeElement).toBe(input)
+
+    // ...and Shift+Tab from the first wraps back to the last.
+    await overlay.trigger('keydown', { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(footerButton)
+
+    wrapper.unmount()
   })
 })

--- a/packages/tuffex/packages/components/src/command-palette/src/TxCommandPalette.vue
+++ b/packages/tuffex/packages/components/src/command-palette/src/TxCommandPalette.vue
@@ -20,6 +20,7 @@ const props = withDefaults(defineProps<CommandPaletteProps>(), {
 const emit = defineEmits<CommandPaletteEmits>()
 
 const inputRef = ref<HTMLInputElement | null>(null)
+const overlayRef = ref<HTMLElement | null>(null)
 const query = ref(props.query ?? '')
 
 // `update:query` was emitted with no matching prop, so v-model:query could only
@@ -129,6 +130,44 @@ function selectItem(item: CommandPaletteItem) {
   emit('select', item)
   if (props.closeOnSelect)
     close()
+}
+
+/**
+ * aria-modal="true" promises the background is inert, so Tab must cycle inside
+ * the dialog. Mirrors TxModal/TxDrawer, which both implement this already.
+ */
+function trapFocus(event: KeyboardEvent): void {
+  const root = overlayRef.value
+  if (!root)
+    return
+
+  const focusable = Array.from(
+    root.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]',
+    ),
+    // The options are real <button>s held out of the tab order with
+    // tabindex="-1", so the selector alone is not enough — a tag-based match
+    // would hand Tab straight back to them.
+  ).filter(el => el.tabIndex >= 0)
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  if (!first || !last) {
+    event.preventDefault()
+    inputRef.value?.focus()
+    return
+  }
+
+  const active = document.activeElement
+  if (event.shiftKey) {
+    if (active === first || active === root) {
+      event.preventDefault()
+      last.focus()
+    }
+  }
+  else if (active === last) {
+    event.preventDefault()
+    first.focus()
+  }
 }
 
 function onInput(value: string) {
@@ -255,10 +294,12 @@ function onKeydown(e: KeyboardEvent) {
         class="tx-command-palette__overlay"
         :class="overlayClass"
         :style="{ zIndex }"
+        ref="overlayRef"
         role="dialog"
         aria-modal="true"
         :aria-label="ariaLabel"
         @click.self="close"
+        @keydown.tab="trapFocus"
       >
         <div
           class="tx-command-palette__panel"
@@ -296,7 +337,7 @@ function onKeydown(e: KeyboardEvent) {
               role="option"
               :aria-selected="index === activeIndex"
               :aria-disabled="cmd.disabled || undefined"
-              :tabindex="cmd.disabled ? -1 : 0"
+              tabindex="-1"
               :class="{
                 'is-active': index === activeIndex,
                 'is-disabled': cmd.disabled,


### PR DESCRIPTION
Two coupled defects.

**No focus trap.** The overlay is `role="dialog" aria-modal="true"` but bound no Tab handler, unlike sibling `TxModal`/`TxDrawer` which both implement one — so Tab walked straight into the page the dialog declares inert.

**Options doubled as tab stops.** Every command was a real `<button :tabindex="cmd.disabled ? -1 : 0">` inside a `role="listbox"`. The ARIA combobox contract says options are `tabindex="-1"` and driven by `aria-activedescendant` from the input, which this component already sets. They are now all `-1`.

**The two interact, which is worth calling out:** the options remain real `<button>` elements, so the conventional focusable selector (`button:not([disabled])`, copied from TxModal) still matches them by tag and would have handed Tab straight back. The trap therefore filters on `tabIndex >= 0` rather than trusting the selector. I found this because the first version of the trap test moved focus onto an option.

**Test-quality note.** My first trap test focused the input and pressed Tab — it passed against the *unfixed* component, because jsdom does not implement Tab navigation, so "focus did not move" is vacuously true. Rewritten to add a footer-slot button and assert the wrap: Tab from the last tabbable lands on the input, Shift+Tab from the first lands back on the button. That version fails on baseline.

**Stale assertion:** `command-palette.test.ts` asserted enabled options had `tabindex="0"` — it encoded the defect. Updated with the contract reason inline.

**Gates:** vue-tsc --noEmit 0 errors · vitest 145 files / 1100 tests green · eslint clean. One full run showed an unrelated `context-menu` failure; that suite is untouched by this diff, passes isolated (17/17), and passed on the next full run — the repo's known concurrent-run flake, reported rather than quietly re-run.

Fixes #942