### PR TITLE
refactor(nexus): drop dead locale branches from live demos (#362)

### DIFF
--- a/apps/nexus/app/components/content/demos/BadgeBadgeVariantsDemo.vue
+++ b/apps/nexus/app/components/content/demos/BadgeBadgeVariantsDemo.vue
@@ -1,15 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-        <TxBadge :value="8" />
-        <TxBadge value="New" variant="primary" />
-        <TxBadge value="99+" variant="success" />
-        <TxBadge dot variant="error" />
-  </div>
-  <div v-else>
+  <div>
         <TxBadge :value="8" />
         <TxBadge value="New" variant="primary" />
         <TxBadge value="99+" variant="success" />

--- a/apps/nexus/app/components/content/demos/EmptyStateEmptyStateHorizontalDemo.vue
+++ b/apps/nexus/app/components/content/demos/EmptyStateEmptyStateHorizontalDemo.vue
@@ -1,18 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-        <TxEmptyState
-          variant="no-selection"
-          layout="horizontal"
-          surface="card"
-          title="No selection"
-          description="Pick an item from the left to continue."
-        />
-  </div>
-  <div v-else>
+  <div>
         <TxEmptyState
           variant="no-selection"
           layout="horizontal"

--- a/apps/nexus/app/components/content/demos/EmptyStateEmptyStateSlotsDemo.vue
+++ b/apps/nexus/app/components/content/demos/EmptyStateEmptyStateSlotsDemo.vue
@@ -1,28 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-        <TxEmptyState variant="custom">
-          <template #icon>
-            <TxIcon name="i-carbon-search" :size="28" />
-          </template>
-          <template #title>
-            Setup required
-          </template>
-          <template #description>
-            Connect a workspace to enable this feature.
-          </template>
-          <template #actions>
-            <TxButton type="primary">
-Connect
-</TxButton>
-            <TxButton>Learn more</TxButton>
-          </template>
-        </TxEmptyState>
-  </div>
-  <div v-else>
+  <div>
         <TxEmptyState variant="custom">
           <template #icon>
             <TxIcon name="i-carbon-search" :size="28" />

--- a/apps/nexus/app/components/content/demos/EmptyStateEmptyStateVariantDemo.vue
+++ b/apps/nexus/app/components/content/demos/EmptyStateEmptyStateVariantDemo.vue
@@ -1,16 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-        <TxEmptyState
-          variant="no-data"
-          :primary-action="{ label: 'Create', type: 'primary' }"
-          :secondary-action="{ label: 'Refresh' }"
-        />
-  </div>
-  <div v-else>
+  <div>
         <TxEmptyState
           variant="no-data"
           :primary-action="{ label: 'Create', type: 'primary' }"

--- a/apps/nexus/app/components/content/demos/FlexFlexDemo.vue
+++ b/apps/nexus/app/components/content/demos/FlexFlexDemo.vue
@@ -1,19 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-      <div style="width: 360px; padding: 16px; border: 1px solid var(--tx-border-color); border-radius: 12px;">
-        <TxFlex justify="space-between" align="center">
-          <TxTag label="Left" />
-          <TxButton variant="primary">
-            Action
-          </TxButton>
-        </TxFlex>
-      </div>
-  </div>
-  <div v-else>
+  <div>
       <div style="width: 360px; padding: 16px; border: 1px solid var(--tx-border-color); border-radius: 12px;">
         <TxFlex justify="space-between" align="center">
           <TxTag label="Left" />

--- a/apps/nexus/app/components/content/demos/GradualBlurGradualBlurDemo.vue
+++ b/apps/nexus/app/components/content/demos/GradualBlurGradualBlurDemo.vue
@@ -1,42 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-      <section style="position: relative; height: 320px; overflow: hidden; border-radius: 12px; border: 1px solid var(--tx-border-color);">
-        <div style="height: 100%; overflow-y: auto; padding: 2rem 1rem; background: linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0));">
-          <div style="font-weight: 600; margin-bottom: 8px;">
-            Scrollable Content
-          </div>
-          <div style="color: var(--tx-text-color-secondary); line-height: 1.7;">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-            <div style="height: 16px;" />
-            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-            <div style="height: 16px;" />
-            Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-            <div style="height: 16px;" />
-            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-            <div style="height: 16px;" />
-            More lines. More lines. More lines. More lines. More lines.
-            <div style="height: 120px;" />
-            Bottom.
-          </div>
-        </div>
-
-        <TxGradualBlur
-          target="parent"
-          position="bottom"
-          height="6rem"
-          :strength="2"
-          :div-count="5"
-          curve="bezier"
-          :exponential="true"
-          :opacity="1"
-        />
-      </section>
-  </div>
-  <div v-else>
+  <div>
       <section style="position: relative; height: 320px; overflow: hidden; border-radius: 12px; border: 1px solid var(--tx-border-color);">
         <div style="height: 100%; overflow-y: auto; padding: 2rem 1rem; background: linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0));">
           <div style="font-weight: 600; margin-bottom: 8px;">

--- a/apps/nexus/app/components/content/demos/GradualBlurResponsiveSizesDemo.vue
+++ b/apps/nexus/app/components/content/demos/GradualBlurResponsiveSizesDemo.vue
@@ -1,33 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-      <section style="position: relative; height: 220px; overflow: hidden; border-radius: 12px; border: 1px solid var(--tx-border-color);">
-        <div style="height: 100%; overflow-y: auto; padding: 1.25rem 1rem;">
-          <div style="font-weight: 600; margin-bottom: 8px;">
-            Resize window to see height changes
-          </div>
-          <div style="color: var(--tx-text-color-secondary); line-height: 1.7;">
-            desktop/tablet/mobile heights can be configured.
-            <div style="height: 220px;" />
-            End.
-          </div>
-        </div>
-
-        <TxGradualBlur
-          position="bottom"
-          :strength="2"
-          responsive
-          height="6rem"
-          mobile-height="4rem"
-          tablet-height="5rem"
-          desktop-height="7rem"
-        />
-      </section>
-  </div>
-  <div v-else>
+  <div>
       <section style="position: relative; height: 220px; overflow: hidden; border-radius: 12px; border: 1px solid var(--tx-border-color);">
         <div style="height: 100%; overflow-y: auto; padding: 1.25rem 1rem;">
           <div style="font-weight: 600; margin-bottom: 8px;">

--- a/apps/nexus/app/components/content/demos/LayoutSkeletonLayoutPlaceholderDemo.vue
+++ b/apps/nexus/app/components/content/demos/LayoutSkeletonLayoutPlaceholderDemo.vue
@@ -1,14 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-        <div style="height: 240px;">
-          <TxLayoutSkeleton />
-        </div>
-  </div>
-  <div v-else>
+  <div>
         <div style="height: 240px;">
           <TxLayoutSkeleton />
         </div>

--- a/apps/nexus/app/components/content/demos/LayoutSkeletonPanelPlaceholderDemo.vue
+++ b/apps/nexus/app/components/content/demos/LayoutSkeletonPanelPlaceholderDemo.vue
@@ -1,14 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-        <TxCard>
-          <TxLayoutSkeleton />
-        </TxCard>
-  </div>
-  <div v-else>
+  <div>
         <TxCard>
           <TxLayoutSkeleton />
         </TxCard>

--- a/apps/nexus/app/components/content/demos/ScrollScrollBounceAlwaysShowScrollbarDemo.vue
+++ b/apps/nexus/app/components/content/demos/ScrollScrollBounceAlwaysShowScrollbarDemo.vue
@@ -1,25 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-      <div class="demo-container" style="height: 220px;">
-        <div style="height: 100%;">
-          <TxScroll :bounce="true" :scrollbar-always-visible="true" style="height: 100%;">
-            <div style="height: 160px; display: flex; flex-direction: column; gap: 8px;">
-              <div class="demo-scroll-item">
-                Short content
-              </div>
-              <div class="demo-scroll-item">
-                No boundary but scrollbar should be visible
-              </div>
-            </div>
-          </TxScroll>
-        </div>
-      </div>
-  </div>
-  <div v-else>
+  <div>
       <div class="demo-container" style="height: 220px;">
         <div style="height: 100%;">
           <TxScroll :bounce="true" :scrollbar-always-visible="true" style="height: 100%;">

--- a/apps/nexus/app/components/content/demos/SkeletonCardPlaceholderDemo.vue
+++ b/apps/nexus/app/components/content/demos/SkeletonCardPlaceholderDemo.vue
@@ -1,14 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-        <TxCard>
-          <TxSkeleton :loading="true" :lines="2" />
-        </TxCard>
-  </div>
-  <div v-else>
+  <div>
         <TxCard>
           <TxSkeleton :loading="true" :lines="2" />
         </TxCard>

--- a/apps/nexus/app/components/content/demos/SpinnerSpinnerDemo.vue
+++ b/apps/nexus/app/components/content/demos/SpinnerSpinnerDemo.vue
@@ -1,12 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-      <TxSpinner />
-  </div>
-  <div v-else>
+  <div>
       <TxSpinner />
   </div>
 </template>

--- a/apps/nexus/app/components/content/demos/SpinnerSpinnerSizesDemo.vue
+++ b/apps/nexus/app/components/content/demos/SpinnerSpinnerSizesDemo.vue
@@ -1,17 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-      <div style="display: flex; gap: 12px; align-items: center;">
-        <TxSpinner :size="12" />
-        <TxSpinner :size="16" />
-        <TxSpinner :size="24" />
-        <TxSpinner :size="32" />
-      </div>
-  </div>
-  <div v-else>
+  <div>
       <div style="display: flex; gap: 12px; align-items: center;">
         <TxSpinner :size="12" />
         <TxSpinner :size="16" />

--- a/apps/nexus/app/components/content/demos/StackStackDemo.vue
+++ b/apps/nexus/app/components/content/demos/StackStackDemo.vue
@@ -1,22 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-      <div style="width: 360px; padding: 16px; border: 1px solid var(--tx-border-color); border-radius: 12px;">
-        <TxStack :gap="10">
-          <TxButton>One</TxButton>
-          <TxButton variant="secondary">
-            Two
-          </TxButton>
-          <TxButton variant="ghost">
-            Three
-          </TxButton>
-        </TxStack>
-      </div>
-  </div>
-  <div v-else>
+  <div>
       <div style="width: 360px; padding: 16px; border: 1px solid var(--tx-border-color); border-radius: 12px;">
         <TxStack :gap="10">
           <TxButton>One</TxButton>

--- a/apps/nexus/app/components/content/demos/TypingIndicatorTypingIndicatorDemo.vue
+++ b/apps/nexus/app/components/content/demos/TypingIndicatorTypingIndicatorDemo.vue
@@ -1,12 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-        <TxTypingIndicator />
-  </div>
-  <div v-else>
+  <div>
         <TxTypingIndicator />
   </div>
 </template>

--- a/apps/nexus/app/components/content/demos/TypingIndicatorTypingIndicatorVariantsDemo.vue
+++ b/apps/nexus/app/components/content/demos/TypingIndicatorTypingIndicatorVariantsDemo.vue
@@ -1,56 +1,5 @@
-<script setup lang="ts">
-const { locale } = useI18n()
-</script>
-
 <template>
-  <div v-if="locale === 'zh'">
-      <div style="display: flex; flex-direction: column; gap: 10px;">
-        <div style="display: flex; align-items: center; gap: 12px; padding: 8px 10px; border: 1px solid var(--tx-border-color-light); border-radius: 12px;">
-          <code style="width: 90px; color: var(--tx-text-color-secondary);">dots</code>
-          <TxTypingIndicator text="Typing…" />
-          <TxTypingIndicator :show-text="false" />
-        </div>
-
-        <div style="display: flex; align-items: center; gap: 12px; padding: 8px 10px; border: 1px solid var(--tx-border-color-light); border-radius: 12px;">
-          <code style="width: 90px; color: var(--tx-text-color-secondary);">ai</code>
-          <TxTypingIndicator variant="ai" text="Generating…" />
-          <TxTypingIndicator variant="ai" :loader-size="32" text="32px" />
-          <TxTypingIndicator variant="ai" :loader-size="24" :show-text="false" />
-        </div>
-
-        <div style="display: flex; align-items: center; gap: 12px; padding: 8px 10px; border: 1px solid var(--tx-border-color-light); border-radius: 12px;">
-          <code style="width: 90px; color: var(--tx-text-color-secondary);">pure</code>
-          <TxTypingIndicator variant="pure" text="Loading" />
-          <TxTypingIndicator variant="pure" :pure-size="12" text="12px" />
-          <div style="display: inline-flex; gap: 6px; align-items: center; color: var(--tx-text-color-secondary);">
-            <span style="width: 16px; height: 16px; border-radius: 4px; background: var(--tx-fill-color); display: inline-block;" />
-            <TxTypingIndicator variant="pure" :pure-size="12" :show-text="false" />
-            <span style="font-size: 12px;">Icon</span>
-          </div>
-        </div>
-
-        <div style="display: flex; align-items: center; gap: 12px; padding: 8px 10px; border: 1px solid var(--tx-border-color-light); border-radius: 12px;">
-          <code style="width: 90px; color: var(--tx-text-color-secondary);">ring</code>
-          <TxTypingIndicator variant="ring" :show-text="false" />
-          <TxTypingIndicator variant="ring" :ring-size="14" :show-text="false" />
-          <TxTypingIndicator variant="ring" :ring-size="22" :ring-thickness="3" :show-text="false" />
-        </div>
-
-        <div style="display: flex; align-items: center; gap: 12px; padding: 8px 10px; border: 1px solid var(--tx-border-color-light); border-radius: 12px;">
-          <code style="width: 90px; color: var(--tx-text-color-secondary);">circle-dash</code>
-          <TxTypingIndicator variant="circle-dash" :show-text="false" />
-          <TxTypingIndicator variant="circle-dash" :circle-dash-size="14" :show-text="false" />
-          <TxTypingIndicator variant="circle-dash" :circle-dash-size="22" :circle-dash-thickness="3" :circle-dash-dash-deg="10" :circle-dash-gap-deg="10" :show-text="false" />
-        </div>
-
-        <div style="display: flex; align-items: center; gap: 12px; padding: 8px 10px; border: 1px solid var(--tx-border-color-light); border-radius: 12px;">
-          <code style="width: 90px; color: var(--tx-text-color-secondary);">bars</code>
-          <TxTypingIndicator variant="bars" :show-text="false" />
-          <TxTypingIndicator variant="bars" :bars-size="16" :show-text="false" />
-        </div>
-      </div>
-  </div>
-  <div v-else>
+  <div>
       <div style="display: flex; flex-direction: column; gap: 10px;">
         <div style="display: flex; align-items: center; gap: 12px; padding: 8px 10px; border: 1px solid var(--tx-border-color-light); border-radius: 12px;">
           <code style="width: 90px; color: var(--tx-text-color-secondary);">dots</code>


### PR DESCRIPTION
Found while surveying the demo surface for umbrella #362.

**77 of 309 live demos** wrap their markup in a `locale === 'zh'` / `v-else` pair. In **51** of them the two branches are **byte-identical**, so `useI18n` is imported purely to choose between two copies of the same thing.

This PR lands the **16** of those that are actually live (registered in `demo-registry.ts` or referenced from `content/`). The retained branch is kept byte-identical — only the `v-if` attribute and the `v-else` sibling are removed — so nothing about what renders changes.

**Measured delta on exactly these 16 files:** eslint `348 errors → 174 errors`, 0 warnings, none introduced. The near-halving is itself the evidence that the removed branch was a duplicate: the same violations were being counted twice.

**Two corrections I made mid-way, worth recording:**
1. My first transform de-indented the retained branch by 2, which produced 182 fresh `vue/html-indent` errors. Redone to preserve the original indentation exactly.
2. It also touched 16 files that are themselves orphans. Those are reverted — they are part of the pending deletion decision on #362, and editing them would either be wasted or would prejudge that call.

**Gates:** `check:mdc-fences` exit 0 · all 16 demos verified still reachable (registry or doc reference) · no leftover `useI18n`/`locale` references in the changed files.

Refs #362