### PR TITLE
fix(tuffex): declare vitest and @vue/test-utils (#579)

### DIFF
--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -96,6 +96,7 @@
     "@types/gulp-autoprefixer": "^0.0.37",
     "@types/node": "catalog:dev",
     "@vitejs/plugin-vue": "^6.0.7",
+    "@vue/test-utils": "^2.4.11",
     "chalk": "^5.6.2",
     "dotenv": "^16.6.1",
     "esno": "^4.8.0",
@@ -106,6 +107,7 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.6",
     "vite-plugin-dts": "^4.5.4",
+    "vitest": "^3.2.7",
     "vue": "^3.5.39",
     "vue-tsc": "^3.3.6"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1062,6 +1062,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
         version: 6.0.8(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))
+      '@vue/test-utils':
+        specifier: ^2.4.11
+        version: 2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -1092,6 +1095,9 @@ importers:
       vite-plugin-dts:
         specifier: ^4.5.4
         version: 4.5.4(@types/node@24.13.2)(rollup@2.80.0)(typescript@5.9.3)(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+      vitest:
+        specifier: ^3.2.7
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.2)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(sass@1.101.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
       vue:
         specifier: ^3.5.39
         version: 3.5.39(typescript@5.9.3)


### PR DESCRIPTION
Continues #579 beyond `apps/core-app`. Declares the two test-tooling packages that `packages/tuffex` — a **published** package — has been resolving through `shamefully-hoist`:

| package | sites | why it was invisible |
|---|--:|---|
| `vitest` | `vitest.config.ts` + 146 test files | not in the manifest at all |
| `@vue/test-utils` | 135 test files | same |

**devDependencies only, so the published bundle cannot change.** `packages/components/vite.config.js` computes `external` from `dependencies + peerDependencies`, so dev entries are structurally incapable of affecting it. Proven rather than argued: the dist fingerprint over 1788 files is **identical before and after** — `890d234debcee46e`.

**Gates:** tuffex 145 files / 1114 tests green · `vue-tsc --noEmit` 0 errors · build exit 0.

## A more serious finding from the same scan — not fixed here

`packages/tuffex` also imports two packages it does not declare, and these are **runtime imports in shipped components**:

- **`@talex-touch/utils`** — 8 files, including `TxCodeEditorRuntime.vue`, `TxMarkdownEditor.vue`, `TxMarkdownView.vue`, `scroll-wheel.ts`
- **`@lezer/highlight`** — `TxCodeEditorRuntime.vue`

Because `external` is derived from the manifest, undeclared means **not externalized**, so both are **inlined into the published bundle**. Verified: there is no `from '@talex-touch/utils'` import anywhere in `dist/`, while `hasDocument` (a utils export) appears inlined in `dist/es/index.js`.

That means a consumer installing both `@talex-touch/tuffex` and `@talex-touch/utils` gets **two copies of utils** — one standalone, one baked into tuffex. `@talex-touch/utils` holds module-scope singletons; a duplicated copy is exactly the failure mode fixed in #956 for the z-index allocator, reintroduced through the bundle instead of through SSR.

Declaring them would flip both to external and **change the published dist**, so it is deliberately not in this PR — it needs a decision on whether they become `dependencies` or `peerDependencies`, and a release note. Details on #579.

Refs #579
