### PR TITLE
ci: run the sensitive-data inventory gate that nothing was running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,17 @@ jobs:
       - name: Verify search-index writer ownership
         run: pnpm -C apps/core-app check:search-index-writers && pnpm -C apps/core-app check:search-index-writers:self-test
 
+      # The script existed but no workflow ran it (#555). ~1s: re-derives the sensitive-data
+      # inventory's 28 evidence anchors from the TypeScript AST, so it needs the root
+      # `typescript` dependency and nothing else.
+      #
+      # `pnpm plugins:validate` (#554) belongs here too and is deliberately absent: it shells
+      # out to `tsx`, which no package.json in this workspace declares. It resolved only
+      # through `shamefully-hoist=true`, removed in #1099, so the script is currently broken
+      # on this branch. Wiring it before `tsx` is declared would just turn this job red.
+      - name: Verify sensitive-data inventory
+        run: pnpm privacy:inventory:verify
+
       - name: Run PR quality gate
         run: pnpm quality:pr
 


### PR DESCRIPTION
## What

Wires `pnpm privacy:inventory:verify` into the PR Quality job. The script shipped with a package script and no caller, so the sensitive-data inventory could drift from the sources it describes with nothing to catch it.

## Verified green *before* wiring, on this branch's content

```
$ node scripts/verify-sensitive-data-inventory.mjs   → exit 0
{ "ok": true, "entries": 13, "portableEntries": 3, "nonPortableEntries": 10,
  "evidenceReferences": 28, "evidenceAnchors": "structural",
  "sourceVerification": "typescript-ast" }
```

Runs in ~1s. Its only non-builtin import is `typescript`, which the root manifest declares.

That run happened in a checkout with a dirty working tree, so it does not automatically predict CI. I checked the inputs rather than assume: `docs/engineering/sensitive-data-inventory.json` is clean, and so are all **22** source paths its evidence anchors reference. The exit 0 is therefore the result CI gets on this branch.

## `plugins:validate` (#554) is deliberately *not* wired — it is broken

It belongs in this job for the same reason. I left it out because adding it would turn the job red immediately, and the reason is worth its own attention:

```
$ git grep '"tsx"' origin/TalexDreamSoul/app-shell-v2 -- '*package.json'
(no results — declared in no workspace)
```

`tsx` resolved only through `shamefully-hoist=true`, which #1099 removed when closing #579. So `pnpm plugins:validate` — and six `visible:experience:*` scripts in `apps/core-app`, and `plugins:release:audit` — now shell out to a binary that is not installed.

This is invisible today precisely *because* of #554: no workflow runs any of them, so nothing has failed. Filed as #1128.

Caught only by checking `origin`. My first attempt ran the script in the main checkout, where `.npmrc` still has `shamefully-hoist=true` — that tree is behind origin, and the command succeeded there.

Fixes #555
