### PR TITLE
test(nexus): sign the scan fixtures for real and cover the waiver rejection paths (#327)

### DIFF
--- a/apps/nexus/server/utils/__tests__/plugin-security-scan.test.ts
+++ b/apps/nexus/server/utils/__tests__/plugin-security-scan.test.ts
@@ -94,8 +94,12 @@ describe('TPEX authoritative security scan admission', () => {
       ruleId: 'PLUGIN_SCAN_DYNAMIC_EXECUTION',
       owner: 'nexus-security',
       reason: 'Approved compatibility exception',
-      createdAt: '2026-07-17T12:00:00.000Z',
-      expiresAt: '2026-07-19T12:00:00.000Z',
+      // Relative to the run, not written out: these were 2026-07-17/19, which
+      // were in the future when the test was written and have since passed.
+      // The waiver then expired, the finding correctly blocked, and the test
+      // stopped exercising the path its name describes.
+      createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
     }])
 
     expect(metadata.securityScan).toMatchObject({
@@ -106,5 +110,48 @@ describe('TPEX authoritative security scan admission', () => {
       })],
     })
     expect(getTpexAdmissionFailure(metadata)).toBeNull()
+  })
+
+  // The test above says "only a valid waiver" but never proved the negative
+  // half. It was passing accidentally while its own waiver was expired, so the
+  // expired path had no deliberate coverage at all.
+  it('ignores an expired waiver and keeps the finding blocking', async () => {
+    const artifact = createTpex([{ name: 'dynamic.js', content: 'eval("runtime")' }])
+    const artifactSha256 = createHash('sha256').update(artifact).digest('hex')
+
+    const metadata = await extractTpexMetadata(artifact, undefined, [{
+      id: 'nexus-waiver-expired',
+      artifactSha256,
+      ruleId: 'PLUGIN_SCAN_DYNAMIC_EXECUTION',
+      owner: 'nexus-security',
+      reason: 'Lapsed compatibility exception',
+      createdAt: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
+      expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+    }])
+
+    expect(metadata.securityScan.decision).toBe('blocked')
+    expect(metadata.securityScan.findings[0]).toMatchObject({
+      code: 'PLUGIN_SCAN_DYNAMIC_EXECUTION',
+    })
+    expect(metadata.securityScan.findings[0]?.waiver).toBeFalsy()
+    expect(getTpexAdmissionFailure(metadata)).not.toBeNull()
+  })
+
+  it('ignores a waiver issued for a different artifact', async () => {
+    const artifact = createTpex([{ name: 'dynamic.js', content: 'eval("runtime")' }])
+
+    const metadata = await extractTpexMetadata(artifact, undefined, [{
+      id: 'nexus-waiver-other-artifact',
+      artifactSha256: createHash('sha256').update('a different artifact').digest('hex'),
+      ruleId: 'PLUGIN_SCAN_DYNAMIC_EXECUTION',
+      owner: 'nexus-security',
+      reason: 'Approved for another package',
+      createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    }])
+
+    expect(metadata.securityScan.decision).toBe('blocked')
+    expect(metadata.securityScan.findings[0]?.waiver).toBeFalsy()
+    expect(getTpexAdmissionFailure(metadata)).not.toBeNull()
   })
 })

--- a/apps/nexus/server/utils/__tests__/pluginsStore-security-scan.test.ts
+++ b/apps/nexus/server/utils/__tests__/pluginsStore-security-scan.test.ts
@@ -1,9 +1,15 @@
 import type { H3Event } from 'h3'
 import { Buffer } from 'node:buffer'
-import { createHash } from 'node:crypto'
+import { createHash, generateKeyPairSync, sign } from 'node:crypto'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DashboardPluginVersion } from '../pluginsStore'
 
+import {
+  PLUGIN_SIGNING_ALGORITHM,
+  PLUGIN_SIGNING_CONTRACT,
+  serializePluginFileMap,
+  serializePluginSigningPayload,
+} from '@talex-touch/utils/plugin'
 import { extractTpexMetadata } from '../tpex'
 import {
   createPlugin,
@@ -137,6 +143,55 @@ function packageFile(archive: Buffer): File {
   } as File
 }
 
