### PR TITLE
fix(release): make the release gate fail the process, and stop gating v2.4.7

### DIFF
--- a/scripts/check-release-gates.mjs
+++ b/scripts/check-release-gates.mjs
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
 import process from 'node:process'
 import { runLocalReleaseGateChecks } from './check-release-gates/local-checks.mjs'
 import { checkRemoteRelease } from './check-release-gates/remote-checks.mjs'
@@ -6,12 +8,33 @@ import { normalizeBaseUrl } from './lib/http-utils.mjs'
 
 const repoRoot = process.cwd()
 const argv = process.argv
-const tag = getArgValue(argv, '--tag', 'v2.4.7')
+
+/**
+ * The shipped product's own version, so `--tag` has a default that cannot go stale. It used
+ * to be the literal `v2.4.7`, which meant a run without `--tag` silently gated a release
+ * seven versions old and reported its verdict as if it were about the current one (#557).
+ */
+export function defaultTagFrom(root = repoRoot) {
+  const manifest = JSON.parse(
+    readFileSync(path.join(root, 'apps', 'core-app', 'package.json'), 'utf8'),
+  )
+  return `v${manifest.version}`
+}
+
+const tag = getArgValue(argv, '--tag', defaultTagFrom())
 const version = getArgValue(argv, '--version', tag.replace(/^v/, ''))
 const stage = String(getArgValue(argv, '--stage', 'gate-d'))
   .trim()
   .toLowerCase()
-const strict = toBool(getArgValue(argv, '--strict', hasFlag(argv, '--strict')))
+
+/**
+ * A release gate that reports `"result": "fail"` and exits 0 is not a gate (#558). Failure is
+ * fatal by default now; `--report-only` restores the survey behaviour for the case this was
+ * presumably written for — inspecting the JSON without the process dying. `--strict` stays
+ * accepted so existing invocations keep working, but it no longer decides anything.
+ */
+const reportOnly = toBool(getArgValue(argv, '--report-only', hasFlag(argv, '--report-only')))
+const strict = !reportOnly
 const manifestArg = getArgValue(argv, '--manifest')
 const baseUrlArg = getArgValue(argv, '--base-url')
 const timeoutMs = Number(getArgValue(argv, '--timeout-ms', '20000')) || 20000
