### PR TITLE
ref(core-box): drop the unconsumed expectedDuration provider contract (#333)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.ts
@@ -433,7 +433,6 @@ class AppProvider implements ISearchProvider<ProviderContext> {
   readonly type = 'application' as const
   readonly supportedInputTypes = [TuffInputType.Text]
   readonly priority = 'fast' as const
-  readonly expectedDuration = 50
 
   private dbUtils: DbUtils | null = null
   private context: ProviderContext | null = null

--- a/apps/core-app/src/main/modules/box-tool/addon/context-actions/context-actions-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/context-actions/context-actions-provider.ts
@@ -590,7 +590,6 @@ export class ContextActionsProvider implements ISearchProvider<ProviderContext> 
   readonly icon = { type: 'class' as const, value: 'i-ri-magic-line' }
   readonly supportedInputTypes = [TuffInputType.Text, TuffInputType.Image]
   readonly priority = 'fast' as const
-  readonly expectedDuration = 40
 
   private readonly builtinProvider = new BuiltinContextActionProvider()
   private readonly executionStates = new Map<string, ContextActionExecutionState>()

--- a/apps/core-app/src/main/modules/box-tool/addon/files/everything-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/everything-provider.ts
@@ -164,7 +164,6 @@ class EverythingProvider implements ISearchProvider<ProviderContext> {
   readonly type = 'file' as const
   readonly supportedInputTypes = [TuffInputType.Text, TuffInputType.Files]
   readonly priority = 'fast' as const
-  readonly expectedDuration = 50
 
   private esPath: string | null = null
   private configuredCliPath: string | null = null

--- a/apps/core-app/src/main/modules/box-tool/addon/files/file-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/file-provider.ts
@@ -389,7 +389,6 @@ class FileProvider implements ISearchProvider<ProviderContext> {
   readonly type = 'file' as const
   readonly supportedInputTypes = [TuffInputType.Text, TuffInputType.Files]
   readonly priority = 'deferred' as const
-  readonly expectedDuration = 500
 
   private dbUtils: ReturnType<typeof createDbUtils> | null = null
   private isInitializing: Promise<FileIndexSyncStats> | null = null

--- a/apps/core-app/src/main/modules/box-tool/addon/files/native-file-search-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/native-file-search-provider.ts
@@ -243,7 +243,6 @@ abstract class BaseNativeFileSearchProvider implements NativeFileSearchProvider 
   readonly type = 'file' as const
   readonly supportedInputTypes = [TuffInputType.Text, TuffInputType.Files]
   readonly priority = 'fast' as const
-  readonly expectedDuration = 75
   private readonly iconCache = new EverythingIconCache()
   protected available = false
   protected lastError: string | null = null

--- a/apps/core-app/src/main/modules/box-tool/addon/preview/preview-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/preview/preview-provider.ts
@@ -61,7 +61,6 @@ export class PreviewProvider implements ISearchProvider<ProviderContext> {
   readonly name = '即时预览'
   readonly supportedInputTypes = [TuffInputType.Text, TuffInputType.Html]
   readonly priority = 'fast' as const
-  readonly expectedDuration = 200
 
   constructor(private readonly sdk: PreviewSdk) {}
 

--- a/apps/core-app/src/main/modules/box-tool/addon/system/main-window-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/system/main-window-provider.ts
@@ -110,7 +110,6 @@ export class MainWindowProvider implements ISearchProvider<ProviderContext> {
   readonly name = 'Main Window'
   readonly supportedInputTypes = [TuffInputType.Text]
   readonly priority = 'fast' as const
-  readonly expectedDuration = 20
 
   private context: ProviderContext | null = null
 

--- a/apps/core-app/src/main/modules/box-tool/addon/system/system-actions-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/system/system-actions-provider.ts
@@ -364,7 +364,6 @@ export class SystemActionsProvider implements ISearchProvider<ProviderContext> {
   readonly name = 'System Actions'
   readonly supportedInputTypes = [TuffInputType.Text, TuffInputType.Files, TuffInputType.Html]
   readonly priority = 'fast' as const
-  readonly expectedDuration = 30
 
   private context: ProviderContext | null = null
 

--- a/apps/core-app/src/main/modules/box-tool/addon/system/windows-shell-file-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/system/windows-shell-file-provider.ts
@@ -200,7 +200,6 @@ export class WindowsShellFileProvider implements ISearchProvider<ProviderContext
   readonly name = 'Windows Shell File Entries'
   readonly supportedInputTypes = [TuffInputType.Text]
   readonly priority = 'fast' as const
-  readonly expectedDuration = 15
 
   async onSearch(query: TuffQuery, signal: AbortSignal): Promise<TuffSearchResult> {
     const startTime = performance.now()

--- a/apps/core-app/src/main/modules/plugin/adapters/plugin-features-adapter.ts
+++ b/apps/core-app/src/main/modules/plugin/adapters/plugin-features-adapter.ts
@@ -116,7 +116,6 @@ export class PluginFeaturesAdapter implements ISearchProvider<ProviderContext> {
   ]
 
   public readonly priority = 'fast' as const
-  public readonly expectedDuration = 30
 
   public async handleActiveFeatureInput(payload: CoreBoxInputChangeRequest): Promise<boolean> {
     const query = payload.query

--- a/docs/design/corebox/corebox-vs-utools-gap.md
+++ b/docs/design/corebox/corebox-vs-utools-gap.md
@@ -28,7 +28,7 @@
 ## CoreBox 现有能力依据（仓库内）
 
 - CoreBox 输入类型与查询结构：`packages/utils/core-box/tuff/tuff-dsl.ts`  
-- Provider 优先级 fast/deferred 与 expectedDuration：`packages/utils/core-box/tuff/tuff-dsl.ts`  
+- Provider 优先级 fast/deferred：`packages/utils/core-box/tuff/tuff-dsl.ts`（分层由 `search-gather.ts` 消费；不存在按预估耗时排序的机制）  
 - Windows Everything 集成与“fast”搜索层：`docs/everything-integration.md`  
 - CoreBox/DivisionBox 规划项与未实现功能：`docs/plan-prd/05-archive/codebase_analysis.md.resolved`  
 - 剪贴板输入与 CoreBox 交互说明：`docs/clipboard-mechanism-analysis.md`  

--- a/packages/utils/core-box/tuff/tuff-dsl.ts
+++ b/packages/utils/core-box/tuff/tuff-dsl.ts
@@ -1603,14 +1603,6 @@ export interface ISearchProvider<C> {
   readonly priority?: 'fast' | 'deferred'
 
   /**
-   * Expected search duration in milliseconds
-   * @description Used for sorting providers within the same layer and timeout estimation.
-   * Providers with lower expected duration run first within their layer.
-   * @default 1000
-   */
-  readonly expectedDuration?: number
-
-  /**
    * Core search method (PULL mode).
    * The engine calls this method to get results from the provider.
    *


### PR DESCRIPTION
`expectedDuration` had ten declarations and **zero readers**. Removed, per the issue's own instruction not to retain a configuration value with no consumer.

Fixes #333.

## What it claimed vs what it did

`ISearchProvider` documented it as:

> Used for sorting providers within the same layer and timeout estimation. Providers with lower expected duration run first within their layer.

Nothing reads the field anywhere in `apps/`, `packages/`, `plugins/` or `docs/`. So the nine core-app providers and the plugin-features adapter were carrying tuned numbers (15, 20, 30, 40, 50, 50, 75, 200, 500) that changed nothing, and maintainers could keep tuning them forever with no runtime effect. That is a phantom API, not just dead config.

The scan behind that claim was run with a positive control first, so the empty result means absent rather than "the scan broke".

## Why option 1 and not option 2

The issue offers "remove" or "implement a bounded scheduling policy". Option 2 is a scheduling design with its own starvation and first-result-latency risks, and it is explicitly out of scope of a contract cleanup ("Non-goals: broad search ranking redesign"). Removing is also the reversible direction: the field can come back with a real consumer and real tests, whereas leaving it invites someone to tune it again.

## What is NOT touched

The sibling `priority: 'fast' | 'deferred'` field is genuinely consumed — `search-gather.ts:364` partitions on `p.priority === 'fast'`. Fast/deferred layering, timeouts and provider ordering are unchanged; the only thing that goes is the within-layer ordering claim that was never implemented.

Also updated the one design-doc line that cited the field (`docs/design/corebox/corebox-vs-utools-gap.md`) so the documentation matches runtime behaviour, which is one of the acceptance criteria.

## Verification

- repository search for `expectedDuration` → **zero declarations remain**
- `packages/utils` suite — **129 files / 1014 tests passing**
- core-app `typecheck:node` and `typecheck:web` — **0 errors each**
- `src/main/modules/plugin/adapters` — 15 passing
- eslint on every changed file — clean

`src/main/modules/box-tool` reported one failure, `search-core.contracts.test.ts`. It is the known intermittent hook timeout (`Hook timed out in 10000ms` in a `beforeEach` doing `vi.resetModules()` plus dynamic imports) documented on #342 — it passes in isolation (20/20), fails on unmodified trees, and its failing set drifts between runs. Tracked under #323.

## Note for the SDK docs criterion

`ISearchProvider` is exported from `@talex-touch/utils`, so this is technically a public-surface change. It removes an **optional** field, so classes implementing the interface are unaffected; only an object literal that set it would newly error, and no such literal exists in this repo.
