### PR TITLE
chore(docs): guard README metadata against drifting from the manifests (#335)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,10 @@ jobs:
       - name: Verify build-script allowlist
         run: pnpm check:build-allowlist
 
+      # Reads LICENSE and the manifests only, so it does not need the install above.
+      - name: Verify entry documentation metadata
+        run: pnpm check:doc-metadata && pnpm check:doc-metadata:self-test
+
       - name: Run PR quality gate
         run: pnpm quality:pr
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
     "lint:fix": "pnpm -r --no-bail --filter \"./apps/core-app\" --filter \"./apps/nexus\" --filter \"./apps/tuff-analyse\" --filter \"./packages/*\" --filter \"./plugins/*\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored --no-error-on-unmatched-pattern \"**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}\" && eslint --cache --fix --max-warnings=0 --no-warn-ignored --no-error-on-unmatched-pattern \"scripts/**/*.{js,jsx,ts,tsx,mjs,cjs,cts,mts}\" \"workers/**/*.{js,jsx,ts,tsx,mjs,cjs,cts,mts}\" \"plugins/{touch-window-manager,touch-window-presets,touch-dev-toolbox,touch-batch-rename,touch-browser-bookmarks,touch-browser-open,touch-system-actions,touch-text-snippets,touch-snipaste,touch-quick-actions,touch-code-snippets}/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}\"",
     "lint:changed": "node scripts/run-eslint-changed.mjs",
     "lint:staged": "lint-staged",
-    "check:build-allowlist": "node scripts/check-build-allowlist.mjs"
+    "check:build-allowlist": "node scripts/check-build-allowlist.mjs",
+    "check:doc-metadata": "node scripts/check-doc-metadata.mjs",
+    "check:doc-metadata:self-test": "node scripts/check-doc-metadata.mjs --self-test"
   },
   "dependencies": {
     "@sentry/vite-plugin": "^4.9.1",

--- a/scripts/check-doc-metadata.mjs
+++ b/scripts/check-doc-metadata.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+/**
+ * Guards the entry-point documentation against drifting from the machine-readable sources.
+ *
+ * `LICENSE`, the root and CoreApp manifests, `.node-version` and the Volta pin are the truth;
+ * the READMEs are a rendering of it. Both READMEs currently avoid restating volatile versions
+ * and point at the manifests instead, which is the shape this check defends: a wrong license or
+ * a hardcoded Node/toolchain claim that contradicts the manifests must fail, rather than sit
+ * there misleading contributors, packagers and licence scanners.
+ *
+ * Read-only. Nothing here rewrites a file.
+ *
+ * `--self-test` runs the fixtures instead: mismatched license, Node and homepage inputs must all
+ * be rejected, which is what stops this from silently degrading into a no-op.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const READMES = ['README.md', 'README.zh-CN.md']
+
+function readJson(file) {
+  return JSON.parse(readFileSync(path.join(ROOT, file), 'utf8'))
+}
+
+/** `MPL-2.0 license` and `MPL-2.0` mean the same thing; compare the identifier only. */
+export function normalizeLicenseId(value) {
+  return String(value ?? '')
+    .trim()
+    .replace(/\s+licen[cs]e$/i, '')
+    .toUpperCase()
+}
+
+/** The SPDX id implied by the LICENSE file's own heading. */
+export function licenseIdFromText(licenseText) {
+  const heading = licenseText.split('\n', 1)[0].trim()
+  if (/^Mozilla Public License Version 2\.0$/i.test(heading))
+    return 'MPL-2.0'
+  if (/^MIT License$/i.test(heading))
+    return 'MIT'
+  if (/^Apache License$/i.test(heading))
+    return 'APACHE-2.0'
+  return null
+}
+
+/**
+ * Version-like claims that would contradict the manifests if hardcoded. Matches a prose
+ * statement such as "requires Node >= 22" but not a link or a changelog entry.
+ */
+const HARDCODED_CLAIM_PATTERNS = [
+  { label: 'Node version', pattern: /\bnode(?:\.js)?\s*(?:(?:>=?|≥|v)\s*)?(\d{2})(?:\.\d+)*/gi },
+  { label: 'Electron version', pattern: /\belectron\s*(?:(?:>=?|≥|v)\s*)?(\d{2})(?:\.\d+)*/gi },
+  { label: 'pnpm version', pattern: /\bpnpm\s*(?:(?:>=?|≥|v)\s*)?(\d+)(?:\.\d+)+/gi },
+]
+
+export function collectProblems(sources) {
+  const { licenseText, rootManifest, coreAppManifest, nodeVersionFile, readmes } = sources
+  const problems = []
+
+  // --- license ---------------------------------------------------------------
+  const licenseId = licenseIdFromText(licenseText)
+  if (!licenseId) {
+    problems.push('LICENSE heading is not a recognised licence; teach this script the new one.')
+  }
+
+  for (const [name, manifest] of [['root', rootManifest], ['apps/core-app', coreAppManifest]]) {
+    const declared = normalizeLicenseId(manifest.license)
+    if (licenseId && declared !== licenseId) {
+      problems.push(`${name} package.json declares license "${manifest.license}" but LICENSE is ${licenseId}.`)
+    }
+  }
+
+  for (const { file, text } of readmes) {
+    if (licenseId && !text.includes(licenseId)) {
+      problems.push(`${file} never states the ${licenseId} licence.`)
+    }
+    for (const other of ['MIT', 'Apache-2.0', 'GPL-3.0']) {
+      if (other !== licenseId && new RegExp(`\\b${other}\\b`).test(text)) {
+        problems.push(`${file} mentions ${other} while the project is ${licenseId}.`)
+      }
+    }
+  }
+
+  // --- runtime ---------------------------------------------------------------
+  const enginesNode = rootManifest.engines?.node
+  const voltaNode = rootManifest.volta?.node
+  const pinnedNode = nodeVersionFile.trim()
+  const enginesMajor = enginesNode?.match(/(\d+)/)?.[1]
+  const pinnedMajor = pinnedNode.match(/^(\d+)/)?.[1]
+  const voltaMajor = voltaNode?.match(/^(\d+)/)?.[1]
+
+  if (enginesMajor && pinnedMajor && enginesMajor !== pinnedMajor) {
+    problems.push(`engines.node (${enginesNode}) and .node-version (${pinnedNode}) disagree on the major version.`)
+  }
+  if (voltaMajor && pinnedMajor && voltaMajor !== pinnedMajor) {
+    problems.push(`volta.node (${voltaNode}) and .node-version (${pinnedNode}) disagree.`)
+  }
+
+  // A README must not restate a version that the manifests could move underneath it.
+  for (const { file, text } of readmes) {
+    for (const { label, pattern } of HARDCODED_CLAIM_PATTERNS) {
+      pattern.lastIndex = 0
+      for (const match of text.matchAll(pattern)) {
+        const claimed = match[1]
+        const expected = label === 'Node version' ? pinnedMajor : null
+        if (expected && claimed !== expected) {
+          problems.push(`${file} hardcodes ${label} "${match[0].trim()}", which contradicts .node-version (${pinnedNode}). Point at the manifest instead of restating it.`)
+        }
+        else if (!expected) {
+          problems.push(`${file} hardcodes ${label} "${match[0].trim()}". Manifests move; link to them instead.`)
+        }
+      }
+    }
+  }
+
+  // --- homepage --------------------------------------------------------------
+  const homepages = new Set(
+    [rootManifest.homepage, coreAppManifest.homepage].filter(Boolean).map(value => value.replace(/\/$/, '')),
+  )
+  if (homepages.size > 1) {
+    problems.push(`Manifests disagree on homepage: ${[...homepages].join(' vs ')}. See #306 for the canonical value.`)
+  }
+
+  // --- links -----------------------------------------------------------------
+  for (const { file, text, dir } of readmes) {
+    const targets = new Set([...text.matchAll(/\]\((\.[^)#]+)(?:#[^)]*)?\)/g)].map(match => match[1]))
+    for (const target of targets) {
+      if (!existsSync(path.resolve(dir, target))) {
+        problems.push(`${file} links to ${target}, which does not exist.`)
+      }
+    }
+  }
+
+  return problems
+}
+
+function loadSources() {
+  return {
+    licenseText: readFileSync(path.join(ROOT, 'LICENSE'), 'utf8'),
+    rootManifest: readJson('package.json'),
+    coreAppManifest: readJson('apps/core-app/package.json'),
+    nodeVersionFile: readFileSync(path.join(ROOT, '.node-version'), 'utf8'),
+    readmes: READMES.map(file => ({
+      file,
+      text: readFileSync(path.join(ROOT, file), 'utf8'),
+      dir: ROOT,
+    })),
+  }
+}
+
+function selfTest() {
+  const base = loadSources()
+  const cases = [
+    {
+      name: 'mismatched license in a manifest',
+      mutate: sources => ({ ...sources, rootManifest: { ...sources.rootManifest, license: 'MIT' } }),
+      expect: /declares license "MIT"/,
+    },
+    {
+      name: 'a README claiming the wrong licence',
+      mutate: sources => ({
+        ...sources,
+        readmes: sources.readmes.map((entry, index) =>
+          index === 0 ? { ...entry, text: `${entry.text}\n\nReleased under the MIT license.\n` } : entry,
+        ),
+      }),
+      expect: /mentions MIT while the project is MPL-2\.0/,
+    },
+    {
+      name: 'a README hardcoding a stale Node version',
+      mutate: sources => ({
+        ...sources,
+        readmes: sources.readmes.map((entry, index) =>
+          index === 0 ? { ...entry, text: `${entry.text}\n\nRequires Node >= 22.\n` } : entry,
+        ),
+      }),
+      expect: /hardcodes Node version/,
+    },
+    {
+      name: 'manifests disagreeing on homepage',
+      mutate: sources => ({
+        ...sources,
+        rootManifest: { ...sources.rootManifest, homepage: 'https://example.invalid' },
+      }),
+      expect: /disagree on homepage/,
+    },
+    {
+      name: 'engines and .node-version disagreeing',
+      mutate: sources => ({ ...sources, nodeVersionFile: '22.11.0\n' }),
+      expect: /disagree on the major version/,
+    },
+    {
+      name: 'a README link that does not resolve',
+      mutate: sources => ({
+        ...sources,
+        readmes: sources.readmes.map((entry, index) =>
+          index === 0 ? { ...entry, text: `${entry.text}\n\n[gone](./this-file-does-not-exist.md)\n` } : entry,
+        ),
+      }),
+      expect: /does not exist/,
+    },
+  ]
+
+  let failures = 0
+  for (const testCase of cases) {
+    const problems = collectProblems(testCase.mutate(base))
+    const matched = problems.some(problem => testCase.expect.test(problem))
+    console.log(`${matched ? 'ok  ' : 'FAIL'} ${testCase.name}`)
+    if (!matched) {
+      failures += 1
+      console.log(`     expected a problem matching ${testCase.expect}, got: ${JSON.stringify(problems)}`)
+    }
+  }
+
+  const clean = collectProblems(base)
+  console.log(`${clean.length === 0 ? 'ok  ' : 'FAIL'} the real tree is clean`)
+  if (clean.length > 0) {
+    failures += 1
+    for (const problem of clean) console.log(`     ${problem}`)
+  }
+
+  return failures
+}
+
+if (process.argv.includes('--self-test')) {
+  process.exit(selfTest() > 0 ? 1 : 0)
+}
+
+const problems = collectProblems(loadSources())
+if (problems.length > 0) {
+  console.error('[doc-metadata] entry documentation disagrees with the machine-readable sources:\n')
+  for (const problem of problems) console.error(`  - ${problem}`)
+  console.error(`\n${problems.length} problem(s).`)
+  process.exit(1)
+}
+
+console.log('[doc-metadata] README licence, runtime and links match LICENSE and the manifests')


### PR DESCRIPTION
The license and runtime claims #335 reported are **already corrected**. What was missing is the check that keeps them corrected — that is what this adds.

Fixes #335.

## Current state, verified

| criterion | state |
|---|---|
| README licence matches `LICENSE` and manifests | already true — both READMEs say **MPL-2.0**, `LICENSE` is Mozilla Public License 2.0, both manifests declare `MPL-2.0 license` |
| Node/package-manager prerequisites match | already true — and better than the proposal: instead of restating versions, both READMEs now say *"do not rely on version numbers copied into this README"* / *"不要依赖 README 中复制的版本号"* and link to the manifests |
| Framework/toolchain versions accurate | already true, by the same removal — no `MIT`, no `Node >= 22`, no `Electron 37` survives in either file |
| Links resolve | verified — 12 relative links in each README, **0 missing** |

Restating versions and then policing them is the more fragile of the two shapes; the READMEs already picked the durable one, so the checker defends *that* rather than reintroducing hardcoded numbers.

## The checker

`scripts/check-doc-metadata.mjs`, wired into the PR Quality job. Read-only — it never rewrites a file. It fails on:

- a manifest whose `license` disagrees with the `LICENSE` heading (normalising `MPL-2.0 license` → `MPL-2.0`)
- a README that never states the project licence, or that names a different one
- a README hardcoding a Node/Electron/pnpm version — either contradicting `.node-version`, or restating a version the manifests can move underneath it
- `engines.node`, `.node-version` and the Volta pin disagreeing
- the root and CoreApp manifests disagreeing on `homepage` (the #306 source-of-truth rule)
- a relative README link that does not resolve

## It tests itself

The issue asks for fixtures proving mismatched license, Node and homepage values fail. `--self-test` mutates the real inputs six ways and requires each to be rejected:

```
ok   mismatched license in a manifest
ok   a README claiming the wrong licence
ok   a README hardcoding a stale Node version
ok   manifests disagreeing on homepage
ok   engines and .node-version disagreeing
ok   a README link that does not resolve
ok   the real tree is clean
```

The last line matters as much as the rest: a checker that passes on everything looks identical to a clean repo, so both directions are asserted. CI runs `check:doc-metadata && check:doc-metadata:self-test`, so the guard cannot decay into a no-op unnoticed.

## One thing I noticed and did not change

Both manifests declare `"license": "MPL-2.0 license"`, which is not a valid SPDX identifier — the trailing word should not be there, and tooling that parses SPDX strictly will not recognise it. The checker normalises it rather than rejecting it, because correcting the field touches licence metadata and #335 lists *"Changing the project license in this issue"* as a non-goal. Worth a follow-up if you want registry and scanner output to be right.
