### PR TITLE
ci: run the workspace typecheck on pull requests (#553)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,31 @@ jobs:
         run: pnpm quality:pr
 
 
+  job_typecheck_all:
+    name: Typecheck (workspace)
+    runs-on: ubuntu-latest
+    needs: job1
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # quality:pr only type-checks apps/core-app. typecheck:all covers the rest
+      # of the workspaces that declare a typecheck script; see #553.
+      - name: Run workspace typecheck
+        run: pnpm typecheck:all
+
   job_app_tests:
     name: App suites (${{ matrix.app }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
`quality:pr` ends at `pnpm -C apps/core-app run typecheck`; the workspace-wide `typecheck:all` script exists but no workflow calls it.

Adds it as its own job (parallel, so it does not lengthen the quality gate). **Verified green on this branch first** — `pnpm typecheck:all` exits 0 — so this lands blocking rather than as another red-on-arrival gate.

## One correction to the issue, worth acting on separately

The issue states that `tuff-cli`, `tuff-cli-core`, `tuff-core`, `tuff-intelligence`, `intelligence-uikit`, `tuff-business` and `nexus` "are never type-checked by CI", implying `typecheck:all` would cover them. **It would not.** The script ends in `pnpm -r --if-present run typecheck`, and only **7 of 28 workspaces declare a `typecheck` script at all**.

Actually covered by this PR: `apps/core-app`, `apps/nexus`, `apps/tuff-analyse`, `packages/intelligence-uikit`, `plugins/clipboard-history`, `plugins/touch-translation` — plus `packages/tuffex`, which the script builds rather than checks.

Still invisible — **21 workspaces with no `typecheck` script**, including every one the issue names except `nexus` and `intelligence-uikit`, and notably `packages/utils`, which publishes raw TypeScript:

```
pi-extension-tuff, test, tuff-business, tuff-cli, tuff-cli-core, tuff-core,
tuff-intelligence, tuff-native, unplugin-export-plugin, utils,
reverse-proxy-design, and 10 plugins
```

So this PR closes the "script exists but nothing runs it" half. Giving those 21 workspaces a `typecheck` script is a larger, separate piece of work — flagged on the issue rather than smuggled in here.

Refs #553
