### PR TITLE
refactor(tuffex): scope the z-index allocator to the app instead of the module (#956)

### DIFF
--- a/packages/tuffex/packages/components/src/__tests__/global-install.test.ts
+++ b/packages/tuffex/packages/components/src/__tests__/global-install.test.ts
@@ -33,6 +33,8 @@ describe('global install', () => {
         return fakeApp
       },
       component: () => undefined,
+      // install() also provides the per-app z-index allocator (#956).
+      provide: () => fakeApp,
     }
 
     install(fakeApp as never)

--- a/packages/tuffex/packages/components/src/base-anchor/src/TxBaseAnchor.vue
+++ b/packages/tuffex/packages/components/src/base-anchor/src/TxBaseAnchor.vue
@@ -6,10 +6,13 @@ import type { BaseAnchorClassValue, BaseAnchorProps, BaseAnchorVirtualReference 
 import { arrow, autoUpdate, flip, offset as offsetMw, shift, size, useFloating } from '@floating-ui/vue'
 import { computed, getCurrentInstance, nextTick, onBeforeUnmount, onMounted, ref, useAttrs, watch } from 'vue'
 import { hasWindow } from '../../../../utils/env'
-import { getZIndex, nextZIndex } from '../../../../utils/z-index-manager'
+import { useZIndexAllocator } from '../../../../utils/z-index-manager'
 import TxCard from '../../card/src/TxCard.vue'
 import { beadPinchRatio, beadSpanAt, createLiquidMetrics, geometryAt, itemOpacityAt, LIQUID_DEFAULTS, neckClipAt } from './base-anchor-liquid'
 import { useBaseAnchorMotion } from './base-anchor-motion'
+
+// Resolved in setup: inject is only valid here, while allocation happens later.
+const zIndexAllocator = useZIndexAllocator()
 
 defineOptions({ name: 'TxBaseAnchor', inheritAttrs: false })
 
@@ -108,7 +111,7 @@ const liquidGooId = `tx-ba-liquid-goo-${uid}`
 const liquidOutlineId = `tx-ba-liquid-outline-${uid}`
 const liquidMaskId = `tx-ba-liquid-mask-${uid}`
 
-const zIndex = ref(getZIndex())
+const zIndex = ref(zIndexAllocator.get())
 const mounted = ref(false)
 const cleanupAutoUpdate = ref<(() => void) | null>(null)
 const cleanupResizeObserver = ref<(() => void) | null>(null)
@@ -800,7 +803,7 @@ watch(
     }
 
     mounted.value = true
-    zIndex.value = nextZIndex()
+    zIndex.value = zIndexAllocator.next()
     lastOpenedAt.value = performance.now()
 
     await nextTick()

--- a/packages/tuffex/packages/components/src/command-palette/src/TxCommandPalette.vue
+++ b/packages/tuffex/packages/components/src/command-palette/src/TxCommandPalette.vue
@@ -2,8 +2,11 @@
 import type { TxIconSource } from '../../icon'
 import type { CommandPaletteEmits, CommandPaletteItem, CommandPaletteProps } from './types'
 import { computed, nextTick, ref, useId, watch } from 'vue'
-import { getZIndex, nextZIndex } from '../../../../utils/z-index-manager'
+import { useZIndexAllocator } from '../../../../utils/z-index-manager'
 import { TxIcon } from '../../icon'
+
+// Resolved in setup: inject is only valid here, while allocation happens later.
+const zIndexAllocator = useZIndexAllocator()
 
 defineOptions({ name: 'TxCommandPalette' })
 
@@ -34,7 +37,7 @@ watch(
   },
 )
 const activeIndex = ref(0)
-const zIndex = ref(getZIndex())
+const zIndex = ref(zIndexAllocator.get())
 const composing = ref(false)
 
 const visible = computed({
@@ -93,7 +96,7 @@ watch(
   () => props.modelValue,
   async (v, oldValue) => {
     if (v) {
-      zIndex.value = nextZIndex()
+      zIndex.value = zIndexAllocator.next()
       emit('open')
       activeIndex.value = firstEnabledIndex()
       await nextTick()

--- a/packages/tuffex/packages/components/src/dialog/src/TxBlowDialog.vue
+++ b/packages/tuffex/packages/components/src/dialog/src/TxBlowDialog.vue
@@ -29,8 +29,11 @@ import {
   useId,
 
 } from 'vue'
-import { getZIndex, nextZIndex } from '../../../../utils/z-index-manager'
+import { useZIndexAllocator } from '../../../../utils/z-index-manager'
 import { TxButton } from '../../button'
+
+// Resolved in setup: inject is only valid here, while allocation happens later.
+const zIndexAllocator = useZIndexAllocator()
 
 defineOptions({
   name: 'TxBlowDialog',
@@ -48,7 +51,7 @@ const props = withDefaults(defineProps<BlowDialogProps>(), {
 const isClosing = ref(false)
 const renderComp = ref<Component | null>(null)
 const dialogWrapper = ref<HTMLElement | null>(null)
-const zIndex = ref(getZIndex())
+const zIndex = ref(zIndexAllocator.get())
 // Instance-scoped ids (mirroring Bottom/TouchTip) so the dialog announces both its
 // title and its message, and stacked dialogs never collide on a hard-coded id.
 const titleId = useId()
@@ -65,7 +68,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 onMounted(() => {
-  zIndex.value = nextZIndex()
+  zIndex.value = zIndexAllocator.next()
   previouslyFocusedElement = document.activeElement as HTMLElement
 
   if (props.render) {

--- a/packages/tuffex/packages/components/src/dialog/src/TxBottomDialog.vue
+++ b/packages/tuffex/packages/components/src/dialog/src/TxBottomDialog.vue
@@ -22,8 +22,11 @@ import type { BottomDialogProps, DialogButton } from './types'
  * @component
  */
 import { computed, onMounted, onUnmounted, ref, useId, watchEffect } from 'vue'
-import { getZIndex, nextZIndex } from '../../../../utils/z-index-manager'
+import { useZIndexAllocator } from '../../../../utils/z-index-manager'
 import { TxButton } from '../../button'
+
+// Resolved in setup: inject is only valid here, while allocation happens later.
+const zIndexAllocator = useZIndexAllocator()
 
 defineOptions({
   name: 'TxBottomDialog',
@@ -51,7 +54,7 @@ interface ButtonState {
 
 const wholeDom = ref<HTMLElement | null>(null)
 const btnArray = ref<Array<{ value: ButtonState }>>([])
-const baseZIndex = ref(getZIndex())
+const baseZIndex = ref(zIndexAllocator.get())
 const zIndex = computed(() => baseZIndex.value + (props.index ?? 0))
 const titleId = useId()
 const messageId = useId()
@@ -159,7 +162,7 @@ function scrollListener(): void {
 }
 
 onMounted(() => {
-  baseZIndex.value = nextZIndex()
+  baseZIndex.value = zIndexAllocator.next()
   previouslyFocusedElement = document.activeElement as HTMLElement
   if (wholeDom.value) {
     wholeDom.value.focus()

--- a/packages/tuffex/packages/components/src/dialog/src/TxPopperDialog.vue
+++ b/packages/tuffex/packages/components/src/dialog/src/TxPopperDialog.vue
@@ -12,8 +12,11 @@ import {
   useId,
 
 } from 'vue'
-import { getZIndex, nextZIndex } from '../../../../utils/z-index-manager'
+import { useZIndexAllocator } from '../../../../utils/z-index-manager'
 import { TxButton } from '../../button'
+
+// Resolved in setup: inject is only valid here, while allocation happens later.
+const zIndexAllocator = useZIndexAllocator()
 
 defineOptions({
   name: 'TxPopperDialog',
@@ -34,7 +37,7 @@ const contentId = useId()
 const isClosing = ref(false)
 const renderComp = ref<Component | null>(null)
 const dialogWrapper = ref<HTMLElement | null>(null)
-const zIndex = ref(getZIndex())
+const zIndex = ref(zIndexAllocator.get())
 let previouslyFocusedElement: HTMLElement | null = null
 
 function sleep(ms: number): Promise<void> {
@@ -42,7 +45,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 onMounted(() => {
-  zIndex.value = nextZIndex()
+  zIndex.value = zIndexAllocator.next()
   previouslyFocusedElement = document.activeElement as HTMLElement
 
   if (props.render) {

--- a/packages/tuffex/packages/components/src/dialog/src/TxTouchTip.vue
+++ b/packages/tuffex/packages/components/src/dialog/src/TxTouchTip.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import type { TouchTipButton, TouchTipProps } from './types'
 import { onMounted, onUnmounted, ref, useId, watchEffect } from 'vue'
-import { getZIndex, nextZIndex } from '../../../../utils/z-index-manager'
+import { useZIndexAllocator } from '../../../../utils/z-index-manager'
 import { TxButton } from '../../button'
+
+// Resolved in setup: inject is only valid here, while allocation happens later.
+const zIndexAllocator = useZIndexAllocator()
 
 defineOptions({
   name: 'TxTouchTip',
@@ -24,7 +27,7 @@ interface ButtonState {
 
 const btnArray = ref<Array<{ value: ButtonState }>>([])
 const wholeDom = ref<HTMLElement | null>(null)
-const zIndex = ref(getZIndex())
+const zIndex = ref(zIndexAllocator.get())
 const titleId = useId()
 const messageId = useId()
 let previouslyFocusedElement: HTMLElement | null = null
@@ -98,7 +101,7 @@ async function forClose(): Promise<void> {
 }
 
 onMounted(() => {
-  zIndex.value = nextZIndex()
+  zIndex.value = zIndexAllocator.next()
   previouslyFocusedElement = document.activeElement as HTMLElement
 
   if (wholeDom.value) {

--- a/packages/tuffex/packages/components/src/drawer/src/TxDrawer.vue
+++ b/packages/tuffex/packages/components/src/drawer/src/TxDrawer.vue
@@ -3,7 +3,10 @@ import type { CSSProperties, Slots } from 'vue'
 import type { DrawerDirection, DrawerEmits, DrawerProps } from './types'
 import { computed, nextTick, onMounted, onUnmounted, ref, useId, useSlots, watch } from 'vue'
 import TxDivider from '../../divider/src/TxDivider.vue'
-import { getZIndex, nextZIndex, refreshZIndex } from '../../../../utils/z-index-manager'
+import { useZIndexAllocator } from '../../../../utils/z-index-manager'
+
+// Resolved in setup: inject is only valid here, while allocation happens later.
+const zIndexAllocator = useZIndexAllocator()
 
 const MOBILE_BREAKPOINT = 768
 const DRAWER_Z_INDEX_SEED = 10000
@@ -45,7 +48,7 @@ const emit = defineEmits<DrawerEmits>()
 const slots: Slots = useSlots()
 
 const drawerRef = ref<HTMLElement | null>(null)
-const internalZIndex = ref(getZIndex())
+const internalZIndex = ref(zIndexAllocator.get())
 const titleId = useId()
 const isMobile = ref(false)
 let previouslyFocusedElement: HTMLElement | null = null
@@ -170,12 +173,12 @@ watch(
   (newVal) => {
     if (newVal) {
       if (props.zIndex != null) {
-        refreshZIndex(props.zIndex, 'drawer(zIndex prop)')
+        zIndexAllocator.refresh(props.zIndex, 'drawer(zIndex prop)')
       }
       else {
-        refreshZIndex(DRAWER_Z_INDEX_SEED, 'drawer')
+        zIndexAllocator.refresh(DRAWER_Z_INDEX_SEED, 'drawer')
       }
-      internalZIndex.value = props.zIndex ?? nextZIndex()
+      internalZIndex.value = props.zIndex ?? zIndexAllocator.next()
       previouslyFocusedElement = typeof document !== 'undefined' ? document.activeElement as HTMLElement : null
       emit('open')
       nextTick(() => {

--- a/packages/tuffex/packages/components/src/flip-overlay/src/TxFlipOverlay.vue
+++ b/packages/tuffex/packages/components/src/flip-overlay/src/TxFlipOverlay.vue
@@ -6,7 +6,7 @@ import TxButton from '../../button/src/button.vue'
 import { computed, nextTick, onBeforeUnmount, ref, useId, useSlots, watch } from 'vue'
 import TxBaseSurface from '../../base-surface/src/TxBaseSurface.vue'
 import { hasWindow } from '../../../../utils/env'
-import { getZIndex, nextZIndex } from '../../../../utils/z-index-manager'
+import { useZIndexAllocator } from '../../../../utils/z-index-manager'
 import {
   lockFlipOverlayBodyScroll,
   unlockFlipOverlayBodyScroll,
@@ -27,6 +27,9 @@ import {
   type FlipOverlayStackEntry,
 } from './flip-overlay-stack'
 import { useFlipOverlayMotion } from './flip-overlay-motion'
+
+// Resolved in setup: inject is only valid here, while allocation happens later.
+const zIndexAllocator = useZIndexAllocator()
 
 defineOptions({
   name: 'TxFlipOverlay',
@@ -75,7 +78,7 @@ const cardRef = ref<HTMLElement | null>(null)
 const visible = ref(Boolean(props.modelValue))
 const expanded = ref(typeof props.expanded === 'boolean' ? props.expanded : false)
 const animating = ref(typeof props.animating === 'boolean' ? props.animating : false)
-const zIndex = ref(getZIndex())
+const zIndex = ref(zIndexAllocator.get())
 const sourceRect = ref<DOMRect | null>(null)
 const sourceRadius = ref<string | null>(null)
 const tilt = ref({ x: 0, y: 0 })
@@ -458,7 +461,7 @@ const {
 })
 
 function requestOpen(): void {
-  zIndex.value = nextZIndex()
+  zIndex.value = zIndexAllocator.next()
   openSequence.value = nextOverlayOpenSequence()
   if (!hasWindow()) {
     visible.value = true

--- a/packages/tuffex/packages/components/src/index.ts
+++ b/packages/tuffex/packages/components/src/index.ts
@@ -1,11 +1,16 @@
 import type { App, Plugin } from 'vue'
 import * as components from './components'
+import { provideZIndexAllocator } from '../../utils/z-index-manager'
 import '../style/index.scss'
 
 export * from './components'
 export * from './utils'
 
 function install(app: App) {
+  // One allocator per app. Vue SSR builds an app per request, so this is what
+  // keeps overlay z-indexes from leaking across requests in a server process.
+  provideZIndexAllocator(app)
+
   for (const key in components) {
     const candidate = (components as Record<string, unknown>)[key] as Plugin | undefined
     // Only values carrying a runtime `install` are plugins. This barrel is

--- a/packages/tuffex/packages/components/src/loading-overlay/src/TxLoadingOverlay.vue
+++ b/packages/tuffex/packages/components/src/loading-overlay/src/TxLoadingOverlay.vue
@@ -3,7 +3,10 @@ import type { CSSProperties } from 'vue'
 import type { LoadingOverlayProps } from '../index'
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import { TxSpinner } from '../../spinner'
-import { getZIndex, nextZIndex } from '../../../../utils/z-index-manager'
+import { useZIndexAllocator } from '../../../../utils/z-index-manager'
+
+// Resolved in setup: inject is only valid here, while allocation happens later.
+const zIndexAllocator = useZIndexAllocator()
 
 defineOptions({
   name: 'TxLoadingOverlay',
@@ -17,7 +20,7 @@ const props = withDefaults(defineProps<LoadingOverlayProps>(), {
   background: 'color-mix(in srgb, var(--tx-bg-color, #fff) 70%, transparent)',
 })
 
-const zIndex = ref(getZIndex())
+const zIndex = ref(zIndexAllocator.get())
 
 const overlayStyle = computed<CSSProperties>(() => {
   return {
@@ -32,7 +35,7 @@ watch(
   () => props.loading && props.fullscreen,
   (open) => {
     if (open) {
-      zIndex.value = nextZIndex()
+      zIndex.value = zIndexAllocator.next()
       // Park focus on the blocking overlay so keyboard users can't Tab to the page
       // behind a fullscreen loading state, and remember where to return afterwards.
       restoreFocus = (document.activeElement as HTMLElement | null) ?? null

--- a/packages/tuffex/packages/components/src/modal/src/TxModal.vue
+++ b/packages/tuffex/packages/components/src/modal/src/TxModal.vue
@@ -1,7 +1,10 @@
 <script lang="ts" setup>
 import { computed, nextTick, onUnmounted, ref, useId, watch } from 'vue'
 import { hasDocument } from '../../../../utils/env'
-import { getZIndex, nextZIndex } from '../../../../utils/z-index-manager'
+import { useZIndexAllocator } from '../../../../utils/z-index-manager'
+
+// Resolved in setup: inject is only valid here, while allocation happens later.
+const zIndexAllocator = useZIndexAllocator()
 
 defineOptions({
   name: 'TxModal',
@@ -29,7 +32,7 @@ const visible = computed({
   set: (v: boolean) => emit('update:modelValue', v),
 })
 
-const zIndex = ref(getZIndex())
+const zIndex = ref(zIndexAllocator.get())
 const overlayRef = ref<HTMLElement | null>(null)
 const titleId = useId()
 let previouslyFocusedElement: HTMLElement | null = null
@@ -38,7 +41,7 @@ watch(
   visible,
   (v) => {
     if (v) {
-      zIndex.value = nextZIndex()
+      zIndex.value = zIndexAllocator.next()
       if (hasDocument())
         previouslyFocusedElement = document.activeElement as HTMLElement
       nextTick(() => {

--- a/packages/tuffex/packages/components/src/picker/src/TxPicker.vue
+++ b/packages/tuffex/packages/components/src/picker/src/TxPicker.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import type { PickerColumn, PickerEmits, PickerProps, PickerValue } from './types'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue'
-import { getZIndex, nextZIndex } from '../../../../utils/z-index-manager'
+import { useZIndexAllocator } from '../../../../utils/z-index-manager'
+
+// Resolved in setup: inject is only valid here, while allocation happens later.
+const zIndexAllocator = useZIndexAllocator()
 
 defineOptions({ name: 'TxPicker' })
 
@@ -29,7 +32,7 @@ const open = computed({
 })
 
 const mountedOnce = ref(false)
-const popupZIndex = ref(getZIndex())
+const popupZIndex = ref(zIndexAllocator.get())
 
 const columns = computed<PickerColumn[]>(() => props.columns ?? [])
 
@@ -302,7 +305,7 @@ watch(
   async (v) => {
     if (v) {
       if (props.popup)
-        popupZIndex.value = nextZIndex()
+        popupZIndex.value = zIndexAllocator.next()
       emit('open')
       mountedOnce.value = true
       await syncScrollPositions('auto')

--- a/packages/tuffex/packages/utils/__tests__/z-index-manager.test.ts
+++ b/packages/tuffex/packages/utils/__tests__/z-index-manager.test.ts
@@ -1,11 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSSRApp, defineComponent, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
 import {
+  DEFAULT_Z_INDEX_SEED,
   configureZIndex,
   getZIndex,
   nextZIndex,
   onZIndexEvent,
   refreshZIndex,
   resetZIndex,
+  createZIndexAllocator,
+  provideZIndexAllocator,
+  useZIndexAllocator,
 } from '../z-index-manager'
 
 describe('z-index-manager', () => {
@@ -89,4 +95,67 @@ describe('z-index-manager', () => {
   })
 })
 
-type TxEventType = 'next' | 'refresh' | 'reset' | 'configure'
+describe('z-index allocator scoping', () => {
+  function probe(seen: number[]) {
+    return defineComponent({
+      setup() {
+        seen.push(useZIndexAllocator().next())
+        return () => h('div')
+      },
+    })
+  }
+
+  it('gives each SSR app its own counter, so one request cannot shift another', async () => {
+    const seen: number[] = []
+
+    // Two SSR apps stand in for two requests handled by the same process: the
+    // module-scope counter used to carry the first request's allocation into
+    // every later one, so the client's cold start never matched.
+    const first = createSSRApp(probe(seen))
+    provideZIndexAllocator(first)
+    await renderToString(first)
+
+    const second = createSSRApp(probe(seen))
+    provideZIndexAllocator(second)
+    await renderToString(second)
+
+    expect(seen).toHaveLength(2)
+    expect(seen[0]).toBe(DEFAULT_Z_INDEX_SEED + 1)
+    expect(seen[1]).toBe(seen[0])
+  })
+
+  it('falls back to the module allocator when no app provided one', async () => {
+    resetZIndex(DEFAULT_Z_INDEX_SEED, 'test')
+    const seen: number[] = []
+
+    // A component rendered outside app.use(Tuffex) must still allocate.
+    await renderToString(createSSRApp(probe(seen)))
+
+    expect(seen[0]).toBe(DEFAULT_Z_INDEX_SEED + 1)
+    expect(getZIndex()).toBe(seen[0])
+  })
+
+  it('shares the module allocator across apps that were never provided one', async () => {
+    resetZIndex(DEFAULT_Z_INDEX_SEED, 'test')
+    const seen: number[] = []
+
+    await renderToString(createSSRApp(probe(seen)))
+    await renderToString(createSSRApp(probe(seen)))
+
+    // This is the pre-fix behaviour, kept explicit: without a provided
+    // allocator the counter is process-wide and keeps climbing. The contrast
+    // with the test above is exactly what install() buys.
+    expect(seen).toEqual([DEFAULT_Z_INDEX_SEED + 1, DEFAULT_Z_INDEX_SEED + 2])
+  })
+
+  it('keeps standalone allocators independent', () => {
+    const one = createZIndexAllocator()
+    const two = createZIndexAllocator()
+
+    one.next()
+    one.next()
+
+    expect(one.get()).toBe(DEFAULT_Z_INDEX_SEED + 2)
+    expect(two.get()).toBe(DEFAULT_Z_INDEX_SEED)
+  })
+})

--- a/packages/tuffex/packages/utils/z-index-manager.ts
+++ b/packages/tuffex/packages/utils/z-index-manager.ts
@@ -1,3 +1,5 @@
+import type { App, InjectionKey } from 'vue'
+import { getCurrentInstance, inject } from 'vue'
 import { hasDocument, hasWindow } from './env'
 
 export interface TxZIndexContext {
@@ -41,28 +43,21 @@ interface ZIndexState {
   listeners: Set<ZIndexListener>
 }
 
-const state: ZIndexState = {
-  seed: DEFAULT_Z_INDEX_SEED,
-  current: DEFAULT_Z_INDEX_SEED,
-  overrides: null,
-  seedSource: null,
-  seedSourceUnsubscribe: null,
-  listeners: new Set(),
+export interface TxZIndexAllocator {
+  configure: (options: {
+    seed?: number
+    overrides?: TxZIndexOverrides
+    seedSource?: TxZIndexSeedSource | null
+  }) => void
+  onEvent: (listener: ZIndexListener) => () => void
+  get: () => number
+  next: () => number
+  refresh: (seed?: number, reason?: string) => number
+  reset: (seed?: number, reason?: string) => number
 }
 
 function isFiniteNumber(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v)
-}
-
-function emitEvent(e: TxZIndexEvent) {
-  state.listeners.forEach((listener) => {
-    try {
-      listener(e)
-    }
-    catch {
-      // ignore listener errors
-    }
-  })
 }
 
 function parseCssZIndex(value: string): number | null {
@@ -88,15 +83,167 @@ function resolveSeedFromCssVar(): number | null {
   return Math.max(DEFAULT_Z_INDEX_SEED, n)
 }
 
-function resolveSeed(inputSeed?: number): number {
-  if (isFiniteNumber(inputSeed))
-    return inputSeed
+/**
+ * Builds an allocator with its own counter.
+ *
+ * The state used to live at module scope. In a Node SSR process that module is
+ * instantiated once and shared by every request, so one request's overlay
+ * allocation shifted the z-index every later request rendered, and the value a
+ * cold client computed never matched (#956).
+ */
+export function createZIndexAllocator(): TxZIndexAllocator {
+  const state: ZIndexState = {
+    seed: DEFAULT_Z_INDEX_SEED,
+    current: DEFAULT_Z_INDEX_SEED,
+    overrides: null,
+    seedSource: null,
+    seedSourceUnsubscribe: null,
+    listeners: new Set(),
+  }
 
-  const fromSource = state.seedSource?.getSeed?.()
-  if (isFiniteNumber(fromSource))
-    return fromSource
+  function emitEvent(e: TxZIndexEvent): void {
+    state.listeners.forEach((listener) => {
+      try {
+        listener(e)
+      }
+      catch {
+        // ignore listener errors
+      }
+    })
+  }
 
-  return resolveSeedFromCssVar() ?? DEFAULT_Z_INDEX_SEED
+  function resolveSeed(inputSeed?: number): number {
+    if (isFiniteNumber(inputSeed))
+      return inputSeed
+
+    const fromSource = state.seedSource?.getSeed?.()
+    if (isFiniteNumber(fromSource))
+      return fromSource
+
+    return resolveSeedFromCssVar() ?? DEFAULT_Z_INDEX_SEED
+  }
+
+  function refresh(seed?: number, reason?: string): number {
+    const prev = state.current
+    const resolvedSeed = resolveSeed(seed)
+
+    state.seed = resolvedSeed
+    state.current = Math.max(state.current, resolvedSeed)
+
+    emitEvent({ type: 'refresh', seed: state.seed, current: state.current, prev, reason })
+    return state.current
+  }
+
+  function reset(seed?: number, reason?: string): number {
+    const prev = state.current
+    const resolvedSeed = resolveSeed(seed)
+
+    state.seed = resolvedSeed
+    state.current = resolvedSeed
+
+    emitEvent({ type: 'reset', seed: state.seed, current: state.current, prev, reason })
+    return state.current
+  }
+
+  function configure(options: {
+    seed?: number
+    overrides?: TxZIndexOverrides
+    seedSource?: TxZIndexSeedSource | null
+  }): void {
+    const prev = state.current
+
+    const hasOverrides = Object.prototype.hasOwnProperty.call(options, 'overrides')
+    const hasSeedSource = Object.prototype.hasOwnProperty.call(options, 'seedSource')
+    const hasSeed = Object.prototype.hasOwnProperty.call(options, 'seed')
+
+    if (hasOverrides) {
+      state.overrides = options.overrides ?? null
+    }
+
+    if (hasSeedSource) {
+      state.seedSourceUnsubscribe?.()
+      state.seedSourceUnsubscribe = null
+      state.seedSource = options.seedSource ?? null
+
+      const src = state.seedSource
+      if (src?.subscribe) {
+        state.seedSourceUnsubscribe = src.subscribe(() => {
+          refresh(undefined, 'seedSource')
+        })
+      }
+    }
+
+    if (hasSeed) {
+      refresh(options.seed, 'configure')
+    }
+    else if (hasSeedSource && state.seedSource) {
+      refresh(undefined, 'configure')
+    }
+
+    emitEvent({ type: 'configure', seed: state.seed, current: state.current, prev })
+  }
+
+  function onEvent(listener: ZIndexListener): () => void {
+    state.listeners.add(listener)
+    return () => state.listeners.delete(listener)
+  }
+
+  function get(): number {
+    const ctx: TxZIndexContext = { seed: state.seed, current: state.current }
+    const overridden = state.overrides?.get?.(ctx)
+    if (isFiniteNumber(overridden))
+      return overridden
+    return state.current
+  }
+
+  function next(): number {
+    const prev = state.current
+    const ctx: TxZIndexContext = { seed: state.seed, current: state.current }
+    const overridden = state.overrides?.next?.(ctx)
+
+    const value = isFiniteNumber(overridden) ? overridden : state.current + 1
+    state.current = value
+
+    emitEvent({ type: 'next', seed: state.seed, current: state.current, prev })
+    return state.current
+  }
+
+  return { configure, onEvent, get, next, refresh, reset }
+}
+
+export const TX_Z_INDEX_ALLOCATOR_KEY: InjectionKey<TxZIndexAllocator>
+  = Symbol('tx-z-index-allocator')
+
+/**
+ * Allocator for callers with no Vue app in scope: the module-level functions
+ * below, tests, and external consumers of the published API.
+ */
+const fallbackAllocator = createZIndexAllocator()
+
+/**
+ * Gives one app its own allocator. Vue SSR builds an app per request, so this
+ * is what makes the counter request-scoped on the server.
+ */
+export function provideZIndexAllocator(
+  app: App,
+  allocator: TxZIndexAllocator = createZIndexAllocator(),
+): TxZIndexAllocator {
+  app.provide(TX_Z_INDEX_ALLOCATOR_KEY, allocator)
+  return allocator
+}
+
+/**
+ * Resolves the app-scoped allocator, falling back to the module-level one when
+ * no app provided it — so a component still works when mounted outside
+ * `app.use(Tuffex)`.
+ *
+ * Call this in `setup` and keep the result: `inject` is only valid there, while
+ * allocation typically happens later from a watcher or event handler.
+ */
+export function useZIndexAllocator(): TxZIndexAllocator {
+  if (!getCurrentInstance())
+    return fallbackAllocator
+  return inject(TX_Z_INDEX_ALLOCATOR_KEY, fallbackAllocator)
 }
 
 export function configureZIndex(options: {
@@ -104,83 +251,25 @@ export function configureZIndex(options: {
   overrides?: TxZIndexOverrides
   seedSource?: TxZIndexSeedSource | null
 }): void {
-  const prev = state.current
-
-  const hasOverrides = Object.prototype.hasOwnProperty.call(options, 'overrides')
-  const hasSeedSource = Object.prototype.hasOwnProperty.call(options, 'seedSource')
-  const hasSeed = Object.prototype.hasOwnProperty.call(options, 'seed')
-
-  if (hasOverrides) {
-    state.overrides = options.overrides ?? null
-  }
-
-  if (hasSeedSource) {
-    state.seedSourceUnsubscribe?.()
-    state.seedSourceUnsubscribe = null
-    state.seedSource = options.seedSource ?? null
-
-    const src = state.seedSource
-    if (src?.subscribe) {
-      state.seedSourceUnsubscribe = src.subscribe(() => {
-        refreshZIndex(undefined, 'seedSource')
-      })
-    }
-  }
-
-  if (hasSeed) {
-    refreshZIndex(options.seed, 'configure')
-  }
-  else if (hasSeedSource && state.seedSource) {
-    refreshZIndex(undefined, 'configure')
-  }
-
-  emitEvent({ type: 'configure', seed: state.seed, current: state.current, prev })
+  fallbackAllocator.configure(options)
 }
 
-export function onZIndexEvent(listener: (e: TxZIndexEvent) => void): () => void {
-  state.listeners.add(listener)
-  return () => state.listeners.delete(listener)
+export function onZIndexEvent(listener: ZIndexListener): () => void {
+  return fallbackAllocator.onEvent(listener)
 }
 
 export function getZIndex(): number {
-  const ctx: TxZIndexContext = { seed: state.seed, current: state.current }
-  const overridden = state.overrides?.get?.(ctx)
-  if (isFiniteNumber(overridden))
-    return overridden
-  return state.current
+  return fallbackAllocator.get()
 }
 
 export function nextZIndex(): number {
-  const prev = state.current
-  const ctx: TxZIndexContext = { seed: state.seed, current: state.current }
-  const overridden = state.overrides?.next?.(ctx)
-
-  const next = isFiniteNumber(overridden) ? overridden : state.current + 1
-  state.current = next
-
-  emitEvent({ type: 'next', seed: state.seed, current: state.current, prev })
-  return state.current
+  return fallbackAllocator.next()
 }
 
 export function refreshZIndex(seed?: number, reason?: string): number {
-  const prev = state.current
-  const resolvedSeed = resolveSeed(seed)
-
-  state.seed = resolvedSeed
-  state.current = Math.max(state.current, resolvedSeed)
-
-  emitEvent({ type: 'refresh', seed: state.seed, current: state.current, prev, reason })
-  return state.current
+  return fallbackAllocator.refresh(seed, reason)
 }
 
 export function resetZIndex(seed?: number, reason?: string): number {
-  const prev = state.current
-  const resolvedSeed = resolveSeed(seed)
-
-  state.seed = resolvedSeed
-  state.current = resolvedSeed
-
-  emitEvent({ type: 'reset', seed: state.seed, current: state.current, prev, reason })
-  return state.current
+  return fallbackAllocator.reset(seed, reason)
 }
-


### PR DESCRIPTION
The root-cause fix for #956, following up PR #1042 which only contained the symptom app-side.

**The leak.** The allocator's counter lived in a module-scope object. A Node SSR process instantiates that module once and shares it across every request, so `TxDrawer` SSR-rendering with `visible: true` permanently moved the shared counter for every subsequent request in that process — and the freshly-loaded client started from the seed, producing a hydration mismatch on the inline `style`.

**The change.**
- `createZIndexAllocator()` builds an allocator closing over its own state; all the existing logic (overrides, seed sources, CSS-var seeding, events) moved inside unchanged.
- `install()` calls `provideZIndexAllocator(app)`, so **each app gets its own counter**. Vue SSR builds one app per request — that is what makes it request-scoped.
- The **11 overlay components** (`TxDrawer`, `TxModal`, `TxBaseAnchor`, `TxCommandPalette`, `TxFlipOverlay`, `TxPicker`, `TxLoadingOverlay` and the four dialogs) resolve it via `useZIndexAllocator()` **in setup** and keep the handle — `inject` is only valid there, while allocation happens later from watchers and handlers.

**Non-breaking.** `getZIndex` / `nextZIndex` / `refreshZIndex` / `resetZIndex` / `configureZIndex` / `onZIndexEvent` are still exported with identical signatures, now delegating to a fallback allocator. External consumers, the existing tests, and a component mounted outside `app.use(Tuffex)` all keep working — the last case is pinned by a test.

**Tests.** Four new ones, rendered through `vue/server-renderer` rather than jsdom so they exercise the actual SSR path:
- two SSR apps with provided allocators both get `seed + 1` — neither shifts the other
- two SSR apps *without* one share the module counter (`+1`, `+2`) — the pre-fix behaviour, kept explicit so the contrast is what `install()` buys, and so a regression to module-sharing is caught
- fallback path allocates when no app provided one
- standalone allocators stay independent

**Honest note on adversarial verification:** these tests fail on baseline with "is not a function" rather than a behavioural mismatch, because the API is new. The behavioural guarantee is the equality assertion in the first test plus the inequality in the second; together they would fail if the allocator ever became shared again.

**One real breakage caught and fixed:** `global-install.test.ts` drives `install()` with a fake app that had no `provide`. Updated.

**Gates:** vue-tsc --noEmit 0 errors · vitest 145 files / 1113 tests green · eslint clean on all changed files. Five suites failed in one full run and every one passed isolated (`virtual-list`, `code-editor`, `context-menu`, `thinking-orb` — the last two being the known canvas/concurrency flakes); the sixth, `global-install`, was the genuine breakage above.

Fixes #956