### PR TITLE
fix(core-app): register each canonical CoreBox event once (#477)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/core-box/ipc.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/core-box/ipc.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+// Every registration is kept, mirroring TuffMainTransport's Set of handlers. A Map holding one
+// handler per event would let a second registration overwrite the first, which is how the
+// duplicate registrations in #477 stayed invisible.
 const mocks = vi.hoisted(() => ({
   handlers: new Map<
     string,
-    (payload?: unknown, context?: { sender?: { id: number } }) => unknown
+    Array<(payload?: unknown, context?: { sender?: { id: number } }) => unknown>
   >(),
   streamHandlers: new Map<string, (payload: unknown, context: unknown) => unknown>(),
   on: vi.fn(
@@ -12,9 +15,14 @@ const mocks = vi.hoisted(() => ({
       handler: (payload?: unknown, context?: { sender?: { id: number } }) => unknown
     ) => {
       const eventName = typeof event === 'string' ? event : event.toEventName?.() || String(event)
-      mocks.handlers.set(eventName, handler)
+      const registered = mocks.handlers.get(eventName)
+      if (registered) registered.push(handler)
+      else mocks.handlers.set(eventName, [handler])
       return () => {
-        mocks.handlers.delete(eventName)
+        const current = mocks.handlers.get(eventName)
+        if (!current) return
+        const index = current.indexOf(handler)
+        if (index >= 0) current.splice(index, 1)
       }
     }
   ),
@@ -192,6 +200,21 @@ import { CoreBoxEvents } from '@talex-touch/utils/transport/events'
 import { OnboardingGateError } from '../../storage'
 import { ipcManager } from './ipc'
 
+/**
+ * Reads the single handler registered for an event, failing if the count is anything but one.
+ * Every existing assertion doubles as a cardinality check this way, so a duplicate registration
+ * breaks many tests loudly instead of hiding behind a last-write-wins lookup.
+ */
+function soleHandler(event: {
+  toEventName: () => string
+}): ((payload?: unknown, context?: { sender?: { id: number } }) => unknown) | undefined {
+  const eventName = event.toEventName()
+  const registered = mocks.handlers.get(eventName)
+  if (!registered) return undefined
+  expect(registered, `expected exactly one handler for ${eventName}`).toHaveLength(1)
+  return registered[0]
+}
+
 describe('CoreBox IPC hide transport', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -218,13 +241,31 @@ describe('CoreBox IPC hide transport', () => {
     expect(mocks.searchEngineCore.registerIndexCommitStream).toHaveBeenCalledWith(context)
   })
 
+  it('registers every canonical event exactly once', () => {
+    const counts = new Map<string, number>()
+    for (const [event] of mocks.on.mock.calls) {
+      const eventName =
+        typeof event === 'string'
+          ? event
+          : ((event as { toEventName?: () => string }).toEventName?.() ?? String(event))
+      counts.set(eventName, (counts.get(eventName) ?? 0) + 1)
+    }
+
+    const duplicated = [...counts.entries()]
+      .filter(([, count]) => count > 1)
+      .map(([eventName, count]) => `${eventName} ×${count}`)
+
+    expect(counts.size).toBeGreaterThan(0)
+    expect(duplicated).toEqual([])
+  })
+
   it('allows only the owning CoreBox renderer to detach the main-owned plugin view', async () => {
     mocks.currentWindow = {
       isDestroyed: () => false,
       isVisible: () => true,
       webContents: { id: 71 }
     }
-    const handler = mocks.handlers.get(CoreBoxEvents.uiMode.detach.toEventName())
+    const handler = soleHandler(CoreBoxEvents.uiMode.detach)
     const detachRegistrations = mocks.on.mock.calls.filter(([event]) => {
       const eventName =
         typeof event === 'string'
@@ -246,7 +287,7 @@ describe('CoreBox IPC hide transport', () => {
       isVisible: () => true,
       webContents: { id: 71 }
     }
-    const handler = mocks.handlers.get(CoreBoxEvents.uiMode.detach.toEventName())
+    const handler = soleHandler(CoreBoxEvents.uiMode.detach)
 
     const response = await handler?.(undefined, { sender: { id: 99 } })
 
@@ -393,7 +434,7 @@ describe('CoreBox IPC hide transport', () => {
       expect.objectContaining({ type: 'complete', sessionId: 'session-22' })
     ])
     expect(firstContext.end).toHaveBeenCalledTimes(1)
-    const queryHandler = mocks.handlers.get(CoreBoxEvents.search.query.toEventName()) as unknown as
+    const queryHandler = soleHandler(CoreBoxEvents.search.query) as unknown as
       | ((payload: unknown, context: { sender: { id: number } }) => Promise<unknown>)
       | undefined
     mocks.search.mockImplementation(
@@ -450,7 +491,7 @@ describe('CoreBox IPC hide transport', () => {
     mocks.searchEngineCore.cancelSearchFromSender.mockImplementation(
       (sessionId: string, senderId: number) => sessionId === 'session-11' && senderId === 11
     )
-    const cancelHandler = mocks.handlers.get(CoreBoxEvents.search.cancel.toEventName()) as
+    const cancelHandler = soleHandler(CoreBoxEvents.search.cancel) as
       | ((
           payload: { searchId: string },
           context: { sender: { id: number } }
@@ -494,13 +535,13 @@ describe('CoreBox IPC hide transport', () => {
     ]
   ])('answers native visibility from the current %s', (_case, currentWindow, expected) => {
     mocks.currentWindow = currentWindow
-    const handler = mocks.handlers.get(CoreBoxEvents.ui.getVisibility.toEventName())
+    const handler = soleHandler(CoreBoxEvents.ui.getVisibility)
 
     expect(handler?.()).toEqual(expected)
   })
 
   it('maps canonical hide payload into an immediate manager trigger', () => {
-    const handler = mocks.handlers.get(CoreBoxEvents.ui.hide.toEventName())
+    const handler = soleHandler(CoreBoxEvents.ui.hide)
 
     expect(handler).toBeTypeOf('function')
     handler?.({ immediate: true, reason: 'execute' })
@@ -510,7 +551,7 @@ describe('CoreBox IPC hide transport', () => {
 
   it('applies canonical window pin requests through the window manager', () => {
     mocks.isPinned.mockReturnValue(true)
-    const handler = mocks.handlers.get(CoreBoxEvents.ui.setPinned.toEventName())
+    const handler = soleHandler(CoreBoxEvents.ui.setPinned)
 
     expect(handler).toBeTypeOf('function')
     const response = handler?.({ pinned: true })
@@ -520,7 +561,7 @@ describe('CoreBox IPC hide transport', () => {
   })
 
   it('uses the CoreBox header height as the layout minimum', () => {
-    const handler = mocks.handlers.get(CoreBoxEvents.layout.setHeight.toEventName())
+    const handler = soleHandler(CoreBoxEvents.layout.setHeight)
 
     expect(handler).toBeTypeOf('function')
     expect(() => handler?.({ height: 55 })).toThrow('Invalid height (must be 56-650)')
@@ -541,7 +582,7 @@ describe('CoreBox IPC hide transport', () => {
       isVisible: () => true,
       webContents: { id: 41 }
     }
-    const handler = mocks.handlers.get(CoreBoxEvents.ui.expand.toEventName())
+    const handler = soleHandler(CoreBoxEvents.ui.expand)
 
     expect(handler).toBeTypeOf('function')
     handler?.({ forceMax: true })

--- a/apps/core-app/src/main/modules/box-tool/core-box/ipc.ts
+++ b/apps/core-app/src/main/modules/box-tool/core-box/ipc.ts
@@ -263,18 +263,12 @@ export class IpcManager {
         coreBoxManager.trigger(true)
       })
     )
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.ui.show, () => {
-        coreBoxManager.trigger(true)
-      })
-    )
 
     const handleHide = (payload?: CoreBoxHideRequest | void) => {
       coreBoxManager.trigger(false, { immediate: payload?.immediate === true })
     }
 
     this.transportDisposers.push(transport.on(CoreBoxEvents.ui.hide, handleHide))
-    this.transportDisposers.push(this.ensureTransport().on(CoreBoxEvents.ui.hide, handleHide))
 
     this.transportDisposers.push(
       transport.on(CoreBoxEvents.ui.getVisibility, () => {
@@ -300,11 +294,6 @@ export class IpcManager {
         this.handleExpandRequest(payload as ExpandOptions | number)
       })
     )
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.ui.expand, (payload) => {
-        this.handleExpandRequest(payload as ExpandOptions | number)
-      })
-    )
 
     const handleFocusWindow = () => {
       const window = getCoreBoxWindow()
@@ -315,9 +304,6 @@ export class IpcManager {
     }
 
     this.transportDisposers.push(transport.on(CoreBoxEvents.ui.focusWindow, handleFocusWindow))
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.ui.focusWindow, handleFocusWindow)
-    )
 
     this.transportDisposers.push(
       transport.on(CoreBoxEvents.search.query, async ({ query, activations, surface }, context) => {
@@ -401,7 +387,6 @@ export class IpcManager {
     }
 
     this.transportDisposers.push(transport.on(CoreBoxEvents.input.get, handleGetInput))
-    this.transportDisposers.push(this.ensureTransport().on(CoreBoxEvents.input.get, handleGetInput))
 
     this.transportDisposers.push(
       transport.on(coreBoxImageTranslateEvent, async (request) => {
@@ -426,7 +411,6 @@ export class IpcManager {
     }
 
     this.transportDisposers.push(transport.on(CoreBoxEvents.input.set, handleSetInput))
-    this.transportDisposers.push(this.ensureTransport().on(CoreBoxEvents.input.set, handleSetInput))
 
     const handleSetQuery = async (request: SetQueryRequest) => {
       const value = typeof request?.value === 'string' ? request.value : ''
@@ -437,9 +421,6 @@ export class IpcManager {
     }
 
     this.transportDisposers.push(transport.on(CoreBoxEvents.input.setQuery, handleSetQuery))
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.input.setQuery, handleSetQuery)
-    )
 
     const handleClearInput = async () => {
       await this.sendInputValueToRenderer({ value: '' })
@@ -447,9 +428,6 @@ export class IpcManager {
     }
 
     this.transportDisposers.push(transport.on(CoreBoxEvents.input.clear, handleClearInput))
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.input.clear, handleClearInput)
-    )
 
     const handleSetInputVisibility = async (request: SetInputVisibilityRequest) => {
       await this.setInputVisibility(Boolean(request?.visible))
@@ -457,9 +435,6 @@ export class IpcManager {
 
     this.transportDisposers.push(
       transport.on(CoreBoxEvents.input.setVisibility, handleSetInputVisibility)
-    )
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.input.setVisibility, handleSetInputVisibility)
     )
 
     const handleDeactivateProvider = async (request: DeactivateProviderRequest) => {
@@ -515,31 +490,17 @@ export class IpcManager {
     this.transportDisposers.push(
       transport.on(CoreBoxEvents.provider.deactivate, handleDeactivateProvider)
     )
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.provider.deactivate, handleDeactivateProvider)
-    )
 
     this.transportDisposers.push(
       transport.on(CoreBoxEvents.provider.deactivateAll, handleDeactivateAllProviders)
-    )
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.provider.deactivateAll, handleDeactivateAllProviders)
     )
 
     this.transportDisposers.push(
       transport.on(CoreBoxEvents.provider.getActivated, async () => this.getActiveProvidersState())
     )
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.provider.getActivated, async () =>
-        this.getActiveProvidersState()
-      )
-    )
 
     this.transportDisposers.push(
       transport.on(CoreBoxEvents.provider.getDetails, handleGetProviderDetails)
-    )
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.provider.getDetails, handleGetProviderDetails)
     )
 
     const handleDetachUIMode = async (
@@ -571,9 +532,6 @@ export class IpcManager {
     }
 
     this.transportDisposers.push(transport.on(CoreBoxEvents.uiMode.exit, handleExitUIMode))
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.uiMode.exit, handleExitUIMode)
-    )
 
     const handleAllowClipboard = (request: AllowClipboardRequest) => {
       const types = request?.types ?? 0
@@ -582,9 +540,6 @@ export class IpcManager {
     }
 
     this.transportDisposers.push(transport.on(CoreBoxEvents.clipboard.allow, handleAllowClipboard))
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.clipboard.allow, handleAllowClipboard)
-    )
 
     this.transportDisposers.push(
       transport.on(CoreBoxEvents.inputMonitoring.allow, () => {
@@ -601,30 +556,9 @@ export class IpcManager {
     )
 
     this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.ui.hideInput, async () => {
-        await this.setInputVisibility(false)
-        return { hidden: true }
-      })
-    )
-
-    this.transportDisposers.push(
       transport.on(CoreBoxEvents.ui.showInput, async () => {
         await this.setInputVisibility(true)
         return { shown: true }
-      })
-    )
-
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.ui.showInput, async () => {
-        await this.setInputVisibility(true)
-        return { shown: true }
-      })
-    )
-
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.inputMonitoring.allow, () => {
-        windowManager.enableInputMonitoring()
-        return { enabled: true }
       })
     )
 
@@ -659,20 +593,11 @@ export class IpcManager {
     }
 
     this.transportDisposers.push(transport.on(CoreBoxEvents.layout.setHeight, handleSetHeight))
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.layout.setHeight, handleSetHeight)
-    )
 
     this.transportDisposers.push(transport.on(CoreBoxEvents.layout.getBounds, handleGetBounds))
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.layout.getBounds, handleGetBounds)
-    )
 
     this.transportDisposers.push(
       transport.on(CoreBoxEvents.layout.setPositionOffset, handleSetPositionOffset)
-    )
-    this.transportDisposers.push(
-      this.ensureTransport().on(CoreBoxEvents.layout.setPositionOffset, handleSetPositionOffset)
     )
 
     this.transportDisposers.push(


### PR DESCRIPTION
`registerTransportHandlers()` called `transport.on()` twice for **21 of the 26** canonical CoreBox events — once on the local `transport` binding, once on `this.ensureTransport()`, which returns that same transport. Both registrations are now gone, leaving exactly one per event.

Fixes #477.

## The duplicates were real, not deduplicated

Worth stating because the first read suggests otherwise. `TuffMainTransport` keeps a **`Set`** of handlers per event, and 15 of the 21 pass a *shared named function* (`handleSetInput`, `handleHide`, …) to both calls — which looks like it would collapse to one Set entry.

It does not. `on()` wraps the caller's function in fresh `baseHandler` / `localHandler` / `channelHandler` / `invokeHandler` closures on **every call**, and registers those on four paths (`regChannel` MAIN, `regChannel` PLUGIN, invoke, local). Two `on()` calls therefore produce two independent registrations regardless of whether the caller's reference is shared.

So the reported P1 stands: one `input.set` / `input.setQuery` / `input.clear` sent two input updates to the renderer, each starting a forced search, and the superseded stream surfaced as `Uncaught (in promise) Error: Search stream superseded`.

## Removed registrations

`ui.show` `ui.hide` `ui.expand` `ui.focusWindow` `ui.hideInput` `ui.showInput` · `input.get` `input.set` `input.setQuery` `input.clear` `input.setVisibility` · `provider.deactivate` `provider.deactivateAll` `provider.getActivated` `provider.getDetails` · `layout.setHeight` `layout.getBounds` `layout.setPositionOffset` · `uiMode.exit` · `clipboard.allow` · `inputMonitoring.allow`

Each pair was verified to be the same handler — either the identical named reference or a byte-identical inline arrow — so nothing is lost by dropping the second. The five singly-registered events (`ui.setPinned`, `ui.getVisibility`, `uiMode.detach`, `search.query`, `search.cancel`) are untouched, and `TuffMainTransport` keeps its multi-subscriber semantics and disposer contract (a non-goal of the issue).

## The test mock was hiding it

`ipc.test.ts` stored one handler per event in a `Map`, so the second registration overwrote the first and duplication was unobservable. Two changes:

1. The mock now keeps **every** registration per event, mirroring the transport's `Set`.
2. Lookups go through a `soleHandler()` helper that fails unless exactly one handler is registered. Every existing assertion is therefore also a cardinality check, and a future duplicate breaks several tests loudly rather than silently resolving to the last writer.

Plus a dedicated `registers every canonical event exactly once` test that reports any event registered more than once, by name and count.

## Verification

Ran the issue's prescribed set:

- `ipc.test.ts` + `window.test.ts` + `useSearch.core.test.ts` — **44 passed**
- `packages/utils` `main-transport-identity.test.ts` — **5 passed**
- `typecheck:node` — **0 errors**
- `typecheck:web` — **0 errors**
- eslint on both changed files — clean
- whole `src/main/modules/box-tool` suite — **150 files / 1199 tests, all passing**

**Adversarial check**: with the new tests in place and `ipc.ts` restored to its unfixed state (`git show HEAD:…`), the suite fails as it should — the cardinality test lists all 21 offenders (`core-box:ui:show ×2`, `core-box:input:set ×2`, …) and three more tests fail through `soleHandler`. The guards are not vacuous.

## Not covered here

The acceptance list's final item — running the isolated packaged programmatic-input matrix twice and confirming zero `Search stream superseded` errors — needs a packaged build on a real profile and is not something this branch can demonstrate. The registration cardinality that caused it is fixed and now asserted.
