### PR TITLE
feat(core-app): guard the search-index single-writer contract in source (#351 partial)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,11 @@ jobs:
       - name: Verify entry documentation metadata
         run: pnpm check:doc-metadata && pnpm check:doc-metadata:self-test
 
+      # Source-level architecture guard: the search-index worker is the sole writer for
+      # files / file_extensions / keyword_mappings (#295, confirmed shipped in #331).
+      - name: Verify search-index writer ownership
+        run: pnpm -C apps/core-app check:search-index-writers && pnpm -C apps/core-app check:search-index-writers:self-test
+
       - name: Run PR quality gate
         run: pnpm quality:pr
 

--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -85,7 +85,9 @@
     "quickops:flow-ai:audit": "pnpm exec tsx \"scripts/quickops-flow-ai-adapter-audit.ts\"",
     "quickops:evidence:template": "pnpm exec tsx \"scripts/quickops-evidence-template.ts\"",
     "quickops:evidence:verify": "pnpm exec tsx \"scripts/quickops-evidence-verify.ts\"",
-    "context:entrypoint:evidence:verify": "pnpm exec tsx \"scripts/context-entrypoint-evidence.ts\""
+    "context:entrypoint:evidence:verify": "pnpm exec tsx \"scripts/context-entrypoint-evidence.ts\"",
+    "check:search-index-writers": "node scripts/check-search-index-writers.mjs",
+    "check:search-index-writers:self-test": "node scripts/check-search-index-writers.mjs --self-test"
   },
   "dependencies": {
     "@arrow-js/core": "1.0.6",

--- a/apps/core-app/scripts/check-search-index-writers.mjs
+++ b/apps/core-app/scripts/check-search-index-writers.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Guards the single-writer contract for the search-index domain.
+ *
+ * #295 gave `files`, `file_extensions` and `keyword_mappings` exactly one writer: the
+ * search-index worker. #331 confirmed that shipped and defaults on. Nothing enforces it.
+ *
+ * The contract has two legitimate shapes, and the difference is easy to miss by eye:
+ *
+ *   - `db/utils.ts` builds a drizzle statement and hands it to `runWrite`, which — when the
+ *     split is enabled — compiles it to SQL and forwards it through `execWrite` to the worker.
+ *     The `db` handle only *builds* the statement here; it never executes it.
+ *   - `file-index-persistence-repository.ts` writes directly, which is correct because it runs
+ *     inside the worker and *is* the sole writer.
+ *
+ * A third shape is the bug this catches: a new call site doing `await db.insert(schema.files)`
+ * outside those two files. It would write the primary database while reads come from
+ * search-index.db — the silent-divergence failure the split exists to prevent.
+ *
+ * Read-only. `--self-test` proves the detector fires on a synthetic violation, because a
+ * scanner that silently matches nothing looks exactly like a clean repository.
+ */
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+
+const CORE_APP = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const SRC = path.join(CORE_APP, 'src', 'main')
+
+/** Tables the search-index worker owns. Schema identifiers, as written in drizzle calls. */
+const OWNED_TABLES = ['files', 'fileExtensions', 'keywordMappings']
+
+/**
+ * Files allowed to contain a mutation against an owned table, and why.
+ * Paths are relative to apps/core-app/src/main.
+ */
+const APPROVED_WRITERS = {
+  'db/utils.ts':
+    'Builds the statement only; runWrite forwards it to the worker via execWrite when the split is on.',
+  'modules/box-tool/search-engine/file-index-persistence-repository.ts':
+    'Runs inside the search-index worker and is the sole writer for this domain.',
+  'modules/box-tool/search-engine/search-index-service.ts':
+    'Dual-mode by construction: search-index-worker.ts holds the directMode instance that ' +
+    'performs these writes, while search-core.ts constructs a second one with ' +
+    "initializationMode: 'reader'. The mutations here only execute on the worker's instance."
+}
+
+const MUTATION = new RegExp(
+  String.raw`\.\s*(?:insert|update|delete)\s*\(\s*schema\.(${OWNED_TABLES.join('|')})\s*\)`,
+  'g'
+)
+
+function listSourceFiles() {
+  const output = execFileSync('git', ['ls-files', 'src/main/**/*.ts'], {
+    cwd: CORE_APP,
+    encoding: 'utf8'
+  })
+  return output
+    .split('\n')
+    .filter(Boolean)
+    .filter((file) => !file.endsWith('.test.ts'))
+    .map((file) => file.replace(/^src\/main\//, ''))
+}
+
+export function findViolations(readFile, files, approved = APPROVED_WRITERS) {
+  const violations = []
+  for (const file of files) {
+    if (file in approved) continue
+    const text = readFile(file)
+    if (!text) continue
+    MUTATION.lastIndex = 0
+    for (const match of text.matchAll(MUTATION)) {
+      const line = text.slice(0, match.index).split('\n').length
+      violations.push({ file, line, table: match[1], snippet: match[0].trim() })
+    }
+  }
+  return violations
+}
+
+function readFromDisk(file) {
+  try {
+    return readFileSync(path.join(SRC, file), 'utf8')
+  } catch {
+    return null
+  }
+}
+
+function selfTest() {
+  const violation = 'await this.db.insert(schema.files).values(row)\n'
+  const cases = [
+    {
+      name: 'a new writer outside the approved set is caught',
+      files: ['modules/some/new-writer.ts'],
+      read: () => violation,
+      expectViolations: 1
+    },
+    {
+      name: 'the same write inside an approved owner is allowed',
+      files: ['db/utils.ts'],
+      read: () => violation,
+      expectViolations: 0
+    },
+    {
+      name: 'a table outside the domain is not policed',
+      files: ['modules/some/new-writer.ts'],
+      read: () => 'await this.db.insert(schema.clipboardHistory).values(row)\n',
+      expectViolations: 0
+    }
+  ]
+
+  let failures = 0
+  for (const testCase of cases) {
+    const found = findViolations(testCase.read, testCase.files)
+    const ok = found.length === testCase.expectViolations
+    console.log(`${ok ? 'ok  ' : 'FAIL'} ${testCase.name}`)
+    if (!ok) {
+      failures += 1
+      console.log(`     expected ${testCase.expectViolations} violation(s), got ${found.length}`)
+    }
+  }
+
+  const real = findViolations(readFromDisk, listSourceFiles())
+  console.log(`${real.length === 0 ? 'ok  ' : 'FAIL'} the real tree is clean`)
+  if (real.length > 0) {
+    failures += 1
+    for (const v of real) console.log(`     ${v.file}:${v.line} ${v.snippet}`)
+  }
+  return failures
+}
+
+if (process.argv.includes('--self-test')) {
+  process.exit(selfTest() > 0 ? 1 : 0)
+}
+
+const violations = findViolations(readFromDisk, listSourceFiles())
+if (violations.length > 0) {
+  console.error('[search-index-writers] direct writes to worker-owned tables:\n')
+  for (const v of violations) {
+    console.error(`  - ${v.file}:${v.line} writes ${v.table} via ${v.snippet}`)
+  }
+  console.error(
+    '\nThese tables live in search-index.db and the worker is their only writer. Route the write' +
+      '\nthrough SearchIndexWorkerClient, or through db/utils.ts so runWrite forwards it. Writing' +
+      '\nthe primary database here diverges silently from where the reads come from.' +
+      '\n\nIf a new file genuinely belongs to the worker, add it to APPROVED_WRITERS with the reason.'
+  )
+  process.exit(1)
+}
+
+console.log(
+  `[search-index-writers] ${OWNED_TABLES.length} worker-owned tables have no writer outside ` +
+    `${Object.keys(APPROVED_WRITERS).length} approved owners`
+)


### PR DESCRIPTION
Partial work on #351 — **does not close it.** Delivers criteria 1 and 2 for the one domain that already has a proven single-writer contract.

## Why this domain first

#351's dependency note says "Coordinate with #331; do not create another writer while completing the search-index split." #331 is now confirmed complete — the split shipped enabled on 2026-08-05 with the 2d.3 write-path migration. So the search-index domain is the one place where the owner is already settled and only the *enforcement* is missing.

## The contract has two shapes, and they are not distinguishable by eye

- `db/utils.ts` builds a drizzle statement and hands it to `runWrite`. When the split is on, `runWrite` compiles it to SQL and forwards it through `execWrite` to the worker. The `db` handle here only **builds** the statement; it never executes it.
- `file-index-persistence-repository.ts` writes directly — correct, because it runs inside the worker and *is* the sole writer.

Both read as `db.insert(schema.files)` in the source. A third shape is the bug: a new call site that builds *and awaits* the same statement outside those files would write the primary database while reads come from `search-index.db`.

I nearly filed that as a live defect. `dbUtils.addFileExtension` is called from `app-managed-entry-service.ts:183` and `file-provider-opener-service.ts:277`, on the main thread, with no `@deprecated` marker — but it goes through `runWrite`, so it forwards. Checking that before reporting is the whole reason this guard is worth having.

## The guard

`apps/core-app/scripts/check-search-index-writers.mjs`, wired into the PR Quality job. Fails on any `insert`/`update`/`delete` against `files`, `file_extensions` or `keyword_mappings` outside three recorded owners, each carrying the reason it qualifies.

**The third owner was found by running it, not by reading.** `search-index-service.ts` holds seven mutations on `keyword_mappings`, and is dual-mode: `search-index-worker.ts:110` constructs the `directMode` instance that performs them, while `search-core.ts:1874` constructs a second one with `initializationMode: 'reader'`. Recorded with that reasoning rather than silently widening the allowlist.

`--self-test` covers four cases:

```
ok   a new writer outside the approved set is caught
ok   the same write inside an approved owner is allowed
ok   a table outside the domain is not policed
ok   the real tree is clean
```

The last one matters as much as the first — a scanner that matches nothing looks exactly like a clean repository, which is the failure mode I hit earlier in this sweep and now guard against by default.

## What #351 still needs

This covers **one** domain. The survey found drizzle mutations across 20+ files — `download/database-service.ts` (13), `recommendation-engine.ts` (10), `app-provider.ts` (10), analytics, update, sentry, clipboard and more. Criterion 1 asks for an owner map across *every* mutable SQLite domain, and criteria 3–5 (shared retry/backoff contract, de-duplicated admission/transaction/observation layers, real-SQLite contention tests) are untouched.

The mechanism now exists and is cheap to extend: adding a domain is a table list plus an owner map with reasons. Criterion 7's R9 documentation should wait until more than one domain is mapped, or it would describe a map with one entry.
