### PR TITLE
build(tuffex): drop ts-node and run the gulpfile on Node's native TypeScript (#336)

### DIFF
--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -45,7 +45,7 @@
     }
   },
   "scripts": {
-    "build": "node --import ./scripts/register-ts-node.mjs ./node_modules/gulp/bin/gulp.js -f packages/script/build/index.ts",
+    "build": "node ./node_modules/gulp/bin/gulp.js -f packages/script/build/index.ts",
     "build:vite": "vite build",
     "dev": "vite build --watch",
     "lint": "pnpm exec eslint --cache .",
@@ -103,7 +103,6 @@
     "gulp-autoprefixer": "^9.0.0",
     "sass": "^1.101.0",
     "sucrase": "^3.35.1",
-    "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
     "vite": "^7.3.6",
     "vite-plugin-dts": "^4.5.4",

--- a/packages/tuffex/scripts/register-ts-node.mjs
+++ b/packages/tuffex/scripts/register-ts-node.mjs
@@ -1,8 +1,0 @@
-// The build gulpfile is TypeScript, so the runner needs a TS loader. `--loader`
-// is the deprecated flag Node warns about and plans to remove; this is the
-// supported entry point it points at, keeping ts-node as the transformer so the
-// emitted bundle is unchanged.
-import { register } from 'node:module'
-import { pathToFileURL } from 'node:url'
-
-register('ts-node/esm', pathToFileURL('./'))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,9 +1014,6 @@ importers:
       '@types/gulp-autoprefixer':
         specifier: ^0.0.37
         version: 0.0.37
-      '@types/gulp-sass':
-        specifier: ^5.0.4
-        version: 5.0.4
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -1038,18 +1035,12 @@ importers:
       gulp-autoprefixer:
         specifier: ^9.0.0
         version: 9.0.0(gulp@5.0.1)
-      gulp-sass:
-        specifier: ^5.1.0
-        version: 5.1.0
       sass:
         specifier: ^1.101.0
         version: 1.101.0
       sucrase:
         specifier: ^3.35.1
         version: 3.35.1
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@types/node@24.13.2)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -5571,9 +5562,6 @@ packages:
   '@types/gulp-autoprefixer@0.0.37':
     resolution: {integrity: sha512-GLPDrYHQ7+7i9cHEGIkV4eB/iYF5I9YylpLxsFbHTsR+rbZ17nlZrwWfzolSvpHfjk3u0HIO9FrJdCr182SgeQ==}
 
-  '@types/gulp-sass@5.0.4':
-    resolution: {integrity: sha512-wDgpyM9fRq/k7kn1ZGcoY69Pj8+AlB50U9TKmBdbmHUduy+4b7WZ1zrDl4df43W+IqJegEgen6XAKO2+/RQILA==}
-
   '@types/gulp@4.0.18':
     resolution: {integrity: sha512-IqkYa4sXkwH2uwqO2aXYOoAisJpLX13BPaS6lmEAoG4BbgOay3qqGQFsT9LMSSQVMQlEKU7wTUW0sPV46V0olw==}
 
@@ -5630,9 +5618,6 @@ packages:
 
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
-
-  '@types/node-sass@4.11.8':
-    resolution: {integrity: sha512-dWWMGPX8uselSQ1MLzDvQnVz5Qy1pe7SJuUl1Yqi2NCNRkrk5DmHlP44VZmTWm+buR2T217+5zEAPbAmTwKIOQ==}
 
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
@@ -6579,10 +6564,6 @@ packages:
   alien-signals@3.2.1:
     resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
-  ansi-colors@1.1.0:
-    resolution: {integrity: sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==}
-    engines: {node: '>=0.10.0'}
-
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -6610,10 +6591,6 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
-
-  ansi-wrap@0.1.0:
-    resolution: {integrity: sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw==}
-    engines: {node: '>=0.10.0'}
 
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
@@ -6664,14 +6641,6 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
-  arr-diff@4.0.0:
-    resolution: {integrity: sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==}
-    engines: {node: '>=0.10.0'}
-
-  arr-union@3.1.0:
-    resolution: {integrity: sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==}
-    engines: {node: '>=0.10.0'}
-
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
@@ -6701,10 +6670,6 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
-
-  assign-symbols@1.0.0:
-    resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
-    engines: {node: '>=0.10.0'}
 
   ast-kit@1.4.3:
     resolution: {integrity: sha512-MdJqjpodkS5J149zN0Po+HPshkTdUyrvF7CKTafUgv69vBSPtncrj+3IiUgqdd7ElIEkbeXCsEouBUwLrw9Ilg==}
