### PR TITLE
build(tuffex): drop the ignored build.lib.formats declaration (#336)

### DIFF
--- a/packages/tuffex/packages/components/vite.config.js
+++ b/packages/tuffex/packages/components/vite.config.js
@@ -66,7 +66,10 @@ export default defineConfig({
     lib: {
       entry: 'src/index.ts',
       name: 'vuecomp',
-      formats: ['es', 'cjs', 'umd'],
+      // No `formats` here on purpose: rollupOptions.output above is an array, so
+      // it already owns the output shape and Vite ignores this field entirely —
+      // declaring both only produced a warning and a second, untrue source of
+      // truth (it listed umd, which nothing emits).
     },
   },
   plugins: [


### PR DESCRIPTION
`build.rollupOptions.output` is an array, so Vite ignores `build.lib.formats` outright and prints `"build.lib.formats" will be ignored because "build.rollupOptions.output" is already an array format.` on every build.

Beyond the noise, the ignored field was **wrong**: it listed `['es', 'cjs', 'umd']` while the output array emits only `es` and `lib` — a second, untrue source of truth for the package's output shape (the umd block next to it is commented out). Removed, with a comment recording why it must stay absent.

**Output unchanged:** dist fingerprint over all 1788 files identical before and after (`6e9b34fe91416625`); build exits 0; `pnpm exec eslint --cache .` exits 0.

**This is the 4th of the 5 warnings #336 tracks.** Current state of that list on this branch:

| warning | status |
|---|---|
| `--experimental-loader` | gone — #1054 |
| Sass `legacy-js-api` | gone — #1056 |
| `caniuse-lite` out of date | no longer reproduces |
| `build.lib.formats` ignored | **gone — this PR** |
| `fs.Stats` constructor deprecated | **still present** |

`fs.Stats` originates inside **ts-node**, not in this repo's code or its invocation. Removing it means replacing ts-node, and I showed in #1054 that esno/tsx both break the in-process style pass. So #336 stays open on that one item rather than being closed as done.

Refs #336