### PR TITLE
build(tuffex): compile styles through the modern Sass API (#600)

### DIFF
--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -94,7 +94,6 @@
   "devDependencies": {
     "@types/gulp": "^4.0.18",
     "@types/gulp-autoprefixer": "^0.0.37",
-    "@types/gulp-sass": "^5.0.4",
     "@types/node": "catalog:dev",
     "@vitejs/plugin-vue": "^6.0.7",
     "chalk": "^5.6.2",
@@ -102,7 +101,6 @@
     "esno": "^4.8.0",
     "gulp": "^5.0.1",
     "gulp-autoprefixer": "^9.0.0",
-    "gulp-sass": "^5.1.0",
     "sass": "^1.101.0",
     "sucrase": "^3.35.1",
     "ts-node": "^10.9.2",

--- a/packages/tuffex/packages/script/build/index.ts
+++ b/packages/tuffex/packages/script/build/index.ts
@@ -1,10 +1,11 @@
 import { series, dest, src, parallel } from 'gulp'
 import type { TaskFunction } from 'gulp'
-import gulpSass from 'gulp-sass'
 import autoPrefixer from 'gulp-autoprefixer'
 import * as sassLang from 'sass'
+import { Buffer } from 'node:buffer'
+import { Transform } from 'node:stream'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { resolve, dirname } from 'path'
+import { basename, dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
 import { delPath } from './del.ts'
 import run from './run.ts'
@@ -23,7 +24,36 @@ export const removeDist = () => {
   return delPath(distPath);
 }
 
-const sass = gulpSass(sassLang)
+/**
+ * gulp-sass 5.x only speaks Dart Sass's legacy render/renderSync API, which is
+ * deprecated and slated for removal in Sass 2.0 — bumping the sass catalog entry
+ * past that would break the build outright with "renderSync is not a function".
+ * This is the same pipeline stage on the modern compile() API, as a plain stream
+ * so no replacement gulp plugin is needed.
+ */
+function sass() {
+  return new Transform({
+    objectMode: true,
+    transform(file: any, _encoding, done) {
+      // Partials are only ever @use'd by an entry file; compiling one directly
+      // would emit a stray stylesheet, which gulp-sass also skipped.
+      if (file.isNull() || basename(file.path).startsWith('_')) {
+        done(null, undefined)
+        return
+      }
+
+      try {
+        const result = sassLang.compile(file.path, { loadPaths: [dirname(file.path)] })
+        file.contents = Buffer.from(result.css)
+        file.path = file.path.replace(/\.s[ac]ss$/, '.css')
+        done(null, file)
+      }
+      catch (error) {
+        done(error as Error)
+      }
+    },
+  })
+}
 
 export const buildStyle = () => {
 return src(`${componentPath}/src/**/src/style/**/*.scss`)


### PR DESCRIPTION
`gulp-sass` 5.x only speaks Dart Sass's **legacy** `render`/`renderSync` API — deprecated, and slated for deletion in Sass 2.0. It has no modern-API path, so bumping the `sass` catalog entry past 2.0 would have broken the tuffex build outright with `sass.renderSync is not a function`, taking down the component CSS that `apps/core-app`, `apps/nexus` and `apps/tuff-analyse` all consume from `dist`.

Replaced the plugin with a small `node:stream` `Transform` calling `sass.compile()`. No replacement gulp plugin is pulled in, and `gulp-sass` + `@types/gulp-sass` are dropped. The partial guard (`_`-prefixed files are skipped) is preserved, since gulp-sass did that too and compiling a partial directly would emit a stray stylesheet.

**Output verified unchanged, not just "builds green":**

| | before | after |
|---|---|---|
| `pnpm run build` | exit 0 | exit 0 |
| dist files | 1788 | 1788 |
| fingerprint (sha of all file shas) | `6e9b34fe91416625` | **`6e9b34fe91416625`** |
| `legacy-js-api` warnings | 6 | **0** |

**One interruption worth recording.** Mid-verification the build started failing with `Cannot find module …/gulp/bin/gulp.js`, and an earlier run surfaced a path from a *different* worktree (`…/tx6/node_modules`). That was a concurrent agent's `pnpm install` (for #1055) transiently pruning `packages/tuffex/node_modules` — `gulp` is still declared at `^5.0.1`, and the directory repopulated on its own. I took read-only evidence and waited rather than running `pnpm install` in the maintainer's tree to force it, then re-ran the full verification above. Nothing here was shipped against an unverified build.

**Gates:** `pnpm run build` exit 0 with identical output · `pnpm exec eslint --cache .` exit 0 (package-local config, the one CI runs).

Fixes #600