### PR TITLE
chore(unplugin): clear the last package lint-gate failures (#924)

### DIFF
--- a/packages/unplugin-export-plugin/README.md
+++ b/packages/unplugin-export-plugin/README.md
@@ -27,7 +27,7 @@ import TouchPluginExport from '@talex-touch/unplugin-export-plugin/vite'
 
 export default defineConfig({
   plugins: [
-    ....,
+    // ...your other plugins
     TouchPluginExport()
   ],
 })

--- a/packages/unplugin-export-plugin/package.json
+++ b/packages/unplugin-export-plugin/package.json
@@ -2,9 +2,6 @@
   "name": "@talex-touch/unplugin-export-plugin",
   "type": "module",
   "version": "1.2.16",
-  "engines": {
-    "node": ">=24.0.0"
-  },
   "description": "Export unplugin for talex-touch",
   "license": "MIT",
   "homepage": "https://github.com/talex-touch/unplugin-export-plugin#readme",
@@ -58,6 +55,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "build": "tsup",
     "test": "vitest run",


### PR DESCRIPTION
Last blocker in the series. `package-unplugin-ci.yml` has `run-lint: true`, and at the pushed tip its lint step fails on two things:

- `package.json`: `engines` sorted before `files` — the same #1053 fallout already fixed for utils and tuff-intelligence in #1065
- `README.md:30`: the vite config example used a bare `....,` placeholder. The markdown code-block linter parses ``` ts fences as TypeScript, and `....` is not an expression. Replaced with `// ...your other plugins`, which is valid and says what it means.

**Verified inert:** the manifest parses to an identical object (only key order differs), `pnpm install --lockfile-only` leaves the lockfile byte-identical, and the package's `vitest run` exits 0.

**All five workspace packages now pass lint at the pushed tip** — see the summary I am posting on #924.

Refs #924