### PR TITLE
ci: survive an unreachable before-sha in the package publish workflows (#563)

### DIFF
--- a/.github/workflows/package-tuff-intelligence-publish.yml
+++ b/.github/workflows/package-tuff-intelligence-publish.yml
@@ -58,7 +58,17 @@ jobs:
             exit 0
           fi
 
-          previous_version=$(git show "${before_sha}:packages/tuff-intelligence/package.json" | node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync(0,'utf8')); console.log(pkg.version)")
+          # A force-push (or any branch rewrite) leaves github.event.before pointing at a
+          # commit that is not in the fetched history. Under `set -e`/pipefail an
+          # unguarded `git show` then fails the whole version check, so a real version
+          # bump in that same push is silently never published. Treat an unreachable
+          # before-sha as "no previous version", matching package-tuff-cli-publish.yml.
+          if git cat-file -e "${before_sha}^{commit}" >/dev/null 2>&1; then
+            previous_version=$(git show "${before_sha}:packages/tuff-intelligence/package.json" 2>/dev/null | node -e "const fs=require('fs'); const input=fs.readFileSync(0,'utf8'); if(!input){process.exit(0)}; const pkg=JSON.parse(input); console.log(pkg.version)" || true)
+          else
+            echo "Previous commit ${before_sha} is unreachable (force-push?); treating as no previous version."
+            previous_version=""
+          fi
           echo "previous_version=${previous_version}" >> "$GITHUB_OUTPUT"
 
           if [ "${current_version}" != "${previous_version}" ] || [ "${npm_has_version}" != "true" ]; then

--- a/.github/workflows/package-tuffex-publish.yml
+++ b/.github/workflows/package-tuffex-publish.yml
@@ -61,7 +61,17 @@ jobs:
             exit 0
           fi
 
-          previous_version=$(git show "$before_sha:packages/tuffex/package.json" | node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync(0,'utf8')); console.log(pkg.version)")
+          # A force-push (or any branch rewrite) leaves github.event.before pointing at a
+          # commit that is not in the fetched history. Under `set -e`/pipefail an
+          # unguarded `git show` then fails the whole version check, so a real version
+          # bump in that same push is silently never published. Treat an unreachable
+          # before-sha as "no previous version", matching package-tuff-cli-publish.yml.
+          if git cat-file -e "$before_sha^{commit}" >/dev/null 2>&1; then
+            previous_version=$(git show "$before_sha:packages/tuffex/package.json" 2>/dev/null | node -e "const fs=require('fs'); const input=fs.readFileSync(0,'utf8'); if(!input){process.exit(0)}; const pkg=JSON.parse(input); console.log(pkg.version)" || true)
+          else
+            echo "Previous commit $before_sha is unreachable (force-push?); treating as no previous version."
+            previous_version=""
+          fi
           echo "previous_version=$previous_version" >> "$GITHUB_OUTPUT"
 
           if [ "$current_version" != "$previous_version" ] || [ "${npm_has_version}" != "true" ]; then

--- a/.github/workflows/package-utils-publish.yml
+++ b/.github/workflows/package-utils-publish.yml
@@ -57,7 +57,17 @@ jobs:
             exit 0
           fi
 
-          previous_version=$(git show "${before_sha}:packages/utils/package.json" | node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync(0,'utf8')); console.log(pkg.version)")
+          # A force-push (or any branch rewrite) leaves github.event.before pointing at a
+          # commit that is not in the fetched history. Under `set -e`/pipefail an
+          # unguarded `git show` then fails the whole version check, so a real version
+          # bump in that same push is silently never published. Treat an unreachable
+          # before-sha as "no previous version", matching package-tuff-cli-publish.yml.
+          if git cat-file -e "${before_sha}^{commit}" >/dev/null 2>&1; then
+            previous_version=$(git show "${before_sha}:packages/utils/package.json" 2>/dev/null | node -e "const fs=require('fs'); const input=fs.readFileSync(0,'utf8'); if(!input){process.exit(0)}; const pkg=JSON.parse(input); console.log(pkg.version)" || true)
+          else
+            echo "Previous commit ${before_sha} is unreachable (force-push?); treating as no previous version."
+            previous_version=""
+          fi
           echo "previous_version=${previous_version}" >> "$GITHUB_OUTPUT"
 
           if [ "${current_version}" != "${previous_version}" ] || [ "${npm_has_version}" != "true" ]; then


### PR DESCRIPTION
The version-check step ran `git show "$before_sha:<pkg>/package.json"` unguarded under `set -e`/`pipefail`. After a force-push — or any branch rewrite that orphans the previous head — `github.event.before` points at a commit that is not in the fetched history. `git show` exits non-zero, the step fails, and **a genuine version bump in that same push is never published**, with a bare git error as the only clue.

Adopts the `git cat-file -e` guard that `package-tuff-cli-publish.yml` already carries, treating an unreachable before-sha as "no previous version" (which makes the workflow publish rather than silently skip). The node reader is also hardened against empty stdin the same way that sibling does — otherwise `JSON.parse('')` throws on the empty-output path.

**Scope: three workflows, not two.** The issue named `package-utils-publish.yml` and `package-tuffex-publish.yml`. `package-tuff-intelligence-publish.yml:61` has the identical unguarded call, so it is fixed here too — fixing two of three would have left the same latent break in place for no reason. `package-tuff-cli-publish.yml` was already correct and is untouched.

**Behaviour verified in a scratch git repo**, running the exact injected block:

| before-sha | result |
|---|---|
| reachable | `previous_version=[1.0.0]`, exit 0 |
| unreachable (force-push case) | guard branch taken, `previous_version=[]`, exit 0 |
| unreachable, **old unguarded code** | node crashes on `JSON.parse('')` after `git show` fails |

**Gates:** all four workflow files parse; each injected block extracted and checked with `bash -n`.

Fixes #563