### PR TITLE
build: put every @types/node declaration on one catalog entry (#575)

### DIFF
--- a/packages/tuff-cli-core/package.json
+++ b/packages/tuff-cli-core/package.json
@@ -45,7 +45,7 @@
     "@types/cli-progress": "^3.11.6",
     "@types/fs-extra": "^11.0.4",
     "@types/glob": "^8.1.0",
-    "@types/node": "^18.19.130",
+    "@types/node": "catalog:dev",
     "eslint": "^9.39.4",
     "rimraf": "^5.0.10",
     "tsup": "^8.5.1",

--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -92,7 +92,7 @@
     "@types/gulp": "^4.0.18",
     "@types/gulp-autoprefixer": "^0.0.37",
     "@types/gulp-sass": "^5.0.4",
-    "@types/node": "^22.20.0",
+    "@types/node": "catalog:dev",
     "@vitejs/plugin-vue": "^6.0.7",
     "chalk": "^5.6.2",
     "dotenv": "^16.6.1",

--- a/packages/unplugin-export-plugin/package.json
+++ b/packages/unplugin-export-plugin/package.json
@@ -75,7 +75,7 @@
     "@antfu/eslint-config": "^5.4.1",
     "@types/debug": "^4.1.13",
     "@types/fs-extra": "^11.0.4",
-    "@types/node": "^18.19.130",
+    "@types/node": "catalog:dev",
     "bumpp": "^11.1.0",
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",

--- a/plugins/touch-translation/package.json
+++ b/plugins/touch-translation/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@antfu/eslint-config": "^5.4.1",
     "@iconify-json/carbon": "^1.2.24",
-    "@types/node": "^24.13.2",
+    "@types/node": "catalog:dev",
     "@unocss/eslint-config": "^66.7.5",
     "@unocss/eslint-plugin": "^66.7.5",
     "@unocss/reset": "^66.7.5",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -84,6 +84,7 @@ catalogs:
   dev:
     '@antfu/eslint-config': ^5.4.1
     '@cloudflare/workers-types': ^4.20260702.1
+    '@types/node': ^24.13.2
     baseline-browser-mapping: ^2.10.43
     eslint: ^9.39.4
     eslint-plugin-format: ^1.5.0


### PR DESCRIPTION
The monorepo declared **three** `@types/node` baselines — `^18.19.130` (tuff-cli-core, unplugin-export-plugin), `^22.20.0` (tuffex), `^24.13.2` (touch-translation) — which the root `pnpm.overrides` entry `"@types/node": "24.13.2"` silently collapsed to one version. None of the declarations described what was actually installed.

This matters for tuffex specifically: its `tsconfig.json` sets `"types": ["vite/client", "node"]`, so `vue-tsc` has always resolved **24.x** while the manifest claimed 22.x. Building tuffex standalone for the npm publish workflow — or removing the override — would swap the ambient Node typings under every component, surfacing errors CI has never seen.

All four packages now point at a single `catalog:dev` entry pinned to `^24.13.2`, the version that was already resolving.

**Verified lockfile-neutral, not assumed.** I snapshotted `pnpm-lock.yaml`, ran `pnpm install --lockfile-only`, and diffed: **byte-identical**. The reason is visible in the lockfile — every importer already recorded `specifier: 24.13.2`, because the override rewrites the specifier before resolution. So this PR makes the manifests honest and changes no resolution, no download, no installed tree.

**Scope note:** the root override is **kept**. The audit called it redundant, but it also pins *transitive* `@types/node` requests, which the catalog does not — removing it is a separate change with a different blast radius, and this PR deliberately does not take it.

**Gates:** `pnpm install --lockfile-only` exits 0 with a zero-line lockfile diff · all four manifests remain valid JSON · tuffex `vue-tsc --noEmit` 0 errors.

Fixes #575