### PR TITLE
fix(tuffex): escape markdown punctuation when serializing editor text (#938)

### DIFF
--- a/packages/tuffex/packages/components/src/markdown-editor/__tests__/markdown-editor.test.ts
+++ b/packages/tuffex/packages/components/src/markdown-editor/__tests__/markdown-editor.test.ts
@@ -128,4 +128,50 @@ describe('txMarkdownEditor', () => {
     expect(wrapper.find('.tx-markdown-editor__surface').attributes('aria-label')).toBe('Notes editor')
     expect(wrapper.find('textarea').attributes('aria-label')).toBe('Notes editor')
   })
+
+  it('escapes markdown punctuation typed as literal text', async () => {
+    const wrapper = mount(TxMarkdownEditor, {
+      props: { modelValue: '', sanitize: false },
+      attachTo: document.body,
+    })
+    await flushMarkdown()
+
+    const surface = wrapper.find('.tx-markdown-editor__surface')
+    surface.element.innerHTML = '<table><tr><td>a | b</td><td>other</td></tr></table>'
+    await surface.trigger('input')
+
+    const table = wrapper.emitted('update:modelValue')?.at(-1)?.[0] as string
+    // A literal pipe used to re-emit as a column break, so the row no longer
+    // matched its own separator and the table stopped rendering as a table.
+    expect(table).toContain('a \\| b')
+
+    surface.element.innerHTML = '<p>use *stars* and _underscores_ and `ticks`</p>'
+    await surface.trigger('input')
+
+    const inline = wrapper.emitted('update:modelValue')?.at(-1)?.[0] as string
+    expect(inline).toContain('\\*stars\\*')
+    expect(inline).toContain('\\_underscores\\_')
+    expect(inline).toContain('\\`ticks\\`')
+
+    wrapper.unmount()
+  })
+
+  it('leaves code and pre content verbatim', async () => {
+    const wrapper = mount(TxMarkdownEditor, {
+      props: { modelValue: '', sanitize: false },
+      attachTo: document.body,
+    })
+    await flushMarkdown()
+
+    const surface = wrapper.find('.tx-markdown-editor__surface')
+    surface.element.innerHTML = '<pre><code>a | b *not emphasis*</code></pre>'
+    await surface.trigger('input')
+
+    const emitted = wrapper.emitted('update:modelValue')?.at(-1)?.[0] as string
+    // Escaping must not leak into verbatim spans.
+    expect(emitted).toContain('a | b *not emphasis*')
+    expect(emitted).not.toContain('\\|')
+
+    wrapper.unmount()
+  })
 })

--- a/packages/tuffex/packages/components/src/markdown-editor/src/markdown-serializer.ts
+++ b/packages/tuffex/packages/components/src/markdown-editor/src/markdown-serializer.ts
@@ -6,6 +6,25 @@ function textOf(node: Node): string {
   return node.textContent?.replace(/\u00a0/g, ' ') ?? ''
 }
 
+/**
+ * Text typed into the contenteditable surface is literal, so any markdown
+ * punctuation in it has to be escaped on the way out — otherwise `a | b` in a
+ * table cell re-emits as a column break, and `*text*` round-trips into emphasis
+ * the user never asked for.
+ *
+ * Only text nodes go through here. `code`/`pre` read their content with
+ * `textOf` directly and do their own escaping, so verbatim spans are untouched.
+ */
+function escapeMarkdownText(value: string): string {
+  return value
+    // Backslash first, or it would double-escape the escapes added below.
+    .replace(/\\/g, '\\\\')
+    .replace(/([`*_[\]|])/g, '\\$1')
+    // Block markers only bite at the start of a line.
+    .replace(/^(\s*)([#>+-])/gm, '$1\\$2')
+    .replace(/^(\s*)(\d+)\./gm, '$1$2\\.')
+}
+
 function normalizeMarkdown(markdown: string): string {
   return markdown
     .replace(/[ \t]+\n/g, '\n')
@@ -70,7 +89,7 @@ function serializeTable(element: HTMLElement): string {
 
 function serializeNode(node: Node): string {
   if (node.nodeType === Node.TEXT_NODE)
-    return textOf(node)
+    return escapeMarkdownText(textOf(node))
 
   if (!isElement(node))
     return ''


### PR DESCRIPTION
`serializeTable` joined cell text with ` | ` and every other branch emitted `serializeInlineChildren(node)` verbatim. Nothing escaped `|`, `*`, `_`, backticks or a leading `#`, so plain text typed into the contenteditable surface was re-emitted **as markdown syntax**. The headline case: typing `a | b` into a cell produced `| a | b | other |`, which reads as three columns and no longer matches the `| --- | --- |` separator, so the table stops rendering as a table.

Escaping is applied in the **text-node path only**:
- always: `\`, backtick, `*`, `_`, `[`, `]`, `|`
- line-leading only: `#`, `>`, `+`, `-`, and `N.` — these are block markers that only bite at the start of a line, so escaping them everywhere would mangle ordinary prose

**Verbatim spans are untouched:** the `code` and `pre` branches read their content through `textOf` directly rather than recursing into `serializeNode`, so text inside them never reaches the escaper. A second test pins that, since over-escaping code blocks would be a worse regression than the bug.

Generated syntax is also unaffected — the `hr` `---` and list markers are emitted by the serializer, not read from text nodes.

**Adversarial verification:** the escaping test fails against the unfixed serializer (`git show HEAD:<path>`).

**Gates:** vue-tsc --noEmit 0 errors · vitest 145 files / 1105 tests green · eslint clean.

Fixes #938