@@ -8545,10 +8510,6 @@ packages:
   exsolve@1.1.0:
     resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
 
-  extend-shallow@3.0.2:
-    resolution: {integrity: sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==}
-    engines: {node: '>=0.10.0'}
-
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -9041,10 +9002,6 @@ packages:
     resolution: {integrity: sha512-0gssXzTNrrOocYBWN4qOZqd03cz3bxhjxVUPZV9iJdBR0ZZbwMQO/OT8hZChYoc9GjKaA5meaqDr6CjkmKA7BA==}
     engines: {node: '>=18'}
 
-  gulp-sass@5.1.0:
-    resolution: {integrity: sha512-7VT0uaF+VZCmkNBglfe1b34bxn/AfcssquLKVDYnCDJ3xNBaW7cUuI3p3BQmoKcoKFrs9jdzUxyb+u+NGfL4OQ==}
-    engines: {node: '>=12'}
-
   gulp@5.0.1:
     resolution: {integrity: sha512-PErok3DZSA5WGMd6XXV3IRNO0mlB+wW3OzhFJLEec1jSERg2j1bxJ6e5Fh6N6fn3FH2T9AP4UYNb/pYlADB9sA==}
     engines: {node: '>=10.13.0'}
@@ -9423,10 +9380,6 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  is-extendable@1.0.1:
-    resolution: {integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==}
-    engines: {node: '>=0.10.0'}
-
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -9505,10 +9458,6 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
-
-  is-plain-object@2.0.4:
-    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
-    engines: {node: '>=0.10.0'}
 
   is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
@@ -9974,9 +9923,6 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-
-  lodash.clonedeep@4.5.0:
-    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -11141,10 +11087,6 @@ packages:
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
-
-  plugin-error@1.0.1:
-    resolution: {integrity: sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==}
-    engines: {node: '>= 0.10'}
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -18870,11 +18812,6 @@ snapshots:
     dependencies:
       '@types/node': 24.13.2
 
-  '@types/gulp-sass@5.0.4':
-    dependencies:
-      '@types/node': 24.13.2
-      '@types/node-sass': 4.11.8
-
   '@types/gulp@4.0.18':
     dependencies:
       '@types/node': 24.13.2
@@ -18935,10 +18872,6 @@ snapshots:
     dependencies:
       '@types/node': 24.13.2
       form-data: 4.0.6
-
-  '@types/node-sass@4.11.8':
-    dependencies:
-      '@types/node': 24.13.2
 
   '@types/node@24.13.2':
     dependencies:
@@ -20246,10 +20179,6 @@ snapshots:
 
   alien-signals@3.2.1: {}
 
-  ansi-colors@1.1.0:
-    dependencies:
-      ansi-wrap: 0.1.0
-
   ansi-colors@4.1.3: {}
 
   ansi-escapes@7.3.0:
@@ -20267,8 +20196,6 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
-
-  ansi-wrap@0.1.0: {}
 
   ansis@4.3.1: {}
 
@@ -20366,10 +20293,6 @@ snapshots:
 
   aria-query@5.3.2: {}
 
-  arr-diff@4.0.0: {}
-
-  arr-union@3.1.0: {}
-
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -20400,8 +20323,6 @@ snapshots:
       tslib: 2.8.1
 
   assertion-error@2.0.1: {}
-
-  assign-symbols@1.0.0: {}
 
   ast-kit@1.4.3:
     dependencies:
@@ -22523,11 +22444,6 @@ snapshots:
 
   exsolve@1.1.0: {}
 
-  extend-shallow@3.0.2:
-    dependencies:
-      assign-symbols: 1.0.0
-      is-extendable: 1.0.1
-
   extend@3.0.2: {}
 
   extract-file-icon@0.3.2:
@@ -23102,15 +23018,6 @@ snapshots:
       chalk: 5.6.2
       easy-transform-stream: 1.0.1
 
