### PR TITLE
chore(trellis): record the actionlint result and keep the visual gap open (#482 partial)

### DIFF
--- a/.trellis/tasks/07-27-bilingual-whats-changed/task.json
+++ b/.trellis/tasks/07-27-bilingual-whats-changed/task.json
@@ -23,8 +23,8 @@
   "relatedFiles": [],
   "notes": "Implementation complete across gateway, workflow, Nexus, typed transport, SQLite/main service, startup modal, and Update history UI. Automated verification passes; actionlint and isolated Electron visual screenshots remain external acceptance gaps.",
   "meta": {
-    "nextAction": "Run actionlint on build-and-release.yml, then repeat desktop/narrow CDP screenshots when no release build is running.",
-    "blocker": "actionlint is unavailable locally; Electron dev visual launch is blocked by the active release-build startup guard.",
-    "evidence": "107 focused tests passed; package ESLint, CoreApp node/web typechecks, Nexus typecheck, pnpm quality:pr, workflow YAML parse, CoreApp build, release:notes:verify, and git diff --check passed."
+    "nextAction": "Capture desktop and narrow-window CoreApp screenshots of the release-notes modal and the Update history route, once no release build holds the startup guard.",
+    "blocker": "Visual runtime evidence only. Electron dev launch is still gated by the release-build startup guard; the coreapp-visible-* probe family needs a running app, so no screenshot can be produced from this environment.",
+    "evidence": "Evidence is recorded in three separate kinds, which must not substitute for one another.\n1. Workflow syntax — RESOLVED 2026-08-07. actionlint 1.7.12 (installed by mise on darwin/arm64, built with go1.26.1) reports zero findings for .github/workflows/build-and-release.yml, and zero across all 18 workflow files when run with no path argument. Commands: `mise x actionlint@1.7.12 -- actionlint .github/workflows/build-and-release.yml` and `mise x actionlint@1.7.12 -- actionlint`; both exit 0 with empty output. This supersedes the earlier \"workflow YAML parse\" check, which only proved the file was well-formed YAML, not that its Actions expressions and job graph were valid.\n2. Automation — 107 focused tests passed; package ESLint, CoreApp node/web typechecks, Nexus typecheck, pnpm quality:pr, CoreApp build, release:notes:verify and git diff --check all passed.\n3. Visual runtime — STILL OPEN. No screenshot has been taken. Nothing above is a substitute for it."
   }
 }


### PR DESCRIPTION
Partial work on #482 — **does not close it.** Clears the actionlint gap; the screenshot gap stays open and is now stated as such.

## actionlint: available, and clean

It was listed as blocked because "actionlint is unavailable in the local environment". It is available through mise:

```
$ mise x actionlint@1.7.12 -- actionlint --version
1.7.12
installed by downloading from release page
built with go1.26.1 compiler for darwin/arm64

$ mise x actionlint@1.7.12 -- actionlint .github/workflows/build-and-release.yml
$ mise x actionlint@1.7.12 -- actionlint
```

Both exit **0** with **empty output** — zero findings for the target file, and zero across all **18** workflow files when run with no path argument.

Worth noting what this replaces. The task's prior evidence listed a "workflow YAML parse" check, which only proved the file was well-formed YAML. actionlint validates the Actions expression syntax, job graph, `runs-on` labels, shell scripts inside `run:` and action input schemas — a different claim entirely. Recording the first as if it covered the second is exactly the substitution this issue is about.

## The visual gap stays open, and is labelled

The task's `evidence` field mixed automation, workflow syntax and visual runtime into one sentence. It now separates them:

1. **Workflow syntax** — resolved, with the exact commands, tool version and platform.
2. **Automation** — the 107 focused tests, ESLint, typechecks, `quality:pr`, build, `release:notes:verify`.
3. **Visual runtime** — **STILL OPEN. No screenshot has been taken. Nothing above is a substitute for it.**

`blocker` now says specifically why: Electron dev launch is still gated by the release-build startup guard, and the `coreapp-visible-*` probe family needs a running app, so no screenshot can come out of this environment. `nextAction` is the screenshot capture alone.

## What closing this needs

Criterion 2 — desktop and narrow-window CoreApp screenshots of the release-notes modal and the Update history route — needs a machine where no release build holds the startup guard. That is the whole remaining scope.
