### PR TITLE
test(nexus): re-point two drifted guards at the code they guard (#327)

### DIFF
--- a/apps/nexus/app/pages/dashboard/notifications.test.ts
+++ b/apps/nexus/app/pages/dashboard/notifications.test.ts
@@ -51,7 +51,10 @@ describe('dashboard notification inbox UI contract', () => {
     expect(page).toContain('urlBase64ToArrayBuffer(browserPushPublicKey.value)')
     expect(page).toContain('runtimeConfig.public?.notificationWebPush?.publicKey')
     expect(page).toContain('browserPushStatusLabel')
-    expect(page).toContain('browserNotificationActionDisabled')
+    // Assert the guard condition, not the identifier that used to hold it:
+    // `browserNotificationActionDisabled` was a computed and is now inlined on
+    // the button, so grepping the name failed while the behaviour was intact.
+    expect(page).toMatch(/:disabled="browserNotificationBusy[^"]*browserNotificationPermission === 'denied'[^"]*browserNotificationPermission === 'unsupported'"/)
     expect(page).toContain('browserNotificationPermissionLabel')
     expect(page).toContain('dashboard.notifications.browser.testSent')
     expect(page).toContain('dashboard.notifications.browser.webPushSubscribed')

--- a/apps/nexus/build/check-worker-bundle.test.ts
+++ b/apps/nexus/build/check-worker-bundle.test.ts
@@ -380,27 +380,15 @@ describe('Nexus deploy asset budget', () => {
   })
 
   it('keeps public pricing and password-reset locale contracts complete', () => {
-    const pricingKeys = [
-      'freeTitle',
-      'freePrice',
-      'freeDesc',
-      'freeFeature1',
-      'freeFeature2',
-      'freeFeature3',
-      'plusTitle',
-      'plusPrice',
-      'plusDesc',
-      'plusFeature1',
-      'plusFeature2',
-      'plusFeature3',
-      'teamTitle',
-      'teamPrice',
-      'teamDesc',
-      'teamFeature1',
-      'teamFeature2',
-      'teamFeature3',
-      'cta',
-    ] as const
+    // The plan list is read off the locale rather than hardcoded, so a new plan
+    // is covered the moment it is added. The previous version named free/plus/
+    // team with flat `freeTitle`-style keys, which stopped matching the locale
+    // once plans moved under `pricing.plans.*` -- and it never covered `pro`.
+    const planKeys = Object.keys(enLocale.pricing.plans)
+    expect(planKeys.length).toBeGreaterThan(0)
+    expect(Object.keys(zhLocale.pricing.plans)).toEqual(planKeys)
+
+    const shellKeys = ['eyebrow', 'title', 'subtitle', 'ctaFree', 'ctaWaitlist', 'perMonth'] as const
     const authKeys = [
       'forgotTitle',
       'forgotSubtitle',
@@ -409,10 +397,28 @@ describe('Nexus deploy asset budget', () => {
       'resetEmailSent',
     ] as const
 
-    for (const key of pricingKeys) {
-      expect(enLocale.pricing[key]).toBeTruthy()
-      expect(enLocale.pricing[key]).not.toMatch(/\p{Script=Han}/u)
-      expect(zhLocale.pricing[key]).toBeTruthy()
+    for (const plan of planKeys) {
+      const en = enLocale.pricing.plans[plan]
+      const zh = zhLocale.pricing.plans[plan]
+
+      // Only the free plan quotes a price; the rest are gated behind
+      // `comingSoonHint`, so requiring `price` everywhere would be wrong.
+      for (const key of ['name', 'desc', 'feature1', 'feature2', 'feature3'] as const) {
+        expect(en[key], `en pricing.plans.${plan}.${key}`).toBeTruthy()
+        expect(en[key], `en pricing.plans.${plan}.${key} must not be Chinese`).not.toMatch(/\p{Script=Han}/u)
+        expect(zh[key], `zh pricing.plans.${plan}.${key}`).toBeTruthy()
+      }
+      // Both locales must describe the same plan, not merely be non-empty.
+      expect(Object.keys(zh), `pricing.plans.${plan} key parity`).toEqual(Object.keys(en))
+    }
+
+    expect(enLocale.pricing.plans.free.price).toBeTruthy()
+    expect(zhLocale.pricing.plans.free.price).toBeTruthy()
+
+    for (const key of shellKeys) {
+      expect(enLocale.pricing[key], `en pricing.${key}`).toBeTruthy()
+      expect(enLocale.pricing[key], `en pricing.${key} must not be Chinese`).not.toMatch(/\p{Script=Han}/u)
+      expect(zhLocale.pricing[key], `zh pricing.${key}`).toBeTruthy()
     }
     for (const key of authKeys) {
       expect(enLocale.auth[key]).toBeTruthy()


### PR DESCRIPTION
First two of #327's twelve failing files. Both were guards that drifted away from the code they guard, not product regressions — so each is rewritten at the current shape rather than deleted.

## `check-worker-bundle.test.ts` — pricing locale contract

Asserted flat keys: `pricing.freeTitle`, `pricing.freePrice`, `pricing.freeFeature1`, `pricing.cta`. The locale has since moved plans under `pricing.plans.{free,plus,pro,team}.{name,price,desc,featureN}`, so every lookup returned `undefined` and it failed on the first assertion in the loop.

The invariant is still worth guarding — both locales carry complete pricing content, English contains no Han characters — so it is rewritten, and gains two things:

- **the plan list is read off the locale** instead of hardcoded, so a new plan is covered the moment it is added. The old list named free/plus/team and **never covered `pro` at all**.
- **key parity is asserted per plan**, so `zh` cannot quietly drop a feature line while staying non-empty.

`price` is asserted only on `free`; the others sit behind `comingSoonHint` and legitimately have none.

## `notifications.test.ts` — browser notification guard

Grepped the page source for `browserNotificationActionDisabled`. That was a computed and is now inlined on the button at `notifications.vue:484`; the grep failed while the behaviour never changed.

Replaced with a match on the actual condition — busy, or permission `denied`, or permission `unsupported`. That is what the assertion means, and it survives the computed being renamed or inlined again.

This is the direction #327 asks for: *"move fragile implementation-text checks toward exported helpers, artifact budgets, or runtime responses."*

## Adversarially verified

Every rewritten assertion was proved non-vacuous by breaking the thing it guards, then restoring:

| control | result |
|---|---|
| blank `en pricing.plans.pro.feature1` | 1 failed |
| Chinese text in `en pricing.ctaFree` | 1 failed |
| drop `feature4` from `zh pricing.plans.pro` | 1 failed |
| remove the denied/unsupported branch from `notifications.vue` | 1 failed |
| all restored | 19 + 3 passed |

Two controls target `pro` deliberately — it is the plan the previous version would have missed. Both source files are byte-identical to `HEAD` afterwards.

## Remaining in #327

10 files / 12 tests, enumerated in [my comment on the issue](https://github.com/talex-touch/tuff/issues/327). The largest is not a test fix at all: `tuffex-component-docs-coverage.test.ts` reports **twelve components with no docs in either locale** (the AI/chat family — `attachment-tray`, `chain-of-thought`, `context-indicator`, `conversation-stream`, `message-actions`, `reasoning-disclosure`, `sources`, `stream-markdown`, `suggestion-chips`, `thinking-orb`, `tool-call-card`, `tool-confirmation`), none with a registered demo. At 300–600 lines per existing component doc that is 24 documents plus demos — its own piece of work, and the criterion allows the alternative of removing them from public exports, so it needs a decision first.

Refs #327
