### PR TITLE
ci: run lint, test and typecheck for the tuffex package (#542)

### DIFF
--- a/.github/workflows/package-tuffex-ci.yml
+++ b/.github/workflows/package-tuffex-ci.yml
@@ -31,8 +31,8 @@ jobs:
     with:
       package-name: tuffex
       package-path: packages/tuffex
-      run-typecheck: false # Add if typecheck script exists
-      run-lint: false # Add if lint script exists
-      run-test: false # Add if test script exists
+      run-typecheck: true
+      run-lint: true
+      run-test: true
       run-build: true
       build-command: pnpm build


### PR DESCRIPTION
`package-tuffex-ci.yml` called the reusable workflow with `run-typecheck`, `run-lint` and `run-test` all `false`, each carrying an inline comment claiming the script does not exist. All three **do** exist in `packages/tuffex/package.json`. The only gate the component library actually had was `pnpm build` — so a PR that broke a unit test or introduced a `vue-tsc` error passed CI as long as Vite emitted output, and the failure surfaced later in `apps/core-app`'s `typecheck:web` (which builds tuffex from source) or after release.

**Verified green before flipping**, running each exactly as the reusable workflow does:

| gate | command | result |
|---|---|---|
| lint | `pnpm exec eslint --cache .` | exit 0, 0 errors, 0 warnings |
| typecheck | `pnpm exec vue-tsc --noEmit -p tsconfig.json` | exit 0 |
| test | `pnpm exec vitest run` | exit 0, 147 files / 1102 tests |

Enabling a gate that is already red would have blocked every PR, so this mattered more than the one-line diff suggests. Worth noting the typecheck gate is now also stricter than when this issue was filed — `noUncheckedIndexedAccess` was enabled in #1041.

**Checked the siblings rather than assuming.** `package-unplugin-ci.yml` carries the same `# Add if typecheck script exists` comment, but `unplugin-export-plugin` genuinely has **no** typecheck script — its `false` is correct, not stale, so it is left alone. Only tuffex's comments were false.

Fixes #542