### PR TITLE
fix(tuffex): declare the ts loader its gulp build actually uses (#579)

### DIFF
--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -106,6 +106,7 @@
     "gulp-autoprefixer": "^9.0.0",
     "sass": "^1.101.0",
     "sucrase": "^3.35.1",
+    "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
     "vite": "^7.3.6",
     "vite-plugin-dts": "^4.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1125,6 +1125,9 @@ importers:
       sucrase:
         specifier: ^3.35.1
         version: 3.35.1
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@24.13.2)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
The build-toolchain half of #579, split out of #1095 as promised there.

## The bug

`packages/tuffex`'s build runs `gulp -f packages/script/build/index.ts`. gulp resolves a `.ts` loader through `interpret`, which tries in order:

```
ts-node/register  ->  sucrase/register/ts  ->  @babel/register
```

tuffex declares `sucrase` and not `ts-node`, so on paper sucrase is its loader. **It is not.** `ts-node` is declared by `packages/test`, `shamefully-hoist=true` lifts it into the root `node_modules`, and `interpret` picks it first — from a workspace that has nothing to do with tuffex.

Remove the hoist and the build falls through to sucrase and dies:

```
[..] Loaded external module: sucrase/register/ts
ReferenceError: exports is not defined in ES module scope
    at packages/script/build/index.ts:1:36
    at ModuleJobSync.runSync
    at loadESMFromCJS (node:internal/modules/cjs/loader:1690:24)
    at Module._compile (pirates/lib/index.js:129:24)
```

sucrase's register is a pirates require-hook that emits CJS. The nearest `package.json` to `index.ts` is `packages/tuffex`'s own, which is `"type": "module"` — so Node routes that CJS output through `loadESMFromCJS` and executes it in ES module scope, where `exports` does not exist.

This is the failure that made me revert the `.npmrc` change in #1095. It is worth calling out as its own category: the flag was masking not an undeclared *dependency* but an undeclared *build-tool resolution*, which no dependency scan would ever surface.

## The fix

Declare `ts-node ^10.9.2` — the loader tuffex has been using all along, at the version `packages/test` already pins. This makes existing behaviour explicit rather than changing it.

`sucrase` stays as `interpret`'s declared fallback.

## Verified

Both halves reproduced locally against a genuinely non-hoisted `node_modules`:

| | loader gulp selects | result |
|---|---|---|
| before | `sucrase/register/ts` | `ReferenceError: exports is not defined in ES module scope` |
| after | `ts-node/register` | build exits **0** in 4.33 min |

`dist` is unchanged at **1782 files**, matching the count since #1080.

`pnpm install --lockfile-only --frozen-lockfile` passes. The diff is one manifest line and three lockfile lines, with zero deletions.

Refs #579
