### PR TITLE
test(core-app): restore four uninstall tests I reported as passing but did not ship (#323 partial, corrects #1070)

### DIFF
--- a/apps/core-app/src/main/modules/plugin/plugin-module.test.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-module.test.ts
@@ -1,6 +1,6 @@
-import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 import path from 'node:path'
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, statSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, statSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { PluginStatus, type IPluginManager, type ITouchPlugin } from '@talex-touch/utils/plugin'
 import type { PluginApiUninstallRequest } from '@talex-touch/utils/transport/events/types'
@@ -1839,7 +1839,20 @@ describe('PluginModule facade', () => {
 
   it('refuses a symlinked plugin code owner and never follows it during uninstall', async () => {
     const { manager } = await createActualManagerHarness()
-    mocks.symbolicPaths.add(fixturePath('plugins', 'calendar'))
+    // A real symlink, not a mock flag: captureDirectoryIdentity stats the disk, so a flag the
+    // lstat mock knows about is invisible to it. Refusal therefore happens at the admission
+    // barrier rather than at the code stage — stricter than the old expectation, and the
+    // property the test name claims ("never follows it") holds more strongly.
+    const owner = fixturePath('plugins', 'calendar')
+    const decoy = fixturePath('plugins', 'calendar-decoy')
+    rmSync(owner, { recursive: true, force: true })
+    mkdirSync(decoy, { recursive: true })
+    symlinkSync(decoy, owner)
+    onTestFinished(() => {
+      rmSync(owner, { recursive: true, force: true })
+      rmSync(decoy, { recursive: true, force: true })
+      mkdirSync(owner, { recursive: true })
+    })
 
     const result = await uninstallWithDisposition(manager, {
       ordinaryExport: { enabled: false },
@@ -1848,14 +1861,10 @@ describe('PluginModule facade', () => {
 
     expect(result).toMatchObject({
       success: false,
-      code: 'PLUGIN_UNINSTALL_CLEANUP_FAILED',
+      code: 'PLUGIN_UNINSTALL_TEARDOWN_FAILED',
       installed: true,
       stages: expect.arrayContaining([
-        expect.objectContaining({
-          stage: 'code',
-          status: 'failed',
-          code: 'PLUGIN_UNINSTALL_CODE_DELETE_FAILED'
-        })
+        expect.objectContaining({ stage: 'admission', status: 'failed' })
       ])
     })
     expect(mocks.fsRemove).not.toHaveBeenCalledWith(fixturePath('plugins', 'calendar'))
@@ -1872,9 +1881,13 @@ describe('PluginModule facade', () => {
       const { manager } = await createActualManagerHarness()
       if (failedStage === 'code' || failedStage === 'data') {
         mocks.fsRemove.mockImplementation(async (target: string) => {
+          // The coordinator quarantines the owner by renaming it to `.recovery` and deletes
+          // that name, so matching the pre-rename path never fires. Resolve back through the
+          // rename bookkeeping before deciding whether to inject.
+          const original = mocks.renamedPaths.get(target) ?? target
           if (
-            (failedStage === 'code' && target === fixturePath('plugins', 'calendar')) ||
-            (failedStage === 'data' && target === fixturePath('plugin-data', 'calendar', 'config'))
+            (failedStage === 'code' && original === fixturePath('plugins', 'calendar')) ||
+            (failedStage === 'data' && original === fixturePath('calendar', 'data'))
           ) {
             throw new Error(`synthetic ${failedStage} delete failure`)
           }
@@ -1890,7 +1903,7 @@ describe('PluginModule facade', () => {
         portableSecretBackup: { enabled: false }
       })
 
-      expect(mocks.fsRemove).toHaveBeenCalledTimes(failedStage === 'code' ? 5 : 4)
+      expect(mocks.fsRemove).toHaveBeenCalledTimes(failedStage === 'plugin-data' ? 1 : 2)
       expect(mocks.dbUtils.deletePluginData).toHaveBeenCalledWith('calendar')
       expect(mocks.reportPluginUninstall).not.toHaveBeenCalled()
       expect(manager.plugins.has('calendar')).toBe(true)
@@ -1977,9 +1990,15 @@ describe('PluginModule facade', () => {
       fixturePath('plugins', 'calendar'),
       fixturePath('plugin-data', 'calendar')
     ])
-    mocks.fsPathExists.mockImplementation(async (target: string) => existing.has(target))
+    // Owners are quarantined to a `.recovery` name before deletion, so both the existence
+    // probe and the delete arrive under the renamed path. Resolve back, or the set looks
+    // untouched and the test reads as "nothing was deleted".
+    const resolveOwner = (target: string) => mocks.renamedPaths.get(target) ?? target
+    mocks.fsPathExists.mockImplementation(async (target: string) =>
+      existing.has(resolveOwner(target))
+    )
     mocks.fsRemove.mockImplementation(async (target: string) => {
-      existing.delete(target)
+      existing.delete(resolveOwner(target))
     })
     const pending = (
       manager as IPluginManager & {


### PR DESCRIPTION
Two things: a correction to work I closed earlier in this sweep, and the deterministic triage #323 asks for.

## I closed #1070 on a false measurement

I reported `plugin-module.test.ts` as **35/35**. At my own merge commit `395df59c0`, with `plugin-data-disposition*.ts` untouched since, it is **30/35**.

The harness rewrite landed — `renamedPaths`, the real `rename` passthrough, the disk-trusting `lstat`. The five test bodies that consume it did not. That "35/35" measured a working tree the commit never contained; the baseline stash/restore cycles I ran for before/after comparison almost certainly took those edits with them. I have a standing note not to use stash/checkout for verification precisely because of this, and I used it anyway.

Four are restored here and verified against the **committed** tree:

- **three failure-injection cases** matched the pre-quarantine path, so the injection never fired and the flow silently took the success path. They now resolve the target back through `mocks.renamedPaths`, and the `fsRemove` counts follow the two-quarantine-root shape rather than per-directory deletes.
- **the success case** tracked existence and deletion by pre-rename path, so the set looked untouched and the test read as "nothing was deleted".
- **the symlink case** set a lstat mock flag that `captureDirectoryIdentity` cannot see, because it stats the disk. It now creates a real symlink and asserts refusal where it happens — the `admission` barrier with `PLUGIN_UNINSTALL_TEARDOWN_FAILED`, stricter than the code-stage expectation it replaces.

`src/main/modules/plugin`: **87 files, 1 failing** (was 5).

**One is left failing rather than skipped.** Injecting at the `data` stage does not stop `reportPluginUninstall`, and correcting the target to the real `dataRootPath` (`fixturePath('calendar','data')`, not the `plugin-data/…/config` I had) did not change it — `deletePinnedDirectory` appears not to route that root through `mocks.fsRemove`. Whether a data-stage failure *should* suppress the report is a product question I have not answered, and skipping it would hide it.

## The #323 triage

Measured on `app-shell-v2`, clean install, full suite:

```
Test Files  23 failed | 603 passed | 3 skipped (629)
Tests       54 failed | 5124 passed | 8 skipped (5186)
```

The issue records 6 files / 18 tests at v2.4.13. It is now **23 files / 54 tests**.

**Every one is deterministic.** Re-running exactly those 23 files in isolation reproduces 23 failed files and the same 54 failures — nothing in this set is load- or parallelism-dependent. That matters for the issue's category 3: no failure here is fixed by a bigger timeout, and none needs a deterministic-clock rewrite for flakiness reasons, because none of them flake.

(That is a real change. Earlier in this sweep I measured `permission-guard` and `app-provider` failing under full-suite load and passing in isolation. Those are now absent from the failing set; the 23 that remain fail either way.)

Six of the 23 carry vitest's `[ path ]` suffix — collection/unhandled-error failures rather than assertion failures, which need separating from the other 17 before per-file triage.

`plugin-module.test.ts` is one of the 23, and this PR takes it from 5 failures to 1.
