### PR TITLE
build: drop the deprecated `install` verb from the husky prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=24.15.0"
   },
   "scripts": {
-    "prepare": "husky install",
+    "prepare": "husky",
     "preinstall": "npx only-allow pnpm",
     "postinstall": "node scripts/sync-core-package.mjs && node scripts/patch-nuxt-content-serialize.mjs",
     "typecheck": "pnpm -F @talex-touch/core-app run typecheck",


### PR DESCRIPTION
## What

`package.json:13` called the pre-v9 `husky install` form. One word.

## Why it is safe

husky 9.1.7 routes `install` into the same call as the bare command:

```js
// node_modules/husky/bin.js:26
p.stdout.write(i(a == 'install' ? undefined : a))
```

`a === 'install'` → `i(undefined)`; bare `husky` → `a === undefined` → `i(undefined)`. Same path.

Rather than rely on reading that, I ran both forms against a throwaway `git init` repo:

```
install exit=0
bare    exit=0
--- stdout identical? ---
  YES (byte-identical)
--- stderr, install form ---
husky - install command is DEPRECATED
--- stderr, bare form ---
  (empty)
```

The deprecation banner is the *only* observable difference.

## Why it matters

`add`, `set` and `uninstall` already `exit 1` in 9.1.7:

```js
if (['add', 'set', 'uninstall'].includes(a)) { d(a); p.exit(1) }
if (a == 'install') d(a)      // warns only — for now
```

When `install` joins that list in v10, `pnpm install` fails at the prepare step for every contributor and every CI job that installs dependencies. Fixing it now costs one word; fixing it after the bump costs a red tree.

`husky init` itself writes `prepare: 'husky'` (`bin.js:14`), so this is the form husky's own scaffolding produces.

## Scope

Only the script changed. I checked the hooks for the *other* husky 9 deprecation — the `#!/usr/bin/env sh` + `. "$(dirname -- "$0")/_/husky.sh"` preamble that `index.js:6` warns "WILL FAIL in v10.0.0" — and both `.husky/pre-commit` and `.husky/commit-msg` are already in the modern form. Nothing to widen into.

Fixes #549
