### PR TITLE
fix(lint): let lint:changed see files that were never git-added

### DIFF
--- a/scripts/run-eslint-changed.mjs
+++ b/scripts/run-eslint-changed.mjs
@@ -85,15 +85,31 @@ function getDiffArgs() {
   return ['diff', '--name-only', '--diff-filter=ACMRTUXB', `${remoteBaseRef}...HEAD`]
 }
 
-function getChangedFiles() {
-  const result = spawnSync(
-    'git',
-    getDiffArgs(),
-    {
-      cwd: workspaceRoot,
-      encoding: 'utf8',
-    },
-  )
+export function parseFileList(stdout) {
+  return stdout
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(file => file.replaceAll(path.sep, '/'))
+}
+
+/**
+ * Union of every list, keeping only lintable extensions and dropping duplicates. A file can
+ * legitimately appear in more than one list — `git status` reports a path as untracked right
+ * up until it is staged, and the two probes are taken separately.
+ */
+export function selectLintableFiles(...lists) {
+  const selected = new Set()
+  for (const list of lists) {
+    for (const file of list) {
+      if (lintExtensions.has(path.extname(file)))
+        selected.add(file)
+    }
+  }
+  return [...selected]
+}
+
+function gitLines(args) {
+  const result = spawnSync('git', args, { cwd: workspaceRoot, encoding: 'utf8' })
 
   if (result.status !== 0) {
     if (result.stderr)
@@ -101,11 +117,20 @@ function getChangedFiles() {
     process.exit(result.status ?? 1)
   }
 
-  return result.stdout
-    .split(/\r?\n/)
-    .filter(Boolean)
-    .map(file => file.replaceAll(path.sep, '/'))
-    .filter(file => lintExtensions.has(path.extname(file)))
+  return parseFileList(result.stdout)
+}
+
+function getChangedFiles() {
+  // `git diff HEAD` reports tracked paths only, so a file that has never been `git add`ed is
+  // invisible to it. Inside CI that costs nothing — the three-dot diff against the base ref
+  // sees the file because the PR already committed it — but a developer running
+  // `pnpm lint:changed` before their first commit got "no changed files" and a green exit
+  // while the new file went entirely unlinted. #547.
+  const insideCi = Boolean(process.env.GITHUB_BASE_REF)
+  const tracked = gitLines(getDiffArgs())
+  const untracked = insideCi ? [] : gitLines(['ls-files', '--others', '--exclude-standard'])
+
+  return selectLintableFiles(tracked, untracked)
 }
 
 export function groupByWorkspace(files, workspaces = collectWorkspaceDirectories()) {

--- a/scripts/run-eslint-changed.test.mjs
+++ b/scripts/run-eslint-changed.test.mjs
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'vitest'
-import { buildRootArgs, buildWorkspaceArgs, groupByWorkspace } from './run-eslint-changed.mjs'
+import {
+  buildRootArgs,
+  buildWorkspaceArgs,
+  groupByWorkspace,
+  parseFileList,
+  selectLintableFiles,
+} from './run-eslint-changed.mjs'
 
 // Mirrors collectWorkspaceDirectories()'s contract: longest prefix first.
 const WORKSPACES = [
@@ -58,6 +64,37 @@ describe('groupByWorkspace', () => {
 
     assert.deepEqual(groups.get('apps/nexus'), ['app/a.vue', 'app/b.ts'])
     assert.deepEqual(groups.get('apps/core-app'), ['src/c.ts'])
+  })
+})
+
+describe('file collection', () => {
+  it('keeps an untracked file that the tracked diff never reported', () => {
+    // The bug: `git diff HEAD` lists tracked changes only, so a new file that has not been
+    // `git add`ed yields an empty list and the gate exits green having linted nothing.
+    const tracked = parseFileList('')
+    const untracked = parseFileList('scripts/brand-new.mjs\n')
+
+    assert.deepEqual(selectLintableFiles(tracked, untracked), ['scripts/brand-new.mjs'])
+  })
+
+  it('does not lint a file twice when both probes report it', () => {
+    const files = selectLintableFiles(
+      ['apps/nexus/app/a.ts'],
+      ['apps/nexus/app/a.ts'],
+    )
+
+    assert.deepEqual(files, ['apps/nexus/app/a.ts'])
+  })
+
+  it('applies the extension filter to untracked files as well', () => {
+    const files = selectLintableFiles([], ['docs/notes.md', 'assets/logo.svg', 'scripts/a.mjs'])
+
+    assert.deepEqual(files, ['scripts/a.mjs'])
+  })
+
+  it('drops blank lines and normalises separators', () => {
+    assert.deepEqual(parseFileList('a.ts\n\nb.vue\n'), ['a.ts', 'b.vue'])
+    assert.deepEqual(parseFileList(''), [])
   })
 })
 


### PR DESCRIPTION
## The gap, reproduced

Dropped one untracked `.mjs` file into the tree and ran the gate on the current `main`-line script:

```
  git diff HEAD sees      : 0 probe file(s)
  ls-files --others sees  : 1 probe file(s)

$ node scripts/run-eslint-changed.mjs
[lint:changed] OK: no changed JS/TS/Vue files.
```

Green exit, nothing linted. `git diff --name-only … HEAD` reports tracked paths only, so a file that has never been `git add`ed does not exist as far as the gate is concerned.

## Why CI never caught it

With `GITHUB_BASE_REF` set the script takes the other branch — a three-dot diff against the base ref — and by then the PR has *committed* the file, so it shows up. The blind spot is exactly the pre-commit window, which is the only window a developer runs `pnpm lint:changed` in. The gate was most useless precisely when it was being used by hand.

## Fix

The non-CI path now unions `git ls-files --others --exclude-standard` into the file list. `--exclude-standard` keeps `.gitignore`d files out, so build output and `node_modules` are not swept in.

File selection is pulled into two pure helpers (`parseFileList`, `selectLintableFiles`) so it can be tested without standing up a git fixture. The extension filter and de-duplication now apply across both probes rather than only the diff — a path can legitimately appear in both, since `git status` calls a file untracked right up until it is staged.

## Verification

**After** — the probe file is now seen:

```
$ printf 'const unused = 1\n' > scripts/probe-untracked-sample.mjs
$ node scripts/run-eslint-changed.mjs
[lint:changed] root: 3 file(s)      ← 2 without the probe
```

**Tests, adversarially checked.** I restored the pre-fix script with `git show HEAD:… > …` and reran, expecting the new cases to fail:

```
baseline:  Tests  4 failed | 8 passed (12)     ← the 4 new ones
fixed:     Tests  12 passed (12)
```

The 8 pre-existing cases pass either way, so the 4 new ones are genuinely pinned to this change rather than passing incidentally.

**Lint on the two touched files:** `eslint --max-warnings=0` exits 0 with empty output. Verified against a positive control (a deliberately bad file exits 1), because an empty output from a linter that silently did nothing looks identical to a clean run.

Fixes #547
