### PR TITLE
chore(deps): pin marked to one catalog version (#571)

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "lint-staged": "^16.4.0",
     "markdown-it": "14.1.0",
     "markdownlint": "0.39.0",
-    "marked": "17.0.6",
+    "marked": "catalog:",
     "remark-mdc": "3.11.1",
     "remark-parse": "11.0.0",
     "typescript": "^5.9.3",

--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -85,7 +85,7 @@
     "@vueuse/core": "^14.3.0",
     "dompurify": "^3.4.11",
     "gsap": "^3.15.0",
-    "marked": "^12.0.2",
+    "marked": "catalog:",
     "mermaid": "catalog:",
     "shiki": "^4.4.2",
     "v-wave": "^3.1.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@vueuse/core": "^14.3.0",
     "dayjs": "^1.11.21",
-    "marked": "^17.0.6",
+    "marked": "catalog:",
     "mathjs": "^15.2.0",
     "path-browserify": "^1.0.1",
     "vue": "^3.5.39"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ catalogs:
     jszip:
       specifier: ^3.10.1
       version: 3.10.1
+    marked:
+      specifier: ^17.0.6
+      version: 17.0.6
     mermaid:
       specifier: ^11.16.0
       version: 11.16.0
@@ -246,7 +249,7 @@ importers:
         specifier: 0.39.0
         version: 0.39.0
       marked:
-        specifier: 17.0.6
+        specifier: 'catalog:'
         version: 17.0.6
       remark-mdc:
         specifier: 3.11.1
@@ -990,8 +993,8 @@ importers:
         specifier: ^3.15.0
         version: 3.15.0
       marked:
-        specifier: ^12.0.2
-        version: 12.0.2
+        specifier: 'catalog:'
+        version: 17.0.6
       mermaid:
         specifier: 'catalog:'
         version: 11.16.0
@@ -1121,7 +1124,7 @@ importers:
         specifier: ^1.11.21
         version: 1.11.21
       marked:
-        specifier: ^17.0.6
+        specifier: 'catalog:'
         version: 17.0.6
       mathjs:
         specifier: ^15.2.0
@@ -10107,11 +10110,6 @@ packages:
   markdownlint@0.39.0:
     resolution: {integrity: sha512-Xt/oY7bAiHwukL1iru2np5LIkhwD19Y7frlsiDILK62v3jucXCD6JXlZlwMG12HZOR+roHIVuJZrfCkOhp6k3g==}
     engines: {node: '>=20'}
-
-  marked@12.0.2:
-    resolution: {integrity: sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==}
-    engines: {node: '>= 18'}
-    hasBin: true
 
   marked@16.4.2:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
@@ -24286,8 +24284,6 @@ snapshots:
       micromark-util-types: 2.0.2
     transitivePeerDependencies:
       - supports-color
-
-  marked@12.0.2: {}
 
   marked@16.4.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,6 +50,7 @@ catalog:
   jsqr: ^1.4.0
   jszip: ^3.10.1
   markdown-it: ^14.3.0
+  marked: ^17.0.6
   mermaid: ^11.16.0
   next-auth: ~4.21.1
   nodemailer: ^9.0.3


### PR DESCRIPTION
`packages/tuffex` declared `marked: ^12.0.2` while `packages/utils` declared `^17.0.6` and the root toolchain pinned `17.0.6`. The core-app renderer bundles both tuffex and utils, so two markdown engines with different renderer/extension APIs shipped in one output.

All three declarations now point at a **catalog** entry (`marked: ^17.0.6`), the same consolidation used for `@types/node`, so a single version is enforced by construction rather than by three manifests agreeing.

**Lockfile result**
- `marked@12.0.2` — **gone**
- every declared importer (tuffex, utils, root) → `17.0.6` via `catalog:`
- `marked@16.4.2` remains, but it is a **transitive dependency of `mermaid@11.16.0`**, not something this repo declares. Pinning it would mean overriding mermaid's own constraint, which is a separate decision — flagged rather than silently forced.

**One correction to the issue's risk assessment.** It states "tuffex's TxStreamMarkdown renderer extensions are written against v12 and would break". There are **no renderer or tokenizer extensions** anywhere in tuffex — the entire usage is `new Marked({ gfm: true, breaks: true })` + `.parse()` in `TxMarkdownView`, and `marked.parse(md, { breaks, gfm })` in `TxMarkdownEditor`. Both options and both entry points are unchanged in v17, which is why the upgrade is low-risk rather than a rewrite.

**Verified on the new resolution:** tuffex markdown suites 6 files / 64 tests green · full tuffex 145 files / 1113 tests green · vue-tsc 0 errors · utils 129 files / 1014 tests green.

Fixes #571