@@ -55,6 +78,7 @@ async function main() {
     version,
     stage,
     strict,
+    reportOnly,
     baseUrl: baseUrlArg ? normalizeBaseUrl(baseUrlArg) : null,
     result,
     checks,
@@ -62,7 +86,8 @@ async function main() {
 
   console.log(JSON.stringify(summary, null, 2))
 
-  if (strict && result !== 'pass') {
+  // Anything short of `pass` is fatal unless the caller explicitly asked for a survey.
+  if (!reportOnly && result !== 'pass') {
     process.exit(1)
   }
 }

--- a/scripts/check-release-gates.test.mjs
+++ b/scripts/check-release-gates.test.mjs
@@ -1,34 +1,97 @@
 import assert from 'node:assert/strict'
-import { execFileSync } from 'node:child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, it } from 'vitest'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const SCRIPT = 'scripts/check-release-gates.mjs'
+
+/** Runs the CLI without throwing, so the exit code itself can be asserted. */
+function runGates(args) {
+  const result = spawnSync('node', [SCRIPT, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+  return { status: result.status, summary: JSON.parse(result.stdout) }
+}
 
 describe('check-release-gates cli', () => {
   it('parses --strict as a flag when followed by another option', () => {
-    const output = execFileSync(
-      'node',
-      [
-        'scripts/check-release-gates.mjs',
-        '--tag',
-        'v2.4.12-beta.8',
-        '--stage',
-        'gate-d',
-        '--strict',
-        '--timeout-ms',
-        '1',
-      ],
-      {
-        cwd: repoRoot,
-        encoding: 'utf8',
-      },
-    )
-    const summary = JSON.parse(output)
+    const { summary } = runGates([
+      '--tag',
+      'v2.4.12-beta.8',
+      '--stage',
+      'gate-d',
+      '--strict',
+      '--timeout-ms',
+      '1',
+    ])
 
     assert.equal(summary.strict, true)
     assert.equal(summary.tag, 'v2.4.12-beta.8')
     assert.equal(summary.stage, 'gate-d')
+  })
+
+  it('defaults --tag to the shipped version rather than a literal', () => {
+    // The default used to be `v2.4.7`, so a run without --tag gated a release seven
+    // versions old and labelled the verdict with that stale tag.
+    const shipped = JSON.parse(
+      readFileSync(path.join(repoRoot, 'apps', 'core-app', 'package.json'), 'utf8'),
+    ).version
+    const { summary } = runGates(['--report-only'])
+
+    assert.equal(summary.tag, `v${shipped}`)
+    assert.equal(summary.version, shipped)
+  })
+
+  it('still lets --tag win over the default', () => {
+    const { summary } = runGates(['--tag', 'v9.9.9', '--report-only'])
+
+    assert.equal(summary.tag, 'v9.9.9')
+    assert.equal(summary.version, '9.9.9')
+  })
+
+  it('exits non-zero whenever the gate does not pass', () => {
+    // Asserted against the run's own verdict rather than a hardcoded expectation, so the
+    // test states the contract — non-pass is fatal — instead of pinning today's gate state.
+    const { status, summary } = runGates([])
+
+    assert.equal(summary.reportOnly, false)
+    assert.equal(status, summary.result === 'pass' ? 0 : 1)
+  })
+
+  it('exits zero under --report-only even when the gate fails', () => {
+    const { status, summary } = runGates(['--report-only'])
+
+    assert.equal(summary.reportOnly, true)
+    assert.equal(status, 0)
+    // Guards against the test passing vacuously if every gate ever goes green: this case is
+    // only meaningful while there is a non-pass result for --report-only to swallow.
+    if (summary.result === 'pass')
+      console.warn('[check-release-gates.test] gates all pass; --report-only case is vacuous')
+  })
+
+  it('emits parseable JSON on the failing path, not just the passing one', () => {
+    const result = spawnSync('node', [SCRIPT], { cwd: repoRoot, encoding: 'utf8' })
+
+    assert.doesNotThrow(() => JSON.parse(result.stdout))
+    assert.ok(Array.isArray(JSON.parse(result.stdout).checks))
+  })
+})
+
+describe('check-release-gates argv contract', () => {
+  it('keeps --report-only out of the way of --tag parsing', () => {
+    // `--report-only` immediately before `--tag` must not be consumed as its value.
+    const output = execFileSync(
+      'node',
+      [SCRIPT, '--report-only', '--tag', 'v1.2.3'],
+      { cwd: repoRoot, encoding: 'utf8' },
+    )
+    const summary = JSON.parse(output)
+
+    assert.equal(summary.tag, 'v1.2.3')
+    assert.equal(summary.reportOnly, true)
   })
 })


### PR DESCRIPTION
## Both defects, demonstrated together in one run

`node scripts/check-release-gates.mjs` with no arguments, on this branch:

```
tag: v2.4.7   version: 2.4.7   RESULT: fail   exit=0
  pass     notes
  warn     version-baseline
  pending  manifest
  fail     publish-manifests
  fail     publish-manifests-pack
```

Three things wrong at once: it gated **v2.4.7** while the repo is on **2.4.14-beta.2**, it found real failures, and it **exited 0**. A pipeline calling this gets a green step, on a failed gate, about the wrong release.

## #557 — the default tag

`--tag` now defaults to `apps/core-app`'s own version, so it tracks the product instead of a literal that ages out. Requiring the flag was the alternative; defaulting keeps the manual workflow the script is clearly written for, and a self-updating default cannot silently drift the way `v2.4.7` did.

## #558 — the exit code

Non-`pass` is fatal by default. `--report-only` restores the exit-0 survey, which is presumably what the original branch was for — reading the JSON without the process dying.

`--strict` stays accepted so any existing invocation keeps working; it is still reported in the summary for compatibility, but no longer decides anything.

## Verification

```
A. no args          → tag v2.4.14-beta.2, reportOnly false, RESULT fail, exit 1   ✅
B. --report-only    → RESULT fail, exit 0                                          ✅
C. --strict --tag v9.9.9 → tag v9.9.9, strict true, exit 1                         ✅
```

## The existing test was already failing

`scripts/check-release-gates.test.mjs` ran the real script with `--strict` under `execFileSync`, which throws on a non-zero exit — so it could only pass while every gate passed. It has been red.

Rewritten to assert the **contract** rather than today's gate state:

```js
const { status, summary } = runGates([])
assert.equal(status, summary.result === 'pass' ? 0 : 1)
```

That stays correct whether the gates pass or fail. The `--report-only` case warns rather than silently passing if the gates ever all go green, since it would otherwise become vacuous.

7 cases. Adversarially checked by restoring the pre-fix script with `git show HEAD:… > …`:

```
with the fix:   Tests  7 passed (7)
baseline:       Tests  4 failed | 3 passed (7)
```

## Worth knowing: nothing runs these tests

While verifying I checked what actually executes `scripts/**/*.test.mjs`. Nothing does — `test:targeted` names specific files in `packages/utils`, `apps/core-app` and `apps/nexus`; the `App suites` matrix runs `pnpm -C apps/<app> exec vitest run`; there is no root vitest config. Running them by hand gives **34 files, 5 failing**.

That is why a red test sat here unnoticed. Filed as #1135 rather than folded in, since wiring 34 files worth of currently-unknown state into CI is not a side effect this PR should have.

Fixes #557
Fixes #558
