### PR TITLE
fix: untrack three node_modules symlinks pointing at an absolute local path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ pids/
 # Dependencies (all package managers)
 # ========================
 node_modules/
+node_modules
 jspm_packages/
 bower_components/
 web_modules/

--- a/apps/nexus/node_modules
+++ b/apps/nexus/node_modules
@@ -1,1 +1,0 @@
-/Users/talexdreamsoul/Workspace/Projects/talex-touch/apps/nexus/node_modules

--- a/packages/tuffex/node_modules
+++ b/packages/tuffex/node_modules
@@ -1,1 +1,0 @@
-/Users/talexdreamsoul/Workspace/Projects/talex-touch/packages/tuffex/node_modules

--- a/packages/tuffex/packages/components/node_modules
+++ b/packages/tuffex/packages/components/node_modules
@@ -1,1 +1,0 @@
-/Users/talexdreamsoul/Workspace/Projects/talex-touch/packages/tuffex/packages/components/node_modules


### PR DESCRIPTION
**This is my regression, and it breaks the branch for everyone but me.**

`18b45d2f5` (my PR #1003) committed three entries as **symlinks**:

```
apps/nexus/node_modules                          -> /Users/talexdreamsoul/Workspace/Projects/talex-touch/apps/nexus/node_modules
packages/tuffex/node_modules                     -> /Users/talexdreamsoul/Workspace/Projects/talex-touch/packages/tuffex/node_modules
packages/tuffex/packages/components/node_modules -> /Users/talexdreamsoul/Workspace/Projects/talex-touch/packages/tuffex/packages/components/node_modules
```

They are git mode `120000` with an **absolute path that exists on exactly one machine**. Any other checkout — another developer, or CI — gets three broken symlinks sitting exactly where the real dependency directories belong.

**Why `.gitignore` did not stop it:** the rule is `node_modules/`, and a trailing slash matches *directories only*. A symlink named `node_modules` is not a directory, so it was never ignored. Added the slashless form alongside it.

`git rm --cached` only untracks them; nobody's working copy loses anything.

**How it was found:** while verifying gates for #924, `git diff --stat` on an unrelated change listed `apps/nexus/node_modules` and `packages/tuffex/node_modules` as modified. That was the tell — a diff should never mention node_modules. `git ls-files -s | awk '$1=="120000"'` then turned up all three.

This is also more evidence for #924 itself: the branch has had broken absolute-path symlinks committed for hours with no CI to catch it.

Refs #924