### PR TITLE
fix(deps): declare tsx, which 38 scripts call and nothing installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,13 +100,15 @@ jobs:
       # The script existed but no workflow ran it (#555). ~1s: re-derives the sensitive-data
       # inventory's 28 evidence anchors from the TypeScript AST, so it needs the root
       # `typescript` dependency and nothing else.
-      #
-      # `pnpm plugins:validate` (#554) belongs here too and is deliberately absent: it shells
-      # out to `tsx`, which no package.json in this workspace declares. It resolved only
-      # through `shamefully-hoist=true`, removed in #1099, so the script is currently broken
-      # on this branch. Wiring it before `tsx` is declared would just turn this job red.
       - name: Verify sensitive-data inventory
         run: pnpm privacy:inventory:verify
+
+      # Ran nowhere until now (#554). It also doubles as the resolution check for `tsx`: the
+      # binary was undeclared workspace-wide and survived only on `shamefully-hoist=true`
+      # until #1099 removed it (#1128). If the declaration this commit adds is wrong, this
+      # step is where it shows up rather than in whichever release script runs next.
+      - name: Validate plugin manifests and package policy
+        run: pnpm plugins:validate
 
       - name: Run PR quality gate
         run: pnpm quality:pr

--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -178,6 +178,7 @@
     "eslint-plugin-vue": "^10.9.2",
     "lottie-web": "^5.13.0",
     "openai": "^6.26.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "unocss": "catalog:build",
     "unplugin-auto-import": "^20.3.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "marked": "catalog:",
     "remark-mdc": "3.11.1",
     "remark-parse": "11.0.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "unified": "11.0.5",
     "vite": "^7.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,9 @@ importers:
       remark-parse:
         specifier: 11.0.0
         version: 11.0.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -516,6 +519,9 @@ importers:
       openai:
         specifier: ^6.26.0
         version: 6.26.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
## What

`tsx` is declared in no `package.json` in this workspace. It resolved through `shamefully-hoist=true`, which #1099 removed when closing #579 — so on this branch the binary is not installed and every caller is broken.

```
$ git grep '"tsx"' origin/TalexDreamSoul/app-shell-v2 -- '*package.json'
(no results)

# positive control — the same scan finds a real declaration
$ rg '"typescript":' package.json
87:    "typescript": "^5.9.3",
```

## The surface is 38 scripts, not 8

#1128 counted 8 from the callers I had happened to look at. Enumerating every `scripts` entry across all manifests:

| package | scripts calling `tsx` |
|---|---|
| root | 3 — `plugins:validate`, `plugins:release:audit`, `evidence:transport-legacy-alias` |
| apps/core-app | **35** — the ten `visible:experience:*` probes, `smoke:assistant`, `clipboard:stress{,:verify}`, five `*:diagnostic*:verify`, eight `search:*` migration/trace/readiness scripts, four `windows:*` capability and acceptance scripts, four `quickops:*` audits, `context:entrypoint:evidence:verify` |

(The matcher was positive-controlled: `node scripts/validate-plugins.mjs` correctly does *not* match.)

## Change

`"tsx": "^4.21.0"` in root and `apps/core-app` devDependencies — one line each, no reformatting.

**4.21.0 is the version already in the lockfile**, resolved as a vite/vitest peer. So the lockfile gains exactly 6 lines — the two importer entries — and nothing else moves:

```
 pnpm-lock.yaml | 6 ++++++

+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
```

No build-allowlist entry needed: `tsx@4.21.0` has `"scripts": {}`, and its only build-scripted dependency, `esbuild`, is already in `onlyBuiltDependencies`.

## Self-checking

This also wires `pnpm plugins:validate` into the PR Quality job — which is **#554**, and which turns this PR into its own test. `plugins:validate` shells out to `tsx`, so if the declaration is wrong, that step goes red here rather than surfacing later in whichever release script runs next.

## Why a local run cannot verify this

`pnpm exec tsx …` still succeeds in a checkout whose `.npmrc` predates #1099 — the main checkout is in exactly that state, and my first run there passed. That is the trap this PR exists because of. The real verification is the CI run on this PR.

Fixes #1128
Fixes #554