-  gulp-sass@5.1.0:
-    dependencies:
-      lodash.clonedeep: 4.5.0
-      picocolors: 1.1.1
-      plugin-error: 1.0.1
-      replace-ext: 2.0.0
-      strip-ansi: 6.0.1
-      vinyl-sourcemaps-apply: 0.2.1
-
   gulp@5.0.1:
     dependencies:
       glob-watcher: 6.0.0
@@ -23575,10 +23482,6 @@ snapshots:
 
   is-docker@4.0.0: {}
 
-  is-extendable@1.0.1:
-    dependencies:
-      is-plain-object: 2.0.4
-
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -23638,10 +23541,6 @@ snapshots:
   is-path-inside@4.0.0: {}
 
   is-plain-obj@4.1.0: {}
-
-  is-plain-object@2.0.4:
-    dependencies:
-      isobject: 3.0.1
 
   is-plain-object@5.0.0: {}
 
@@ -24119,8 +24018,6 @@ snapshots:
   lodash-es@4.18.1: {}
 
   lodash.camelcase@4.3.0: {}
-
-  lodash.clonedeep@4.5.0: {}
 
   lodash.debounce@4.0.8: {}
 
@@ -25987,13 +25884,6 @@ snapshots:
       '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
-
-  plugin-error@1.0.1:
-    dependencies:
-      ansi-colors: 1.1.0
-      arr-diff: 4.0.0
-      arr-union: 3.1.0
-      extend-shallow: 3.0.2
 
   pluralize@8.0.0: {}
 


### PR DESCRIPTION
Closes out the last of the five build warnings #336 tracks.

**Traced instead of assumed.** I had previously attributed `fs.Stats constructor is deprecated` to ts-node from the outside. `--trace-deprecation` confirms it precisely: it comes from ts-node's **own vendored copy of Node's internal resolver** (`ts-node/dist-raw/node-internal-modules-esm-resolve.js:146`), fired inside `createEsmHooks` → `registerAndCreateEsmHooks` — i.e. at loader-registration time, before any build work happens.

**So the fix is to stop needing a loader.** `packages/tuffex` already declares `engines: { node: ">=24.0.0" }` and CI pins `.node-version` at 24.18.0. Node 24 strips types natively by default, and the build scripts use only erasable syntax (no enums, namespaces or parameter properties — checked). Plain `node ./node_modules/gulp/bin/gulp.js -f …/index.ts` runs the gulpfile with **no loader at all**.

This also removes `ts-node` from the dependency tree and deletes the `register-ts-node.mjs` shim I added in #1054 — that shim was the right intermediate step (it killed the `--experimental-loader` warning while keeping output identical), and it is now unnecessary.

**All five warnings, measured on the built tree:**

| warning | before this PR | after |
|---|--:|--:|
| `--experimental-loader` | 0 (fixed #1054) | 0 |
| `legacy-js-api` | 0 (fixed #1056) | 0 |
| `caniuse-lite` | 0 | 0 |
| `build.lib.formats` | 0 (fixed #1057) | 0 |
| **`fs.Stats`** | **1** | **0** |

**Output unchanged:** dist fingerprint `6e9b34fe91416625` over 1788 files — identical to the ts-node runner and to every earlier step in this series. `require('./dist/lib/index.js')` returns 359 exports.

**Lockfile: 110 removed lines, 0 added.** All of it is `ts-node`, `gulp-sass`, `@types/gulp-sass` and their transitives. That includes a **gap in my own #1056** — it dropped `gulp-sass` from `package.json` but never regenerated the lockfile, so the entries were still there. Corrected here.

**What I could not run, and why.** `typecheck` and `test` fail to *start* in my worktree right now — `vue-tsc`'s package directory and `vitest` are missing from the shared `node_modules`, and one error cites a fourth worktree's path (`…/tx9/…`). Concurrent agents are rewriting the install; the same suites were 147 files / 1102 tests green earlier this session. These are startup `MODULE_NOT_FOUND` errors, not assertion failures, and this change cannot affect them in any case — it only alters how the *gulpfile* is executed, and neither vue-tsc nor vitest goes through the build script. `eslint --cache .` did run: exit 0.

Refs #336