### PR TITLE
chore(packaging): give the canonical homepage an owner at the root (#306)

### DIFF
--- a/docs/engineering/monorepo-standards.md
+++ b/docs/engineering/monorepo-standards.md
@@ -34,6 +34,14 @@
 
 其余“仅某个 workspace 使用”的配置，优先放到对应 workspace 内（例如 `apps/core-app/.prettierrc.yaml`）。
 
+### 包元数据的唯一来源
+
+`version` / `description` / `author` / `homepage` / `license` 以**根 `package.json` 为准**，由 `scripts/sync-core-package.mjs`（`postinstall` 触发）向下同步到 `apps/core-app/package.json`。
+
+规范主页是 `https://tuff.tagzxia.com`——与 `packages/tuff-cli` 的 `OFFICIAL_SITE_URL`、`packages/tuff-intelligence` 的 `NEXUS_BASE_URL` 以及发布脚本的默认 base URL 一致。
+
+注意同步脚本对根未定义的字段是**跳过**而非清空（`if (typeof rootPkg[field] === 'undefined') continue`），所以根上缺字段不会删掉下游的值——它只是让那个值**无人拥有**、从而悄悄漂移。`pnpm check:doc-metadata` 会在根缺少 `homepage`、或根与 CoreApp 不一致时失败。
+
 ## 代码质量与提交流程（标准化）
 
 ### ESLint

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@talex-touch/tuff",
+  "homepage": "https://tuff.tagzxia.com",
   "type": "module",
   "version": "2.4.14-beta.2",
   "packageManager": "pnpm@10.34.4",

--- a/scripts/check-doc-metadata.mjs
+++ b/scripts/check-doc-metadata.mjs
@@ -117,11 +117,16 @@ export function collectProblems(sources) {
   }
 
   // --- homepage --------------------------------------------------------------
-  const homepages = new Set(
-    [rootManifest.homepage, coreAppManifest.homepage].filter(Boolean).map(value => value.replace(/\/$/, '')),
-  )
-  if (homepages.size > 1) {
-    problems.push(`Manifests disagree on homepage: ${[...homepages].join(' vs ')}. See #306 for the canonical value.`)
+  // The root manifest is the source of truth: sync-core-package.mjs copies homepage down into
+  // CoreApp, and it skips fields the root leaves undefined. A missing root homepage therefore
+  // does not break the sync — it silently makes CoreApp's value unowned, which is how the two
+  // drifted apart in the first place (#306).
+  const stripSlash = value => String(value).replace(/\/$/, '')
+  if (!rootManifest.homepage) {
+    problems.push('Root package.json declares no homepage, so nothing owns the canonical value that sync-core-package.mjs propagates.')
+  }
+  else if (coreAppManifest.homepage && stripSlash(rootManifest.homepage) !== stripSlash(coreAppManifest.homepage)) {
+    problems.push(`Manifests disagree on homepage: ${stripSlash(rootManifest.homepage)} (root) vs ${stripSlash(coreAppManifest.homepage)} (apps/core-app). Run sync-core-package.mjs.`)
   }
 
   // --- links -----------------------------------------------------------------
@@ -186,6 +191,15 @@ function selfTest() {
         rootManifest: { ...sources.rootManifest, homepage: 'https://example.invalid' },
       }),
       expect: /disagree on homepage/,
+    },
+    {
+      name: 'no root homepage to own the canonical value',
+      mutate: (sources) => {
+        const rootManifest = { ...sources.rootManifest }
+        delete rootManifest.homepage
+        return { ...sources, rootManifest }
+      },
+      expect: /declares no homepage/,
     },
     {
       name: 'engines and .node-version disagreeing',


### PR DESCRIPTION
Gives the canonical homepage an owner, and makes its absence a failure rather than silence.

Fixes #306.

## One correction to the premise

The issue says "running `sync-core-package.mjs` now would remove CoreApp's homepage". It would not — the script skips fields the root leaves undefined:

```js
for (const field of fieldsToSync) {
  if (typeof rootPkg[field] === 'undefined')
    continue
```

But that skip is precisely the problem, just a quieter one than described: with no root value, CoreApp's `https://tuff.tagzxia.com` was **owned by nobody**. It could drift, or be edited, with nothing to compare it against.

## Canonical value

`https://tuff.tagzxia.com`, now declared at the root. It is not a new decision — it is what the rest of the repo already treats as official:

- `packages/tuff-cli/src/bin/tuff.ts` → `OFFICIAL_SITE_URL`
- `packages/tuff-intelligence/src/env/index.ts` → `NEXUS_BASE_URL`
- `scripts/backfill-release-assets-from-github.mjs` → default `--base-url`
- nexus OAuth tests build their URLs from it

`sync-core-package.mjs` now propagates it; CoreApp already had the same value, so the sync is a no-op (`apps/core-app/package.json already in sync`).

## Consistency check

`scripts/check-doc-metadata.mjs` (added for #335) already compared root vs CoreApp — but with the root undefined, the comparison set had one entry and passed. It now fails when the **root declares no homepage at all**, which is the state #306 is actually about, with a matching fixture:

```
ok   manifests disagreeing on homepage
ok   no root homepage to own the canonical value
```

Eight fixtures now, plus the "the real tree is clean" assertion, all green. The check runs in the PR Quality job.

Documented under a new **包元数据的唯一来源** heading in `docs/engineering/monorepo-standards.md`, including the skip-not-delete behaviour so the next reader does not have to re-derive it from the script.

## Verification

- `node scripts/sync-core-package.mjs` — already in sync, no write
- `check:doc-metadata` — passes; `--self-test` — 8/8 fixtures rejected as expected
- eslint on the changed script — clean
