### PR TITLE
ref(core-app): drop the accumulating scan() from the file scan worker client (#480 partial)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/addon/files/workers/file-scan-worker-client.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/workers/file-scan-worker-client.test.ts
@@ -51,6 +51,7 @@ vi.mock('@talex-touch/utils/common/logger', () => ({
   })
 }))
 
+import type { ScannedFileInfo } from '../types'
 import { FileScanWorkerClient } from './file-scan-worker-client'
 
 function taskIdOf(message: unknown): string {
@@ -67,9 +68,20 @@ function messageTypeOf(message: unknown): string {
   return String((message as { type: unknown }).type)
 }
 
+/**
+ * Drains scanBatches for tests that only care about the final list. The client deliberately
+ * exposes no accumulating scan(): materialising a whole root is the OOM shape #480 is about,
+ * so the convenience stays here, bounded to a fixture, instead of in production code.
+ */
+async function drainScan(client: FileScanWorkerClient, paths: string[]) {
+  const files: ScannedFileInfo[] = []
+  for await (const batch of client.scanBatches(paths)) files.push(...batch)
+  return files
+}
+
 /** Runs one scan to completion so the client is idle with its shutdown window armed. */
 async function scanOnceAndSettle(client: FileScanWorkerClient) {
-  const scan = client.scan(['/tmp'])
+  const scan = drainScan(client, ['/tmp'])
   const worker = workerMock.workers.at(-1)!
   worker.emit('message', {
     type: 'done',
@@ -92,7 +104,7 @@ describe('FileScanWorkerClient idle shutdown', () => {
   it('terminates the idle worker after scan completion and restarts on next scan', async () => {
     vi.useFakeTimers()
     const client = new FileScanWorkerClient()
-    const firstScan = client.scan(['/tmp'])
+    const firstScan = drainScan(client, ['/tmp'])
     const firstWorker = workerMock.workers.at(-1)!
 
     expect(firstWorker.messages[0]).toMatchObject({
@@ -110,7 +122,7 @@ describe('FileScanWorkerClient idle shutdown', () => {
     await vi.advanceTimersByTimeAsync(60_000)
     expect(firstWorker.terminateCalls).toBe(1)
 
-    const secondScan = client.scan(['/var'])
+    const secondScan = drainScan(client, ['/var'])
     const secondWorker = workerMock.workers.at(-1)!
 
     expect(workerMock.workers).toHaveLength(2)
@@ -197,7 +209,7 @@ describe('FileScanWorkerClient idle shutdown', () => {
   it('holds the worker while a scan is active and only then starts the idle window', async () => {
     vi.useFakeTimers()
     const client = new FileScanWorkerClient()
-    const scan = client.scan(['/tmp'])
+    const scan = drainScan(client, ['/tmp'])
     const worker = workerMock.workers.at(-1)!
 
     await vi.advanceTimersByTimeAsync(600_000)
@@ -231,7 +243,7 @@ describe('FileScanWorkerClient idle shutdown', () => {
     await expect(statusPromise).resolves.toMatchObject({ metrics: null })
     expect(worker.terminateCalls).toBe(1)
 
-    await expect(client.scan(['/var'])).rejects.toThrow('FILE_SCAN_WORKER_CLOSED')
+    await expect(drainScan(client, ['/var'])).rejects.toThrow('FILE_SCAN_WORKER_CLOSED')
     expect(workerMock.workers).toHaveLength(1)
 
     // Repeated shutdown is a no-op rather than a second terminate or a throw.
@@ -246,7 +258,7 @@ describe('FileScanWorkerClient idle shutdown', () => {
   it('fails in-flight scans on shutdown', async () => {
     vi.useFakeTimers()
     const client = new FileScanWorkerClient()
-    const scan = client.scan(['/tmp'])
+    const scan = drainScan(client, ['/tmp'])
     const worker = workerMock.workers.at(-1)!
     await vi.waitFor(() => expect(worker.messages).toHaveLength(1))
 

--- a/apps/core-app/src/main/modules/box-tool/addon/files/workers/file-scan-worker-client.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/workers/file-scan-worker-client.ts
@@ -58,19 +58,6 @@ export class FileScanWorkerClient {
     shutdown: () => this.terminateWorker()
   })
 
-  async scan(
-    paths: string[],
-    excludePaths?: Set<string>,
-    batchSize?: number,
-    signal?: AbortSignal
-  ): Promise<ScannedFileInfo[]> {
-    const results: ScannedFileInfo[] = []
-    for await (const batch of this.scanBatches(paths, excludePaths, batchSize, signal)) {
-      results.push(...batch)
-    }
-    return results
-  }
-
   /**
    * @param onStats Invoked once when the worker reports a completed run. It is
    *   NOT called when the run aborts or fails — an absent callback means "this


### PR DESCRIPTION
Partial work on #480 — **does not close it.**

`FileScanWorkerClient.scan()` is one of the three layers #480 names as materialising a whole directory listing (`file-scan-worker-client.ts:132`, the `results.push(...batch)` accumulator). It has **no production callers**: the pipeline consumes `scanBatches()` at `file-provider.ts:3090`, and a repo-wide search finds `scan()` used only by its own test file.

So it was a dormant way to reintroduce exactly the allocation the issue is about. Removed; the tests that used it as a convenience now drain `scanBatches` through a local helper, keeping the accumulation in a fixture rather than in shipped code.

## Why this is only partial

Rechecking the three cited sites first — as issues of this age deserve — shows two of them have already been reworked since the audit:

- **client** (`file-scan-worker-client.ts`) — `scanBatches()` streams with `batchAck` backpressure; the accumulating sibling had no callers, and is gone as of this PR.
- **reconciliation** (`file-provider-reconciliation-run-service.ts`) — no longer holds full disk and DB sets. It consumes an `AsyncIterable<ScannedFileInfo[]>`, and `reconcile()` is invoked **per batch** with `getDbFilesByPaths(diskPaths)` scoped to that batch's paths. Row counting went to a `countRootRows` census instead of a materialised set, and there are explicit `yieldAfterDbRead` / `yieldAfterPathScan` cooperative yields.
- **worker** (`file-scan-worker.ts`) — posts batches and waits on `batchAckWaiters`, i.e. the bounded/backpressured shape the issue asks for.

What genuinely remains is the **measured** part of the acceptance criteria, and none of it can be done from this branch:

- a controlled million-entry fixture completing within an explicit memory budget
- peak memory measured for worker, client and reconciliation, shown to be bounded by batch size rather than directory cardinality
- packaged-app responsiveness during the run

Those need a fixture generator and a memory-instrumented run, and the "explicit memory budget" is a number someone has to choose. Correctness tests for additions/removals/duplicates/batch boundaries also still want writing against that fixture.

## Verification

- `src/main/modules/box-tool/addon/files` — **47 files / 316 tests passing**
- `typecheck:node` — 0 errors (the first attempt failed with TS2345: the helper's `const files = []` inferred `never[]`; it is now typed `ScannedFileInfo[]`)
- eslint on the workers directory — clean
