### PR TITLE
fix(tuffex): scope dist/lib as CommonJS so require() consumers can load it (#565)

### DIFF
--- a/packages/tuffex/packages/script/build/index.ts
+++ b/packages/tuffex/packages/script/build/index.ts
@@ -76,6 +76,24 @@ export const buildStyleEntry = async () => {
   await writeFile(resolve(distPath, 'style.css'), '@import "./es/components.css";\n')
 }
 
+/**
+ * The package declares `"type": "module"`, so Node parses every `.js` under it as
+ * ESM — including `dist/lib`, which the component build emits as CommonJS. Any
+ * consumer resolving the `require` condition therefore died on load with
+ * "exports is not defined in ES module scope".
+ *
+ * Scoping the subtree with its own manifest is the fix that does not touch the
+ * emitted code: renaming to `.cjs` would also mean rewriting every internal
+ * `require('./x.js')` specifier the build produces.
+ */
+export const writeCjsScopeManifest = async () => {
+  await mkdir(resolve(distPath, 'lib'), { recursive: true })
+  await writeFile(
+    resolve(distPath, 'lib/package.json'),
+    `${JSON.stringify({ type: 'commonjs' }, null, 2)}\n`,
+  )
+}
+
 const build: TaskFunction = series(
   async () => removeDist(),
   parallel(
@@ -86,6 +104,7 @@ const build: TaskFunction = series(
   async () => fixComponentDeclarations(),
   async () => buildComponentStyles(),
   async () => buildStyleEntry(),
+  async () => writeCjsScopeManifest(),
 )
 
 export default build


### PR DESCRIPTION
`packages/tuffex` declares `"type": "module"`, so Node parses every `.js` beneath it as ESM — including `dist/lib`, which the component build emits as CommonJS (`'use strict'`, `exports`, `require('./components.js')`) and which **both** `"main"` and the `"require"` export condition point at. Every CJS consumer of the published package broke at load.

The build now writes `dist/lib/package.json` = `{"type":"commonjs"}` as its final step, scoping that subtree back to CommonJS.

**Why the manifest and not `.cjs`.** Renaming the output would also mean rewriting every internal `require('./x.js')` specifier the build emits, since the CJS chunks reference each other by `.js`. The manifest fixes the same problem without touching a byte of emitted code.

**Reproduced and verified against the real `dist`**, on Node v24.18.0, in a scratch copy of the package:

| | `require('./dist/lib/index.js')` | `import('./dist/es/index.js')` |
|---|---|---|
| without the marker | **fails** | ok |
| with the marker | **ok — 358 exports** | ok — 358 exports |

The subpath condition was checked too: `require('./dist/lib/utils/index.js')` returns 28 exports with the marker.

**One correction to the issue text.** It reports the failure as `exports is not defined in ES module scope`. On Node 24.18.0 the observed error is instead `Error: Cannot find module './components.js'` with `Require stack: … [eval]` — because Node 24 supports `require(esm)`, so it does not reject the file outright; the CJS `require` calls *inside* the ESM-parsed module resolve against the wrong context. Different symptom, same defect and same fix. Recording it so nobody later concludes the issue was misfiled.

**Gates:** the new build task was executed directly and emits the expected file; eslint reports no errors (the build script sits in an ignore pattern, same as before this change).

Fixes #565