### PR TITLE
test(nexus): re-point five drifted guards at the behaviour they defend (#327)

### DIFF
--- a/apps/nexus/app/pages/store-page-performance.test.ts
+++ b/apps/nexus/app/pages/store-page-performance.test.ts
@@ -31,7 +31,13 @@ describe('store page remote search performance boundaries', () => {
     expect(storePage).toContain('const STORE_PLUGIN_PAGE_SIZE = 50')
     expect(storePage).toMatch(/function resolveStoreSearchQuery\(offset = 0\) \{[\s\S]*compact: 1,[\s\S]*q: activeSearch\.value \|\| undefined,[\s\S]*category: activeCategory\.value === 'all' \? undefined : activeCategory\.value,[\s\S]*limit: STORE_PLUGIN_PAGE_SIZE,[\s\S]*offset,[\s\S]*\}/)
     expect(storePage).toContain('const storeSearchQuery = computed(() => resolveStoreSearchQuery(0))')
-    expect(storePage).toMatch(/await useAsyncData\('store-plugins', \(\) =>\s*requestJson<StorePluginSearchResponse>\('\/api\/store\/search', \{\s*query: storeSearchQuery\.value,\s*\}\),\s*\{\s*watch: \[storeSearchQuery\],\s*\}\)/)
+    // Asserted as separate properties rather than one exact multi-line shape:
+    // the previous regex pinned the whole call including brace placement, so
+    // adding `lazy: true` / `server: false` and a comment broke it while the
+    // request boundary it defends was unchanged.
+    expect(storePage).toContain("useAsyncData('store-plugins'")
+    expect(storePage).toMatch(/requestJson<StorePluginSearchResponse>\(\s*'\/api\/store\/search',\s*\{\s*query: storeSearchQuery\.value,/)
+    expect(storePage).toMatch(/watch:\s*\[storeSearchQuery\]/)
     expect(storePage).not.toMatch(/await useAsyncData\('store-plugins',[\s\S]*requestJson<[^>]*>\('\/api\/store\/plugins'/)
   })
 
@@ -75,7 +81,10 @@ describe('store page remote search performance boundaries', () => {
 
   it('keeps plugin detail overlay code out of the initial store page imports', () => {
     expect(storePage).toContain("const LazyFlipDialog = defineAsyncComponent(() => import('~/components/base/dialog/FlipDialog.vue'))")
-    expect(storePage).toContain("const LazyPluginMetaHeader = defineAsyncComponent(() => import('~/components/dashboard/PluginMetaHeader.vue'))")
+    // Path-agnostic: what keeps this component out of the initial bundle is
+    // defineAsyncComponent around a dynamic import, not where the file lives.
+    // It moved from ~/components/dashboard/ to ~/components/plugin/.
+    expect(storePage).toMatch(/const LazyPluginMetaHeader = defineAsyncComponent\(\(\) => import\('[^']*\/PluginMetaHeader\.vue'\)\)/)
     expect(storePage).toContain("const LazyTxTabs = defineAsyncComponent(() => import('@talex-touch/tuffex/tabs').then(module => module.TxTabs))")
     expect(storePage).toContain('v-if="selectedSlug || detailPending"')
     expect(storePage).toContain('<LazyFlipDialog')

--- a/apps/nexus/package.json
+++ b/apps/nexus/package.json
@@ -86,6 +86,7 @@
     "@unocss/nuxt": "catalog:build",
     "@unocss/preset-typography": "catalog:build",
     "@vite-pwa/nuxt": "catalog:build",
+    "@vue/compiler-sfc": "^3.5.39",
     "@vueuse/core": "^14.3.0",
     "baseline-browser-mapping": "catalog:dev",
     "better-sqlite3": "^12.11.1",

--- a/apps/nexus/test/api/app-auth/sign-in-token.post.test.ts
+++ b/apps/nexus/test/api/app-auth/sign-in-token.post.test.ts
@@ -26,8 +26,13 @@ describe('/api/app-auth/sign-in-token', () => {
     const result = await handler({ headers: {} })
 
     expect(result).toEqual({ appToken: 'app-token' })
+    // The grant type and TTL are asserted, not just the device: issueAppSignInToken
+    // mints a long-term token via LONG_TERM_APP_TOKEN_OPTIONS, and a change to
+    // either is a change to how long a desktop token stays valid.
     expect(authMocks.createAppToken).toHaveBeenCalledWith(expect.anything(), 'user-1', {
       deviceId: 'device-1',
+      grantType: 'long',
+      ttlSeconds: 60 * 60 * 24 * 30,
     })
   })
 

--- a/apps/nexus/test/api/auth/auth-email-channel-contract.test.ts
+++ b/apps/nexus/test/api/auth/auth-email-channel-contract.test.ts
@@ -16,7 +16,11 @@ describe('auth email notification channel contract', () => {
     for (const handler of handlers)
       expect(handler).toContain('}, event)')
 
-    expect(readAuthHandler('[...].ts')).toContain('}, tryCreateAuthEvent())')
+    // Whitespace-tolerant: the handler now spreads sendEmail's arguments over
+    // several lines, so the literal '}, tryCreateAuthEvent())' no longer
+    // appears even though the event is still passed as the second argument.
+    // The three '}, event)' checks above are exposed to the same reformatting.
+    expect(readAuthHandler('[...].ts')).toMatch(/\}\s*,\s*tryCreateAuthEvent\(\)\s*,?\s*\)/)
   })
 
   it('tags auth email actions for notification channel routing', () => {

--- a/apps/nexus/test/api/v1/intelligence/invoke.api.test.ts
+++ b/apps/nexus/test/api/v1/intelligence/invoke.api.test.ts
@@ -109,12 +109,19 @@ describe('/api/v1/intelligence/invoke', () => {
       }),
     )
 
+    // The route no longer passes the provider's error through verbatim: it
+    // normalizes data through the intelligence error contract, so the raw
+    // CREDITS_EXCEEDED becomes the canonical QUOTA_EXHAUSTED with a reason and
+    // a recovery hint. statusCode and statusMessage still carry the original,
+    // so a caller keying on either is unaffected.
     await expect(invokeHandler(makeEvent())).rejects.toMatchObject({
       statusCode: 402,
       statusMessage: 'CREDITS_EXCEEDED',
       data: {
-        code: 'CREDITS_EXCEEDED',
-        reason: 'User credits exceeded.',
+        code: 'QUOTA_EXHAUSTED',
+        message: 'CREDITS_EXCEEDED',
+        reason: 'The caller has exhausted its request, token, or cost quota.',
+        recovery: 'Wait for quota reset, lower token usage, or adjust quota settings.',
       },
     })
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -695,6 +695,9 @@ importers:
       '@vite-pwa/nuxt':
         specifier: catalog:build
         version: 1.1.1(magicast@0.5.3)(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+      '@vue/compiler-sfc':
+        specifier: ^3.5.39
+        version: 3.5.39
       '@vueuse/core':
         specifier: ^14.3.0
         version: 14.3.0(vue@3.5.39(typescript@5.9.3))


### PR DESCRIPTION
Five more of #327's failing files — everything except the docs-coverage one, which is a decision rather than a fix.

Each guard is re-pointed at the behaviour it defends rather than the source text it happened to match, which is the direction this issue asks for: *"move fragile implementation-text checks toward exported helpers, artifact budgets, or runtime responses"* and *"defend request count, payload boundary, and first-load behavior rather than exact incidental syntax."*

## What broke, and why none of it was a product regression

| file | cause |
|---|---|
| `store-page-performance` (2) | one regex pinned the whole `useAsyncData` call including brace placement — adding `lazy: true` / `server: false` broke it. And `LazyPluginMetaHeader`'s import path was hardcoded to `~/components/dashboard/`; the component moved to `~/components/plugin/` |
| `sign-in-token.post` (1) | expected `createAppToken` to get only `{ deviceId }`. It also gets `LONG_TERM_APP_TOKEN_OPTIONS` — `grantType: 'long'` and a 30-day TTL — which is deliberate, named behaviour in `appAuthToken.ts` |
| `auth-email-channel-contract` (1) | asserted the literal `'}, tryCreateAuthEvent())'`; the handler now spreads `sendEmail`'s arguments across lines |
| `intelligence/invoke.api` (1) | expected the provider error verbatim. The route normalizes through the intelligence error contract, so `CREDITS_EXCEEDED` becomes canonical `QUOTA_EXHAUSTED` with a reason and recovery hint |
| `governance.runtime` (1) | imports `@vue/compiler-sfc` directly and `apps/nexus` never declared it — it died at **collection**, so no assertion ran, which reads like a broken test rather than a missing dependency |

## Two assertions got stronger rather than looser

**`sign-in-token`** now asserts `grantType` and `ttlSeconds` too. Token lifetime and grant type are security-relevant, and the old expectation would not have noticed either changing — the negative control below is the point.

**`intelligence/invoke.api`** now asserts all four of status, code, reason and recovery, which is exactly what this issue's *"assert canonical status/code/reason/recovery behavior"* criterion asks for. `statusCode` and `statusMessage` still carry the original, so callers keying on either are unaffected.

## Verified against the production sources

| control | result |
|---|---|
| point the store fetch at `/api/store/plugins` | 1 failed |
| import `PluginMetaHeader` eagerly | 1 failed |
| drop `watch: [storeSearchQuery]` | 2 failed |
| shorten `LONG_TERM_APP_TOKEN_TTL_SECONDS` to 7 days | 1 failed |
| drop `tryCreateAuthEvent()` from the magic-link handler | 1 failed |
| all restored | 5 + 2 + 2 + 3 + 5 passed |

Each control breaks the *production* file, not the fixture, so these confirm the guards would catch a real regression.

## Expected effect

**6 → 1 failing file, 8 → 2 failing tests.** The remainder is `tuffex-component-docs-coverage`: twelve components (the AI/chat family) with no docs in either locale and no registered demos. At 300–600 lines per existing component doc that is 24 documents plus demos — and the criterion allows the alternative *"or is intentionally removed from public exports"*, so it needs a decision before anyone writes them.

Lockfile is additive: 2932 resolved packages before and after, nothing added or removed.

Refs #327
