### PR TITLE
fix(tuffex): stop TxTabs arrow navigation depending on the CSS global

### DIFF
--- a/packages/tuffex/packages/components/src/tabs/__tests__/tabs.test.ts
+++ b/packages/tuffex/packages/components/src/tabs/__tests__/tabs.test.ts
@@ -399,4 +399,36 @@ describe('txTabs', () => {
     await nextTick()
     expect(wrapper.findAll('.tx-tab-item')[1].attributes('aria-selected')).toBe('true')
   })
+
+  it('moves focus without depending on the CSS global', async () => {
+    // jsdom (and SSR) has no `CSS`, so building a `#id` selector via CSS.escape
+    // rejected inside the nextTick callback. Every assertion still passed, so the
+    // only symptom was vitest exiting non-zero on an unhandled rejection — assert
+    // on the rejection itself, not on the visible outcome.
+    const originalCss = (globalThis as any).CSS
+    delete (globalThis as any).CSS
+
+    const rejections: unknown[] = []
+    const onUnhandled = (reason: unknown) => rejections.push(reason)
+    process.on('unhandledRejection', onUnhandled)
+
+    try {
+      const wrapper = mountTabs({ placement: 'top' })
+      await nextTick()
+
+      const tablist = wrapper.find('[role="tablist"]')
+      await tablist.trigger('keydown', { key: 'ArrowRight' })
+      await nextTick()
+      await nextTick()
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(rejections).toEqual([])
+      expect(wrapper.findAll('.tx-tab-item')[1].attributes('aria-selected')).toBe('true')
+    }
+    finally {
+      process.off('unhandledRejection', onUnhandled)
+      if (originalCss !== undefined)
+        (globalThis as any).CSS = originalCss
+    }
+  })
 })

--- a/packages/tuffex/packages/components/src/tabs/src/TxTabs.vue
+++ b/packages/tuffex/packages/components/src/tabs/src/TxTabs.vue
@@ -546,8 +546,17 @@ export default defineComponent({
       setActive(target)
       void nextTick(() => {
         const name = getNodeName(target)
-        const el = navInnerElRef.value?.querySelector<HTMLElement>(`#${CSS.escape(tabDomId(name))}`)
-        el?.focus()
+        const id = tabDomId(name)
+        // Match on the id property rather than building a `#id` selector: tab
+        // names are author-supplied, and `CSS.escape` is undefined outside a
+        // browser (jsdom, SSR), where it threw an unhandled rejection here.
+        const tabs = navInnerElRef.value?.querySelectorAll<HTMLElement>('[role="tab"]')
+        for (const el of tabs ?? []) {
+          if (el.id === id) {
+            el.focus()
+            break
+          }
+        }
       })
     }
 


### PR DESCRIPTION
**This is my regression, found while measuring CI gates for #924.**

The roving-focus lookup I added in #1037 (issue #951) built a `#id` selector with `CSS.escape`. `CSS` is a browser global — it is undefined in jsdom and under SSR — so the call **rejected inside the `nextTick` callback**.

The failure mode is nasty: every assertion still passed. `setActive` runs *before* the throw, so focus and `aria-selected` end up correct. The only symptom was **vitest exiting non-zero on five unhandled rejections** while printing `145 files / 1113 tests passed`. The tuffex test gate has been red this whole time in a way that reads as green.

**Fix:** match on the element's `id` property while iterating `[role="tab"]`, instead of building a selector. No `CSS` dependency at all.

**The test had to assert on the rejection, not the outcome.** My first version deleted `globalThis.CSS` and asserted the tab became selected — it passed against the *unfixed* component, because the visible result was already correct. Rewritten to register an `unhandledRejection` listener and assert it never fires; that version fails on baseline and passes with the fix.

| | before | after |
|---|---|---|
| `vitest run` exit code | **1** | **0** |
| unhandled errors | 5 | 0 |
| tests | 1113 passed | 1114 passed |
| `vue-tsc --noEmit` | 0 errors | 0 errors |
| `eslint --cache .` | 0 | 0 |

**Also worth flagging for #924:** this is precisely the class of defect the CI gap hides. PR #1037 merged to `app-shell-v2`, where no package CI runs, so the non-zero exit was never surfaced.

Refs #951