### PR TITLE
fix(tuffex)!: stop emitting the legacy TGroupBlock/TBlockSlot class names (#1079)

### DIFF
--- a/packages/tuffex/packages/components/src/group-block/src/TxBlockSlot.vue
+++ b/packages/tuffex/packages/components/src/group-block/src/TxBlockSlot.vue
@@ -78,7 +78,7 @@ const currentIcon = computed(() => {
 
 <template>
   <div
-    class="tx-block-slot TBlockSlot-Container TBlockSelection fake-background index-fix"
+    class="tx-block-slot fake-background index-fix"
     :class="{ 'tx-block-slot--disabled': disabled, disabled }"
     :role="interactive ? 'button' : undefined"
     :tabindex="interactive && !disabled ? 0 : undefined"
@@ -86,11 +86,11 @@ const currentIcon = computed(() => {
     @click="handleClick"
     @keydown="handleKeydown"
   >
-    <div class="tx-block-slot__content TBlockSlot-Content TBlockSelection-Content">
+    <div class="tx-block-slot__content">
       <slot name="icon" :active="active">
         <TuffIcon v-if="currentIcon" :icon="currentIcon" :size="iconSize" />
       </slot>
-      <div class="tx-block-slot__label TBlockSlot-Label TBlockSelection-Label">
+      <div class="tx-block-slot__label">
         <template v-if="$slots.label">
           <slot name="label" />
           <div v-if="$slots.tags" class="tx-block-slot__tags tx-block-slot__tags--after">
@@ -112,15 +112,14 @@ const currentIcon = computed(() => {
         </template>
       </div>
     </div>
-    <div class="tx-block-slot__slot TBlockSlot-Slot TBlockSelection-Func">
+    <div class="tx-block-slot__slot">
       <slot :active="active" />
     </div>
   </div>
 </template>
 
 <style lang="scss">
-.tx-block-slot,
-.TBlockSlot-Container {
+.tx-block-slot {
   position: relative;
   display: flex;
   gap: 16px;
@@ -227,8 +226,7 @@ const currentIcon = computed(() => {
   }
 }
 
-.touch-blur .tx-block-slot,
-.touch-blur .TBlockSlot-Container {
+.touch-blur .tx-block-slot {
   --fake-color: var(--tx-fill-color, #f0f2f5);
 
   &:hover {

--- a/packages/tuffex/packages/components/src/group-block/src/TxGroupBlock.vue
+++ b/packages/tuffex/packages/components/src/group-block/src/TxGroupBlock.vue
@@ -210,11 +210,11 @@ onMounted(() => {
 
 <template>
   <div
-    class="tx-group-block TGroupBlock-Container"
+    class="tx-group-block"
     :class="{ 'tx-group-block--expanded': expanded, 'expand': expanded }"
   >
     <div
-      class="tx-group-block__header TGroupBlock-Header fake-background index-fix"
+      class="tx-group-block__header fake-background index-fix"
       :class="{ 'tx-group-block__header--static': !collapsible, 'is-static': !collapsible }"
     >
       <button
@@ -227,11 +227,11 @@ onMounted(() => {
         @click="toggle"
       />
 
-      <div class="tx-group-block__content TGroupBlock-Content">
+      <div class="tx-group-block__content">
         <slot name="icon" :active="expanded">
           <TuffIcon v-if="headerIcon" :icon="headerIcon" :size="iconSize" />
         </slot>
-        <div class="tx-group-block__label TGroupBlock-Label">
+        <div class="tx-group-block__label">
           <h3 class="tx-group-block__name">
             {{ name }}
           </h3>
@@ -247,13 +247,13 @@ onMounted(() => {
 
       <div
         v-if="collapsible"
-        class="tx-group-block__toggle TGroupBlock-Mode i-carbon-chevron-down"
+        class="tx-group-block__toggle i-carbon-chevron-down"
         :class="{ 'is-expanded': expanded }"
         aria-hidden="true"
       />
     </div>
 
-    <div :id="contentId" ref="contentRef" class="tx-group-block__body TGroupBlock-Main">
+    <div :id="contentId" ref="contentRef" class="tx-group-block__body">
       <slot />
     </div>
   </div>
@@ -393,7 +393,6 @@ onMounted(() => {
     padding: 0;
     overflow: visible;
 
-    :deep(.TBlockSelection),
     :deep(.tx-block-slot),
     :deep(.tx-block-switch) {
       margin: 0;
@@ -401,11 +400,11 @@ onMounted(() => {
       --fake-radius: 0 !important;
       --fake-inner-opacity: 0.5;
 
-      .TBlockSelection-Content > * {
+      .tx-block-slot__content > * {
         font-size: 20px;
       }
 
-      .TBlockSelection-Func {
+      .tx-block-slot__slot {
         margin-right: 32px;
       }
     }
@@ -420,7 +419,6 @@ onMounted(() => {
   }
 }
 
-.touch-blur .tx-group-block__body :deep(.TBlockSelection),
 .touch-blur .tx-group-block__body :deep(.tx-block-slot),
 .touch-blur .tx-group-block__body :deep(.tx-block-switch) {
   &:hover {


### PR DESCRIPTION
Closes #1079 — the third step of #1030, which that PR resolved the first two of but explicitly could not finish.

## What was wrong

`.TGroupBlock-*`, `.TBlockSlot-*` and `.TBlockSelection*` were emitted by **two unrelated component families**: tuffex's `TxGroupBlock`/`TxBlockSlot` and CoreApp's `TuffGroupBlock`/`TuffBlockSlot`, which are independent re-implementations rather than wrappers. `:deep(.TBlockSlot-Container)` did not say which one it meant.

Both tuffex style blocks are **unscoped**, so their rules on the legacy names were reaching CoreApp's DOM — the leak the issue describes.

## The fix, and why it needs no consumer changes

tuffex already carried its own BEM name on every one of those elements, right next to the legacy alias. Dropping the aliases gives each family sole ownership of its class names.

The issue anticipated having to rewrite every `:deep()` site. That turned out to be unnecessary: **every one of them renders the `Tuff*` family — none render `Tx*`.**

| consumer | `Tuff*` | `Tx*` |
|---|--:|--:|
| `SettingUpdate.vue` | 4 | 0 |
| `SettingDownload.vue` | 4 | 0 |
| `SettingEverything.vue` | 15 | 0 |
| `SettingPlatformCapabilities.vue` | 1 | 0 |
| `IntelligencePromptsPage.vue` | 12 | 0 |
| `IntelligenceCapabilityInfo.vue` | 5 | 0 |
| `IntelligenceInfo.vue` | 6 | 0 |

So once tuffex stops emitting them, the legacy families have exactly one emitter and every existing selector — including the runtime `querySelectorAll` in `coreapp-visible-assistant-floating-ball-probe.ts`, the one that would have failed silently — becomes unambiguous without being touched.

## Why removing tuffex's unscoped rules is safe

CoreApp's `TuffBlockSlot` carries a **complete scoped copy** of the container declarations: `position`, `display`, `gap`, `justify-content`, `align-items`, `padding`, `width`, `height`, `user-select`, `box-sizing`, all three `--fake-*` customs and the `transition`, plus `&.disabled`, `&:hover`, `&:active` and the `.touch-blur` variant.

The only rule it lacks is `&:focus-visible`, and its `TuffBlockSlot` sets neither `tabindex` nor `role` — nothing focuses it.

*(I initially misread this: the base declarations sit **after** the nested blocks in the same rule, so a partial read makes CoreApp look structurally dependent on tuffex's global. It is not.)*

`TuffBlockSwitch.vue:83` uses `.TBlockSlot-Container:hover .TuffBlockSwitch-Chevron`, whose ancestor still comes from CoreApp's own `TuffBlockSlot`.

## The four internal references translate exactly

tuffex's own SCSS used the aliases in four places. Each maps one-to-one because the alias and the BEM name are on the same element:

| | | source |
|---|---|---|
| `.TBlockSlot-Container` | `.tx-block-slot` | `TxBlockSlot.vue:81` |
| `.TBlockSelection` | `.tx-block-slot` | same element, `:81` |
| `.TBlockSelection-Content` | `.tx-block-slot__content` | `:89` |
| `.TBlockSelection-Func` | `.tx-block-slot__slot` | `:115` |

Two were redundant selector-list entries sitting next to the BEM name that already matched the same element, so they are simply dropped rather than rewritten.

## Verified

- Repo-wide scan (with a positive control, since this is an absence claim): the three families are now emitted only by `apps/core-app/src/renderer/src/components/tuff/*`. tuffex references them nowhere; `apps/nexus` never did.
- tuffex suite: **145 files / 1114 tests pass**. Stating plainly what that is worth — it is a regression check, not a verification of this change. No test asserts on these class names, which is exactly why the collision survived.

## Breaking change

For anyone outside this repo styling tuffex through `.TGroupBlock-*` / `.TBlockSlot-*` / `.TBlockSelection*`. The aliases are undocumented — the component docs never mention them.

## Left for the maintainer

The issue also asks whether `components/tuff/*` should exist at all, or whether CoreApp should consume `@talex-touch/tuffex/group-block` directly and collapse the duplication. That is an architecture call, not a defect fix, and it is entangled with the in-flight settings v2.5 work — so this PR resolves the ambiguity without pre-empting that decision. Renaming CoreApp's family to `tuff-group-block__*` is likewise cosmetic once each name has a single owner.

Closes #1079
