### PR TITLE
feat(tuffex): make the TxSelect combobox keyboard operable (#935)

### DIFF
--- a/packages/tuffex/packages/components/src/select/__tests__/select.test.ts
+++ b/packages/tuffex/packages/components/src/select/__tests__/select.test.ts
@@ -365,4 +365,85 @@ describe('txSelect', () => {
     expect(options).toHaveLength(1)
     expect(options[0].text()).toContain('Beta')
   })
+
+  it('opens and commits the combobox from the keyboard', async () => {
+    const wrapper = mount(TxSelect, {
+      props: {
+        modelValue: '',
+        options: [
+          { value: 'alpha', label: 'Alpha' },
+          { value: 'beta', label: 'Beta' },
+        ],
+      },
+      global: {
+        stubs: { TxPopover: PopoverStub },
+      },
+    })
+    await nextTick()
+
+    const trigger = wrapper.find('.tuff-select__trigger input')
+    expect(trigger.attributes('role')).toBe('combobox')
+
+    // ArrowDown opens the panel and highlights the first option; nothing bound a
+    // keydown handler before, so there was no keyboard path to open it at all.
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await nextTick()
+    expect(trigger.attributes('aria-expanded')).toBe('true')
+
+    const firstId = wrapper.findAll('[role="option"]')[0]?.attributes('id')
+    expect(trigger.attributes('aria-activedescendant')).toBe(firstId)
+
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await nextTick()
+    const secondId = wrapper.findAll('[role="option"]')[1]?.attributes('id')
+    expect(trigger.attributes('aria-activedescendant')).toBe(secondId)
+
+    await trigger.trigger('keydown', { key: 'Enter' })
+    await nextTick()
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['beta'])
+  })
+
+  it('closes the combobox panel on Escape', async () => {
+    const wrapper = mount(TxSelect, {
+      props: {
+        modelValue: '',
+        options: [{ value: 'alpha', label: 'Alpha' }],
+      },
+      global: { stubs: { TxPopover: PopoverStub } },
+    })
+    await nextTick()
+
+    const trigger = wrapper.find('.tuff-select__trigger input')
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await nextTick()
+    expect(trigger.attributes('aria-expanded')).toBe('true')
+
+    await trigger.trigger('keydown', { key: 'Escape' })
+    await nextTick()
+    expect(trigger.attributes('aria-expanded')).toBe('false')
+  })
+
+  it('skips disabled options during keyboard navigation', async () => {
+    const wrapper = mount(TxSelect, {
+      props: {
+        modelValue: '',
+        options: [
+          { value: 'alpha', label: 'Alpha' },
+          { value: 'beta', label: 'Beta', disabled: true },
+          { value: 'gamma', label: 'Gamma' },
+        ],
+      },
+      global: { stubs: { TxPopover: PopoverStub } },
+    })
+    await nextTick()
+
+    const trigger = wrapper.find('.tuff-select__trigger input')
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await nextTick()
+    await trigger.trigger('keydown', { key: 'Enter' })
+
+    // Beta is disabled, so the second step lands on Gamma.
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['gamma'])
+  })
 })

--- a/packages/tuffex/packages/components/src/select/src/TxSelect.vue
+++ b/packages/tuffex/packages/components/src/select/src/TxSelect.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { TxSelectModelValue, TxSelectOption, TxSelectOptionGroup, TxSelectOptionId, TxSelectOptionLike, TxSelectProps, TxSelectValue } from './types'
-import { computed, nextTick, onBeforeUnmount, onMounted, provide, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, provide, ref, useId, watch } from 'vue'
 import TxCardItem from '../../card-item/src/TxCardItem.vue'
 import TuffInput from '../../input/src/TxInput.vue'
 import TxPopover from '../../popover/src/TxPopover.vue'
@@ -55,6 +55,7 @@ const emit = defineEmits<{
 }>()
 
 const isOpen = ref(false)
+const listDomId = `${useId() ?? 'tuff-select'}-list`
 const selectedLabel = ref('')
 const multiInput = ref('')
 
@@ -309,6 +310,97 @@ function removeSelectedValue(value: TxSelectValue) {
     return
   currentValue.value = selectedValues.value.filter(item => !isSelectValueEqual(item, value))
 }
