### PR TITLE
chore(trellis): reconcile the audit task records with their closed issues (#481)

### DIFF
--- a/.trellis/tasks/07-27-audit-plugin-privileged-security/task.json
+++ b/.trellis/tasks/07-27-audit-plugin-privileged-security/task.json
@@ -3,7 +3,7 @@
   "name": "audit-plugin-privileged-security",
   "title": "审计插件高权限能力与隐私安全",
   "description": "",
-  "status": "planning",
+  "status": "completed",
   "dev_type": null,
   "scope": null,
   "package": null,
@@ -11,7 +11,7 @@
   "creator": "TalexDreamSoul",
   "assignee": "TalexDreamSoul",
   "createdAt": "2026-07-27",
-  "completedAt": null,
+  "completedAt": "2026-08-07",
   "branch": null,
   "base_branch": "master",
   "worktree_path": null,
@@ -23,8 +23,8 @@
   "relatedFiles": [],
   "notes": "",
   "meta": {
-    "nextAction": "Audit the listed plugin capability, SQLite, privacy, transport, and host-trust boundaries and record reproducible evidence for each finding.",
-    "blocker": "No blocker is recorded; planning requires the evidence inventory before implementation tasks can be scoped.",
-    "evidence": "prd.md, research/*.md, and check.jsonl define the audit scope and required evidence."
+    "nextAction": "None. The audit shipped as issues #296-#302; remediation and verification live there.",
+    "blocker": "",
+    "evidence": "Every finding this audit was scoped to produce was published and closed: #296 permission-revocation invalidation, #297 out-of-process isolation, #298 secure view defaults, #299 SQLite isolation/fail-close, #300 transport caller verification, #301 sensitive-data retention, and parent #302 with the superseding 460/460 capability matrix. All seven verified CLOSED on 2026-08-07. The unchecked capability/data-flow/SQLite/transport items in check.jsonl are the audit intake list, not an outstanding acceptance gap — they were superseded by #302 rather than left undone. Do not reopen these as current vulnerabilities; they are historical fixed findings."
   }
 }

--- a/.trellis/tasks/07-27-base-anchor-liquid-animation/check.jsonl
+++ b/.trellis/tasks/07-27-base-anchor-liquid-animation/check.jsonl
@@ -1,4 +1,3 @@
-{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}
 {"file": ".trellis/spec/frontend/component-guidelines.md", "reason": "复核 liquid 分支未破坏既有 props/slots 契约与可访问性。"}
 {"file": ".trellis/spec/frontend/type-safety.md", "reason": "复核类型为纯增量扩展，无 any、无强制断言。"}
 {"file": ".trellis/spec/frontend/quality-guidelines.md", "reason": "执行 tuffex 单测、nexus 文档覆盖测试、lint 与 typecheck 门禁。"}

--- a/.trellis/tasks/07-27-base-anchor-liquid-animation/implement.jsonl
+++ b/.trellis/tasks/07-27-base-anchor-liquid-animation/implement.jsonl
@@ -1,4 +1,3 @@
-{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}
 {"file": ".trellis/spec/frontend/component-guidelines.md", "reason": "TxBaseAnchor SFC 结构、props/slots 契约、可访问性与动效约束。"}
 {"file": ".trellis/spec/frontend/type-safety.md", "reason": "BaseAnchorAnimationType 联合扩展与新增可选字段的类型边界，禁止 any/私有 cast。"}
 {"file": ".trellis/spec/frontend/quality-guidelines.md", "reason": "tuffex 组件单测与 nexus 文档校验的质量门禁。"}

--- a/.trellis/tasks/07-27-fix-plugin-folder-button/check.jsonl
+++ b/.trellis/tasks/07-27-fix-plugin-folder-button/check.jsonl
@@ -1,4 +1,3 @@
-{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}
 {"file": ".trellis/spec/frontend/quality-guidelines.md", "reason": "Focused test, typecheck, and diff verification requirements"}
 {"file": ".trellis/spec/frontend/type-safety.md", "reason": "Review typed transport and runtime validation contracts"}
 {"file": ".trellis/spec/frontend/plugin-runtime-security.md", "reason": "Review privileged Electron handler fail-closed behavior"}

