### PR TITLE
docs: classify the platform branches instead of counting them (#349 partial)

### DIFF
--- a/.trellis/tasks/07-13-search-crossplatform-audit/prd.md
+++ b/.trellis/tasks/07-13-search-crossplatform-audit/prd.md
@@ -119,6 +119,9 @@
 
 - [ ] **R6 — 平台分支散落、`withOSAdapter` 采用不足**
   - 位置：main 目录 141 处 `process.platform`（`touch-window.ts:83`、`update-system.ts:1445`、`capability-adapter.ts` 通篇内联三分支…），`withOSAdapter` 几乎只有 startup-guard 用。**注意**：审计 OS-04/OS-05 已判定并非全部是 bypass，迁移需逐项复核。
+  - 2026-08-07 **已完成归类**（[#349](https://github.com/talex-touch/tuff/issues/349)，清单见 `docs/engineering/platform-branch-inventory.md`）：现为 **296 处**，但**只有 209 处比较 + 2 个 switch 是真分支**；53 处是 `platform: process.platform` 数据传递、32 处是模板/日志。**把 296 当迁移目标会高估 41%**；11 个文件的全部出现都属数据传递（`screenshot-service.ts` 独占 8 处），`plugin-module.ts` 的 14 处**全部**如此——它出现在「平台分支」排行第六是误读。
+  - 归类：A 原生/后端边界（保持显式，如 Windows 独有的 `everything-provider.ts`）· B 策略/能力三路判定（`platform-permission-service.ts` 25 处为首选候选）· C adapter 层自身（`capability-adapter.ts`，位置正确）· D 偶发重复（同一决策写多遍，如 `everything-provider.ts:325-330` 六行各自重算 `=== 'win32'`）· E 数据传递（非分支）。
+  - ⚠️ **`withOSAdapter` 目前不是合格的迁移目标**：它返回 `T | undefined`（`packages/utils/electron/env-tool.ts:79`），**没有类型化的 supported/degraded/unsupported，也没有 reason/recovery 码**，而 #349 验收条 4 正要求这些。先补契约再迁移，否则要迁两次。`withOSAdapter` 现有 5 个采用点。
 
 - [x] **R7 — `getStatus` 轮询架空 worker 空闲关闭** ✅ 已修（[#345](https://github.com/talex-touch/tuff/issues/345) / [PR #1089](https://github.com/talex-touch/tuff/pull/1089)，2026-08-07）
   - 根因比原描述窄：`IdleWorkerShutdownController.schedule()` 本就幂等，真正让截止时间可移动的**只有 `getStatus()` 开头那一次 `cancel()`**。移除后状态读取变为纯观察——不创建 worker、不移动截止时间；metrics 在途仍会推迟终止，但走 `shouldShutdown()` 读 `metricsPending`，而不是重置时钟。fake-timer 测试覆盖高频轮询/活跃任务/已终止客户端/shutdown 四类。

--- a/docs/engineering/platform-branch-inventory.md
+++ b/docs/engineering/platform-branch-inventory.md
@@ -1,0 +1,74 @@
+# 平台分支归类清单
+
+> 2026-08-07 对 `apps/core-app/src/main` 的实测归类，服务于 [#349](https://github.com/talex-touch/tuff/issues/349)。
+> 该 issue 明确要求「每一处受审分支都要归类；**不得使用只看数量的迁移目标**」，本文档因此按用途分类，而非按文件计数排序。
+
+## 先纠正一个数字
+
+`process.platform` 在 `src/main`（不含测试）共出现 **296** 次，但其中不是分支的占相当比例：
+
+| 用途 | 次数 | 说明 |
+|---|--:|---|
+| 比较（`===` / `!==`） | **209** | 真正的分支 |
+| `switch (process.platform)` | **2** | 真正的分支 |
+| 作为数据传递（`platform: process.platform`） | **53** | 遥测/诊断字段，不是决策 |
+| 模板字符串、日志、类型默认值 | 32 | 同样不是决策 |
+
+**把 296 当作迁移目标会高估 41%。** 有 11 个文件的全部出现都属于数据传递，其中 `screenshot-service.ts` 一个就有 8 处——它们出现在「平台分支」统计里纯属统计口径问题，不该进任何迁移计划。
+
+## 分类
+
+### A. 原生/后端边界 —— 保持显式
+
+平台切换发生在能力本身只存在于某个系统的地方。验收条 3 要求这类**保持显式并留档**。
+
+- `modules/box-tool/addon/files/everything-provider.ts`（32）：Everything 是 Windows 独有产品，全部分支为 `=== 'win32'`，其余平台返回 `unsupported`。
+- `modules/box-tool/addon/apps/{darwin,win,linux}.ts`：按平台拆分的应用扫描后端。
+- `modules/native-capabilities/*`：原生 addon 的可用性判定。
+
+**但其中混有可去除的重复**：`everything-provider.ts:325-330` 连续六行各自重新求值 `process.platform === 'win32'` 来拼一个状态对象。那是**一个**决策被写了六遍，属 D 类，不是六处边界。
+
+### B. 策略/能力决策 —— 应归入具名 adapter
+
+同一个三路判断在多处重复，且需要类型化结果。这是验收条 2 的目标。
+
+- `modules/system/platform-permission-service.ts`（25）：darwin/win32/linux 三路权限判定，是**最典型的候选**。
+- `modules/system/desktop-shortcut.ts`（4）、`modules/quick-ops/quick-ops-system-service.ts`（5）、`modules/clipboard/clipboard-autopaste-automation.ts`（5）：同型的三路能力判定。
+
+### C. adapter 层自身 —— 位置正确
+
+- `modules/platform/capability-adapter.ts`（22）：它**就是** adapter，分支写在这里是对的。注意它用的是裸 `process.platform` 而非 `withOSAdapter`。
+
+### D. 偶发重复 —— 一个决策被写多遍
+
+不是策略问题，是同一个布尔值没有提取。
+
+- `everything-provider.ts:325-330`（6 处 → 1 个 `isWindows` 常量）
+- `modules/box-tool/addon/apps/app-provider.ts`：已有 `private readonly isMac`（440 行，好写法），但 1469 / 1586 行仍重复 `!this.isMac && process.platform !== 'win32'`。
+
+### E. 数据传递 —— 不是分支
+
+上表 53 处。`plugin-module.ts` 的 14 处**全部**属于此类，它在「平台分支」排行里位列第六完全是误读。
+
+## ⚠️ 结论：`withOSAdapter` 目前还不是合格的迁移目标
+
+验收条 4 要求「平台能力结果暴露 supported/degraded/unsupported 以及稳定的 reason/recovery」。现有实现（`packages/utils/electron/env-tool.ts:79`）是：
+
+```ts
+export function withOSAdapter<R, T>(options: OSAdapter<R, T>): T | undefined {
+  switch (process.platform) {
+    case 'win32': return options.win32?.(arg)
+    case 'darwin': return options.darwin?.(arg)
+    case 'linux': return options.linux?.(arg)
+    default: ...
+  }
+}
+```
+
+返回 `T | undefined`，**既没有类型化的三态结果，也没有 reason/recovery 码**。把 B 类分支搬进去，只会把 `if/else` 换成回调形式，得不到验收条 4 要的东西——`undefined` 无法区分「不支持」与「支持但本次没结果」。
+
+**所以次序必须是：先给 `withOSAdapter`（或其继任者）补上类型化结果契约，再迁移 B 类。** 反过来做等于要迁两次。
+
+## 当前采用情况
+
+`withOSAdapter` 已在 5 个文件使用：`core/startup-version-guard.ts`、`modules/box-tool/addon/apps/app-launch-adapter.ts`、`modules/box-tool/addon/apps/app-scanner.ts`、`modules/system/active-app.ts`、`modules/system/wallpaper-adapter.ts`。


### PR DESCRIPTION
Partial work on #349 — **does not close it.** Delivers criterion 1 (classification) and the finding that blocks the rest.

## Counting first, because the count is wrong

#349 forbids a count-only migration target. Measuring shows why that matters here. `process.platform` appears **296** times in `apps/core-app/src/main` (excluding tests), but:

| use | count | branch? |
|---|--:|---|
| comparison (`===` / `!==`) | **209** | yes |
| `switch (process.platform)` | **2** | yes |
| `platform: process.platform` data field | **53** | no |
| template string, log, type default | **32** | no |

**Treating 296 as the migration target overstates it by 41%.** Eleven files' occurrences are *entirely* data — `screenshot-service.ts` alone holds 8. `plugin-module.ts` ranks sixth in a by-count file ranking with 14, and every one is a metadata field, not a decision. A migration plan built on the raw count would have spent its first effort on a file with no branches in it.

## Classification

`docs/engineering/platform-branch-inventory.md`:

- **A — native/backend boundary**, keep explicit per criterion 3. `everything-provider.ts` (32) gates a Windows-only product; the per-platform app scanners; native-capability availability.
- **B — repeated three-way policy**, the actual adapter candidates. `platform-permission-service.ts` (25) is the clearest; `desktop-shortcut.ts`, `quick-ops-system-service.ts`, `clipboard-autopaste-automation.ts` are the same shape.
- **C — the adapter layer itself.** `capability-adapter.ts` (22) is where a switch belongs.
- **D — incidental repetition**, one decision written several times. `everything-provider.ts:325-330` re-evaluates `process.platform === 'win32'` on six consecutive lines to build one status object. `app-provider.ts` already has `private readonly isMac` but still repeats `!this.isMac && process.platform !== 'win32'` at two later sites.
- **E — data, not a branch.** The 53 above.

Category A and D matter together: 6 of `everything-provider.ts`'s 32 are one decision, not six boundaries. Sorting by file count alone would have made it the top migration target when most of it should stay exactly as it is.

## ⚠️ The finding that blocks criteria 2 and 4

Criterion 4 requires platform capability results to expose supported/degraded/unsupported plus stable reason/recovery. The current adapter cannot express that:

```ts
// packages/utils/electron/env-tool.ts:79
export function withOSAdapter<R, T>(options: OSAdapter<R, T>): T | undefined {
  switch (process.platform) {
    case 'win32': return options.win32?.(arg)
    ...
  }
}
```

`T | undefined`. No typed three-state result, no reason or recovery code — and `undefined` cannot distinguish *unsupported* from *supported but produced nothing*.

So moving category B into `withOSAdapter` today would turn `if/else` into callbacks and satisfy nothing criterion 4 asks for. **The contract has to come first, or the migration is done twice.** It currently has 5 adoption sites.

## What remains

Criteria 2–7: the typed result contract, the actual category-B migration, per-platform focused tests, the bundle check, and R6's final residual scope. R6 in the audit backlog now carries the corrected count, the classification and this ordering constraint, so the next pass starts from measured ground rather than from 296.
