### PR TITLE
fix(nexus): give a docs directory route and its index document one identity (#478)

### DIFF
--- a/apps/nexus/app/pages/docs/docs-page-performance.test.ts
+++ b/apps/nexus/app/pages/docs/docs-page-performance.test.ts
@@ -720,7 +720,9 @@ describe('docs page performance boundaries', () => {
     expect.soft(docsPageClientCache).toContain('export function readCachedDocsFullBody(cacheKey: string)')
     expect.soft(docsPageClientCache).toContain('export function hasCachedDocsFullBody(cacheKey: string)')
     expect.soft(docsPageClientCache).toContain('export function cacheDocsFullBody(value: DocsPageRecord)')
-    expect.soft(docsPageClientCache).toMatch(/return `doc-full:\$\{normalizeDocsPagePath\(path\)\}:\$\{locale\}`/)
+    // canonicalDocsPageIdentity, not the raw path: a directory route and its index document
+    // must land on one cache entry, or the same body is fetched and stored twice.
+    expect.soft(docsPageClientCache).toMatch(/return `doc-full:\$\{canonicalDocsPageIdentity\(path\)\}:\$\{locale\}`/)
     expect.soft(docsPageClientCache).toContain('while (docsFullBodyCache.size > DOCS_FULL_BODY_CACHE_LIMIT)')
     expect.soft(page).toMatch(/const fullDocCacheKey = computed\(\(\) => resolveDocsFullBodyCacheKey\(docPath\.value, docsLocale\.value\)\)/)
     // The page owns its document locally: Nuxt seeds a newly keyed asyncData entry

--- a/apps/nexus/app/utils/docs-page-client-cache.ts
+++ b/apps/nexus/app/utils/docs-page-client-cache.ts
@@ -1,5 +1,5 @@
 import { requestJson } from '~/utils/request'
-import { normalizeDocsPagePath } from '#shared/utils/docs-path'
+import { canonicalDocsPageIdentity, normalizeDocsPagePath } from '#shared/utils/docs-path'
 
 type DocsPageBodyMode = '0' | '1'
 type DocsPageLocale = 'en' | 'zh'
@@ -30,7 +30,7 @@ const docsPageRequestPending = new Map<string, Promise<DocsPageRecord>>()
 const docsFullBodyCache = new Map<string, DocsPageRecord>()
 
 export function resolveDocsFullBodyCacheKey(path: string, locale: DocsPageLocale) {
-  return `doc-full:${normalizeDocsPagePath(path)}:${locale}`
+  return `doc-full:${canonicalDocsPageIdentity(path)}:${locale}`
 }
 
 export function isDocsPageRecordForRoute(
@@ -50,8 +50,11 @@ export function isDocsPageRecordForRoute(
   if (localeMatch?.[1] && localeMatch[1] !== locale)
     return false
 
-  return normalizeDocsPagePath(rawPath.replace(/\.(en|zh)$/, ''))
-    === normalizeDocsPagePath(path)
+  // A directory route resolves to its index document, so `/docs/dev` must accept the
+  // `/docs/dev/index.en` record the API returns. Comparing them raw left SSR in `not-found`
+  // and answered 404 for every directory alias.
+  return canonicalDocsPageIdentity(rawPath.replace(/\.(en|zh)$/, ''))
+    === canonicalDocsPageIdentity(path)
 }
 
 function resolveDocsFullBodyCacheKeyFromDoc(value: DocsPageRecord) {
@@ -107,7 +110,7 @@ export function cacheDocsFullBody(value: DocsPageRecord) {
 }
 
 export function resolveDocsPageRequestCacheKey(input: DocsPageRequestInput) {
-  return `docs-page:${normalizeDocsPagePath(input.path)}:${input.locale}:${input.body}`
+  return `docs-page:${canonicalDocsPageIdentity(input.path)}:${input.locale}:${input.body}`
 }
 
 function readCachedDocsPageRequest(cacheKey: string) {

--- a/apps/nexus/server/utils/docsPath.test.ts
+++ b/apps/nexus/server/utils/docsPath.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import { isDocsPageRecordForRoute } from '../../app/utils/docs-page-client-cache'
 import {
+  canonicalDocsPageIdentity,
   isDocsPath,
   normalizeDocsPagePath,
   resolveDocsLocaleFromRoute,
@@ -8,6 +10,37 @@ import {
 } from './docsPath'
 
 describe('docsPath', () => {
+  it('gives a directory route and its index document one identity', () => {
+    expect(canonicalDocsPageIdentity('/docs/dev/index')).toBe('/docs/dev')
+    expect(canonicalDocsPageIdentity('/docs/dev/index.en')).toBe('/docs/dev')
+    expect(canonicalDocsPageIdentity('/en/docs/dev/components/index.en.mdc')).toBe('/docs/dev/components')
+    expect(canonicalDocsPageIdentity('/zh/docs/guide/index.zh')).toBe('/docs/guide')
+    expect(canonicalDocsPageIdentity('/docs/dev')).toBe('/docs/dev')
+    // The docs root is not an index inside anything, so it must survive untouched.
+    expect(canonicalDocsPageIdentity('/docs')).toBe('/docs')
+    expect(canonicalDocsPageIdentity('/docs/index')).toBe('/docs')
+    // A document that merely contains "index" in its name is not a directory index.
+    expect(canonicalDocsPageIdentity('/docs/dev/indexing')).toBe('/docs/dev/indexing')
+  })
+
+  it('leaves normalizeDocsPagePath alone so prerender inputs keep their index routes', () => {
+    // createDocsPrerenderRoutes goes through this, and the post-build alias materializer
+    // depends on /docs/<dir>/index staying a rendered route of its own.
+    expect(normalizeDocsPagePath('/docs/dev/index')).toBe('/docs/dev/index')
+    expect(normalizeDocsPagePath('/zh/docs/guide/index.zh.mdc')).toBe('/docs/guide/index')
+  })
+
+  it('accepts the index record the API returns for a directory request', () => {
+    // SSR answered 404 for every /en/docs/<dir> route because the API correctly resolved
+    // /docs/<dir>/index.en and this predicate then rejected it as a different route.
+    expect(isDocsPageRecordForRoute({ path: '/docs/dev/index.en' } as never, '/docs/dev', 'en')).toBe(true)
+    expect(isDocsPageRecordForRoute({ path: '/docs/dev/components/index.en' } as never, '/docs/dev/components', 'en')).toBe(true)
+    expect(isDocsPageRecordForRoute({ path: '/docs/guide/index.zh' } as never, '/docs/guide', 'zh')).toBe(true)
+    // Stale-route rejection and the locale check must both survive.
+    expect(isDocsPageRecordForRoute({ path: '/docs/other/index.en' } as never, '/docs/dev', 'en')).toBe(false)
+    expect(isDocsPageRecordForRoute({ path: '/docs/dev/index.zh' } as never, '/docs/dev', 'en')).toBe(false)
+  })
+
   it('normalizes localized markdown component links to the canonical doc path', () => {
     expect(normalizeDocsPagePath('/docs/dev/components/button.zh.md')).toBe('/docs/dev/components/button')
     expect(normalizeDocsPagePath('/zh/docs/dev/components/button.zh.md')).toBe('/docs/dev/components/button')

--- a/apps/nexus/server/utils/docsPath.ts
+++ b/apps/nexus/server/utils/docsPath.ts
@@ -1,4 +1,5 @@
 export {
+  canonicalDocsPageIdentity,
   DOCS_SUPPORTED_LOCALES,
   isDocsLocale,
   isDocsPath,

--- a/apps/nexus/shared/utils/docs-path.ts
+++ b/apps/nexus/shared/utils/docs-path.ts
@@ -6,6 +6,9 @@ const DOCS_SUPPORTED_LOCALE_SET = new Set<string>(DOCS_SUPPORTED_LOCALES)
 const CONTENT_EXTENSION_PATTERN = /\.(md|mdc)$/i
 const LOCALE_SUFFIX_PATTERN = /\.(en|zh)$/i
 const DOCS_PATH_PATTERN = /^\/docs(?=\/|$)/
+// `/docs/dev` and `/docs/dev/index` name the same document. Keeping them apart made SSR
+// reject the record the API had correctly resolved and answer 404 for every directory route.
+const INDEX_SEGMENT_PATTERN = /\/index$/i
 
 export function isDocsLocale(value: unknown): value is DocsLocale {
   return typeof value === 'string' && DOCS_SUPPORTED_LOCALE_SET.has(value)
@@ -46,6 +49,19 @@ export function stripDocsContentExtension(path: string) {
 
 export function stripDocsLocaleSuffix(path: string) {
   return path.replace(LOCALE_SUFFIX_PATTERN, '')
+}
+
+/**
+ * Collapses a trailing `/index` so a directory route and its index document share one identity.
+ *
+ * Deliberately NOT folded into normalizeDocsPagePath: the prerender route generator uses that
+ * function and needs `/docs/dev/index` to stay a distinct renderable input, which the post-build
+ * alias materializer then copies to `/docs/dev`. This is for matching and caching only.
+ */
+export function canonicalDocsPageIdentity(path: string | null | undefined) {
+  const normalized = normalizeDocsPagePath(path)
+  const collapsed = normalized.replace(INDEX_SEGMENT_PATTERN, '')
+  return collapsed || '/docs'
 }
 
 export function normalizeDocsPagePath(path: string | null | undefined) {


### PR DESCRIPTION
`/en/docs/dev` and every other localized docs directory route answered **404 from SSR** while the API had already resolved the correct index record. Fixed by giving a directory route and its index document one identity for matching and caching.

Fixes #478.

## The two halves are in different states

**The build failure is already gone.** `pnpm -C apps/nexus build` exits 0 and prints `[nexus-docs-aliases] materialized 24 directory index aliases` — the same 24. `build/materialize-docs-index-aliases.mjs` copies `dist/en/docs/dev/index/index.html` to `dist/en/docs/dev.html` after the build, and `docs-prerender-routes.ts` now emits only `/index` routes, so Nitro no longer sees directory aliases as prerender errors.

**The SSR 404 was not.** Materializing is a build-output remedy; it cannot change what the server renders. The cause is the one the issue identified:

```ts
return normalizeDocsPagePath(rawPath.replace(/\.(en|zh)$/, ''))
  === normalizeDocsPagePath(path)
```

`normalizeDocsPagePath` does not collapse a trailing `/index`. A request for `/docs/dev` normalizes to `/docs/dev`; the record `/docs/dev/index.en` normalizes to `/docs/dev/index`. Not equal → predicate false → `viewState` stays `not-found` → `setResponseStatus(404)`.

## I fixed it at the wrong layer first

My first attempt made `normalizeDocsPagePath` itself collapse `/index`. That is wrong, and the suite caught it immediately: `build/docs-prerender-routes.test.ts` failed two assertions, one of them literally named `keeps index documents as explicit prerender inputs`. Prerendering deliberately keeps `/docs/<dir>/index` as its own renderable route so the materializer has something to copy from. Folding the collapse into the shared normalizer silently rewrote the prerender input set.

The shipped change is scoped the way the issue words it — "response matching and related cache identities":

- new `canonicalDocsPageIdentity()` = `normalizeDocsPagePath` plus a trailing-`/index` collapse
- used in exactly three places: `isDocsPageRecordForRoute`, the `doc-full:` body cache key, and the `docs-page:` request cache key
- `normalizeDocsPagePath` is untouched, and a test now pins that separation so the next person does not repeat my first attempt

Locale checks and stale-route rejection survive: `/docs/dev/index.zh` is still refused for `en`, `/docs/other/index.en` still for `/docs/dev`. `/docs` itself is not treated as an index inside anything, and `/docs/dev/indexing` is not mistaken for a directory index.

## Verification

**Adversarial** — restoring `docs-page-client-cache.ts` from `HEAD` makes the new predicate test fail (`expected false to be true`); restoring `docs-path.ts` fails the identity test too. The guards are not vacuous.

- full nexus suite: **180 files / 961 tests, 11 files failed, 15 tests failed — identical to the baseline failing set**, which is #327. My three new tests pass.
- `typecheck` — **0 errors** (via the #332 guard, so no silent Volar plugin loss either)
- `build` — **exit 0**, 24 aliases materialised
- eslint on all five changed files — clean

Two follow-on edits were needed for renames: the source-text assertion in `docs-page-performance.test.ts` that matches the cache-key expression, and the `server/utils/docsPath.ts` re-export barrel.

## Not covered here

The issue's reproduction runs against a live dev server (`/en/docs/dev` → 200, `/en/docs/dev/index` → 200). I verified the predicate that produced the 404 rather than the HTTP status itself — booting Nuxt dev and issuing requests is not something this branch demonstrates. The failing comparison is now covered by unit tests in both directions.
