### PR TITLE
fix(tuffex): only treat src directories with an index.ts as build entries

### DIFF
--- a/packages/tuffex/packages/components/vite.config.js
+++ b/packages/tuffex/packages/components/vite.config.js
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
@@ -12,9 +12,14 @@ const externalDeps = Array.from(
     ...Object.keys(pkg.peerDependencies ?? {})
   ])
 )
+// Every directory under src/ was treated as a component and required to have an
+// index.ts, so adding any non-component directory (a shared __tests__ folder,
+// for example) broke the whole build with an unresolved-entry error. Only take
+// directories that actually expose an entry.
 const componentEntries = Object.fromEntries(
   readdirSync(new URL('./src', import.meta.url), { withFileTypes: true })
     .filter(dirent => dirent.isDirectory() && dirent.name !== 'utils')
+    .filter(dirent => existsSync(new URL(`./src/${dirent.name}/index.ts`, import.meta.url)))
     .map(dirent => [`${dirent.name}/index`, `./src/${dirent.name}/index.ts`])
 )
 

--- a/packages/tuffex/packages/script/build/component-styles.ts
+++ b/packages/tuffex/packages/script/build/component-styles.ts
@@ -1,5 +1,5 @@
+import { existsSync, readFileSync } from 'node:fs'
 import { readdir, rm, mkdir, writeFile } from 'node:fs/promises'
-import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import vue from '@vitejs/plugin-vue'
@@ -57,7 +57,13 @@ async function getComponentEntries() {
   for (const dirent of dirents) {
     if (!dirent.isDirectory() || dirent.name === 'utils')
       continue
-    entries[dirent.name] = resolve(componentSrcRoot, dirent.name, 'index.ts')
+    // Not every directory under src/ is a component — a shared __tests__ folder
+    // has no index.ts, and listing it as an entry fails the whole build with an
+    // unresolved-entry error. Mirrors the same guard in components/vite.config.js.
+    const entry = resolve(componentSrcRoot, dirent.name, 'index.ts')
+    if (!existsSync(entry))
+      continue
+    entries[dirent.name] = entry
   }
 
   return entries


### PR DESCRIPTION
**`pnpm -C packages/tuffex build` is currently broken on `app-shell-v2`, and it is my regression.** Reporting it plainly because it is not theoretical: `apps/core-app`'s `typecheck:web` and `apps/nexus`'s `build` both run the tuffex build first, so all three are down together.

**Cause.** Two entry builders — `packages/components/vite.config.js` and the style pass in `packages/script/build/component-styles.ts` — listed *every* directory under `src/` except `utils` as a component and demanded `<dir>/index.ts`. The shared `src/__tests__/` folder I added in PR #1035 (issue #952) has no `index.ts`, so Rollup failed with `Could not resolve entry module "./src/__tests__/index.ts"`.

**Why CI did not catch it.** `package-tuffex-ci.yml` triggers only on `master`/`main`; every PR in this sweep targets `app-shell-v2`, so the build gate never ran on them. Enabling the other gates in #1050 does not change that — the trigger branches are a separate gap, and I have not widened this PR to cover it.

**Fix.** Skip directories that expose no entry rather than assuming every directory is a component. Both sites, because fixing one only moves the failure to the other — which is exactly what happened: hardening the vite config alone left the style pass failing on the same path.

**Verified by running the real build**, not by reasoning:

| | before | after |
|---|---|---|
| `pnpm build` | exit 1, `Could not resolve entry module` | **exit 0** |
| artifacts | partial | `dist/es/index.js`, `dist/lib/index.js`, `dist/style.css`, `dist/lib/package.json` |
| `dist/es` entries | — | 137, no `__tests__` leaked into output |
| `require('./dist/lib/index.js')` | — | ok, 359 exports |

That last row also gives #565's `dist/lib/package.json` fix its first end-to-end confirmation in a real build rather than a hand-assembled copy.

**The new CI gate immediately earned its keep.** My first version of this fix added `import { existsSync } from 'node:fs'` to a file that already imported `node:fs`, introducing two `import/no-duplicates` errors. The **package-local** lint (`pnpm exec eslint --cache .`, which is what #1050 just wired into CI) caught them; linting the same files from the repo root did not, because the root config reports a different, pre-existing set of style errors on `vite.config.js`. Imports merged; package lint now exits 0.

**Gates:** full tuffex build exit 0 · `pnpm exec eslint --cache .` exit 0 (package-local, the config CI uses).