### PR TITLE
test(nexus): move intelligence route tests out of the server/api tree (#479)

### DIFF
--- a/apps/nexus/test/api/admin/analytics/intelligence.get.test.ts
+++ b/apps/nexus/test/api/admin/analytics/intelligence.get.test.ts
@@ -1,4 +1,4 @@
-import type { IntelligenceAuditRecord } from '../../../utils/intelligenceStore'
+import type { IntelligenceAuditRecord } from '../../../../server/utils/intelligenceStore'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const authMocks = vi.hoisted(() => ({
@@ -9,8 +9,8 @@ const intelligenceStoreMocks = vi.hoisted(() => ({
   listRuntimeAudits: vi.fn(),
 }))
 
-vi.mock('../../../utils/auth', () => authMocks)
-vi.mock('../../../utils/intelligenceStore', () => intelligenceStoreMocks)
+vi.mock('../../../../server/utils/auth', () => authMocks)
+vi.mock('../../../../server/utils/intelligenceStore', () => intelligenceStoreMocks)
 
 let handler: (event: unknown) => Promise<unknown>
 let getQueryMock: ReturnType<typeof vi.fn>
@@ -50,7 +50,7 @@ beforeAll(async () => {
   ;(globalThis as typeof globalThis & { defineEventHandler?: unknown }).defineEventHandler = handler => handler
   getQueryMock = vi.fn()
   ;(globalThis as typeof globalThis & { getQuery?: unknown }).getQuery = getQueryMock
-  handler = (await import('./intelligence.get')).default as (event: unknown) => Promise<unknown>
+  handler = (await import('../../../../server/api/admin/analytics/intelligence.get')).default as (event: unknown) => Promise<unknown>
 })
 
 beforeEach(() => {

--- a/apps/nexus/test/api/admin/intelligence-agent/session/stream.post.test.ts
+++ b/apps/nexus/test/api/admin/intelligence-agent/session/stream.post.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import streamIntelligenceAgentHandler from './stream.post'
+import streamIntelligenceAgentHandler from '../../../../../server/api/admin/intelligence-agent/session/stream.post'
 
 const routeGlobals = vi.hoisted(() => {
   const globals = globalThis as typeof globalThis & { readBody?: unknown }
@@ -28,10 +28,10 @@ const sessionMocks = vi.hoisted(() => ({
   pauseIntelligenceLabSession: vi.fn(),
 }))
 
-vi.mock('../../../../utils/auth', () => authMocks)
-vi.mock('../../../../utils/intelligenceAgentGraphRunner', () => graphMocks)
-vi.mock('../../../../utils/tuffIntelligenceRuntimeStore', () => runtimeMocks)
-vi.mock('../../../../utils/tuffIntelligenceLabService', () => sessionMocks)
+vi.mock('../../../../../server/utils/auth', () => authMocks)
+vi.mock('../../../../../server/utils/intelligenceAgentGraphRunner', () => graphMocks)
+vi.mock('../../../../../server/utils/tuffIntelligenceRuntimeStore', () => runtimeMocks)
+vi.mock('../../../../../server/utils/tuffIntelligenceLabService', () => sessionMocks)
 
 function deferred() {
   let resolve!: () => void

--- a/apps/nexus/test/api/admin/intelligence-agent/session/trace.get.test.ts
+++ b/apps/nexus/test/api/admin/intelligence-agent/session/trace.get.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import traceIntelligenceAgentHandler from './trace.get'
+import traceIntelligenceAgentHandler from '../../../../../server/api/admin/intelligence-agent/session/trace.get'
 
 const routeGlobals = vi.hoisted(() => {
   const globals = globalThis as typeof globalThis & { getQuery?: unknown }
@@ -20,8 +20,8 @@ const runtimeMocks = vi.hoisted(() => ({
   listRuntimeTraceEvents: vi.fn(),
 }))
 
-vi.mock('../../../../utils/auth', () => authMocks)
-vi.mock('../../../../utils/tuffIntelligenceRuntimeStore', () => runtimeMocks)
+vi.mock('../../../../../server/utils/auth', () => authMocks)
+vi.mock('../../../../../server/utils/tuffIntelligenceRuntimeStore', () => runtimeMocks)
 
 describe('/api/admin/intelligence-agent/session/trace', () => {
   beforeEach(() => {

--- a/apps/nexus/test/api/v1/intelligence/invoke.post.test.ts
+++ b/apps/nexus/test/api/v1/intelligence/invoke.post.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import invokeIntelligenceHandler from './invoke.post'
+import invokeIntelligenceHandler from '../../../../server/api/v1/intelligence/invoke.post'
 
 const routeGlobals = vi.hoisted(() => {
   const originalDefineEventHandler = globalThis.defineEventHandler
@@ -27,8 +27,8 @@ vi.mock('h3', async () => {
     readBody: h3Mocks.readBody,
   }
 })
-vi.mock('../../../utils/auth', () => authMocks)
-vi.mock('../../../utils/tuffIntelligenceLabService', () => intelligenceMocks)
+vi.mock('../../../../server/utils/auth', () => authMocks)
+vi.mock('../../../../server/utils/tuffIntelligenceLabService', () => intelligenceMocks)
 
 const quotaError = {
   code: 'CREDITS_EXCEEDED',

--- a/apps/nexus/test/api/v1/intelligence/stream.post.test.ts
+++ b/apps/nexus/test/api/v1/intelligence/stream.post.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import streamIntelligenceHandler from './stream.post'
+import streamIntelligenceHandler from '../../../../server/api/v1/intelligence/stream.post'
 
 const routeGlobals = vi.hoisted(() => {
   const originalDefineEventHandler = globalThis.defineEventHandler
@@ -27,8 +27,8 @@ vi.mock('h3', async () => {
     readBody: h3Mocks.readBody,
   }
 })
-vi.mock('../../../utils/auth', () => authMocks)
-vi.mock('../../../utils/tuffIntelligenceLabService', () => intelligenceMocks)
+vi.mock('../../../../server/utils/auth', () => authMocks)
+vi.mock('../../../../server/utils/tuffIntelligenceLabService', () => intelligenceMocks)
 
 const quotaError = {
   code: 'CREDITS_EXCEEDED',


### PR DESCRIPTION
Five Vitest files sat beside their handlers under `apps/nexus/server/api`, a tree `check:api-routes` reserves for runtime route handlers. The guard had been red since the commit that added them. They move to the established `test/api` hierarchy.

Fixes #479.

| from | to |
|---|---|
| `server/api/admin/analytics/intelligence.get.test.ts` | `test/api/admin/analytics/…` |
| `server/api/admin/intelligence-agent/session/stream.post.test.ts` | `test/api/admin/intelligence-agent/session/…` |
| `server/api/admin/intelligence-agent/session/trace.get.test.ts` | `test/api/admin/intelligence-agent/session/…` |
| `server/api/v1/intelligence/invoke.post.test.ts` | `test/api/v1/intelligence/…` |
| `server/api/v1/intelligence/stream.post.test.ts` | `test/api/v1/intelligence/…` |

## Coverage is unchanged, by construction

The only edits are relative references, rewritten to the convention `test/api` already uses — reach back out to the app root and in through `server/`, e.g. `vi.mock('../../../../server/utils/auth')`. `test/api/v1/intelligence/invoke.api.test.ts` already sits at that depth with that exact prefix, which confirms the arithmetic.

`git diff -M` reports **5 files, 18 insertions, 18 deletions** — every changed line is one of these paths. Nothing else in the suites moves, so the positive, auth, quota, stream and sanitization assertions are literally the same code. All eight `it()` blocks still run and pass.

The one non-obvious reference was a dynamic `await import('./intelligence.get')` inside a `beforeAll`, which a `from '…'` grep does not surface; it is rewritten too.

No new ignores were added to the guard — it passes because `server/api` now holds only handlers. `vitest.config.ts` already includes `test/**/*.test.ts`, so no config change was needed.

## Verification

- `check:api-routes` — **passes** (was exit 1); `find server/api` for `*.test.ts` / `test-utils.ts` / `__tests__` returns nothing
- the five moved suites — **5 files, 8 tests, all passing**
- `typecheck` — **0 errors**
- full nexus suite, this branch: **180 files / 958 tests, 11 files failed, 15 tests failed**
- full nexus suite, baseline layout (files restored under `server/api` with `git show HEAD:…`): **180 / 958, the same 11 files, the same 15 tests**

The suite is red on both sides, which is #327. The failing set is identical before and after, including `test/api/v1/intelligence/invoke.api.test.ts` — worth calling out because it shares a directory with a moved file, so it was the one plausible candidate for interference. It fails identically at baseline.

## Not covered here

The acceptance list also asks for a production build and for confirmation that test-like paths are absent from generated Nitro route/type manifests. Those need a full `nuxt build`, which this branch does not run. The structural invariant the manifests derive from — no test modules under `server/api` — is now enforced by the guard rather than by Nitro's ignore rules, which was the point of the issue.
