### PR TITLE
ci: run the PR quality gate on app-shell-v2 (#924)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - master
+      - TalexDreamSoul/app-shell-v2
 
 permissions:
   contents: read

--- a/.github/workflows/package-tuffex-ci.yml
+++ b/.github/workflows/package-tuffex-ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - main
+      - TalexDreamSoul/app-shell-v2
     paths:
       - "packages/tuffex/**"
       - "pnpm-lock.yaml"

--- a/.github/workflows/package-utils-ci.yml
+++ b/.github/workflows/package-utils-ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - master
+      - TalexDreamSoul/app-shell-v2
     paths:
       - "packages/utils/**"
       - ".github/workflows/package-utils-ci.yml"


### PR DESCRIPTION
Fixes the half of #924 that turned out to matter most: the gate exists and is green — it just never ran where the work happens.

`ci.yml` (which runs `quality:pr`), `package-tuffex-ci.yml` and `package-utils-ci.yml` all declared `on: pull_request: branches: [main, master]`. Every PR in this repo's active development targets `app-shell-v2`, so those PRs got **no lint, typecheck or test job at all** — `gh pr checks` on them shows only Cloudflare Pages and the AI reviewers.

That is not theoretical: a regression `quality:pr` **does** catch shipped and survived an entire sweep because of it (`TxChatComposer` TS6133, fixed in #1062).

**Every job enabled here was measured green on this branch first — no job is switched on hopefully:**

| gate | result |
|---|---|
| `quality:pr` — release-notes / `lint:changed` / `test:targeted` / core-app typecheck | 4 / 4 exit 0 |
| tuffex suite | 145 files, 1113 tests, ~22s |
| utils suite | 129 files, 1014 tests, ~9s |

**Deliberately not wired in yet:** `apps/core-app` full suite fails today (**17 files / 46 tests**, 629 files total) and `apps/nexus` has **15** pre-existing failures. Adding either would turn every PR red for reasons unrelated to the PR. Those numbers are recorded on #924 as the remaining work — the issue's original ask ("full `vitest run` per workspace") needs them fixed first.

Scope is 3 lines, one per workflow; `push` triggers are untouched so merge-time CI load is unchanged. All three files re-parsed as valid YAML.

**This PR is its own live test** — if the wiring is right, it is the first PR on this branch to actually show the quality jobs in its checks.

Refs #924