### PR TITLE
ci(publish): serialise the four package publish workflows

### DIFF
--- a/.github/workflows/package-tuff-cli-publish.yml
+++ b/.github/workflows/package-tuff-cli-publish.yml
@@ -19,6 +19,14 @@ on:
       - "packages/unplugin-export-plugin/tsup.config.ts"
       - ".github/workflows/package-tuff-cli-publish.yml"
 
+concurrency:
+  # npm publish is not resumable, so an in-flight run must never be cancelled — queue
+  # behind it instead. Without this, two pushes seconds apart both pass the `npm view`
+  # existence check, both build, and the loser falls back to the duplicate-publish
+  # grep further down this file. Keyed per workflow so the package publishes stay
+  # independent of each other.
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 jobs:
   publish:
     name: Publish CLI Packages

--- a/.github/workflows/package-tuff-intelligence-publish.yml
+++ b/.github/workflows/package-tuff-intelligence-publish.yml
@@ -10,6 +10,14 @@ on:
       - "packages/utils/package.json"
       - ".github/workflows/package-tuff-intelligence-publish.yml"
 
+concurrency:
+  # npm publish is not resumable, so an in-flight run must never be cancelled — queue
+  # behind it instead. Without this, two pushes seconds apart both pass the `npm view`
+  # existence check, both build, and the loser falls back to the duplicate-publish
+  # grep further down this file. Keyed per workflow so the package publishes stay
+  # independent of each other.
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 jobs:
   publish:
     name: Publish - tuff-intelligence

--- a/.github/workflows/package-tuffex-publish.yml
+++ b/.github/workflows/package-tuffex-publish.yml
@@ -14,6 +14,14 @@ on:
       - "scripts/publish-package.mjs"
       - ".github/workflows/package-tuffex-publish.yml"
 
+concurrency:
+  # npm publish is not resumable, so an in-flight run must never be cancelled — queue
+  # behind it instead. Without this, two pushes seconds apart both pass the `npm view`
+  # existence check, both build, and the loser falls back to the duplicate-publish
+  # grep further down this file. Keyed per workflow so the package publishes stay
+  # independent of each other.
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 jobs:
   publish:
     name: Publish - tuffex

--- a/.github/workflows/package-utils-publish.yml
+++ b/.github/workflows/package-utils-publish.yml
@@ -9,6 +9,14 @@ on:
       - "packages/utils/package.json"
       - ".github/workflows/package-utils-publish.yml"
 
+concurrency:
+  # npm publish is not resumable, so an in-flight run must never be cancelled — queue
+  # behind it instead. Without this, two pushes seconds apart both pass the `npm view`
+  # existence check, both build, and the loser falls back to the duplicate-publish
+  # grep further down this file. Keyed per workflow so the package publishes stay
+  # independent of each other.
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 jobs:
   publish:
     name: Publish - utils


### PR DESCRIPTION
## What

Adds a workflow-level `concurrency` guard to the four `package-*-publish.yml` workflows. Pure insertion — 32 lines added, nothing removed or reordered.

## Why `cancel-in-progress: false`

The default reflex is `true`, and it would be wrong here. `npm publish` is not resumable: cancelling a run mid-publish can leave the registry having accepted a version whose workflow never completed its verification steps. Queuing is the correct semantic — the second run waits, then finds the version already published and takes the existing idempotent path.

## Why keyed on `github.workflow`

A bump to `packages/utils/package.json` triggers **both** `package-utils-publish.yml` and `package-tuff-intelligence-publish.yml` (the latter watches the utils manifest too). Those publish different packages and must not serialise against each other. Per-workflow keying gives each package its own queue.

## This race has already been hit

Each of these files carries a fallback for exactly this collision — treating a duplicate publish as success when `npm view` shows the version appeared while the run was publishing:

```sh
if grep -Eqi 'previously published versions|cannot publish over the previously published version' "${publish_log}"; then
  if npm view "@talex-touch/utils@${version}" version >/dev/null 2>&1; then
    echo "... became available during publish. Treating duplicate publish as success."
```

Somebody wrote recovery for a race nobody prevented. This PR prevents it; the fallback stays as defence in depth.

## Verification

`js-yaml` parse of all four after the edit:

```
ok   package-tuff-cli-publish.yml
       group="${{ github.workflow }}" cancel=false branches=["main","master"] jobs=publish
ok   package-tuff-intelligence-publish.yml
       group="${{ github.workflow }}" cancel=false branches=["main","master"] jobs=publish
ok   package-tuffex-publish.yml
       group="${{ github.workflow }}" cancel=false branches=["master","main"] jobs=publish
ok   package-utils-publish.yml
       group="${{ github.workflow }}" cancel=false branches=["main","master"] jobs=publish
```

Triggers, path filters and the `publish` job are unchanged in each. `actionlint` is not installed in this environment, so this is a parse plus a structural assertion rather than a lint.

Fixes #564
