### PR TITLE
fix(utils,deps): stop self-importing, declare four more workspaces' deps (#579)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+shamefully-hoist=true
 auto-install-peers=false
 public-hoist-pattern[]=*electron*
 # electron_mirror="https://registry.npmmirror.com/electron/"

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
-shamefully-hoist=true
 auto-install-peers=false
 public-hoist-pattern[]=*electron*
 # electron_mirror="https://registry.npmmirror.com/electron/"

--- a/apps/nexus/package.json
+++ b/apps/nexus/package.json
@@ -57,6 +57,7 @@
     "echarts": "^6.1.0",
     "fighting-design": "catalog:",
     "gsap": "catalog:",
+    "h3": "1.15.11",
     "jszip": "catalog:",
     "mermaid": "catalog:",
     "ogl": "catalog:",

--- a/packages/tuff-cli/package.json
+++ b/packages/tuff-cli/package.json
@@ -29,6 +29,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
+    "@talex-touch/utils": "workspace:^",
     "@vue/compiler-sfc": "3.5.39",
     "chalk": "^5.6.2",
     "cli-progress": "^3.12.0",

--- a/packages/unplugin-export-plugin/package.json
+++ b/packages/unplugin-export-plugin/package.json
@@ -85,5 +85,12 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.6",
     "vitest": "^3.2.7"
+  },
+  "dependencies": {
+    "debug": "^4.4.3",
+    "esbuild": "^0.28.1",
+    "fs-extra": "^11.3.6",
+    "pathe": "^1.1.2",
+    "unplugin": "catalog:build"
   }
 }

--- a/packages/utils/common/search/index.ts
+++ b/packages/utils/common/search/index.ts
@@ -1,4 +1,4 @@
-import type { ISearchProvider, TuffQuery, TuffSearchResult } from '@talex-touch/utils'
+import type { ISearchProvider, TuffQuery, TuffSearchResult } from '../../core-box/tuff/tuff-dsl'
 import type { SearchPriorityLayer } from './gather'
 
 export * from './gather'

