### PR TITLE
fix(core-app): drop the dead @/typings path alias (#739)

### DIFF
--- a/apps/core-app/tsconfig.node.json
+++ b/apps/core-app/tsconfig.node.json
@@ -16,8 +16,7 @@
       "@talex-touch/tuff-native/*": ["packages/tuff-native/*"],
       "@talex-touch/tuff-intelligence": ["packages/tuff-intelligence/src/index.ts"],
       "@talex-touch/tuff-intelligence/*": ["packages/tuff-intelligence/src/*"],
-      "@/common/*": ["packages/utils/common/*"],
-      "@/typings/*": ["packages/typings/*"]
+      "@/common/*": ["packages/utils/common/*"]
     },
     "resolveJsonModule": true,
     "types": ["electron-vite/node"],


### PR DESCRIPTION
`apps/core-app/tsconfig.node.json` mapped `"@/typings/*": ["packages/typings/*"]`, but `packages/typings` does not exist and is not a workspace member.

The mapping is inert today — nothing imports it — but it reads as a supported alias and editors offer it in autocomplete, so the first person to write `import type { X } from '@/typings/x'` gets a resolution failure with no hint that the target package is gone.

**Verified before removing:**
- `packages/typings` — confirmed absent
- the only occurrence of `@/typings` in the entire repo is the alias line itself; every other hit is inside `.trellis/` audit records
- checked **all 9 path aliases** in the file against `baseUrl: "../.."` — this was the only one whose target is missing

**Gates:** `pnpm -C apps/core-app run typecheck:node` exit 0 · full `typecheck` (node + web) exit 0.

Diff is one line.

Refs #739
