### PR TITLE
ci(native-protocol): fire the push gate on master, the branch that exists

### DIFF
--- a/.github/workflows/native-protocol.yml
+++ b/.github/workflows/native-protocol.yml
@@ -10,8 +10,10 @@ on:
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
   push:
+    # `master` is this repository's default branch; there is no `main`. Every other workflow
+    # that guards a branch lists both names, so this trigger was the only one that never fired.
     branches:
-      - main
+      - master
     paths:
       - '.github/workflows/native-protocol.yml'
       - 'apps/core-app/src/main/modules/native-capabilities/**'


### PR DESCRIPTION
## What

`native-protocol.yml`'s `push` trigger listed `main`. This repository's default branch is `master`, and **no `main` ref exists on origin** — so that trigger had never fired since it was written.

## Evidence

```
$ git ls-remote --heads origin main
(empty)

$ git symbolic-ref refs/remotes/origin/HEAD
master
```

I enumerated every `branches:` block across all 18 workflows to check whether this was systemic:

| | branch names listed |
|---|---|
| **native-protocol.yml** | `['main']` ← the only dead one |
| intelligence.yml, release-drafter.yml, package-{tuffex,utils,tuff-cli,tuff-intelligence,unplugin}-{ci,publish}.yml | `['main', 'master']` |

Every other workflow lists both names, so they keep working. `native-protocol.yml` was the sole outlier, which is exactly the scope #543 describes — no adjacent gap to widen into.

## Impact

Pull requests were the only thing running this workflow. A direct push to `master` touching `packages/tuff-native/**`, `apps/core-app/src/main/modules/native-capabilities/**`, `packages/test/src/native/**` or either pnpm manifest skipped the native protocol check entirely.

## Verification

`js-yaml` parse of the edited file:

```
push.branches = ["master"]
push.paths count = 6
pull_request kept = true
jobs = protocol
```

Nothing else changed — the six path filters, the `pull_request` trigger, the `concurrency` group and the `protocol` job are untouched. `actionlint` is not installed in this environment, so the check is a parse plus a structural diff rather than a lint.

Fixes #543