--- a/packages/utils/plugin/node/logger-manager.ts
+++ b/packages/utils/plugin/node/logger-manager.ts
@@ -3,7 +3,7 @@ import type { LogItem } from '../log/types'
 import { existsSync } from 'node:fs'
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import { structuredStrictStringify } from '@talex-touch/utils'
+import { structuredStrictStringify } from '../../common/utils/index'
 import { PollingService } from '../../common/utils/polling'
 
 /**

--- a/packages/utils/plugin/plugin-source.ts
+++ b/packages/utils/plugin/plugin-source.ts
@@ -1,4 +1,4 @@
-import type { IManifest } from '@talex-touch/utils/plugin'
+import type { IManifest } from './index'
 
 /**
  * Interface for plugin download options.

--- a/packages/utils/plugin/sdk/channel.ts
+++ b/packages/utils/plugin/sdk/channel.ts
@@ -1,8 +1,8 @@
-import type { ITuffTransport } from '@talex-touch/utils/transport'
+import type { ITuffTransport } from '../../transport/index'
 import type { PluginChannelClient, PluginStandardChannelData } from './channel-client'
 import type { IPluginRendererChannel, PluginChannelHandler } from './types'
-import { hasWindow } from '@talex-touch/utils/env'
-import { defineRawEvent } from '@talex-touch/utils/transport/event/builder'
+import { hasWindow } from '../../env/index'
+import { defineRawEvent } from '../../transport/event/builder'
 import { genChannel } from '../channel'
 
 const PLUGIN_CHANNEL_TYPE = 'plugin' as const

--- a/packages/utils/renderer/touch-sdk/env.ts
+++ b/packages/utils/renderer/touch-sdk/env.ts
@@ -1,4 +1,4 @@
-import type { ITuffTransport } from '@talex-touch/utils/transport'
+import type { ITuffTransport } from '../../transport/index'
 import { Terminal } from './terminal'
 
 export class EnvDetector {

--- a/packages/utils/renderer/touch-sdk/index.ts
+++ b/packages/utils/renderer/touch-sdk/index.ts
@@ -1,6 +1,6 @@
-import type { ITuffTransport, TuffEvent } from '@talex-touch/utils/transport'
-import { AppEvents, PluginEvents } from '@talex-touch/utils/transport/events'
-import { defineRawEvent } from '@talex-touch/utils/transport/event/builder'
+import type { ITuffTransport, TuffEvent } from '../../transport/index'
+import { AppEvents, PluginEvents } from '../../transport/events/index'
+import { defineRawEvent } from '../../transport/event/builder'
 
 export interface TouchClientChannelLike {
   regChannel: (eventName: string, callback: (data: any) => void) => () => void

--- a/packages/utils/renderer/touch-sdk/terminal.ts
+++ b/packages/utils/renderer/touch-sdk/terminal.ts
@@ -1,5 +1,5 @@
-import type { ITuffTransport } from "@talex-touch/utils/transport";
-import { TerminalEvents } from "@talex-touch/utils/transport/events";
+import type { ITuffTransport } from "../../transport/index";
+import { TerminalEvents } from "../../transport/events/index";
 
 type DataCallback = (data: string) => void;
 type ExitCallback = (exitCode: number | null) => void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -592,6 +592,9 @@ importers:
       gsap:
         specifier: 'catalog:'
         version: 3.15.0
+      h3:
+        specifier: 1.15.11
+        version: 1.15.11
       jszip:
         specifier: 'catalog:'
         version: 3.10.1
@@ -1155,6 +1158,22 @@ importers:
         version: 4.5.4(@types/node@24.13.2)(rollup@2.80.0)(typescript@5.9.3)(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/unplugin-export-plugin:
+    dependencies:
+      debug:
+        specifier: ^4.4.3
+        version: 4.4.3(supports-color@10.2.2)
+      esbuild:
+        specifier: 0.28.1
+        version: 0.28.1
+      fs-extra:
+        specifier: ^11.3.6
+        version: 11.3.6
+      pathe:
+        specifier: ^1.1.2
+        version: 1.1.2
+      unplugin:
+        specifier: ^2.3.11
+        version: 2.3.11
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^5.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -826,6 +826,9 @@ importers:
 
   packages/tuff-cli:
     dependencies:
+      '@talex-touch/utils':
+        specifier: workspace:^
+        version: link:../utils
       '@vue/compiler-sfc':
         specifier: 3.5.39
         version: 3.5.39


### PR DESCRIPTION
Advances #579 without closing it. The scope changed mid-PR because CI disproved my plan — details below.

## What this lands

**1. `packages/utils` stops importing itself.** Twelve modules import the package by its own name (`@talex-touch/utils/env`, `/transport`, `/transport/events`, `/transport/event/builder`, `/plugin`, and the bare root). Node resolves a self-reference only when the package declares an `exports` field, and this one has none — they work purely because hoisting puts a self-symlink in the root `node_modules`. Rewritten as relative paths, in the extensionless style the package already uses. Two pointed at barrels that could close a cycle, so they now point at the defining module:

| | was | now |
|---|---|---|
| `common/search/index.ts` | root barrel | `core-box/tuff/tuff-dsl` |
| `plugin/node/logger-manager.ts` | root barrel (a **value** import — a real runtime cycle) | `common/utils/index` |

**2. Three more workspaces declare what they import.**

- `packages/unplugin-export-plugin` had an **empty `dependencies`** while `src/index.ts` imports five packages at runtime. Typecheck caught only three: `debug` and `fs-extra` resolve their types through the `@types/*` already in devDeps, so they would have failed at runtime, not compile time.
- `apps/nexus` — `h3`, imported in **404** server modules.
- `packages/tuff-cli` — `@talex-touch/utils`, not declared at all.

`README.md` and `plugin/sdk/examples/` keep the package name, which is correct there — they show consumers how to import.

## What I removed, and why

I originally dropped `shamefully-hoist=true` here, since #1094 had declared every phantom dependency the audit named. CI disproved it. Three rounds in:

| round | new failure | cause |
|---|---|---|
| 1 | `Typecheck`, `tuff-cli` | `unplugin-export-plugin` importing `pathe`/`unplugin`/`esbuild` undeclared |
| 2 | `tuff-cli` | `tuff-cli` importing `@talex-touch/utils` undeclared |
| 2 | **`ci / CI - tuffex`** | not a manifest problem |

That last one is the reason the flag went back. Without hoisting, tuffex's build dies with:

```
ReferenceError: exports is not defined in ES module scope
```

gulp selects its `.ts` loader through `interpret`, and had been finding a transpiler **hoisted from some other workspace** rather than tuffex's own declared `sucrase`. `packages/tuffex` is `"type": "module"`, so the CJS that loader emits cannot execute. That is a build-toolchain fix, not a manifest one, and it deserves its own change rather than riding along here.

Which is itself a finding worth recording: the flag was masking not just undeclared *dependencies* but an undeclared *build-tool resolution*. The issue's one-line "fix the phantoms first, then drop the flag" underestimates the surface.

## Verified

- `packages/utils` suite: **128 files pass, before and after** the self-import rewrite, with the same single pre-existing failure — `preview-sdk.benchmark`'s latency-budget assertion, which I confirmed fails on unmodified `HEAD` on this machine too (restored all 7 files with `git show HEAD:<path>`, re-ran, same failure, restored my edits).
- `pnpm install --lockfile-only --frozen-lockfile` passes — the lockfile matches all 30 manifests, which is the check CI's `--frozen-lockfile` performs.
- Every lockfile change here is additive.

I could not run local gates against the final tree: the registry proxy on this machine has served at ~13 KiB/s with repeated `ECONNRESET`s all session, and several installs stalled on `ffprobe-static` (a `plugins/touch-music` dependency that also failed on the very first install, before any of these edits). CI is the verification.

`Documentation Quality` and `Protocol` ×3 fail identically on #1076, #1077, #1080 and #1094 — Rust `tuff-native` missing `-lgbm`, and 146 `.trellis/tasks/*/task.json` meta violations. Neither is in scope here.

Refs #579
