### PR TITLE
test(nexus): fix time-bomb fixtures and the missing D1 batch mock (#327)

### DIFF
--- a/apps/nexus/server/utils/__tests__/authStore.sync-items-merge.test.ts
+++ b/apps/nexus/server/utils/__tests__/authStore.sync-items-merge.test.ts
@@ -40,6 +40,23 @@ class MockD1Database {
     return new MockStatement(this, sql)
   }
 
+  /**
+   * mergeLegacySyncItemsForUsers builds its statements up front and hands the
+   * whole list to db.batch(), because D1 has no interactive transaction.
+   *
+   * D1 runs a batch sequentially and atomically, and the merge depends on that
+   * ordering — the DELETE that drops superseded source rows has to see the
+   * effect of the statements before it. So this awaits them in array order
+   * rather than with Promise.all, and returns one result per statement the way
+   * D1 does.
+   */
+  async batch(statements: MockStatement[]) {
+    const results: unknown[] = []
+    for (const statement of statements)
+      results.push(await statement.run())
+    return results
+  }
+
   first(sql: string, args: any[]) {
     if (sql.includes('SELECT name FROM sqlite_master')) {
       const tableName = args[0]

--- a/apps/nexus/server/utils/platformGovernanceStore.test.ts
+++ b/apps/nexus/server/utils/platformGovernanceStore.test.ts
@@ -34,6 +34,25 @@ function event(providerId: string) {
   } as any
 }
 
+/**
+ * Analytics fixtures are anchored to the run date rather than written out.
+ *
+ * They used to hardcode 2026-05-20..22 against a `{ days: 30 }` query. That sat
+ * inside the window when it was written and silently fell out of it as time
+ * passed — the query then correctly returned nothing, and every aggregate read
+ * zero. Only the spacing between the days is load-bearing for the derived
+ * averages, so the dates are pinned to UTC midnight and offset backwards.
+ */
+function utcMidnightDaysAgo(days: number) {
+  const base = new Date()
+  base.setUTCDate(base.getUTCDate() - days)
+  return base.toISOString().slice(0, 10)
+}
+
+function daysAgoAt(days: number, hour: string) {
+  return `${utcMidnightDaysAgo(days)}T${hour}:00:00.000Z`
+}
+
 describe('platformGovernanceStore', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
@@ -2636,11 +2655,11 @@ describe('platformGovernanceStore', () => {
     const pluginId = `plugin_retention_${marker}`
 
     const records = [
-      ['retention-returning@example.com', 'download', 1, '2026-05-20T09:00:00.000Z'],
-      ['retention-returning@example.com', 'invoke', 2, '2026-05-21T09:00:00.000Z'],
-      ['retention-repeat@example.com', 'invoke', 1, '2026-05-20T10:00:00.000Z'],
-      ['retention-repeat@example.com', 'invoke', 1, '2026-05-22T10:00:00.000Z'],
-      ['retention-new@example.com', 'install', 1, '2026-05-22T11:00:00.000Z'],
+      ['retention-returning@example.com', 'download', 1, daysAgoAt(3, '09')],
+      ['retention-returning@example.com', 'invoke', 2, daysAgoAt(2, '09')],
+      ['retention-repeat@example.com', 'invoke', 1, daysAgoAt(3, '10')],
+      ['retention-repeat@example.com', 'invoke', 1, daysAgoAt(1, '10')],
+      ['retention-new@example.com', 'install', 1, daysAgoAt(1, '11')],
     ] as const
 
     for (const [actorId, action, quantity, occurredAt] of records) {
@@ -2678,7 +2697,7 @@ describe('platformGovernanceStore', () => {
     ]))
     expect(analytics.retention.trend).toEqual([
       expect.objectContaining({
-        date: '2026-05-20',
+        date: utcMidnightDaysAgo(3),
         newActors: 2,
         returningActors: 0,
         activeActors: 2,
@@ -2687,7 +2706,7 @@ describe('platformGovernanceStore', () => {
         retentionRate: 0,
       }),
       expect.objectContaining({
-        date: '2026-05-21',
+        date: utcMidnightDaysAgo(2),
         newActors: 0,
         returningActors: 1,
         activeActors: 1,
@@ -2696,7 +2715,7 @@ describe('platformGovernanceStore', () => {
         retentionRate: 100,
       }),
       expect.objectContaining({
-        date: '2026-05-22',
+        date: utcMidnightDaysAgo(1),
         newActors: 1,
         returningActors: 1,
         activeActors: 2,
@@ -2716,12 +2735,12 @@ describe('platformGovernanceStore', () => {
     const pluginId = `plugin_owner_action_${marker}`
 
     const records = [
-      [`owner-download-${marker}@example.com`, 'download', 80, '2026-05-20T09:00:00.000Z'],
-      [`owner-install-1-${marker}@example.com`, 'install', 1, '2026-05-21T09:00:00.000Z'],
-      [`owner-install-2-${marker}@example.com`, 'install', 1, '2026-05-21T10:00:00.000Z'],
-      [`owner-install-3-${marker}@example.com`, 'install', 1, '2026-05-21T11:00:00.000Z'],
-      [`owner-install-4-${marker}@example.com`, 'install', 1, '2026-05-21T12:00:00.000Z'],
-      [`owner-invoke-${marker}@example.com`, 'invoke', 5, '2026-05-22T09:00:00.000Z'],
+      [`owner-download-${marker}@example.com`, 'download', 80, daysAgoAt(3, '09')],
+      [`owner-install-1-${marker}@example.com`, 'install', 1, daysAgoAt(2, '09')],
+      [`owner-install-2-${marker}@example.com`, 'install', 1, daysAgoAt(2, '10')],
+      [`owner-install-3-${marker}@example.com`, 'install', 1, daysAgoAt(2, '11')],
+      [`owner-install-4-${marker}@example.com`, 'install', 1, daysAgoAt(2, '12')],
+      [`owner-invoke-${marker}@example.com`, 'invoke', 5, daysAgoAt(1, '09')],
     ] as const
 
     for (const [actorId, action, quantity, occurredAt] of records) {
@@ -2762,7 +2781,7 @@ describe('platformGovernanceStore', () => {
         retentionRate: 0,
         topCountryKey: 'us',
         topCountryShare: 100,
-        latestDate: '2026-05-22',
+        latestDate: utcMidnightDaysAgo(1),
       }),
       expect.objectContaining({
         key: 'low-install-conversion',


### PR DESCRIPTION
Three more of #327's failing files. Both root causes were in the tests, not the store — but neither was a cosmetic drift, so each is verified by reproducing the original failure.

## `platformGovernanceStore.test.ts` — fixtures with an expiry date

Two tests seeded events at `2026-05-20..22` and queried with `{ days: 30 }`. Those dates were inside the window when the tests were written and **fell out of it as time passed**. The query then correctly returned nothing, and every aggregate read zero:

```
activeActors      3 -> 0
retentionRate 66.67 -> 0
actionQueue      [] instead of three entries
```

Nothing was wrong with the store. Only the *spacing* between the three days is load-bearing for the derived averages, so they are now pinned to UTC midnight and offset back 3 / 2 / 1 days. The two assertions that named a date — the retention `trend` and `latestDate` — derive from the same helper.

## `authStore.sync-items-merge.test.ts` — a mock missing `batch`

`MockD1Database` implemented `prepare`/`first`/`run` but not `batch`. `mergeLegacySyncItemsForUsers` builds its statements up front and hands the whole list to `db.batch()`, because D1 has no interactive transaction — so the test failed with `db.batch is not a function` before reaching an assertion.

`batch` now awaits the statements **in array order** and returns one result each, the way D1 does. Ordering is load-bearing rather than incidental: the `DELETE` that drops superseded source rows has to see the effect of the statements before it.

This is the issue's *"sync merge tests exercise the production D1 batch contract"* criterion — and it matters that the mock actually runs them, since one that merely returned would satisfy an existence check and prove nothing.

## Verified by breaking, not by assuming

| control | result |
|---|---|
| shift governance fixtures 60 days back | **2 failed** — reproduces the original failure exactly |
| drop a returning actor's second visit | 1 failed |
| reverse the statement order in `batch` | 1 failed |
| make `batch` a no-op | 1 failed |
| all restored | 22 + 1 passed |

The 60-day control is the one that matters: it reproduces the original two failures precisely, which is what makes the diagnosis a finding rather than a guess.

## Where #327 stands after this

Expected **10 → 8 failing files** (`platformGovernanceStore` ×2 and `authStore.sync-items-merge` ×1 clear). CI will confirm from the JUnit artifact.

Remaining: `store-page-performance` (2), `tuffex-component-docs-coverage` (2), `pluginsStore-security-scan` (2), `plugin-security-scan` (1), `sign-in-token.post` (1), `auth-email-channel-contract` (1), `governance.runtime` (1), `intelligence/invoke.api` (1).

Of those, `tuffex-component-docs-coverage` is not a test fix at all — it reports twelve components with no docs in either locale, which needs a decision on whether that family is public API yet. The two security-scan files and `sign-in-token` are contract drift I have looked at but not finished.

Refs #327
