### PR TITLE
chore(trellis): point the manifest seed at a discovery path that works (#304 partial)

### DIFF
--- a/.trellis/scripts/common/task_store.py
+++ b/.trellis/scripts/common/task_store.py
@@ -134,7 +134,9 @@ _SUBAGENT_CONFIG_DIRS: tuple[str, ...] = (
 _SEED_EXAMPLE = (
     "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. "
     "Put spec/research files only — no code paths. "
-    "Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs. "
+    "List candidates with `find .trellis/spec -name '*.md'` — note that "
+    "`get_context.py --mode packages` reports layers only and omits spec/guides, "
+    "which real manifests do cite. "
     "Delete this line once real entries are added."
 )
 


### PR DESCRIPTION
Partial work on #304 — **does not close it.** Fixes the one thing that made criterion 1 unfollowable.

## The instruction pointed away from a third of the spec tree

Every seeded `implement.jsonl` / `check.jsonl` carries:

> Run `python3 .trellis/scripts/get_context.py --mode packages` to list available specs.

That command prints:

```
Single-repo project (no packages configured)

Spec layers: frontend, main-process
```

Two problems. It reports **layers**, not spec files, so it never "lists available specs". And `_scan_spec_layers` explicitly filters `guides` out:

```python
d.name for d in target.iterdir() if d.is_dir() and d.name != "guides"
```

`spec/guides` is not decorative — real manifests cite it. `cross-layer-thinking-guide.md` appears in the `07-27-base-anchor-liquid-animation`, `07-27-bilingual-whats-changed`, `07-29-macos-screenshot-capture-core` and `08-04-shell-chrome-resizable-sidebar` manifests. Anyone following the seed literally would never find it.

The seed now points at `find .trellis/spec -name '*.md'` and states what the other command does and does not cover. Fixed at the source (`task_store.py::_SEED_EXAMPLE`) so every future task gets it, rather than editing 84 existing rows.

Verified by creating a throwaway task: both manifests carry the corrected text. Probe removed; the only change in this PR is the one constant.

## Why the rest is not here

**The real scope is 47 tasks / 84 files, not 14 / 28.** The issue's count is a 2026-08-04 snapshot; tasks created since more than tripled it — the `08-05-*` family alone adds 20. Split by status: 31 `planning`, 16 `in_progress`.

**Filling them is per-task judgement, not derivable.** A real manifest looks like:

```json
{"file": ".trellis/spec/frontend/component-guidelines.md", "reason": "新增 ShellChromeBar / ShellWindowControls 需遵循的组件约定"}
```

It maps a shared spec (22 files) onto *this* task and justifies why it applies. Writing 47 sets of plausible-sounding justifications for tasks I did not plan would be the same mistake I declined on #481: it makes a reviewer believe the context is prepared when it is not.

**Criterion 3 does not apply to the oldest ones either.** I checked `07-09-*` and `07-13-*` (search lifecycle, CatalogService) for obsolescence: they carry real `prd.md`, some with `design.md` and `research/`, and their issues (#331, #334, #340, #346) are still open. They are pending work, not stale records — archiving is the wrong move.

Suggested split: this discovery fix (done), and per-owner manifest population at task start, which is where Trellis step 1.3 "Configure context" already puts it. Batching 47 backfills produces box-ticking whoever does it.
