### PR TITLE
ci: build tuffex before the nexus suite (#924)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,13 @@ jobs:
       # Running and visible beats not running; flip continue-on-error off once
       # the counts reach zero, and until then use them as the regression
       # baseline to compare against.
+      # apps/nexus imports @talex-touch/tuffex/utils, whose exports map resolves
+      # only into dist/ — without a build those tests fail on module resolution
+      # rather than on anything they actually assert.
+      - name: Build tuffex
+        if: ${{ matrix.app == 'nexus' }}
+        run: pnpm -C packages/tuffex build
+
       - name: Run ${{ matrix.app }} suite
         continue-on-error: true
         run: pnpm -C "apps/${{ matrix.app }}" exec vitest run


### PR DESCRIPTION
Follow-up to #1069, from triaging what that job actually reported.

Two of the nexus failures are not product bugs — they never got as far as an assertion:

```
Error: Cannot find package '@talex-touch/tuffex/utils'
  imported from apps/nexus/server/utils/ssrZIndexReset.test.ts
Caused by: Failed to load url @talex-touch/tuffex/utils in apps/nexus/app/utils/layers.test.ts
```

`@talex-touch/tuffex/utils` resolves **only into `dist/`** via the package exports map (`"./utils": { "import": "./dist/es/utils/index.js" }`, `files: ["dist"]`), and no workflow builds tuffex before running app tests. Locally these pass because a `dist/` is lying around from development.

Adds a `Build tuffex` step gated to the `nexus` leg of the matrix, so the core-app leg does not pay for a build it does not need.

This is a defect in the job I added in #1069, not in nexus.

Refs #924