--- a/.trellis/tasks/07-27-fix-plugin-folder-button/implement.jsonl
+++ b/.trellis/tasks/07-27-fix-plugin-folder-button/implement.jsonl
@@ -1,4 +1,3 @@
-{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}
 {"file": ".trellis/spec/frontend/type-safety.md", "reason": "Typed transport and runtime boundary rules for App SDK/system shell changes"}
 {"file": ".trellis/spec/frontend/component-guidelines.md", "reason": "CoreApp Vue interaction and i18n conventions for renderer feedback"}
 {"file": ".trellis/spec/frontend/plugin-runtime-security.md", "reason": "Privileged Electron boundary and fail-closed requirements"}

--- a/.trellis/tasks/07-28-tuffex-docs-audit/task.json
+++ b/.trellis/tasks/07-28-tuffex-docs-audit/task.json
@@ -3,7 +3,7 @@
   "name": "tuffex-docs-audit",
   "title": "tuffex 组件文档与源码一致性审计",
   "description": "",
-  "status": "in_progress",
+  "status": "completed",
   "dev_type": null,
   "scope": null,
   "package": null,
@@ -11,7 +11,7 @@
   "creator": "TalexDreamSoul",
   "assignee": "TalexDreamSoul",
   "createdAt": "2026-07-28",
-  "completedAt": null,
+  "completedAt": "2026-08-07",
   "branch": null,
   "base_branch": "master",
   "worktree_path": null,
@@ -22,5 +22,9 @@
   "parent": null,
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "None. Every published issue is closed; nothing remains gated on this task.",
+    "blocker": "",
+    "evidence": "Disposition verified against GitHub on 2026-08-07: aggregate #362 CLOSED, and all 112 per-component issues #363-#474 CLOSED (112 closed / 0 open). Labels `tuffex` and `docs-audit` both have zero open issues. Breakdown of the 112: 5 refuted as false positives (closed not-planned with a recorded refutedReason), 45 already fixed before the sweep, 33 verified fixed against current source, 29 remediated during the sweep via PRs #998 / #1003 / #1005. A further 26 governance issues #932-#958 closed in the same rounds. #362 additionally carried the deletion decision for 144 dead duplicate demos, resolved by deleting 135 (444 -> 309 demos). Remediation ownership: the audit produced findings only; every code change went through a per-issue branch -> PR -> merge-verified -> close loop, so no remediation is owned by this task. Round-by-round ledger: issue-loop-log.md in this directory."
+  }
 }

--- a/.trellis/tasks/08-04-batch-settings-razor/check.jsonl
+++ b/.trellis/tasks/08-04-batch-settings-razor/check.jsonl
@@ -1,3 +1,2 @@
-{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}
 {"file": ".trellis/spec/frontend/quality-guidelines.md", "reason": "CoreApp verification and sensitive-data quality constraints"}
 {"file": ".trellis/spec/frontend/privacy-data-lifecycle.md", "reason": "Credential lifecycle validation requirements"}

--- a/.trellis/tasks/08-04-batch-settings-razor/implement.jsonl
+++ b/.trellis/tasks/08-04-batch-settings-razor/implement.jsonl
@@ -1,4 +1,3 @@
-{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}
 {"file": ".trellis/spec/frontend/index.md", "reason": "CoreApp frontend ownership and pre-development checklist"}
 {"file": ".trellis/spec/frontend/privacy-data-lifecycle.md", "reason": "Main-owned credential and secure-store lifecycle contract"}
 {"file": ".trellis/tasks/08-04-batch-settings-razor/research/credential-protection-current-state.md", "reason": "Verified credential protection behavior and product decisions"}

--- a/.trellis/tasks/08-04-shell-chrome-resizable-sidebar/check.jsonl
+++ b/.trellis/tasks/08-04-shell-chrome-resizable-sidebar/check.jsonl
@@ -1,4 +1,3 @@
-{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}
 {"file": ".trellis/spec/frontend/quality-guidelines.md", "reason": "质量检查基线"}
 {"file": ".trellis/spec/frontend/component-guidelines.md", "reason": "核对新增 / 删除的 shell 组件是否合规"}
 {"file": ".trellis/spec/frontend/type-safety.md", "reason": "核对 utils 契约变更是否纯增量、无 any 泄漏"}

