### PR TITLE
docs(tuffex): sync the README component inventory and guard it (#622, #762)

### DIFF
--- a/packages/tuffex/README.md
+++ b/packages/tuffex/README.md
@@ -67,14 +67,14 @@ import { createToastManager, useVibrate } from '@talex-touch/tuffex/utils'
 
 ## Component Inventory
 
-Current source-of-truth export modules: **102**.
+Current source-of-truth export modules: **126**.
 
-- `Foundation & Navigation (19)`: `alert`, `avatar`, `badge`, `base-anchor`, `base-surface`, `breadcrumb`, `button`, `corner-overlay`, `icon`, `nav-bar`, `outline-border`, `status-badge`, `tab-bar`, `tabs`, `tag`, `tooltip`, `popover`, `dropdown-menu`, `context-menu`
-- `Form & Input (22)`: `cascader`, `checkbox`, `code-editor`, `date-picker`, `flat-button`, `flat-input`, `flat-radio`, `flat-select`, `form`, `input`, `picker`, `radio`, `rating`, `search-input`, `search-select`, `segmented-slider`, `select`, `slider`, `switch`, `tag-input`, `tree-select`, `transfer`
-- `Layout & Structure (12)`: `agents`, `auto-sizer`, `card-item`, `container`, `flex`, `grid`, `grid-layout`, `group-block`, `scroll`, `splitter`, `stack`, `virtual-list`
-- `Data & State (21)`: `blank-slate`, `card`, `collapse`, `data-table`, `empty`, `empty-state`, `error-state`, `guide-state`, `layout-skeleton`, `loading-state`, `markdown-view`, `no-data`, `no-selection`, `offline-state`, `pagination`, `permission-state`, `search-empty`, `stat-card`, `steps`, `timeline`, `tree`
+- `Foundation & Navigation (25)`: `alert`, `avatar`, `badge`, `base-anchor`, `base-surface`, `breadcrumb`, `button`, `copy-button`, `corner-overlay`, `divider`, `icon`, `icon-button`, `kbd`, `nav-bar`, `os-icon`, `outline-border`, `status-badge`, `tab-bar`, `tabs`, `tag`, `tooltip`, `popover`, `dropdown-menu`, `context-menu`, `version-capsule`
+- `Form & Input (26)`: `cascader`, `checkbox`, `code-editor`, `date-picker`, `flat-button`, `flat-dropdown`, `flat-input`, `flat-radio`, `flat-select`, `form`, `input`, `markdown-editor`, `number-input`, `picker`, `radio`, `rating`, `search-input`, `search-select`, `segmented-slider`, `select`, `slider`, `switch`, `textarea`, `tag-input`, `tree-select`, `transfer`
+- `Layout & Structure (13)`: `agents`, `auto-sizer`, `card-item`, `container`, `flex`, `grid`, `grid-layout`, `group-block`, `resize-box`, `scroll`, `splitter`, `stack`, `virtual-list`
+- `Data & State (22)`: `blank-slate`, `card`, `collapse`, `context-indicator`, `data-table`, `empty`, `empty-state`, `error-state`, `guide-state`, `layout-skeleton`, `loading-state`, `markdown-view`, `no-data`, `no-selection`, `offline-state`, `pagination`, `permission-state`, `search-empty`, `stat-card`, `steps`, `timeline`, `tree`
 - `Feedback & Overlay (12)`: `command-palette`, `dialog`, `drawer`, `flip-overlay`, `floating`, `loading-overlay`, `modal`, `progress`, `progress-bar`, `skeleton`, `spinner`, `toast`
-- `AI & Content (4)`: `chat`, `file-uploader`, `image-gallery`, `image-uploader`
+- `AI & Content (16)`: `ai-elements`, `attachment-tray`, `chain-of-thought`, `chat`, `conversation-stream`, `file-uploader`, `image-gallery`, `image-uploader`, `message-actions`, `reasoning-disclosure`, `sources`, `stream-markdown`, `suggestion-chips`, `thinking-orb`, `tool-call-card`, `tool-confirmation`
 - `Animation & Visual (12)`: `edge-fade-mask`, `fusion`, `glass-surface`, `glow-text`, `gradient-border`, `gradual-blur`, `keyframe-stroke-text`, `sortable-list`, `stagger`, `text-transformer`, `transition`, `tuff-logo-stroke`
 
 Reference:

--- a/packages/tuffex/README_ZHCN.md
+++ b/packages/tuffex/README_ZHCN.md
@@ -67,14 +67,14 @@ import { createToastManager, useVibrate } from '@talex-touch/tuffex/utils'
 
 ## 组件梳理
 
-当前源码导出模块总数：**102**。
+当前源码导出模块总数：**126**。
 
-- `基础与导航 (19)`: `alert`, `avatar`, `badge`, `base-anchor`, `base-surface`, `breadcrumb`, `button`, `corner-overlay`, `icon`, `nav-bar`, `outline-border`, `status-badge`, `tab-bar`, `tabs`, `tag`, `tooltip`, `popover`, `dropdown-menu`, `context-menu`
-- `表单与输入 (22)`: `cascader`, `checkbox`, `code-editor`, `date-picker`, `flat-button`, `flat-input`, `flat-radio`, `flat-select`, `form`, `input`, `picker`, `radio`, `rating`, `search-input`, `search-select`, `segmented-slider`, `select`, `slider`, `switch`, `tag-input`, `tree-select`, `transfer`
-- `布局与结构 (12)`: `agents`, `auto-sizer`, `card-item`, `container`, `flex`, `grid`, `grid-layout`, `group-block`, `scroll`, `splitter`, `stack`, `virtual-list`
-- `数据与状态 (21)`: `blank-slate`, `card`, `collapse`, `data-table`, `empty`, `empty-state`, `error-state`, `guide-state`, `layout-skeleton`, `loading-state`, `markdown-view`, `no-data`, `no-selection`, `offline-state`, `pagination`, `permission-state`, `search-empty`, `stat-card`, `steps`, `timeline`, `tree`
+- `基础与导航 (25)`: `alert`, `avatar`, `badge`, `base-anchor`, `base-surface`, `breadcrumb`, `button`, `copy-button`, `corner-overlay`, `divider`, `icon`, `icon-button`, `kbd`, `nav-bar`, `os-icon`, `outline-border`, `status-badge`, `tab-bar`, `tabs`, `tag`, `tooltip`, `popover`, `dropdown-menu`, `context-menu`, `version-capsule`
+- `表单与输入 (26)`: `cascader`, `checkbox`, `code-editor`, `date-picker`, `flat-button`, `flat-dropdown`, `flat-input`, `flat-radio`, `flat-select`, `form`, `input`, `markdown-editor`, `number-input`, `picker`, `radio`, `rating`, `search-input`, `search-select`, `segmented-slider`, `select`, `slider`, `switch`, `textarea`, `tag-input`, `tree-select`, `transfer`
+- `布局与结构 (13)`: `agents`, `auto-sizer`, `card-item`, `container`, `flex`, `grid`, `grid-layout`, `group-block`, `resize-box`, `scroll`, `splitter`, `stack`, `virtual-list`
+- `数据与状态 (22)`: `blank-slate`, `card`, `collapse`, `context-indicator`, `data-table`, `empty`, `empty-state`, `error-state`, `guide-state`, `layout-skeleton`, `loading-state`, `markdown-view`, `no-data`, `no-selection`, `offline-state`, `pagination`, `permission-state`, `search-empty`, `stat-card`, `steps`, `timeline`, `tree`
 - `反馈与浮层 (12)`: `command-palette`, `dialog`, `drawer`, `flip-overlay`, `floating`, `loading-overlay`, `modal`, `progress`, `progress-bar`, `skeleton`, `spinner`, `toast`
-- `AI 与内容 (4)`: `chat`, `file-uploader`, `image-gallery`, `image-uploader`
+- `AI 与内容 (16)`: `ai-elements`, `attachment-tray`, `chain-of-thought`, `chat`, `conversation-stream`, `file-uploader`, `image-gallery`, `image-uploader`, `message-actions`, `reasoning-disclosure`, `sources`, `stream-markdown`, `suggestion-chips`, `thinking-orb`, `tool-call-card`, `tool-confirmation`
 - `动效与视觉 (12)`: `edge-fade-mask`, `fusion`, `glass-surface`, `glow-text`, `gradient-border`, `gradual-blur`, `keyframe-stroke-text`, `sortable-list`, `stagger`, `text-transformer`, `transition`, `tuff-logo-stroke`
 
 参考来源：
@@ -105,3 +105,17 @@ pnpm -C "packages/tuffex" run audit:size
 pnpm -C "packages/tuffex" run audit:exports
 pnpm -C "packages/tuffex" run audit:types
 ```
+
+## 与 Tuff 的关系
+
+TuffEx 是 [Tuff](https://tuff.tagzxia.com) 桌面应用的 UI 基础库。核心应用与外部插件开发者通过这个独立发布的库共享同一套组件。
+
+## 参与贡献
+
+- [提交 Issue](https://github.com/talex-touch/tuff/issues)
+- [功能建议](https://github.com/talex-touch/tuff/discussions)
+- [提交 PR](https://github.com/talex-touch/tuff/pulls)
+
+## 许可证
+
+[MIT License](LICENSE) &copy; 2025 TalexDreamSoul

--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -51,6 +51,7 @@
     "typecheck": "vue-tsc --noEmit -p tsconfig.json",
     "audit:exports": "node ./scripts/audit-package-exports.mjs",
     "audit:types": "node ./scripts/audit-package-types.mjs",
+    "audit:readme": "node ./scripts/audit-readme-inventory.mjs",
     "audit:size": "node ./scripts/audit-package-size.mjs"
   },
   "files": [

--- a/packages/tuffex/scripts/audit-readme-inventory.mjs
+++ b/packages/tuffex/scripts/audit-readme-inventory.mjs
@@ -1,0 +1,89 @@
+// The README component inventory is hand-maintained but claims components.ts as
+// its source of truth, so it drifts silently every time a module is added — it
+// was 24 modules and one whole product family behind when this guard was written.
+// Checks both languages: the count line, the per-category subtotals, and that
+// every exported module appears exactly once.
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+const READMES = [
+  {
+    path: resolve(root, 'README.md'),
+    label: 'README.md',
+    countPattern: /Current source-of-truth export modules: \*\*(\d+)\*\*\./,
+    start: '## Component Inventory',
+    end: '\nReference:',
+  },
+  {
+    path: resolve(root, 'README_ZHCN.md'),
+    label: 'README_ZHCN.md',
+    countPattern: /当前源码导出模块总数：\*\*(\d+)\*\*。/,
+    start: '## 组件梳理',
+    end: '\n参考来源：',
+  },
+]
+
+const source = readFileSync(
+  resolve(root, 'packages/components/src/components.ts'),
+  'utf8',
+)
+const exported = [...source.matchAll(/^export \* from '\.\/([^/]+)\/index'/gm)].map(m => m[1])
+const exportedSet = new Set(exported)
+
+const problems = []
+
+for (const readme of READMES) {
+  const body = readFileSync(readme.path, 'utf8')
+
+  const countMatch = body.match(readme.countPattern)
+  if (!countMatch) {
+    problems.push(`${readme.label}: could not find the module-count line`)
+    continue
+  }
+  if (Number(countMatch[1]) !== exported.length)
+    problems.push(`${readme.label}: claims ${countMatch[1]} modules, components.ts exports ${exported.length}`)
+
+  const startIndex = body.indexOf(readme.start)
+  const endIndex = body.indexOf(readme.end, startIndex)
+  if (startIndex === -1 || endIndex === -1) {
+    problems.push(`${readme.label}: could not locate the inventory block`)
+    continue
+  }
+  const inventory = body.slice(startIndex, endIndex)
+
+  const seen = []
+  for (const line of inventory.split('\n')) {
+    const category = line.match(/^- `.+ \((\d+)\)`: (.+)$/)
+    if (!category)
+      continue
+    const items = [...category[2].matchAll(/`([a-z0-9-]+)`/g)].map(m => m[1])
+    if (items.length !== Number(category[1]))
+      problems.push(`${readme.label}: category "${line.slice(3, line.indexOf('`', 3))}" says ${category[1]} but lists ${items.length}`)
+    seen.push(...items)
+  }
+
+  const missing = exported.filter(name => !seen.includes(name))
+  const unknown = seen.filter(name => !exportedSet.has(name))
+  const duplicated = seen.filter((name, index) => seen.indexOf(name) !== index)
+
+  if (missing.length)
+    problems.push(`${readme.label}: missing ${missing.length} exported module(s): ${missing.join(', ')}`)
+  if (unknown.length)
+    problems.push(`${readme.label}: lists ${unknown.length} module(s) that are not exported: ${unknown.join(', ')}`)
+  if (duplicated.length)
+    problems.push(`${readme.label}: lists module(s) more than once: ${[...new Set(duplicated)].join(', ')}`)
+}
+
+if (problems.length) {
+  console.error('README component inventory is out of sync with components.ts:\n')
+  for (const problem of problems)
+    console.error(`  - ${problem}`)
+  console.error('\nUpdate the inventory lists and the count line in both READMEs.')
+  process.exit(1)
+}
+
+console.log(`README component inventory matches components.ts (${exported.length} modules, both languages).`)


### PR DESCRIPTION
The TuffEx README's Component Inventory claimed **102** modules while `packages/components/src/components.ts` — which the README itself names as the source of truth — exports **126**. The Chinese README repeated the same undercount and was additionally missing three sections.

**The 24 absent modules were not a rounding error** — they were most of the AI surface plus later primitives: `ai-elements`, `attachment-tray`, `chain-of-thought`, `conversation-stream`, `message-actions`, `reasoning-disclosure`, `sources`, `stream-markdown`, `suggestion-chips`, `thinking-orb`, `tool-call-card`, `tool-confirmation`, `context-indicator`, `copy-button`, `divider`, `flat-dropdown`, `icon-button`, `kbd`, `markdown-editor`, `number-input`, `os-icon`, `resize-box`, `textarea`, `version-capsule`. Nothing listed was stale — the drift was purely additive.

Both inventories are **regenerated from the export list**, so the count line, every category subtotal and every module name derive from source rather than being retyped. The Chinese README regains **Integration / Contributing / License**, reaching section parity (9 = 9).

**One thing I checked rather than copied.** The English README's License section says MIT, and the repository root is MPL-2.0 — so mirroring it blindly into the Chinese file risked publishing the wrong licence. `packages/tuffex` ships its **own** `LICENSE` (MIT) and declares `"license": "MIT"` in its `package.json`, so MIT is correct for this package and the root's MPL-2.0 belongs to a different file.

**New guard: `pnpm -C packages/tuffex audit:readme`.** This inventory is hand-maintained but claims a generated source of truth, so it drifts silently on every new module — exactly how it fell 24 behind. The guard fails on a wrong count, a category subtotal that disagrees with its own list, a missing/unknown/duplicated module, in **either** language.

**Adversarially verified — the guard, not just the fix:** with a wrong count it exits 1 reporting `claims 102 … exports 126`; with `thinking-orb` deleted from a list it exits 1 reporting both the subtotal mismatch and the missing module; on a clean tree it exits 0.

**Gates:** guard passes both languages · eslint clean on the added script. (The sibling `audit-package-*.mjs` scripts have pre-existing lint errors; per repo convention I judged the delta and left them untouched.)

Fixes #622
Fixes #762