### PR TITLE
build: cover every workspace package in lint-staged (#722)

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,11 +220,32 @@
     "apps/tuff-analyse/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}": [
       "pnpm -C \"apps/tuff-analyse\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored"
     ],
+    "packages/intelligence-uikit/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}": [
+      "pnpm -C \"packages/intelligence-uikit\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored"
+    ],
+    "packages/pi-extension-tuff/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}": [
+      "pnpm -C \"packages/pi-extension-tuff\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored"
+    ],
     "packages/test/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}": [
       "pnpm -C \"packages/test\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored"
     ],
     "packages/tuff-intelligence/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}": [
       "pnpm -C \"packages/tuff-intelligence\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored"
+    ],
+    "packages/tuff-business/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}": [
+      "pnpm -C \"packages/tuff-business\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored"
+    ],
+    "packages/tuff-cli/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}": [
+      "pnpm -C \"packages/tuff-cli\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored"
+    ],
+    "packages/tuff-cli-core/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}": [
+      "pnpm -C \"packages/tuff-cli-core\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored"
+    ],
+    "packages/tuff-core/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}": [
+      "pnpm -C \"packages/tuff-core\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored"
+    ],
+    "packages/tuff-native/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}": [
+      "pnpm -C \"packages/tuff-native\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored"
     ],
     "packages/tuffex/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}": [
       "pnpm -C \"packages/tuffex\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored"


### PR DESCRIPTION
The `lint-staged` map enumerated packages by hand and matched only **5 of the 12** directories under `packages/`. Editing `tuff-cli`, `tuff-cli-core`, `tuff-core`, `intelligence-uikit`, `tuff-native`, `pi-extension-tuff` or `tuff-business` ran **no ESLint at all** on commit — and three of those are published to npm by a workflow that has no lint step either.

**The issue named 5 missing packages; there are 7.** It missed `tuff-native` (28 tracked source files) and `tuff-business`. Every directory under `packages/` is now covered.

**Kept the per-package form instead of one blanket `packages/**` glob.** Each entry runs `pnpm -C "packages/<name>" exec eslint`, so the package resolves *its own* eslint config; a single root-level invocation would bypass `intelligence-uikit`'s and others' local configs and lint them under different rules.

**Verified safe to switch on, not assumed.** Two of the uncovered packages are not clean today — `tuff-native` has 165 errors and `intelligence-uikit` 9. But those are **entirely in `.toml`/`.json` files** (`toml/array-element-newline`, `jsonc/sort-keys`, …), which the `*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}` globs do not match. Linting each package restricted to exactly the extensions these globs select: **all seven exit 0**. So no existing commit path is blocked.

**Adversarially verified the gate actually fires:** staged a deliberately bad `packages/tuff-cli/src/__lint_probe.ts` and ran `lint-staged` — the new `packages/tuff-cli` entry matched it and reported `[FAILED]`. Probe removed.

Diff is `package.json` only, 21 insertions. (An unrelated `pnpm-lock.yaml` drift from a local install was reverted out.)

Fixes #722