--- a/.trellis/tasks/08-04-shell-chrome-resizable-sidebar/implement.jsonl
+++ b/.trellis/tasks/08-04-shell-chrome-resizable-sidebar/implement.jsonl
@@ -1,4 +1,3 @@
-{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. Delete this line once real entries are added."}
 {"file": ".trellis/spec/frontend/index.md", "reason": "前端规范索引，落地 shell 组件前的总入口"}
 {"file": ".trellis/spec/frontend/component-guidelines.md", "reason": "新增 ShellChromeBar / ShellWindowControls 需遵循的组件约定"}
 {"file": ".trellis/spec/frontend/hook-guidelines.md", "reason": "useShellSidebar / useHistoryNavigation 两个 composable 的写法约束"}


### PR DESCRIPTION
Reconciles the two audit task records against their verified issue disposition, and removes template rows from the manifests that actually qualify.

Fixes #481.

## Security audit — closed, not blocked

`07-27-audit-plugin-privileged-security` sat in `planning` with an empty `completedAt`, while every finding it was scoped to produce had already shipped and closed. Verified on GitHub:

| issue | state |
|---|---|
| #296 permission-revocation invalidation | CLOSED |
| #297 out-of-process isolation | CLOSED |
| #298 secure view defaults | CLOSED |
| #299 SQLite isolation / fail-close | CLOSED |
| #300 transport caller verification | CLOSED |
| #301 sensitive-data retention | CLOSED |
| #302 parent, superseding 460/460 matrix | CLOSED |

The record now says `completed`, cites all seven, and states explicitly that the unchecked capability/data-flow/SQLite/transport rows in `check.jsonl` are the audit **intake list** rather than an outstanding acceptance gap — plus a note not to reopen them as current vulnerabilities, per the issue's "do not reopen historical fixed security findings".

## TuffEx audit — full disposition recorded

`07-28-tuffex-docs-audit` sat in `in_progress` with `"meta": {}` while its entire output was dispositioned. Verified by querying every issue individually rather than trusting the aggregate: **#362 CLOSED, #363–#474 = 112 closed / 0 open**, and both the `tuffex` and `docs-audit` labels at zero open.

The record now carries the breakdown — 5 refuted as false positives (closed not-planned with a recorded `refutedReason`), 45 already fixed before the sweep, 33 verified against current source, 29 remediated via PRs #998/#1003/#1005 — plus the 26 governance issues #932–#958 closed in the same rounds, and #362's demo-deletion outcome (135 of 144 deleted, 444 → 309).

On the remediation-ownership boundary the issue asks about: remediation was **never owned by this task**. The audit produced findings; every code change went through its own branch → PR → merge-verified → close loop. There is no remaining integration completion condition, so the task is `completed` rather than left as a tracker.

## Template rows — 8 files, not ~30

The issue lists Windows Everything, OTA, icon, release-notes, split-write and TuffEx among the tasks carrying `_example` rows. Checking each against the issue's own condition — *"once real context/evidence records exist"* — changes the scope substantially:

- **28 files contain only the `_example` row.** There are no real records, so removing it would leave an empty file and destroy the instruction for whoever fills it in. Every task the issue names by category falls here.
- **8 files** (4 tasks × `implement.jsonl` + `check.jsonl`) carry real records alongside the template: `07-27-base-anchor-liquid-animation`, `07-27-fix-plugin-folder-button`, `08-04-batch-settings-razor`, `08-04-shell-chrome-resizable-sidebar`. Those are the ones cleaned.

Verified afterwards that no file mixes a template row with real records, and that every remaining JSONL line parses.

## Not done

The issue also asks to "add missing structured records where work is ongoing" for the template-only tasks. That needs per-task knowledge of which spec/research files belong in each of 27 manifests — it is the task owner's call, not something to guess at from outside. Flagging it rather than filling those files with plausible-looking rows, which would be worse than an honest template.
