### PR TITLE
docs(audit): R1 was checked off against the wrong workflow (#321)

### DIFF
--- a/.trellis/tasks/07-13-search-crossplatform-audit/prd.md
+++ b/.trellis/tasks/07-13-search-crossplatform-audit/prd.md
@@ -88,11 +88,12 @@
 
 ### 🟠 高危工程风险
 
-- [x] **R1 — Rust 截图模块已接入 CI/安装构建链** ✅ 已修（`07-29-macos-screenshot-capture-core`，原跟踪 #321 已关闭）
+- [ ] **R1 — Rust 截图模块已接入 CI/安装构建链** ⚠️ **契约测试已接入，发布路径未接入**（2026-08-07 复验，原判「已修 / #321 已关闭」不成立——[#321](https://github.com/talex-touch/tuff/issues/321) 仍 open）
   - 修复：`native-protocol.yml` 在 macOS/Windows/Linux 安装 xcap 所需 Linux build deps，构建 ordinary screenshot addon，执行真实 dlopen/export contracts；随后构建 deterministic addon 跑 `.node -> NapiCarrier -> NativeTransport` integration，并在结束前恢复 ordinary addon。
   - 包合同：`@talex-touch/tuff-native.files` 显式包含 macOS/AX/stream/xcap production backend 源码与 `build/Release/tuff_native_screenshot.node`，继续排除 fixture、contract test backend 和 Cargo target。
   - 证据：本地 ordinary/deterministic 双构建、普通 addon strict macOS integration、31/31 Node contracts 和 `pnpm pack --dry-run` 通过；tarball 包含 addon 与全部 production backend，未包含 `test_backend.rs`/contract fixtures/target。
   - 边界：Windows/Linux authoritative native build 由新增 CI matrix 执行；signed Electron packaged runtime evidence 仍由 `07-29-screenshot-packaged-evidence` 独立承接。
+  - ⚠️ **发布路径未接入**（2026-08-07 复验）：`build:screenshot` 的 3 处调用全在 `native-protocol.yml`——那是**契约测试**工作流，不产出发布物。真正的 `build-and-release.yml` 对 `screenshot` / `audio` / `cargo` / `rust` **零命中**（正对照：`packages/tuff-native` 命中 2 次），它在该包里只做 Windows 限定的 Everything 自检与 `pnpm run rebuild`（node-gyp）。且 `apps/core-app/scripts/` 里查不到 `tuff_native_screenshot`，preflight/afterPack 都不要求它。发布产物大概率不含该 addon。跟踪：[#321](https://github.com/talex-touch/tuff/issues/321)。
   - ⚠️ **同型风险仍在 audio addon 上**（2026-08-07 复验）：`packages/tuff-native/native-audio/` 存在且有 `build:audio` 脚本，但 `.github/workflows/` 里**没有任何 workflow 构建或加载它**（`native-protocol.yml` 对 audio 零提及）。也就是说截图模块修掉的那个「手工 Cargo 构建、CI 无验证」缺口，在 audio 上原样存在。跟踪：[#322](https://github.com/talex-touch/tuff/issues/322)。
 
 - [ ] **R2 — macOS 发行架构范围未决**


### PR DESCRIPTION
Corrects a finding that was checked off against evidence from the wrong workflow.

Relates to #321 (which stays open) and #340.

## What was wrong

The audit backlog marked **R1** fixed, with "原跟踪 #321 已关闭". #321 is open. Re-running the finding shows the backlog was reading a real green signal from a workflow that does not produce releases.

`build:screenshot` genuinely runs on a `[macos-latest, windows-2022, ubuntu-latest]` matrix — but all three call sites are in **`native-protocol.yml`**, a contract-test workflow triggered by paths under `packages/tuff-native`. It builds and dlopen-tests the addon; it ships nothing.

The release workflow does not:

```
$ rg -c 'packages/tuff-native' .github/workflows/build-and-release.yml
2                                      ← positive control
$ rg -i 'screenshot|audio|cargo|rust' .github/workflows/build-and-release.yml
(only an unrelated "Validate Release Signing Trust Roots" line)
```

Both `packages/tuff-native` hits are Windows-gated — the Everything self-check, and `pnpm run rebuild`, which is node-gyp and never touches either Cargo addon. `electron-builder.yml` excludes the Rust `target/` tree, and CI checks out clean, so there is no workspace residue to fall back on.

And nothing enforces it downstream: `rg 'tuff_native_screenshot' apps/core-app/scripts/` returns nothing, so preflight still requires only `tuff_native_ocr.node` plus `tuff_native_everything.node` on Windows. Removing the screenshot addon would not fail a release build.

## What the entry says now

R1 is **unchecked**, with both halves recorded: the contract-test wiring that genuinely exists, and the release-path gap that does not. The original "已修" text is kept rather than deleted, per the backlog's own rule about invalidated findings.

The same bullet already carried the audio equivalent (#322) from the previous pass; the two now sit together because they are one gap with two instances.

Backlog moves from 12 checked / 13 open to **11 / 14** — the right direction for a re-validation that found an over-claim.
