### PR TITLE
build(tuffex): run the gulpfile through module.register instead of --loader (#601)

### DIFF
--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -45,7 +45,7 @@
     }
   },
   "scripts": {
-    "build": "node --loader ts-node/esm ./node_modules/gulp/bin/gulp.js -f packages/script/build/index.ts",
+    "build": "node --import ./scripts/register-ts-node.mjs ./node_modules/gulp/bin/gulp.js -f packages/script/build/index.ts",
     "build:vite": "vite build",
     "dev": "vite build --watch",
     "lint": "pnpm exec eslint --cache .",

--- a/packages/tuffex/scripts/register-ts-node.mjs
+++ b/packages/tuffex/scripts/register-ts-node.mjs
@@ -1,0 +1,8 @@
+// The build gulpfile is TypeScript, so the runner needs a TS loader. `--loader`
+// is the deprecated flag Node warns about and plans to remove; this is the
+// supported entry point it points at, keeping ts-node as the transformer so the
+// emitted bundle is unchanged.
+import { register } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+register('ts-node/esm', pathToFileURL('./'))


### PR DESCRIPTION
The component-library build ran `node --loader ts-node/esm …`, the experimental ESM loader-hook flag Node warns about and plans to remove. Once it goes, `pnpm tuffex:build` fails with an unknown-option error — and every downstream build with it: `apps/core-app`'s `typecheck:web` and `apps/nexus`'s `build` both build tuffex from source first.

Switched to `node --import ./scripts/register-ts-node.mjs`, which uses `module.register()` — the supported entry point the deprecation message itself names — and **keeps ts-node as the transformer**, so nothing about the emitted code changes.

**Verified byte-identical output, not just "it builds":**

| | baseline (`--loader`) | after (`--import`) |
|---|---|---|
| exit | 0 | 0 |
| dist files | 1788 | 1788 |
| fingerprint (sha of all file shas) | `6e9b34fe91416625` | **`6e9b34fe91416625`** |
| `--experimental-loader` warning | present | **gone** |
| `require('./dist/lib/index.js')` | — | ok, 359 exports |

**esno and tsx were tried first and rejected.** Both are already devDependencies and both remove the warning, but both **break the build**: the main vite pass succeeds and then the in-process style pass (`component-styles.ts` calling Vite's programmatic `build()`) dies with `[vite:build-import-analysis] Cannot read properties of undefined (reading 'get')`. Swapping the transformer is not a drop-in here; swapping only the loader mechanism is.

**Residual warning, deliberately left.** `DeprecationWarning: fs.Stats constructor is deprecated` still appears — it comes from **ts-node's own internals**, not from this invocation, so it cannot be fixed without replacing ts-node, which the paragraph above shows is not currently viable. It is one of the items tracked by umbrella #336 and is called out here so nobody reads the remaining warning as an incomplete fix.

**Gates:** `pnpm run build` exit 0 with identical output · `pnpm exec eslint --cache .` exit 0 (package-local config, the one CI runs).

Fixes #601