### PR TITLE
test: cover the lint:changed gate and match its strictness to pnpm lint (#931)

### DIFF
--- a/scripts/run-eslint-changed.mjs
+++ b/scripts/run-eslint-changed.mjs
@@ -108,10 +108,9 @@ function getChangedFiles() {
     .filter(file => lintExtensions.has(path.extname(file)))
 }
 
-function groupByWorkspace(files) {
+export function groupByWorkspace(files, workspaces = collectWorkspaceDirectories()) {
   const groups = new Map()
   const rootFiles = []
-  const workspaces = collectWorkspaceDirectories()
 
   for (const file of files) {
     const workspace = workspaces.find(prefix => file === prefix || file.startsWith(`${prefix}/`))
@@ -130,25 +129,36 @@ function groupByWorkspace(files) {
   return { groups, rootFiles }
 }
 
-function lintWorkspace(workspace, files) {
-  const args = [
+/**
+ * `--max-warnings=0` mirrors the root `lint` script. Without it this PR gate
+ * accepted warning-level violations that the release gate then rejected.
+ */
+export function buildWorkspaceArgs(workspace, files) {
+  return [
     'pnpm',
     '-C',
     workspace,
     'exec',
     'eslint',
     '--cache',
+    '--max-warnings=0',
     '--no-warn-ignored',
     ...files,
   ]
+}
+
+export function buildRootArgs(files) {
+  return ['pnpm', 'exec', 'eslint', '--cache', '--max-warnings=0', '--no-warn-ignored', ...files]
+}
+
+function lintWorkspace(workspace, files) {
   console.log(`[lint:changed] ${workspace}: ${files.length} file(s)`)
-  return run('corepack', args)
+  return run('corepack', buildWorkspaceArgs(workspace, files))
 }
 
 function lintRoot(files) {
-  const args = ['pnpm', 'exec', 'eslint', '--cache', '--no-warn-ignored', ...files]
   console.log(`[lint:changed] root: ${files.length} file(s)`)
-  return run('corepack', args)
+  return run('corepack', buildRootArgs(files))
 }
 
 function main() {
@@ -180,4 +190,7 @@ function main() {
   console.log('[lint:changed] OK')
 }
 
-main()
+// Guarded so the tests can import the pure helpers without running the gate.
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main()
+}

--- a/scripts/run-eslint-changed.test.mjs
+++ b/scripts/run-eslint-changed.test.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'vitest'
+import { buildRootArgs, buildWorkspaceArgs, groupByWorkspace } from './run-eslint-changed.mjs'
+
+// Mirrors collectWorkspaceDirectories()'s contract: longest prefix first.
+const WORKSPACES = [
+  'packages/tuffex/packages/components',
+  'packages/unplugin-export-plugin',
+  'packages/tuffex',
+  'apps/core-app',
+  'apps/nexus',
+]
+
+describe('groupByWorkspace', () => {
+  it('routes a nested workspace file to the nested package, not its parent', () => {
+    const { groups, rootFiles } = groupByWorkspace(
+      ['packages/tuffex/packages/components/src/index.ts'],
+      WORKSPACES,
+    )
+
+    // The nested package has its own eslint config; matching packages/tuffex
+    // first would lint it under the parent's rules instead.
+    assert.deepEqual([...groups.keys()], ['packages/tuffex/packages/components'])
+    assert.deepEqual(groups.get('packages/tuffex/packages/components'), ['src/index.ts'])
+    assert.deepEqual(rootFiles, [])
+  })
+
+  it('still routes a parent-only file to the parent workspace', () => {
+    const { groups } = groupByWorkspace(['packages/tuffex/vitest.config.ts'], WORKSPACES)
+
+    assert.deepEqual([...groups.keys()], ['packages/tuffex'])
+    assert.deepEqual(groups.get('packages/tuffex'), ['vitest.config.ts'])
+  })
+
+  it('keeps files outside every workspace for the root pass', () => {
+    const { groups, rootFiles } = groupByWorkspace(
+      ['scripts/run-eslint-changed.mjs', 'workers/index.ts'],
+      WORKSPACES,
+    )
+
+    assert.equal(groups.size, 0)
+    assert.deepEqual(rootFiles, ['scripts/run-eslint-changed.mjs', 'workers/index.ts'])
+  })
+
+  it('does not treat a workspace-prefixed sibling directory as that workspace', () => {
+    // 'apps/core-app-extra' merely starts with 'apps/core-app'.
+    const { groups, rootFiles } = groupByWorkspace(['apps/core-app-extra/src/a.ts'], WORKSPACES)
+
+    assert.equal(groups.size, 0)
+    assert.deepEqual(rootFiles, ['apps/core-app-extra/src/a.ts'])
+  })
+
+  it('groups several files per workspace', () => {
+    const { groups } = groupByWorkspace(
+      ['apps/nexus/app/a.vue', 'apps/nexus/app/b.ts', 'apps/core-app/src/c.ts'],
+      WORKSPACES,
+    )
+
+    assert.deepEqual(groups.get('apps/nexus'), ['app/a.vue', 'app/b.ts'])
+    assert.deepEqual(groups.get('apps/core-app'), ['src/c.ts'])
+  })
+})
+
+describe('eslint argv', () => {
+  it('passes --max-warnings=0 for a workspace, matching the root lint script', () => {
+    const args = buildWorkspaceArgs('packages/tuffex', ['src/index.ts'])
+
+    // Without this the PR gate accepted warnings that `pnpm lint` rejects at release.
+    assert.ok(args.includes('--max-warnings=0'))
+    assert.deepEqual(args, [
+      'pnpm',
+      '-C',
+      'packages/tuffex',
+      'exec',
+      'eslint',
+      '--cache',
+      '--max-warnings=0',
+      '--no-warn-ignored',
+      'src/index.ts',
+    ])
+  })
+
+  it('passes --max-warnings=0 for the root pass too', () => {
+    const args = buildRootArgs(['scripts/a.mjs'])
+
+    assert.ok(args.includes('--max-warnings=0'))
+    assert.deepEqual(args, [
+      'pnpm',
+      'exec',
+      'eslint',
+      '--cache',
+      '--max-warnings=0',
+      '--no-warn-ignored',
+      'scripts/a.mjs',
+    ])
+  })
+
+  it('appends every file after the flags', () => {
+    const args = buildWorkspaceArgs('apps/nexus', ['a.ts', 'b.vue'])
+
+    assert.deepEqual(args.slice(-2), ['a.ts', 'b.vue'])
+  })
+})


### PR DESCRIPTION
`scripts/run-eslint-changed.mjs` is the lint half of the PR quality gate (`quality:pr` → `lint:changed`). It had **no test**, and both of its eslint invocations omitted `--max-warnings=0` — which the root `lint` script does pass. Warning-level violations therefore merged through the PR gate and only blew up at release time.

**Strictness.** Both `buildWorkspaceArgs` and `buildRootArgs` now pass `--max-warnings=0`.

Worth noting explicitly: this does **not** invent a stricter rule. The root `lint` already applies `--max-warnings=0` to every workspace *including* `apps/core-app`, so this only makes the PR gate agree with the release gate. (`apps/core-app`'s lint-staged entry omits the flag, but that is the pre-commit convenience path, not the release contract.)

**Tests — the first for this script.** Eight cases covering the two failure modes the issue names:
- `groupByWorkspace` longest-prefix precedence: a file under `packages/tuffex/packages/components` must route to the nested package, not `packages/tuffex`, or it gets linted under the wrong config
- a parent-only file still routes to the parent
- files outside every workspace fall through to the root pass
- a sibling directory that merely *shares* a prefix (`apps/core-app-extra`) is not treated as that workspace
- assembled argv for both passes, asserting `--max-warnings=0` is present and files come last

**Adversarial verification of both modes:**
- removing `--max-warnings=0` → 2 tests fail
- reordering `WORKSPACES` so the parent precedes the nested package → the precedence test fails

**Minimal testability changes:** `groupByWorkspace` takes the workspace list as an optional second argument (defaulting to the real `collectWorkspaceDirectories()`), and `main()` is guarded by a direct-run check so importing the module does not execute the gate. Verified the CLI still runs end-to-end (`[lint:changed] OK`) and both files lint clean.

Fixes #931