### PR TITLE
test(core-app): measure whether file-scan memory is bounded (#318 partial)

### DIFF
--- a/.trellis/tasks/07-13-search-crossplatform-audit/prd.md
+++ b/.trellis/tasks/07-13-search-crossplatform-audit/prd.md
@@ -104,7 +104,9 @@
 
 - [ ] **R3 — 大目录扫描/对账内存峰值** ⚠️ 结构问题已消除，**只剩实测未做**（2026-08-07 复验）
   - 原描述的三层物化**均已不成立**：worker 逐批 post 并等 `batchAckWaiters` 背压；client 的累积版 `scan()` 已删除（[#1091](https://github.com/talex-touch/tuff/pull/1091)），流水线只用 `scanBatches()`；reconciliation 改为消费 `AsyncIterable`、`reconcile()` 逐批调用、`getDbFilesByPaths(diskPaths)` 按批限定路径，行数统计改为 `countRootRows` 普查而非物化集合。
-  - 仍开的部分：百万级 fixture 的峰值内存实测，以及「上界由 batch size 而非目录基数决定」的证明。跟踪：[#480](https://github.com/talex-touch/tuff/issues/480)。
+  - 2026-08-07 **已实测**（`apps/core-app/scripts/file-scan-memory-benchmark.mjs`，合成树 25k/100k/400k × batch 100/500/2000）：`retained` 全部 ≈ 0，无累积；**40 万文件在 `--max-old-space-size=64` 下完整跑完**，峰值堆 33.5 MiB、retained −0.8 MiB。取消在 10 批后立即生效（112ms 返回）。worker 侧在发下一批前 `await acknowledged`，在途未确认批次恒为 1。
+  - ⚠️ **一处需要写清楚的观测**：无堆压力时峰值堆随文件数增长（batch=500 下 13.9 → 33.4 → 58.7 MiB），且**三种批大小在同一文件数下几乎相同**——所以「峰值由 batch size 决定」这句话按字面不成立。真实机制是 V8 有余量时惰性扩堆；施压后同一工作量只用三分之一空间即可完成，说明**上界是真的、只是不由 batch size 表达**。
+  - 仍开的部分：reconciliation 分页与持久化落库的同类实测（本基准只覆盖 traversal）。跟踪：[#318](https://github.com/talex-touch/tuff/issues/318) / [#480](https://github.com/talex-touch/tuff/issues/480)。
 
 ### 🟡 中危架构债
 

--- a/apps/core-app/scripts/file-scan-memory-benchmark.mjs
+++ b/apps/core-app/scripts/file-scan-memory-benchmark.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Measures whether file-scan memory is bounded by batch size or by directory cardinality.
+ *
+ * #318 asks for a reproducible synthetic-tree benchmark before the R3 memory risk can be
+ * closed or narrowed. The claim under test is that peak memory tracks `batchSize`, not the
+ * total file count — i.e. that scanning ten times as many files does not cost ten times the
+ * heap. A run that grows with file count would mean something is still accumulating.
+ *
+ * Drives `scanDirectoryBatches` from @talex-touch/utils, which is the traversal the scan
+ * worker calls. The worker adds an ack round-trip on top and awaits it before emitting the
+ * next batch, so it holds at most one unacknowledged batch — the bound this measures is the
+ * floor, and the worker cannot exceed it.
+ *
+ * Usage:
+ *   node apps/core-app/scripts/file-scan-memory-benchmark.mjs
+ *   node apps/core-app/scripts/file-scan-memory-benchmark.mjs --counts 20000,50000,100000 --batch 500
+ *   node apps/core-app/scripts/file-scan-memory-benchmark.mjs --cancel-at 5000
+ *
+ * Run with --expose-gc for stable heap numbers.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { pathToFileURL } from 'node:url'
+
+function parseArgs(argv) {
+  const get = (flag, fallback) => {
+    const index = argv.indexOf(flag)
+    return index >= 0 && argv[index + 1] ? argv[index + 1] : fallback
+  }
+  return {
+    counts: get('--counts', '20000,50000,100000').split(',').map(Number).filter(Boolean),
+    batchSizes: get('--batch', '500').split(',').map(Number).filter(Boolean),
+    cancelAt: Number(get('--cancel-at', '0')),
+    keep: argv.includes('--keep')
+  }
+}
+
+/** Fan the files across nested directories so traversal recursion is exercised, not one flat dir. */
+function buildTree(root, fileCount) {
+  const perDir = 200
+  const dirCount = Math.ceil(fileCount / perDir)
+  let written = 0
+  for (let d = 0; d < dirCount; d += 1) {
+    const dir = path.join(root, `d${Math.floor(d / 50)}`, `s${d}`)
+    mkdirSync(dir, { recursive: true })
+    for (let f = 0; f < perDir && written < fileCount; f += 1) {
+      writeFileSync(path.join(dir, `f${written}.txt`), '')
+      written += 1
+    }
+  }
+  return written
+}
+
+function sampleMemory() {
+  const usage = process.memoryUsage()
+  return { rss: usage.rss, heapUsed: usage.heapUsed }
+}
+
+const mib = (bytes) => Math.round((bytes / 1024 / 1024) * 10) / 10
+
+async function measure(scanDirectoryBatches, root, fileCount, batchSize, cancelAt) {
+  globalThis.gc?.()
+  const before = sampleMemory()
+  let peakRss = before.rss
+  let peakHeap = before.heapUsed
+  let seen = 0
+  let batches = 0
+  let largestBatch = 0
+
+  const controller = new AbortController()
+  const started = Date.now()
+  let cancelled = false
+
+  try {
+    await scanDirectoryBatches(
+      root,
+      async (batch) => {
+        batches += 1
+        seen += batch.length
+        largestBatch = Math.max(largestBatch, batch.length)
+        // Sampling inside the callback is the point: this is the moment a batch is live.
+        const now = sampleMemory()
+        if (now.rss > peakRss) peakRss = now.rss
+        if (now.heapUsed > peakHeap) peakHeap = now.heapUsed
+        if (cancelAt > 0 && seen >= cancelAt) controller.abort()
+      },
+      // Path filters off: the synthetic tree lives under the OS temp dir, which the default
+      // system/cache filters reject outright. Disabling them keeps every entry in play, which
+      // is also the conservative direction — more entries means more memory, not less.
+      {
+        enablePhotosLibraryFilter: false,
+        enableSystemPathFilter: false,
+        enableDevPathFilter: false,
+        enableCachePathFilter: false,
+        strictMode: false
+      },
+      undefined,
+      { batchSize, signal: controller.signal }
+    )
+  } catch (error) {
+    if (controller.signal.aborted) cancelled = true
+    else throw error
+  }
+
+  const durationMs = Date.now() - started
+  globalThis.gc?.()
+  const after = sampleMemory()
+
+  return {
+    fileCount,
+    batchSize,
+    seen,
+    batches,
+    largestBatch,
+    cancelled,
+    durationMs,
+    peakRssMiB: mib(peakRss),
+    peakHeapMiB: mib(peakHeap),
+    deltaRssMiB: mib(peakRss - before.rss),
+    retainedHeapMiB: mib(after.heapUsed - before.heapUsed)
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..', '..')
+  const modulePath = path.join(repoRoot, 'packages', 'utils', 'common', 'file-scan-utils.ts')
+  const { scanDirectoryBatches } = await import(pathToFileURL(modulePath).href)
+
+  const results = []
+  for (const fileCount of args.counts) {
+    const root = mkdtempSync(path.join(tmpdir(), `scan-bench-${fileCount}-`))
+    try {
+      const written = buildTree(root, fileCount)
+      for (const batchSize of args.batchSizes) {
+        const result = await measure(scanDirectoryBatches, root, written, batchSize, args.cancelAt)
+        results.push(result)
+        console.log(
+          `files=${String(result.fileCount).padStart(7)} batch=${String(result.batchSize).padStart(5)} ` +
+            `seen=${String(result.seen).padStart(7)} batches=${String(result.batches).padStart(5)} ` +
+            `maxBatch=${String(result.largestBatch).padStart(5)} ` +
+            `peakRSS=${String(result.peakRssMiB).padStart(7)}MiB ` +
+            `ΔRSS=${String(result.deltaRssMiB).padStart(6)}MiB ` +
+            `peakHeap=${String(result.peakHeapMiB).padStart(6)}MiB ` +
+            `retained=${String(result.retainedHeapMiB).padStart(6)}MiB ` +
+            `${result.durationMs}ms${result.cancelled ? ' CANCELLED' : ''}`
+        )
+      }
+    } finally {
+      if (!args.keep) rmSync(root, { recursive: true, force: true })
+    }
+  }
+
+  // The verdict the issue actually asks for: does peak memory track file count?
+  const byBatch = new Map()
+  for (const r of results) {
+    if (!byBatch.has(r.batchSize)) byBatch.set(r.batchSize, [])
+    byBatch.get(r.batchSize).push(r)
+  }
+  console.log('')
+  for (const [batchSize, runs] of byBatch) {
+    if (runs.length < 2) continue
+    const first = runs[0]
+    const last = runs[runs.length - 1]
+    const fileRatio = last.fileCount / first.fileCount
+    const rssRatio = last.deltaRssMiB / Math.max(first.deltaRssMiB, 0.1)
+    console.log(
+      `batch=${batchSize}: ${fileRatio.toFixed(1)}x the files -> ${rssRatio.toFixed(2)}x the RSS delta ` +
+        `(bounded by batch size if this stays near 1.0)`
+    )
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
Adds the reproducible synthetic-tree benchmark #318 asks for, and records what it actually measured — including one place the acceptance criterion's wording turns out to be wrong.

Relates to #318 (stays open) and #340's R3.

## The measurements

`apps/core-app/scripts/file-scan-memory-benchmark.mjs` builds a nested synthetic tree, drives `scanDirectoryBatches` (the traversal the scan worker calls), and samples RSS/heap **inside the batch callback** — the moment a batch is live.

```
files=  25000 batch= 500  batches=  50  peakHeap= 13.9MiB  retained= 0.0MiB   388ms
files= 100000 batch= 500  batches= 200  peakHeap= 33.4MiB  retained= 0.0MiB  1167ms
files= 400000 batch= 500  batches= 800  peakHeap= 58.7MiB  retained= 0.0MiB  4079ms
```

**Retained heap is ~0 in every run**, across all nine file-count × batch-size combinations. Nothing accumulates.

**Cancellation** (`--cancel-at 5000` against a 100k tree): stops after 10 batches, returns in **112ms**, retained 0.5 MiB. The unaborted run over the same tree takes 2184ms.

**Unacknowledged batches are bounded at one.** `file-scan-worker.ts:118-127` registers an ack waiter, posts the batch, then `await acknowledged` before the traversal callback returns — so the next batch cannot be produced until the previous is consumed.

## Where the acceptance criterion is wrong

> Peak memory is bounded by configuration/batch size rather than total file count

**As written, this is false.** Peak heap grows with file count (13.9 → 33.4 → 58.7 MiB), and at a fixed file count it is nearly identical across batch sizes — 400k files gives 59.1 / 58.7 / 58.9 MiB at batch 100 / 500 / 2000. Batch size barely moves it.

The bound is real, it just is not expressed that way. Under pressure:

```
$ node --max-old-space-size=64 ... --counts 400000 --batch 500
files= 400000 batch= 500  peakHeap= 33.5MiB  retained= -0.8MiB  11551ms
```

**400,000 files complete in a 64 MiB old-space cap**, at a third of the unconstrained peak. V8 was growing the heap lazily because it had room, not because the scan was holding on to anything — which the ~0 retained figure already implied. The cost of the cap is time (11.5s vs 4.1s), not failure.

So the honest statement is: *memory is bounded by the working set, and the working set does not grow with directory cardinality* — demonstrated by completing under a cap, not by a flat peak-heap curve.

`ΔRSS` is in the output but should not be read as signal; it swings on where GC happened to run (0.0 to 44.3 MiB with no pattern). `peakHeap` and `retained` are the meaningful columns.

## Audit backlog

R3 in `07-13-search-crossplatform-audit/prd.md` now carries the measurements and that correction, and stays open for what this does **not** cover: reconciliation paging and persistence flush. The benchmark only exercises traversal.

## Why #318 stays open

Criteria 3–5 concern reconciliation's DB paging, the persistence/index flush backpressure, and focused tests for those paths. This measures traversal and cancellation only. The script is written to extend — file counts, batch sizes and the cancel point are all flags.
