### PR TITLE
fix(nexus): reset the tuffex z-index allocator per SSR request (#956)

### DIFF
--- a/apps/nexus/server/plugins/ssr-zindex-reset.ts
+++ b/apps/nexus/server/plugins/ssr-zindex-reset.ts
@@ -1,0 +1,9 @@
+import { resetZIndexForRequest } from '../utils/ssrZIndexReset'
+
+export default defineNitroPlugin((nitroApp) => {
+  // Must run before any component setup, so hook the request itself rather than
+  // a render hook — TxDrawer allocates during setup via an immediate watcher.
+  nitroApp.hooks.hook('request', () => {
+    resetZIndexForRequest()
+  })
+})

--- a/apps/nexus/server/utils/ssrZIndexReset.test.ts
+++ b/apps/nexus/server/utils/ssrZIndexReset.test.ts
@@ -1,0 +1,39 @@
+import { getZIndex, nextZIndex, refreshZIndex, resetZIndex } from '@talex-touch/tuffex/utils'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { resetZIndexForRequest } from './ssrZIndexReset'
+
+// Hardcoded in TxDrawer; a drawer rendered with visible: true allocates from it
+// during setup, which is what leaks across requests.
+const DRAWER_Z_INDEX_SEED = 10000
+
+describe('ssr z-index reset', () => {
+  beforeEach(() => {
+    resetZIndex(undefined, 'test')
+  })
+
+  it('restores the allocator to the state a fresh client module starts from', () => {
+    const pristine = getZIndex()
+
+    // Simulate one request rendering a visible drawer: refresh to its seed and
+    // take a layer, exactly as TxDrawer's immediate watcher does.
+    refreshZIndex(DRAWER_Z_INDEX_SEED, 'drawer')
+    const allocated = nextZIndex()
+    expect(allocated).toBeGreaterThan(pristine)
+    expect(getZIndex()).not.toBe(pristine)
+
+    resetZIndexForRequest()
+
+    // Without this, the next request's TxModal would SSR the drifted value while
+    // the client computed the pristine one — a hydration mismatch on the style.
+    expect(getZIndex()).toBe(pristine)
+  })
+
+  it('is idempotent across consecutive requests', () => {
+    const pristine = getZIndex()
+
+    resetZIndexForRequest()
+    resetZIndexForRequest()
+
+    expect(getZIndex()).toBe(pristine)
+  })
+})

--- a/apps/nexus/server/utils/ssrZIndexReset.ts
+++ b/apps/nexus/server/utils/ssrZIndexReset.ts
@@ -1,0 +1,16 @@
+import { resetZIndex } from '@talex-touch/tuffex/utils'
+
+/**
+ * The tuffex z-index allocator keeps its counter in module scope. In a Node SSR
+ * process that module is instantiated once and shared by every request, so an
+ * overlay rendered for one request moves the counter for every later one — the
+ * server then emits a z-index the freshly loaded client module never computes,
+ * and the style attribute mismatches on hydration.
+ *
+ * Resetting at the start of each request restores the "fresh module" state the
+ * client always starts from. Extracted from the Nitro plugin so it can be tested
+ * without booting a server.
+ */
+export function resetZIndexForRequest(): void {
+  resetZIndex(undefined, 'ssr request')
+}


### PR DESCRIPTION
Containment for #956, on the app side.

The tuffex z-index allocator keeps its counter in **module scope**. In a Node SSR process that module is instantiated once and shared by every request, so an overlay rendered for one request moves the counter for every later one. The server then emits a z-index the freshly loaded client module never computes → hydration mismatch on the style attribute. `TxDrawer` makes it reachable during *setup*: its `watch(..., { immediate: true })` refreshes to `DRAWER_Z_INDEX_SEED` and allocates, so SSR-rendering a visible drawer permanently moves shared state for that process.

Hooks Nitro's `request` event — deliberately not a render hook, since the allocation happens during component setup, before render hooks fire. The reset itself lives in `server/utils/ssrZIndexReset.ts` so it is testable without booting a server.

**Why this and not the architectural fix.** Scoping the allocator per app instance is the right long-term answer, but `getZIndex()`/`nextZIndex()` are module-level exports called directly by 11 components — that is a breaking API change plus 11 call-site migrations, and a partial migration degrades into per-component allocators, which is worse than the current bug. #956 **stays open** for that decision; this PR removes the user-visible symptom in the meantime, which is what I recommended in the analysis there.

**Adversarial verification:** replacing the util's body with a no-op makes the test fail, so it guards the reset rather than the allocator's own semantics.

**Gates:** the 2 new tests pass; `eslint` clean on all three added files. The nexus suite has **15 pre-existing failures** (docs coverage, store-page performance, worker-bundle budget) — I verified they are identical with my files moved out of the tree, and my change adds 2 passing tests (941→943) without touching any of them. Reported rather than presented as green.

Refs #956