+const publisherKeys = generateKeyPairSync('ed25519')
+const publisherPublicKeyPem = publisherKeys.publicKey.export({ format: 'pem', type: 'spki' }).toString()
+const PUBLISHER_KEY_ID = 'scan-demo-publisher-key'
+
+/**
+ * publishPluginVersion and reeditPluginVersion verify a publisher signature
+ * unconditionally (pluginsStore.ts:2564 and :2966) -- publishing is fail-closed
+ * on signing -- so a real Ed25519 envelope is built here rather than the
+ * validator being loosened.
+ *
+ * Every field the verifier compares is derived from the same archive the test
+ * publishes, so the fixture cannot drift away from the package it signs:
+ * artifact digest and size from the buffer, plugin name and file map from the
+ * extracted manifest, and the policy version from the package policy.
+ */
+async function publisherSigningInput(archive: Buffer) {
+  const metadata = await extractTpexMetadata(archive, { pluginId: PLUGIN_ID, version: VERSION })
+  const manifest = metadata.manifest as Record<string, unknown>
+  const fileMap = manifest._files as Record<string, string>
+  const issuedAt = new Date().toISOString()
+
+  const payload = {
+    contract: PLUGIN_SIGNING_CONTRACT,
+    policyVersion: metadata.packagePolicy.policyVersion,
+    pluginId: PLUGIN_ID,
+    pluginName: String(manifest.name),
+    version: VERSION,
+    channel: 'RELEASE' as const,
+    artifactSha256: createHash('sha256').update(archive).digest('hex'),
+    artifactSize: archive.length,
+    fileMapSha256: createHash('sha256').update(serializePluginFileMap(fileMap)).digest('hex'),
+    issuedAt,
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+  }
+  const bytes = Buffer.from(serializePluginSigningPayload(payload), 'utf8')
+
+  return {
+    publisherSignature: {
+      algorithm: PLUGIN_SIGNING_ALGORITHM,
+      keyId: PUBLISHER_KEY_ID,
+      payload,
+      payloadSha256: createHash('sha256').update(bytes).digest('hex'),
+      signature: sign(null, bytes, publisherKeys.privateKey).toString('base64'),
+    },
+    publisherPublicKey: publisherPublicKeyPem,
+    publisherKeyValidFrom: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+  }
+}
+
 async function createPublishablePlugin() {
   return createPlugin(event, {
     userId: OWNER_ID,
@@ -190,6 +245,7 @@ describe('pluginsStore Security Scan publish and re-edit admission', () => {
       version: VERSION,
       changelog: 'Initial release.',
       packageFile: packageFile(archive),
+      ...(await publisherSigningInput(archive)),
       createdBy: OWNER_ID,
     })
 
@@ -231,7 +287,27 @@ describe('pluginsStore Security Scan publish and re-edit admission', () => {
           failureCode: null,
         },
       }),
+      // Publishing verifies the publisher signature, so its governance trail is
+      // part of the contract this test guards rather than noise to filter out.
+      expect.objectContaining({
+        scope: 'plugin-signing',
+        action: 'publisher-key.registered',
+        resourceType: 'plugin-publisher-key',
+        resourceId: PUBLISHER_KEY_ID,
+      }),
+      expect.objectContaining({
+        scope: 'plugin-signing',
+        action: 'publisher-signature.verified',
+        actorId: OWNER_ID,
+        resourceType: 'plugin-package',
+        resourceId: expected.report.artifactSha256,
+        metadata: expect.objectContaining({ keyId: PUBLISHER_KEY_ID }),
+      }),
     ])
