### PR TITLE
ci: run the PR gates on pull requests to any branch (#924)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - main
-      - master
 
 permissions:
   contents: read

--- a/.github/workflows/package-tuff-cli-ci.yml
+++ b/.github/workflows/package-tuff-cli-ci.yml
@@ -2,9 +2,6 @@ name: Tuff CLI Package CI
 
 on:
   pull_request:
-    branches:
-      - main
-      - master
     paths:
       - "packages/tuff-cli/**"
       - "packages/tuff-cli-core/**"

--- a/.github/workflows/package-tuff-intelligence-ci.yml
+++ b/.github/workflows/package-tuff-intelligence-ci.yml
@@ -2,9 +2,6 @@ name: Tuff Intelligence Package CI
 
 on:
   pull_request:
-    branches:
-      - main
-      - master
     paths:
       - "packages/tuff-intelligence/**"
       - "packages/utils/**"

--- a/.github/workflows/package-tuffex-ci.yml
+++ b/.github/workflows/package-tuffex-ci.yml
@@ -2,9 +2,6 @@ name: Tuffex Package CI
 
 on:
   pull_request:
-    branches:
-      - master
-      - main
     paths:
       - "packages/tuffex/**"
       - "pnpm-lock.yaml"

--- a/.github/workflows/package-unplugin-ci.yml
+++ b/.github/workflows/package-unplugin-ci.yml
@@ -2,9 +2,6 @@ name: Unplugin Export Plugin CI
 
 on:
   pull_request:
-    branches:
-      - main
-      - master
     paths:
       - "packages/unplugin-export-plugin/**"
       - ".github/workflows/package-unplugin-ci.yml"

--- a/.github/workflows/package-utils-ci.yml
+++ b/.github/workflows/package-utils-ci.yml
@@ -2,9 +2,6 @@ name: Utils Package CI
 
 on:
   pull_request:
-    branches:
-      - main
-      - master
     paths:
       - "packages/utils/**"
       - ".github/workflows/package-utils-ci.yml"


### PR DESCRIPTION
Step 1 of the plan on #924, now that its precondition is met.

**The gap.** Seven of nine PR-triggered workflows only fired for PRs targeting `main`/`master` — including `ci.yml` (which owns `quality:pr`) and every `package-*-ci.yml`. All work lands on `TalexDreamSoul/app-shell-v2` (189 commits ahead of master; the base of every recent merge), so those PRs ran **no build, test, lint or typecheck at all**. PR #1035's complete check list was AI review, apply-labels, release-draft and Cloudflare Pages.

**It has already cost three regressions on the integration branch**, all found by hand rather than by CI:
- `pnpm -C packages/tuffex build` broken outright (#1052) — `package-tuffex-ci.yml` has `run-build: true` and would have caught it
- the tuffex test gate exiting non-zero on 5 unhandled rejections while printing `1113 tests passed` (#1064)
- three `node_modules` symlinks committed with an absolute local path (#1067)

**Scope: only the `pull_request` branch filter is removed.** `paths:` filters are untouched, so each package workflow still runs only when its own files change. `push:` triggers stay pinned to `main`/`master`.

**Verified green before enabling** — this is the part that mattered, since a red gate would block every PR the moment this merges. Measured at the **pushed tip** in a worktree with a **real `pnpm install`**, not symlinked `node_modules`:

| check | result |
|---|---|
| `pnpm quality:pr` (end to end) | **exit 0** |
| ├ `release:notes:verify` | exit 0 |
| ├ `lint:changed` | exit 0 |
| ├ `test:targeted` | exit 0 — 57 + 48 + 2 tests |
| └ `apps/core-app` `typecheck` | **exit 0, 0 errors** |
| utils / tuffex / tuff-intelligence / tuff-cli-core / unplugin — `lint` | all exit 0 |
| utils / tuffex / tuff-cli-core / unplugin — `test` | all exit 0 |

Getting that reading required real installs: with symlinked `node_modules`, core-app's typecheck reported **42 phantom errors** (two copies of `@talex-touch/utils` types — `StorageList.APP_SETTING` "not assignable" to a union containing itself). Those 42 were an artifact, not a defect; the same command against a real install reports 0.

The lint blockers this uncovered were cleared first in #1065 and #1066.

**Not included:** widening `test:targeted` from its 7 hardcoded files to the full suites. That is the substance of #924 and a much bigger change — it should land once these gates are proven stable on real PRs.

Refs #924