### PR TITLE
fix(nexus): resolve the Volar plugins against vue-router 5 (#332)

### DIFF
--- a/apps/nexus/build/check-typecheck-plugin-resolution.mjs
+++ b/apps/nexus/build/check-typecheck-plugin-resolution.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Runs `nuxt typecheck` and fails when Vue language-core cannot resolve a Volar plugin.
+ *
+ * `vue-tsc` prints `[Vue] Resolve plugin path failed: … ERR_PACKAGE_PATH_NOT_EXPORTED` and then
+ * **exits 0**, so a plugin that never loaded looks exactly like a clean run. That is how the
+ * `vue-router/volar/*` failure in #332 stayed hidden: Nuxt 4 writes those plugin paths into
+ * `.nuxt/tsconfig.json` and they only exist in vue-router 5, but apps/nexus did not declare
+ * vue-router, so resolution fell through to the hoisted 4.x that apps/core-app pins.
+ *
+ * Silently losing a plugin costs real coverage — sfc-typed-router is what gives typed route
+ * names and params — so this wrapper turns the message into a non-zero exit until upstream does.
+ */
+
+import { spawn } from 'node:child_process'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const NEXUS_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+/** Substrings that mean a Volar plugin was requested and could not be loaded. */
+const RESOLUTION_FAILURES = ['Resolve plugin path failed', 'ERR_PACKAGE_PATH_NOT_EXPORTED']
+
+const child = spawn('nuxt', ['typecheck'], {
+  cwd: NEXUS_ROOT,
+  shell: true,
+  stdio: ['inherit', 'pipe', 'pipe'],
+})
+
+let captured = ''
+
+for (const stream of [child.stdout, child.stderr]) {
+  stream.setEncoding('utf8')
+  stream.on('data', (chunk) => {
+    captured += chunk
+    process.stdout.write(chunk)
+  })
+}
+
+child.on('close', (code) => {
+  const offending = captured
+    .split('\n')
+    .filter(line => RESOLUTION_FAILURES.some(needle => line.includes(needle)))
+
+  if (offending.length > 0) {
+    console.error('\n[typecheck-guard] vue-tsc could not resolve one or more Volar plugins:\n')
+    for (const line of offending) console.error(`  ${line.trim()}`)
+    console.error(
+      '\nThe plugin did not load, so whatever it checks was skipped. Align the package that owns'
+      + '\nthe subpath (declare it in apps/nexus so it resolves ahead of a hoisted older copy)'
+      + '\nrather than patching an export map.',
+    )
+    process.exit(1)
+  }
+
+  process.exit(code ?? 0)
+})

--- a/apps/nexus/package.json
+++ b/apps/nexus/package.json
@@ -33,11 +33,12 @@
     "start:generate": "npx serve .output/public",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "typecheck": "nuxt typecheck",
+    "typecheck": "node build/check-typecheck-plugin-resolution.mjs",
     "test": "vitest run",
     "visual:smoke:tuffex": "node scripts/tuffex-visual-smoke.mjs",
     "openapi:sync": "openapi-typescript ./openapi/nexus-sync.yaml -o ./types/sync-api.d.ts",
-    "dev:host": "nuxt dev --port 3200 --host 0.0.0.0"
+    "dev:host": "nuxt dev --port 3200 --host 0.0.0.0",
+    "typecheck:raw": "nuxt typecheck"
   },
   "dependencies": {
     "@auth/core": "^0.34.3",
@@ -62,7 +63,8 @@
     "ogl": "catalog:",
     "simplex-noise": "catalog:",
     "theme-colors": "^0.1.0",
-    "typeit": "catalog:"
+    "typeit": "catalog:",
+    "vue-router": "^5.1.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,6 +589,9 @@ importers:
       typeit:
         specifier: 'catalog:'
         version: 8.8.7
+      vue-router:
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.39)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))
     devDependencies:
       '@antfu/eslint-config':
         specifier: catalog:dev


### PR DESCRIPTION
`pnpm -C apps/nexus typecheck` exited 0 while printing two `ERR_PACKAGE_PATH_NOT_EXPORTED` failures for `vue-router/volar/sfc-route-blocks` and `sfc-typed-router`. Both are gone, and a guard now makes their return a non-zero exit.

Fixes #332.

## It was never a version-matrix problem

The subpaths are not obsolete — **they exist in `vue-router@5.1.0`**, which is installed. Nuxt 4.4.8 depends on `vue-router: ^5.1.0` and writes both plugin paths into `.nuxt/tsconfig.json` (`nuxt/dist/index.mjs:1407`). The chain:

1. `apps/nexus` declares `vue`, `nuxt` and `vue-tsc`, but **not** `vue-router`.
2. Resolution therefore walks up to the hoisted root `node_modules/vue-router`, which is **4.6.4** — hoisted because `apps/core-app` and `plugins/{clipboard-history,touch-translation}` pin `^4.6.4`.
3. vue-router 4 exports `./vetur/*` and no `./volar/*`.

The error message says so if you read the path: it points at `<repo>/node_modules/vue-router`, the repo root, not nexus. So nexus was resolving somebody else's copy.

## Fix

Declare `vue-router: ^5.1.0` in `apps/nexus/package.json`, matching Nuxt's own dependency. Nothing in nexus imports `vue-router` directly (it goes through Nuxt auto-imports) and it already ran against the 5.1.0 inside Nuxt's subtree — this writes down what was already true rather than changing a version. No export-map patch, no `node_modules` patch, no peer-dependency suppression.

## The guard, and why it is needed

`vue-tsc` prints these failures and **still exits 0**, so a plugin that never loaded is indistinguishable from a clean run. That is exactly how this hid: what silently went missing is `sfc-typed-router`, the plugin that provides typed route names and params.

`apps/nexus/build/check-typecheck-plugin-resolution.mjs` runs `nuxt typecheck`, streams its output through unchanged, and exits 1 if any line contains `Resolve plugin path failed` or `ERR_PACKAGE_PATH_NOT_EXPORTED`. `typecheck` now points at it; the bare command remains available as `typecheck:raw`.

**Adversarial check** — with the guard in place, removing the `vue-router` declaration from nexus and reinstalling drops resolution back to 4.6.4 and the guard exits **1**, listing both plugins. Restoring it exits 0. The guard is not vacuous.

## Verification

All three commands from the issue:

- `pnpm -C apps/nexus prepare` — **exit 0**
- `pnpm -C apps/nexus typecheck` — **exit 0**, `ERR_PACKAGE_PATH_NOT_EXPORTED` / `Resolve plugin path failed` occurrences: **0**, TS errors: **0**
- `pnpm -C apps/nexus build` — **exit 0**, full Nitro/Cloudflare build completes (24 directory index aliases materialised, root SQL dumps verified)

## One thing I did not do

The issue also asks that typed route blocks and route parameter inference be shown working in representative pages. The plugins now load, which is the precondition, but nexus has no `<route>` block or typed-param page to demonstrate it on — adding one would be new surface rather than a fix. If that demonstration matters, it wants its own change.