+    // The signing trail must not carry key material either.
+    const signingPayload = JSON.stringify(state.governanceEvents.filter(e => e.scope === 'plugin-signing'))
+    expect(signingPayload).not.toContain('PRIVATE KEY')
+    expect(signingPayload).not.toContain(publisherPublicKeyPem)
   })
 
   it('blocks a secret finding before package upload or version persistence and keeps governance metadata redacted', async () => {
@@ -247,6 +323,7 @@ describe('pluginsStore Security Scan publish and re-edit admission', () => {
       version: VERSION,
       changelog: 'Initial release.',
       packageFile: packageFile(archive),
+      ...(await publisherSigningInput(archive)),
       createdBy: OWNER_ID,
     })).rejects.toMatchObject({
       statusCode: 400,
@@ -314,6 +391,7 @@ describe('pluginsStore Security Scan publish and re-edit admission', () => {
       pluginId: plugin.id,
       versionId: rejected.id,
       packageFile: packageFile(archive),
+      ...(await publisherSigningInput(archive)),
       changelog: 'Replaced rejected package with a clean artifact.',
       updatedBy: OWNER_ID,
     })


### PR DESCRIPTION
The three security-scan failures from #327. Both root causes are in the fixtures, and neither was fixed by relaxing an assertion — the issue asks for *"valid canonical envelopes"* and *"retain fail-closed negative cases"*, so both are strengthened instead.

## `pluginsStore-security-scan.test.ts` (2) — an unmet contract, not a stale fixture

`publishPluginVersion` and `reeditPluginVersion` verify a publisher signature **unconditionally** (`pluginsStore.ts:2564` and `:2966`) — publishing is fail-closed on signing. The fixtures passed none, so both tests died with `PLUGIN_SIGNING_ENVELOPE_INVALID` before reaching an assertion.

`publisherSignature` / `publisherPublicKey` / `publisherKeyValidFrom` are in fact **required** on `PublishVersionInput` and `ReeditVersionInput`. Worth noting for anyone reading the same failure: the manifest's own `_signature` md5 at line 127 is an unrelated field and is *not* what fails — it is the first thing that looks wrong and it is a red herring.

The fixture now builds a genuine Ed25519 envelope, following the pattern already proven in `pluginSigning.test.ts` (17/17 green). Every field the verifier compares is derived from **the same archive being published** — artifact digest and size from the buffer, plugin name and file map from the extracted manifest, policy version from the package policy — so the signature cannot drift away from the package it signs.

Verifying also emits `publisher-key.registered` and `publisher-signature.verified`, so the exact governance-event sequence gains both, plus an assertion that the signing trail carries no key material.

## `plugin-security-scan.test.ts` (1) — a waiver that expired

The fixture carried `expiresAt: '2026-07-19T12:00:00.000Z'`. That was in the future when written and has since passed, so `security-scan.ts:375` correctly refused it and the finding blocked. Same shape as the governance fixtures in #1118: an absolute date measured against `now`.

The dates are now relative — but the more useful part: the test is named *"accepts **only** a valid server-provided waiver"* and never proved the "only" half. Because its own waiver had silently expired, **the rejection path had no deliberate coverage at all**. Two negative cases added:

- an **expired** waiver → finding stays blocking, no waiver attached
- a waiver issued for a **different artifact's** sha256 → same

## Verified against the code, not by inspection

| control | result |
|---|---|
| tamper the signature bytes | 2 failed |
| sign the payload with a different key | 2 failed |
| claim a wrong `artifactSize` | 2 failed |
| remove the expiry condition from `security-scan.ts` | 1 failed |
| all restored | 3 + 7 passed |

The first three matter because a fixture that merely satisfies a shape check would prove nothing about a signing path. The fourth is run against the production validator — it confirms the new negative case would catch a real weakening, not just its own fixture.

`plugin-security-scan.test.ts` goes 5 → 7 tests.

## Expected effect on #327

**8 → 5 failing files, 11 → 8 failing tests.** CI will confirm from the JUnit artifact.

Remaining: `store-page-performance` (2), `tuffex-component-docs-coverage` (2, the 24-missing-docs decision), `sign-in-token.post` (1), `auth-email-channel-contract` (1), `governance.runtime` (1), `intelligence/invoke.api` (1).

Refs #327
