### PR TITLE
docs(trellis): record the acceptance evidence two blocking tasks already had (#334 partial)

### DIFF
--- a/.trellis/tasks/07-09-gate-search-on-storage-hydration/prd.md
+++ b/.trellis/tasks/07-09-gate-search-on-storage-hydration/prd.md
@@ -42,7 +42,10 @@ storage read error.
 ## Acceptance Criteria
 
 - [ ] Pending storage cannot start indexing/providers or open CoreBox search.
-- [ ] Ready storage with incomplete onboarding remains blocked.
+- [x] Ready storage with incomplete onboarding remains blocked. — 2026-08-07：
+  `storage/index.ts:1130` 返回类型化的 `{ state: 'blocked', reason: 'onboarding-incomplete',
+  recoverable: true }`，`core-box/ipc.ts:348` 在搜索路径上捕获 `OnboardingGateError`；
+  `ipc.test.ts` "surfaces the onboarding wizard instead of failing the search stream" 覆盖。
 - [ ] Ready storage with completed onboarding starts services once.
 - [ ] Recoverable failure exposes degraded state and retry; successful retry
   re-evaluates onboarding without duplicate services.

--- a/.trellis/tasks/07-09-scope-search-sessions-and-streams/prd.md
+++ b/.trellis/tasks/07-09-scope-search-sessions-and-streams/prd.md
@@ -57,18 +57,29 @@ activating, caching, or receiving results for one another.
 
 ## Acceptance Criteria
 
-- [ ] Concurrent CoreBox and AI queries both complete without cross-cancellation,
-  UI activation inheritance, or renderer leakage.
+- [x] Concurrent CoreBox and AI queries both complete without cross-cancellation,
+  UI activation inheritance, or renderer leakage. — 2026-08-07：取消按 sender 限定
+  （`search-core.ts:587` `cancelSearchFromSender(searchId, senderId)`，`ipc.ts:379` 传入
+  `context.sender.id`）；`search-session.test.ts` "isolates concurrent callers and rejects
+  stale or foreign cancellation"。
 - [ ] Two renderer windows receive only their own snapshots, updates, and
   completion.
-- [ ] Every request, including identical cache hits, has a new session id and
-  trace identity.
-- [ ] Cancelling a stale id cannot cancel a newer request.
-- [ ] The first stream chunk establishes session id before any update/completion
-  processing, eliminating pending-update maps required by invoke ordering.
-- [ ] Renderer unmount or stream cancellation aborts only its session.
-- [ ] No search delivery references `windowManager.current` or a single global
-  gather controller.
+- [x] Every request, including identical cache hits, has a new session id and
+  trace identity. — 2026-08-07：`search-session.test.ts` "creates fresh ids for detached
+  cache snapshots"；缓存快照类型是 `Omit<TuffSearchResult, 'sessionId'>`，sessionId 不可能
+  从缓存带出。
+- [x] Cancelling a stale id cannot cancel a newer request. — 2026-08-07：同上测试的
+  "rejects stale or foreign cancellation" 分支。
+- [x] The first stream chunk establishes session id before any update/completion
+  processing, eliminating pending-update maps required by invoke ordering. — 2026-08-07：
+  `search-session.test.ts` "buffers pre-snapshot updates and publishes exactly one terminal
+  completion in order"。
+- [x] Renderer unmount or stream cancellation aborts only its session. — 2026-08-07：
+  `search-session.test.ts` "aborts live sessions and waits for their cancellation completion
+  during destroy"。
+- [x] No search delivery references `windowManager.current` or a single global
+  gather controller. — 2026-08-07：`search-engine/` 下 `windowManager.current` 零命中；
+  `gatherController` 现为 `SearchSession` 的**实例私有**字段（`search-session.ts:111`），非全局单例。
 - [ ] Existing ranking/provider behavior remains unchanged outside explicit
   caller activation context.
 


### PR DESCRIPTION
Partial work on #334 — **does not close it.** Resolves what its dependency gate actually blocks on.

## The gate was blocked on bookkeeping, not on work

#334 says: *"Do not start until request-scoped sessions, onboarding/storage admission, and single-writer persistence ownership are confirmed complete in the Trellis dependency record."*

Checking all three:

| dependency | in code | in the record |
|---|---|---|
| single-writer persistence | shipped, guarded | **confirmed** — #331 closed, guard added in #351 |
| request-scoped sessions | `SearchSession` + `SearchSessionRegistry`, 5 passing tests | task `07-09-scope-search-sessions-and-streams`: **`planning`, 0/8 criteria ticked** |
| onboarding/storage admission | typed `OnboardingGateError` + admission result, tested | task `07-09-gate-search-on-storage-hydration`: **`planning`, 0/7 ticked** |

So the gate reads as closed indefinitely because two records were never filled in — not because anything is missing.

Worth noting the audit backlog marks **R4 fixed** citing the first of those tasks, while the task itself says `planning` with nothing accepted. That is the same disagreement I corrected on R1 in #321, in the same document.

## What this records

Six of the eight session-scoping criteria now cite the test or code that demonstrates them:

- sender-scoped cancellation — `cancelSearchFromSender(searchId, senderId)` at `search-core.ts:587`, called with `context.sender.id`
- fresh ids for cache hits — the cached snapshot type is `Omit<TuffSearchResult, 'sessionId'>`, so an id cannot survive a cache hit
- stale-cancellation rejection, ordered terminal completion, per-session abort on destroy — the three matching cases in `search-session.test.ts`
- no `windowManager.current` in `search-engine/` (zero hits) and no global gather controller — `gatherController` is a **private field on each SearchSession** (`search-session.ts:111`)

The onboarding gate's blocked-state criterion cites the typed `{ state: 'blocked', reason: 'onboarding-incomplete', recoverable: true }` result at `storage/index.ts:1130`, the catch at `core-box/ipc.ts:348`, and the `ipc.test.ts` case proving search surfaces the wizard rather than an empty result list.

## Deliberately left unticked

Two-renderer-window isolation, the ranking/provider non-regression claim, and most of the storage task's runtime states (pending storage, recoverable retry, terminal fail-closed). Those need runs I cannot produce from here, and ticking them on a plausible reading is how the R1 and R4 over-claims happened in the first place.

## #334 itself

Untouched. Its own criteria — the `load → start → stop → destroy` lifecycle, the registered/loading/ready/degraded state machine, the unified executable registry, the generic FTS-by-source adapter, awaited disposal in `SearchEngineCore.destroy()` — are all still to do. What changes is that the dependency gate now has an accurate picture instead of a blank one: three unticked criteria across two tasks, each naming what would satisfy it.
