### PR TITLE
build(tuffex): drop the ignored vite lib.formats key (#336)

### DIFF
--- a/packages/tuffex/packages/components/vite.config.js
+++ b/packages/tuffex/packages/components/vite.config.js
@@ -66,7 +66,9 @@ export default defineConfig({
     lib: {
       entry: 'src/index.ts',
       name: 'vuecomp',
-      formats: ['es', 'cjs', 'umd'],
+      // No `formats`: `rollupOptions.output` above is already an array and owns
+      // the es/cjs outputs, so Vite ignores this key and warns. Listing 'umd'
+      // here was doubly misleading — the umd output block is commented out.
     },
   },
   plugins: [


### PR DESCRIPTION
One of the deprecated build paths tracked by #336.

`build.rollupOptions.output` is already an array that owns the `es` and `cjs` outputs, so Vite **ignores** `build.lib.formats` and prints on every build:

```
"build.lib.formats" will be ignored because "build.rollupOptions.output" is already an array format.
```

Listing `'umd'` there was doubly misleading — the umd output block right above it is commented out, so no umd bundle was ever produced.

Removed the key and left a comment recording who owns the outputs. `lib.entry`/`lib.name` stay, so Vite's library mode (and its externalization defaults) is untouched.

**Verified by building both ways and hashing every emitted file:**

| | before | after |
|---|--:|--:|
| files in `dist` | 1788 | 1788 |
| `shasum` of all files | — | **identical** |
| the "will be ignored" warning | present | gone |

So this removes a warning and provably changes nothing about the output.

Refs #336