### PR TITLE
fix(tuffex): give the context-menu trigger a keyboard entry point (#362 A3)

### DIFF
--- a/packages/tuffex/packages/components/src/context-menu/__tests__/context-menu.test.ts
+++ b/packages/tuffex/packages/components/src/context-menu/__tests__/context-menu.test.ts
@@ -330,4 +330,63 @@ describe('txContextMenu', () => {
     await wrapper.findComponent(TxContextMenuItem).trigger('click')
     expect(close).toHaveBeenCalledTimes(1)
   })
+
+  it('opens from the keyboard with the ContextMenu key and Shift+F10', async () => {
+    const wrapper = mountMenu({ trigger: 'contextmenu' })
+    await nextTick()
+
+    const el = wrapper.find('.tx-context-menu__trigger')
+    // The panel implements the full menu pattern, but the trigger had no
+    // keyboard entry point at all — it was pointer-only.
+    expect(el.attributes('tabindex')).toBe('0')
+    expect(el.attributes('aria-haspopup')).toBe('menu')
+    expect(el.attributes('aria-expanded')).toBe('false')
+
+    await el.trigger('keydown', { key: 'ContextMenu' })
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([true])
+
+    await wrapper.setProps({ modelValue: false })
+    await el.trigger('keydown', { key: 'F10', shiftKey: true })
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([true])
+
+    wrapper.unmount()
+  })
+
+  it('opens a click-triggered menu with Enter and Space', async () => {
+    const wrapper = mountMenu({ trigger: 'click' })
+    await nextTick()
+
+    const el = wrapper.find('.tx-context-menu__trigger')
+    await el.trigger('keydown', { key: 'Enter' })
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([true])
+
+    await wrapper.setProps({ modelValue: false })
+    await el.trigger('keydown', { key: ' ' })
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([true])
+
+    wrapper.unmount()
+  })
+
+  it('ignores trigger keys that do not match the configured mode', async () => {
+    const wrapper = mountMenu({ trigger: 'contextmenu' })
+    await nextTick()
+
+    // Enter is the click gesture; a contextmenu-only trigger must not react.
+    await wrapper.find('.tx-context-menu__trigger').trigger('keydown', { key: 'Enter' })
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+
+    wrapper.unmount()
+  })
+
+  it('leaves a manual trigger out of the tab order', async () => {
+    const wrapper = mountMenu({ trigger: 'manual' })
+    await nextTick()
+
+    const el = wrapper.find('.tx-context-menu__trigger')
+    // A manual menu is opened programmatically; its wrapper is not a control.
+    expect(el.attributes('tabindex')).toBeUndefined()
+    expect(el.attributes('aria-haspopup')).toBeUndefined()
+
+    wrapper.unmount()
+  })
 })

--- a/packages/tuffex/packages/components/src/context-menu/src/TxContextMenu.vue
+++ b/packages/tuffex/packages/components/src/context-menu/src/TxContextMenu.vue
@@ -151,6 +151,41 @@ function onClick(e: MouseEvent) {
   openFromEvent(e)
 }
 
+/**
+ * The trigger had no keyboard path at all: the panel implements the full menu
+ * pattern (role="menu", roving items, arrow keys), but it could only ever be
+ * reached with a pointer. The ContextMenu key and Shift+F10 are the platform
+ * gestures for a context menu; Enter/Space open a click-triggered one.
+ */
+function triggerAnchorPoint(): ContextMenuPoint | undefined {
+  const el = triggerRef.value
+  if (!el?.getBoundingClientRect)
+    return undefined
+  const rect = el.getBoundingClientRect()
+  // A pointer-opened menu lands under the cursor; a keyboard-opened one has no
+  // cursor, so anchor it to the trigger's bottom-left like the platform does.
+  return { x: Math.round(rect.left), y: Math.round(rect.bottom) }
+}
+
+function onTriggerKeydown(e: KeyboardEvent) {
+  if (props.disabled)
+    return
+
+  const isContextGesture = e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')
+  if (isContextGesture && isContextMenuTriggerEnabled()) {
+    e.preventDefault()
+    openedByContextMenu.value = true
+    openAt(triggerAnchorPoint())
+    return
+  }
+
+  if ((e.key === 'Enter' || e.key === ' ') && isClickTriggerEnabled()) {
+    e.preventDefault()
+    openedByContextMenu.value = false
+    openAt(triggerAnchorPoint())
+  }
+}
+
 function shouldCloseFromTriggerPointerDown(e: MouseEvent) {
   if (!props.closeOnTriggerPointerDown)
     return false
@@ -277,9 +312,14 @@ defineExpose({
     ref="triggerRef"
     class="tx-context-menu__trigger"
     :class="{ 'is-disabled': disabled }"
+    :tabindex="disabled || trigger === 'manual' ? undefined : 0"
+    :aria-haspopup="trigger === 'manual' ? undefined : 'menu'"
+    :aria-expanded="trigger === 'manual' ? undefined : open"
+    :aria-disabled="disabled || undefined"
     @contextmenu="onContextMenu"
     @pointerdown="onTriggerPointerDown"
     @click="onClick"
+    @keydown="onTriggerKeydown"
   >
     <slot name="trigger">
       <slot />


### PR DESCRIPTION
Found while sweeping the three systematic patterns tracked by umbrella #362.

`TxContextMenuPanel` already implements the full menu pattern — `role="menu"`, `role="menuitem"`, roving focus, arrow keys. But the **trigger** was pointer-only: a bare `<div>` with `@contextmenu`/`@click`, no `tabindex`, no role, no keydown handler. There was no way to open the menu from the keyboard at all, so none of that panel work was reachable for keyboard or screen-reader users.

- `tabindex` / `aria-haspopup="menu"` / `aria-expanded` / `aria-disabled` on the trigger
- **ContextMenu key** and **Shift+F10** open a `contextmenu`-mode menu (the platform gestures)
- **Enter** / **Space** open a `click`-mode menu
- Keys that do not match the configured `trigger` mode are ignored — pinned by a test
- `trigger="manual"` stays out of the tab order and advertises nothing, since it is opened programmatically and its wrapper is not a control

A keyboard-opened menu has no cursor position, so it anchors to the trigger's bottom-left rather than reusing the stale pointer point.

**Adversarial verification:** both keyboard tests fail against the unfixed component (restored via `git show HEAD:<path>`).

**Note on the test rewrite:** my first draft mounted `TxContextMenu` directly and the menu opened, but `TxBaseAnchor` throws under jsdom that way. The suite already has a `mountMenu` helper with the right slots and `attachTo`; rewritten to use it.

**Gates:** vue-tsc --noEmit 0 errors · vitest 145 files / 1109 tests green · eslint clean.

Refs #362