### PR TITLE
ci(dependabot): track the tuff-native Cargo workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,18 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+
+  # packages/tuff-native is a five-member Cargo workspace with a tracked Cargo.lock, and its
+  # addons are compiled into the shipped Electron app. The dependency graph already indexes
+  # those crates, so advisories do surface as alerts — what was missing is the update side:
+  # without an ecosystem entry Dependabot opens no PR for them, security or otherwise.
+  - package-ecosystem: cargo
+    directory: /packages/tuff-native
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      cargo-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Adds a `cargo` ecosystem entry for `packages/tuff-native`, mirroring the shape of the existing npm entry.

```
  - npm             dir=/                     limit=5  groups=npm-security-updates
  - github-actions  dir=/                     limit=5  groups=
  - cargo           dir=/packages/tuff-native limit=5  groups=cargo-security-updates   ← new
```

Verified the target is real: `packages/tuff-native/Cargo.toml` exists and is a `[workspace]` root with five members (`native-core`, `native-napi`, `native-screenshot`, `native-audio`, `fixtures/native-protocol-addon`), and `packages/tuff-native/Cargo.lock` is git-tracked. YAML parses to the three entries above.

## One correction to the issue's premise

#545 says a RUSTSEC advisory "produces no PR **and no alert**". The alert half is not right, and it changes what this PR is for.

Dependabot *alerts* come from the dependency graph plus the advisory database — `dependabot.yml` has no bearing on them. The graph already indexes this repo's crates:

```
$ gh api /repos/talex-touch/tuff/dependency-graph/sbom
dependency-graph package counts by ecosystem:
  npm: 3215
  cargo: 352      ← already indexed
  githubactions: 13
cargo detected = true
```

And there are currently zero open cargo alerts (all 52 open alerts are npm), which reflects a genuine absence of advisories rather than a blind spot.

So what this actually fixes is the **update** side: without an ecosystem entry Dependabot opens no PR for those 352 crates — not for routine version bumps, and not for security fixes either. The vulnerable-crate-ships scenario in the issue still holds; it just arrives as an unactioned alert rather than as silence.

## Note

`open-pull-requests-limit: 5` is copied from the npm entry rather than chosen. If the first weekly run floods, that is the knob.

Fixes #545
