### PR TITLE
chore: clear the lint failures blocking the package CI gates (#924)

### DIFF
--- a/packages/tuff-intelligence/README.md
+++ b/packages/tuff-intelligence/README.md
@@ -66,8 +66,8 @@ async function run() {
 import { z } from "zod";
 import {
   createToolKit,
-  LangChainToolAdapter,
   defineTuffTool,
+  LangChainToolAdapter,
   toToolManifest,
 } from "@talex-touch/tuff-intelligence";
 

--- a/packages/tuff-intelligence/package.json
+++ b/packages/tuff-intelligence/package.json
@@ -11,9 +11,6 @@
     "tuff",
     "intelligence"
   ],
-  "main": "src/index.ts",
-  "module": "src/index.ts",
-  "types": "src/index.ts",
   "exports": {
     ".": {
       "types": "./src/index.ts",
@@ -22,8 +19,8 @@
     },
     "./client": {
       "types": "./src/client.ts",
-      "require": "./dist/client.cjs",
       "import": "./src/client.ts",
+      "require": "./dist/client.cjs",
       "default": "./src/client.ts"
     },
     "./light": {
@@ -37,6 +34,9 @@
       "default": "./src/types/intelligence.ts"
     }
   },
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "types": "src/index.ts",
   "files": [
     "dist",
     "src"
@@ -51,14 +51,14 @@
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
     "clean": "rimraf dist"
   },
+  "peerDependencies": {
+    "zod": "^3.25.32"
+  },
   "dependencies": {
     "@langchain/core": "^0.3.80",
     "@langchain/langgraph": "^0.4.9",
     "@talex-touch/utils": "workspace:*",
     "zod": "3.25.76"
-  },
-  "peerDependencies": {
-    "zod": "^3.25.32"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260702.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@talex-touch/utils",
   "version": "1.0.50",
-  "engines": {
-    "node": ">=24.0.0"
-  },
   "private": false,
   "description": "Tuff series utils",
   "author": "TalexDreamSoul",
@@ -48,6 +45,9 @@
     "transport",
     "types"
   ],
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "benchmark:preview": "vitest run \"__tests__/core-box/preview-sdk.benchmark.test.ts\" --reporter verbose",
     "lint": "pnpm exec eslint --cache .",


### PR DESCRIPTION
Prerequisite work for #924. Measured **at the pushed branch tip** (not the local working tree — see below), `package-utils-ci.yml` and `package-tuff-intelligence-ci.yml` would both fail their `run-lint` step today:

| file | violation | origin |
|---|---|---|
| `packages/utils/package.json` | `engines` sorted before `files` | introduced by #1053 when the key was added |
| `packages/tuff-intelligence/package.json` | `exports`/`main`, `require`/`import`, `peerDependencies`/`dependencies` | **pre-existing** — confirmed identical key order before #1053 |
| `packages/tuff-intelligence/README.md` | named imports out of order in the usage snippet | pre-existing |

All are pure reordering, applied with `eslint --fix`.

**Verified inert, not assumed:**
- both manifests parse to **identical objects** before and after (`json.load(before) == json.load(after)` → `True`), with only key order differing
- `pnpm install --lockfile-only` leaves `pnpm-lock.yaml` **byte-identical**
- `packages/utils`: `vitest run` 1014 passed / 1 skipped, `eslint` exit 0
- `packages/tuff-intelligence`: `eslint` exit 0

**Why this was invisible until now.** These gates never run: 7 of 9 PR-triggered workflows only fire on PRs targeting `main`/`master`, while all work lands on `app-shell-v2` (#924). With the triggers fixed, these three files would have red-gated every PR touching either package.

Refs #924