### PR TITLE
docs: the search-index split shipped enabled; the safety gate said otherwise (#331)

### DIFF
--- a/docs/plan-prd/TODO.md
+++ b/docs/plan-prd/TODO.md
@@ -10,8 +10,8 @@
 
 ## Non-negotiable safety gates
 
-- `DB_SEARCH_SPLIT_ENABLED` / `TUFF_DB_SEARCH_SPLIT_ENABLED` defaults **off**. Enabling it before all named 2d/2e writes migrate causes provider writes to land in `database.db` while reads use `search-index.db`: **silent data loss**.
-- A flag-on app run, not typecheck alone, must prove first-launch reindex, matching app/file counts, correct results, populated `search-index.db`, healthy indexing, and flag-off rollback before the split can be enabled.
+- `TUFF_DB_SEARCH_SPLIT_ENABLED` defaults **on** since `cd39bdbf6` (2026-08-05). The 2d.3 write-path migration landed with it, so `database.db` and `search-index.db` each have exactly one writer connection and the half-migrated failure mode this gate used to guard against no longer exists. Setting it to `0` is the emergency revert to the shared-file topology, not the safe default.
+- That flip was proved by three app runs, not by typecheck: schema parity plus a first-launch bootstrap reindex of 4678 items, a second boot that correctly skipped it, and a V2 run with zero `SQLITE_BUSY`, zero cross-home FK failures and zero retry exhaustion. Any future change to the split topology owes the same class of evidence.
 - Historical reports prove only their recorded environment. Packaged and production claims require exact observed artifacts or deployed surfaces; they are never inferred from source state.
 
 ## Task-state rules


### PR DESCRIPTION
The decision #331 asks for was already made — in the other direction from what every document says.

Fixes #331.

## The flag has defaulted **on** since 2026-08-05

The issue, `docs/plan-prd/TODO.md`, and eight consecutive maintenance-audit reports (2026-07-30 through 2026-08-07) all state the flag "defaults **off**" / "默认关闭", and warn that an environment variable can activate a half-migrated mode.

`apps/core-app/src/main/db/runtime-flags.ts:26`:

```ts
export const DB_SEARCH_SPLIT_ENABLED = parseEnvBoolean('TUFF_DB_SEARCH_SPLIT_ENABLED', true)
```

`true`. Since `cd39bdbf6`, *feat(core-app)!: enable the search-index single-writer split by default*, 2026-08-05 — and `=0` is the **emergency revert**, not the safe default.

## Option 1 was taken, and it holds up

The commit is not a bare flip; it lands the migration the issue's decision required:

> database.db and search-index.db each have exactly one writer connection now that the split ships enabled. Validated by three app runs: schema parity + bootstrap reindex on first launch (**4678 items**), second boot skips, final V2 run with the **complete 2d.3 write-path migration** shows **zero SQLITE_BUSY, zero FK cross-home failures, zero retry exhaustion**.

Verified independently rather than taken from the commit message or the code comment:

- `failed-files-cleanup-task.ts:39-43` forwards deletes through `execSearchIndexWrite`, documented as going to "the search-index worker — the sole writer".
- `db/utils.ts:140` and `:233` describe the worker as "now the sole writer for file-index domain (files, file_extensions, …)".
- Searching `src/main` for a main-thread write against the search database (`getSearchIndexDb`, `searchIndexDb.insert|update|delete`) returns **nothing** — criterion 4's "no main-thread second writer".

So the acceptance criteria are largely satisfied by work that already shipped; what was left is the documentation contradicting it.

## What changed here

`TODO.md`'s non-negotiable safety gate now states the real default, says `=0` is the emergency revert rather than the safe position, and keeps the evidence bar (an app run, not a typecheck) for any future change to the topology.

Criterion 7 asks for the repo-level `todo.md` to be retired — there is no `todo.md` at the repo root any more; the surviving copy is `docs/plan-prd/TODO.md`, which is what this corrects.

## One thing worth flagging separately

The maintenance-audit reports dated **2026-08-05, 08-06 and 08-07** were generated *after* the flip and still repeat "默认关闭". Those are dated snapshots, so I have not rewritten them — history should stay history. But whatever produces that line is carrying a stale constant forward, and will keep emitting it tomorrow. Worth its own look.
