### PR TITLE
fix(core-app): stop status polling from extending the scan worker's life (#345)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/addon/files/workers/file-scan-worker-client.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/workers/file-scan-worker-client.test.ts
@@ -67,6 +67,19 @@ function messageTypeOf(message: unknown): string {
   return String((message as { type: unknown }).type)
 }
 
+/** Runs one scan to completion so the client is idle with its shutdown window armed. */
+async function scanOnceAndSettle(client: FileScanWorkerClient) {
+  const scan = client.scan(['/tmp'])
+  const worker = workerMock.workers.at(-1)!
+  worker.emit('message', {
+    type: 'done',
+    taskId: taskIdOf(worker.messages[0]),
+    scannedCount: 0
+  })
+  await expect(scan).resolves.toEqual([])
+  return worker
+}
+
 describe('FileScanWorkerClient idle shutdown', () => {
   beforeEach(() => {
     workerMock.workers.length = 0
@@ -118,8 +131,77 @@ describe('FileScanWorkerClient idle shutdown', () => {
   it('keeps the worker alive while status metrics are pending', async () => {
     vi.useFakeTimers()
     const client = new FileScanWorkerClient()
+    const worker = await scanOnceAndSettle(client)
+
+    // Poll late enough that the metrics request is still in flight when the idle deadline
+    // arrives, which is the only moment the deferral actually matters.
+    await vi.advanceTimersByTimeAsync(59_900)
+    const statusPromise = client.getStatus()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(worker.messages).toHaveLength(2)
+    expect(messageTypeOf(worker.messages[1])).toBe('metrics')
+
+    // The deadline lands here, with metrics still outstanding.
+    await vi.advanceTimersByTimeAsync(100)
+    expect(worker.terminateCalls).toBe(0)
+
+    // Metrics time out at +300ms from the request, which re-arms the window.
+    await vi.advanceTimersByTimeAsync(200)
+    await expect(statusPromise).resolves.toMatchObject({
+      name: 'file-scan',
+      state: 'idle',
+      metrics: null
+    })
+    expect(worker.terminateCalls).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(worker.terminateCalls).toBe(1)
+  })
+
+  it('does not extend worker liveness when polled faster than the idle timeout', async () => {
+    vi.useFakeTimers()
+    const client = new FileScanWorkerClient()
+    const worker = await scanOnceAndSettle(client)
+
+    // A diagnostics panel refreshing every 5s used to reset the whole 60s window on each
+    // call, so the worker never died no matter how long it sat unused. Poll well past the
+    // deadline; the worker must still go.
+    for (let elapsed = 0; elapsed < 75_000; elapsed += 5_000) {
+      const status = client.getStatus()
+      await vi.advanceTimersByTimeAsync(300)
+      await status
+      await vi.advanceTimersByTimeAsync(4_700)
+    }
+
+    expect(worker.terminateCalls).toBe(1)
+  })
+
+  it('reports a cached offline status without spawning a worker', async () => {
+    vi.useFakeTimers()
+    const client = new FileScanWorkerClient()
+    const worker = await scanOnceAndSettle(client)
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(worker.terminateCalls).toBe(1)
+    expect(workerMock.workers).toHaveLength(1)
+
+    await expect(client.getStatus()).resolves.toMatchObject({
+      state: 'offline',
+      threadId: null,
+      uptimeMs: null,
+      metrics: null
+    })
+    expect(workerMock.workers).toHaveLength(1)
+  })
+
+  it('holds the worker while a scan is active and only then starts the idle window', async () => {
+    vi.useFakeTimers()
+    const client = new FileScanWorkerClient()
     const scan = client.scan(['/tmp'])
     const worker = workerMock.workers.at(-1)!
+
+    await vi.advanceTimersByTimeAsync(600_000)
+    expect(worker.terminateCalls).toBe(0)
 
     worker.emit('message', {
       type: 'done',
@@ -128,19 +210,49 @@ describe('FileScanWorkerClient idle shutdown', () => {
     })
     await expect(scan).resolves.toEqual([])
 
+    await vi.advanceTimersByTimeAsync(59_999)
+    expect(worker.terminateCalls).toBe(0)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(worker.terminateCalls).toBe(1)
+  })
+
+  it('settles an in-flight status request on shutdown and refuses to respawn', async () => {
+    vi.useFakeTimers()
+    const client = new FileScanWorkerClient()
+    const worker = await scanOnceAndSettle(client)
+
     const statusPromise = client.getStatus()
     await vi.waitFor(() => expect(worker.messages).toHaveLength(2))
-    expect(messageTypeOf(worker.messages[1])).toBe('metrics')
 
-    await vi.advanceTimersByTimeAsync(60_000)
-    expect(worker.terminateCalls).toBe(0)
-    await expect(statusPromise).resolves.toMatchObject({
-      name: 'file-scan',
-      state: 'idle',
-      metrics: null
-    })
+    client.shutdown()
 
-    await vi.advanceTimersByTimeAsync(300)
+    // Without settling metricsPending this would stay unresolved until the 300ms timer,
+    // which fires against a worker that no longer exists.
+    await expect(statusPromise).resolves.toMatchObject({ metrics: null })
+    expect(worker.terminateCalls).toBe(1)
+
+    await expect(client.scan(['/var'])).rejects.toThrow('FILE_SCAN_WORKER_CLOSED')
+    expect(workerMock.workers).toHaveLength(1)
+
+    // Repeated shutdown is a no-op rather than a second terminate or a throw.
+    client.shutdown()
+    client.shutdown()
+    expect(worker.terminateCalls).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(600_000)
+    expect(worker.terminateCalls).toBe(1)
+  })
+
+  it('fails in-flight scans on shutdown', async () => {
+    vi.useFakeTimers()
+    const client = new FileScanWorkerClient()
+    const scan = client.scan(['/tmp'])
+    const worker = workerMock.workers.at(-1)!
+    await vi.waitFor(() => expect(worker.messages).toHaveLength(1))
+
+    client.shutdown()
+
+    await expect(scan).rejects.toThrow('FILE_SCAN_WORKER_CLOSED')
     expect(worker.terminateCalls).toBe(1)
   })
 })

--- a/apps/core-app/src/main/modules/box-tool/addon/files/workers/file-scan-worker-client.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/workers/file-scan-worker-client.ts
@@ -51,6 +51,7 @@ export class FileScanWorkerClient {
   private workerStartedAt: number | null = null
   private lastMetricsSample: { at: number; cpuUsage: WorkerMetricsPayload['cpuUsage'] } | null =
     null
+  private closed = false
   private readonly idleShutdown = new IdleWorkerShutdownController({
     timeoutMs: FILE_WORKER_IDLE_SHUTDOWN_MS,
     shouldShutdown: () => this.pending.size === 0 && this.metricsPending.size === 0,
@@ -137,8 +138,15 @@ export class FileScanWorkerClient {
     }
   }
 
+  /**
+   * Observational: it never creates a worker and never extends worker liveness.
+   *
+   * Cancelling the idle timer here used to restart the whole window on every call, so a
+   * diagnostics panel polling faster than FILE_WORKER_IDLE_SHUTDOWN_MS kept the worker
+   * alive forever. An in-flight metrics request still defers shutdown, but through
+   * shouldShutdown() reading metricsPending — not by moving the deadline.
+   */
   async getStatus(): Promise<WorkerStatusSnapshot> {
-    this.idleShutdown.cancel()
     const worker = this.worker
     const pendingCount = this.pending.size
     const metrics = worker ? await this.requestMetrics() : null
@@ -156,11 +164,20 @@ export class FileScanWorkerClient {
   }
 
   shutdown(): void {
+    this.closed = true
     this.failPendingScans(new Error('FILE_SCAN_WORKER_CLOSED'))
+    // Metrics requests own a 300ms timer and an unsettled promise each. Terminating without
+    // them leaves getStatus() awaiting a worker that is already gone, and the timers fire
+    // afterwards to re-arm an idle deadline for nothing.
+    this.settlePendingMetrics()
     this.terminateWorker()
   }
 
   private ensureWorker(): Worker {
+    // A scan arriving during application teardown must not resurrect the worker.
+    if (this.closed) {
+      throw new Error('FILE_SCAN_WORKER_CLOSED')
+    }
     this.idleShutdown.cancel()
     if (this.worker) {
       return this.worker
@@ -257,6 +274,14 @@ export class FileScanWorkerClient {
       pending.done = true
       pending.wake?.()
     }
+  }
+
+  private settlePendingMetrics(): void {
+    for (const pending of this.metricsPending.values()) {
+      clearTimeout(pending.timeout)
+      pending.resolve(null)
+    }
+    this.metricsPending.clear()
   }
 
   private async requestMetrics(): Promise<WorkerMetricsPayload | null> {


### PR DESCRIPTION
`FileScanWorkerClient.getStatus()` cancelled the idle-shutdown timer and scheduled a new one, restarting the whole 60s window on every call. A diagnostics panel polling faster than that kept the worker alive forever.

Fixes #345.

## What the recheck found

The issue asks to recheck current code first and keep only verified behaviour. Doing that narrowed the defect considerably:

- `IdleWorkerShutdownController.schedule()` is **already idempotent** (`if (this.timer) return`), so repeated scheduling never extended anything. The single line that made the deadline movable was the `this.idleShutdown.cancel()` at the top of `getStatus()`.
- `getStatus()` **already** avoided spawning: it reads `this.worker` and calls `requestMetrics()` only when one exists — it never calls `ensureWorker()`. That acceptance criterion held before this change; there is now a test pinning it.
- Active-work protection **already** worked through `shouldShutdown: () => this.pending.size === 0 && this.metricsPending.size === 0`.

So the fix is removing the cancel, not rebuilding the lifecycle.

## Also fixed, under "leaves no unresolved promise/timer/listener"

`shutdown()` called `failPendingScans()` and terminated, but never touched `metricsPending`. Each entry owns a 300ms timer and an unsettled promise, so an in-flight `getStatus()` stayed pending against a worker that was already gone, and the timer later fired to re-arm an idle deadline for nothing. `shutdown()` now settles them.

It also marks the client closed, so a scan arriving during teardown fails with `FILE_SCAN_WORKER_CLOSED` instead of resurrecting the worker. This is scoped to `shutdown()` only — idle termination goes through `terminateWorker()`, so the existing restart-after-idle path is untouched, and `shutdown()` has exactly one caller (`file-provider.ts:1119`, in the provider's own teardown `finally`).

## Tests

All with fake timers, as the acceptance list requires. Five new cases plus a rewrite:

- **rapid polling** — polls every 5s across 75s; the worker must still terminate
- **active work** — 600s of a running scan with no termination, then exactly 60s after completion
- **terminated client** — `getStatus()` returns the cached offline snapshot and `workers.length` stays at 1
- **shutdown with a status in flight** — the promise settles immediately, a later scan rejects, repeated `shutdown()` is a no-op, and no timer fires for the next 600s
- **shutdown with a scan in flight** — the scan rejects
- the existing "keeps the worker alive while status metrics are pending" was rewritten to poll at **t=59.9s** so the request is genuinely outstanding when the deadline lands. Previously it polled at t=0, where the old `cancel()` was doing the work rather than the deferral being tested.

**Adversarial check** — with the tests in place and `file-scan-worker-client.ts` restored from `HEAD`, two fail: the polling guard and the shutdown guard. They are not vacuous.

## Verification

- worker client suite — **7/7**
- `src/main/modules/box-tool/addon/files` — **47 files / 316 tests passing**
- `typecheck:node` — 0 errors; eslint on both files — clean

## Not covered here

The "drain in-flight batches and await persistence within a bound" part of the proposal is not implemented — `shutdown()` cancels rather than drains, which is what it already did. The provider calls `drainIndexedSourceMutations('shutdown')` before reaching this client, so batch persistence is handled a layer up; converting this client to a bounded drain would change that division and wants its own issue. The R7 audit entry is not updated here either — I did not find that document in the repo.
