### PR TITLE
fix(tuffex): restore the textareaRef read core-app's typecheck needs

### DIFF
--- a/packages/tuffex/packages/components/src/chat/src/TxChatComposer.vue
+++ b/packages/tuffex/packages/components/src/chat/src/TxChatComposer.vue
@@ -62,6 +62,11 @@ const canSend = computed(() => {
 })
 
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
+// Bound from the template as `ref="textareaRef"`, which consumers compiling with
+// `noUnusedLocals` (apps/core-app) do not count as a read — so this keeps their
+// typecheck green. It looks like dead code and is not; removing it broke
+// `pnpm -C apps/core-app typecheck` once already.
+void textareaRef.value
 
 // ---------------------------------------------------------------------------
 // Attachment intake: paste and drag-and-drop both funnel into `attachmentAdd`.


### PR DESCRIPTION
**A regression I introduced, found by running `quality:pr` manually.**

PR #1015 (issue #948) removed `void textareaRef.value` from `TxChatComposer.vue` as dead code. It was **not** dead — it was a deliberate suppression. The ref is bound from the template as `ref="textareaRef"`, and a consumer compiling with `noUnusedLocals` does not count that string binding as a read:

```
../../packages/tuffex/packages/components/src/chat/src/TxChatComposer.vue(64,7):
error TS6133: 'textareaRef' is declared but its value is never read.
```

So `pnpm -C apps/core-app run typecheck` — the last stage of `quality:pr` — has been failing on `app-shell-v2` since #1015 merged.

**Why my original verification missed it:** I checked that `textareaRef` was used in the template and concluded the `void` statement was redundant. tuffex's own `vue-tsc` agreed, because it does not set `noUnusedLocals`. Only the *consumer's* stricter config disagrees, and I never ran it.

**Why it shipped:** `ci.yml` runs `quality:pr` only for PRs into `main`/`master`; every PR in this sweep targeted `app-shell-v2`, which gets no lint, typecheck or test job at all. Evidence is on #924.

Restored with a comment recording *why* the line exists, so it does not get "cleaned up" a third time.

**Verified:** `apps/core-app typecheck` exit 0 (was exit 2, 1 error) · tuffex `vue-tsc` 0 errors · chat suite 27 tests green · eslint clean.

Refs #924
Refs #948