+
+/**
+ * Keyboard support for the default (non-multiple) combobox. The trigger carried
+ * role="combobox"/aria-expanded but nothing bound a keydown handler, and
+ * TxBaseAnchor only wires click + a document-level Escape — so the panel could
+ * not be opened, navigated or committed from the keyboard at all.
+ */
+const navigableOptions = computed<TxSelectOption[]>(() => {
+  if (shouldRenderPropOptions.value) {
+    return renderedOptionGroups.value
+      .flatMap(group => group.options)
+      .filter(option => !option.disabled)
+  }
+  const q = (props.remote ? '' : searchQuery.value).trim().toLowerCase()
+  return registeredOptionList.value.filter(
+    option => !q || option.label.toLowerCase().includes(q),
+  )
+})
+
+const activeOptionIndex = ref(-1)
+
+const activeDescendantId = computed(() => {
+  const option = navigableOptions.value[activeOptionIndex.value]
+  return option ? optionDomId(option.value) : undefined
+})
+
+function optionDomId(value: string | number): string {
+  return `${listDomId}-opt-${encodeURIComponent(String(value))}`
+}
+
+function moveActiveOption(delta: number): void {
+  const options = navigableOptions.value
+  if (!options.length)
+    return
+  const from = activeOptionIndex.value
+  const next = from < 0
+    ? (delta > 0 ? 0 : options.length - 1)
+    : (from + delta + options.length) % options.length
+  activeOptionIndex.value = next
+}
+
+function handleTriggerKeydown(e: KeyboardEvent): void {
+  if (props.disabled)
+    return
+
+  switch (e.key) {
+    case 'ArrowDown':
+    case 'ArrowUp':
+      e.preventDefault()
+      if (!isOpen.value) {
+        isOpen.value = true
+        activeOptionIndex.value = e.key === 'ArrowDown' ? 0 : navigableOptions.value.length - 1
+        return
+      }
+      moveActiveOption(e.key === 'ArrowDown' ? 1 : -1)
+      break
+    case 'Enter':
+      if (!isOpen.value) {
+        e.preventDefault()
+        isOpen.value = true
+        return
+      }
+      {
+        const option = navigableOptions.value[activeOptionIndex.value]
+        if (option) {
+          e.preventDefault()
+          handleSelect(option.value, option.label)
+        }
+      }
+      break
+    case ' ':
+      // A readonly trigger cannot type a space, so it is an open affordance;
+      // an editable one must keep it as text input.
+      if (!isEditable.value && !isOpen.value) {
+        e.preventDefault()
+        isOpen.value = true
+      }
+      break
+    case 'Escape':
+      if (isOpen.value) {
+        e.preventDefault()
+        isOpen.value = false
+      }
+      break
+  }
+}
+
+watch(isOpen, (open) => {
+  if (!open)
+    activeOptionIndex.value = -1
+})
 
 function handleSelect(value: string | number, label: string) {
   if (props.multiple) {
@@ -670,7 +762,10 @@ onBeforeUnmount(() => {
             role="combobox"
             aria-haspopup="listbox"
             :aria-expanded="isOpen"
+            :aria-controls="listDomId"
+            :aria-activedescendant="activeDescendantId"
             @focus="openFromFocus"
+            @keydown="handleTriggerKeydown"
           >
             <template #suffix>
               <span class="tuff-select__arrow">
@@ -696,7 +791,7 @@ onBeforeUnmount(() => {
           />
         </div>
 
-        <div class="tuff-select__list" role="listbox" :aria-multiselectable="multiple || undefined">
+        <div :id="listDomId" class="tuff-select__list" role="listbox" :aria-multiselectable="multiple || undefined">
           <template v-if="shouldRenderPropOptions">
             <template v-for="group in renderedOptionGroups" :key="group.key">
               <div v-if="group.label" class="tuff-select__group-label">
@@ -712,6 +807,7 @@ onBeforeUnmount(() => {
                   'is-selected': isValueSelected(opt.value),
                   'is-disabled': opt.disabled,
                 }"
+                :id="optionDomId(opt.value)"
                 role="option"
                 :clickable="true"
                 :active="isValueSelected(opt.value)"


### PR DESCRIPTION
The default (non-editable, non-multiple) trigger carried `role="combobox"` / `aria-haspopup="listbox"` / `aria-expanded`, but nothing bound a keydown handler. `TxBaseAnchor` (behind `TxPopover`) only wires `@click.capture` on the reference plus a document-level Escape — so a keyboard user could tab to the trigger and then do nothing: no Enter/Space/ArrowDown to open, no arrow navigation, no `aria-activedescendant`.

Adds:
- **Open**: ArrowDown / ArrowUp / Enter, plus Space on a readonly trigger (an *editable* trigger keeps Space as text input)
- **Navigate**: ArrowDown/ArrowUp with wrapping, over the visible options
- **Commit**: Enter selects the active option
- **Close**: Escape
- **Semantics**: `aria-controls` + `aria-activedescendant` on the trigger, `id` on each option, ids from `useId()`

**Covers both option sources.** The navigable list is built from the `options` prop *and* from slot-registered `TxSelectItem` children via the component's existing `registeredOptions` registry, so slot usage is not left keyboard-inert. Disabled options are skipped — pinned by a test.

**SSR note:** ids come from `useId()`, not a counter or timestamp. My first draft derived the list id from `performance.now()`, which would have produced a hydration mismatch — the same class of problem as #956.

**Adversarial verification:** all three tests fail against the unfixed component (`git show HEAD:<path>`).

**Gates:** vue-tsc --noEmit 0 errors · vitest 145 files / 1103 tests green · eslint clean.

Fixes #935