### PR TITLE
ci: emit JUnit reports from the App suites job (#325)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,10 +155,15 @@ jobs:
       # native-protocol job. See #924.
       #
       # Non-blocking for now: both suites are red before this change — measured
-      # on CI at core-app 20 files / 54 tests and nexus 13 files / 15 tests.
+      # on CI at core-app 28 files / 68 tests and nexus 12 files / 15 tests.
       # Running and visible beats not running; flip continue-on-error off once
       # the counts reach zero, and until then use them as the regression
       # baseline to compare against.
+      #
+      # The counts above are the whole reason for the JUnit report below: a
+      # continue-on-error job reports success, so a jump like 20 -> 28 files is
+      # invisible unless the numbers are an artifact rather than something you
+      # have to scrape out of a 6000-line log.
       # apps/nexus imports @talex-touch/tuffex/utils, whose exports map resolves
       # only into dist/ — without a build those tests fail on module resolution
       # rather than on anything they actually assert.
@@ -168,4 +173,19 @@ jobs:
 
       - name: Run ${{ matrix.app }} suite
         continue-on-error: true
-        run: pnpm -C "apps/${{ matrix.app }}" exec vitest run
+        run: >-
+          pnpm -C "apps/${{ matrix.app }}" exec vitest run
+          --reporter=default
+          --reporter=junit
+          --outputFile.junit=../../test-reports/${{ matrix.app }}.junit.xml
+
+      # if: always() — the report is only interesting when the suite failed, and
+      # the step above is continue-on-error, so it must not be gated on success.
+      - name: Upload ${{ matrix.app }} test report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-report-${{ matrix.app }}
+          path: test-reports/${{ matrix.app }}.junit.xml
+          retention-days: 7
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ apps/quota-gpt-view/
 apps/quota-gpt-ends/
 apps/g-wggu5114-thisai-thisai-ends-/
 apps/g-wggu5114-thisai-thisai-view-/
+
+# Vitest JUnit reports written by the App suites CI job
+test-reports/

--- a/apps/nexus/package.json
+++ b/apps/nexus/package.json
@@ -102,6 +102,7 @@
     "typescript": "catalog:dev",
     "unocss": "catalog:build",
     "vitepress": "catalog:",
+    "vitest": "^3.2.7",
     "vue": "^3.5.39",
     "vue-tsc": "catalog:dev",
     "webpack": "catalog:dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -743,6 +743,9 @@ importers:
       vitepress:
         specifier: 'catalog:'
         version: 2.0.0-alpha.18(@types/node@24.13.2)(axios@1.18.1)(change-case@5.4.4)(fuse.js@7.5.0)(jiti@2.7.0)(postcss@8.5.23)(sass@1.101.0)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+      vitest:
+        specifier: ^3.2.7
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.2)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(sass@1.101.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
       vue:
         specifier: ^3.5.39
         version: 3.5.39(typescript@5.9.3)


### PR DESCRIPTION
One acceptance criterion from #325, landed on its own: *"Upload machine-readable Vitest/JUnit summaries on failure"* / *"Test reports identify failing file, test, duration, and artifact link."*

It does not close #325 — that issue's own dependency ("this gate should become required only after the dedicated CoreApp, Nexus, and integration baseline issues are green") is unmet, measured below.

## Why this one first

The `App suites` job is `continue-on-error`, so it reports **success** whether the suite passes or not. The only record is a 6000-line log.

That hid a real regression. The baseline comment in `ci.yml` — which I wrote — says core-app was **20 files / 54 tests** red. The current run is **28 files / 68 tests**. Eight test files started failing and every check stayed green. I only found it by scraping the log, and my first three attempts to extract the failing file list from that log failed outright.

Current measured state, for the record:

| suite | files | |
|---|---|---|
| core-app | **28 failed** / 598 passed / 3 skipped | 629 |
| nexus | **12 failed** / 168 passed | 180 |

The failures I sampled are environment-shaped rather than caused by recent work — `active-app.test.ts` asserting macOS `EBADF` behaviour on an Ubuntu runner, and `WidgetFrame.vue` hitting `vue-i18n`'s "Need to install with `app.use`". Those want their own issues; this PR only makes them legible.

## What this adds

`--reporter=junit` alongside the default reporter, and an artifact upload under `if: always()` — the interesting case is the failing one, and the step it follows cannot fail the job.

The XML carries per-file name, test counts and duration. It also turns *"flip `continue-on-error` off once the counts reach zero"* into a check against an artifact rather than a log scrape.

## Verified, not assumed

Ran the exact invocation locally against vitest 3.2.7: it accepts `--outputFile.junit`, **creates missing parent directories**, and writes per-suite `tests`/`failures`/`time` attributes.

```
JUNIT report written to /tmp/jtest/sub/dir/out.junit.xml
<testsuites name="vitest tests" tests="1" failures="0" errors="0" time="0.000986833">
    <testsuite name="…/scroll-export.test.ts" tests="1" failures="0" … time="0.000986833">
```

Also parsed the edited workflow with a YAML parser to confirm both steps resolve as intended.

## One dependency declaration

`apps/nexus` never declared `vitest`, though its own `test` script, its `vitest.config.ts` and this job all invoke it — it was resolving transitively. Declared at `^3.2.7`.

Lockfile is additive: 2932 resolved packages before and after, nothing added or removed.

Refs #325
