### PR TITLE
ci: keep the two macOS-only release tests out of the Linux gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,9 @@ jobs:
         run: pnpm check:plugin-lint-coverage && pnpm check:plugin-lint-coverage:self-test
 
       # 17 test files under scripts/ — the release machinery — that no workflow ran (#1135).
-      # Four are excluded, each with its reason named in the config: one needs a prior build,
-      # one fails on a real defect (#1137), and two assert a darwin/arm64 host so they cannot
-      # pass on this runner (#1139). The other 13 run here.
+      # Four are excluded, each with its reason named in the config: one needs a prior build, one
+      # fails on a real defect (#1137), and two exercise a macOS-only release-acceptance contract
+      # that a Linux runner cannot satisfy (#1139). The other 13 run here.
       - name: Run repo-root tooling tests
         run: pnpm test:scripts
 

--- a/vitest.workspace-scripts.config.mjs
+++ b/vitest.workspace-scripts.config.mjs
@@ -35,10 +35,16 @@ export default defineConfig({
       // and immediately ignored. Remove this line when #1137 lands.
       'scripts/check-release-gates/local-checks.test.mjs',
 
-      // Assert evidence from a darwin/arm64 host, so they cannot pass on ubuntu-latest
-      // (#1139). Found by wiring this gate up: they had only ever been run on a Mac.
-      // Excluded rather than `skipIf`-ed — a test that reports itself green while never
-      // executing is the exact state this whole change exists to end.
+      // Exercise a contract that is macOS-only *by design*, so they cannot pass on
+      // ubuntu-latest — and the fixtures are right to hardcode darwin/arm64:
+      //
+      //   scripts/lib/update-downgrade-evidence.mjs:122
+      //   if (pair !== 'darwin/arm64' && executionMode !== 'static-only')
+      //     issues.push(`${label}.${pair} must be static-only on this release acceptance host`)
+      //
+      // The release acceptance host is an Apple-silicon Mac; every other pair must be
+      // static-only. A Linux runner cannot produce a valid `runtime` claim at all. The fix
+      // is a macOS runner, not a fixture change — #1139.
       'scripts/validate-update-downgrade-evidence.test.mjs',
       'scripts/generate-release-test-summary.test.mjs',
     ],


### PR DESCRIPTION
## I was wrong about the premise, and CI caught it

#1139 said these two tests were *accidentally* Mac-bound and should follow the running host. I made that change. CI rejected it with a different error, which turned out to be the actual rule:

```js
// scripts/lib/update-downgrade-evidence.mjs:122
if (pair !== 'darwin/arm64' && executionMode !== 'static-only') {
  issues.push(`${label}.${pair} must be static-only on this release acceptance host`)
}
```

**Only `darwin/arm64` may claim `runtime`.** Every other pair must be static-only. The release acceptance host is an Apple-silicon Mac by design — that is the constraint the file exists to enforce, and there is a dedicated rejection case for `'a fake Linux runtime pass'` asserting exactly the error my "fix" started producing.

So the fixtures were right to hardcode darwin/arm64, and my change made them assert something the validator correctly refuses. Both files are back to their origin bytes, verified by hash:

```
validate-update-downgrade-evidence.test.mjs   IDENTICAL to origin
generate-release-test-summary.test.mjs        IDENTICAL to origin
```

## What this PR does instead

Keeps both excluded from the Linux gate, but replaces the wrong reason with the right one, quoted at the exclusion site so the next person does not repeat my mistake:

```js
// Exercise a contract that is macOS-only *by design*, so they cannot pass on
// ubuntu-latest — and the fixtures are right to hardcode darwin/arm64:
//
//   scripts/lib/update-downgrade-evidence.mjs:122
//   if (pair !== 'darwin/arm64' && executionMode !== 'static-only') …
//
// The fix is a macOS runner, not a fixture change — #1139.
```

The previous comment said they "assert a darwin/arm64 host" as if that were the defect. It is the specification.

## Net effect

No behaviour change from the merged state — 13 of 17 files run, 177 tests. What changes is that the exclusion is now documented as a **platform requirement** rather than a bug to be fixed, and #1139 has been rewritten to ask for the thing that would actually work: running these on `macos-latest`.

Worth stating plainly: a local pass could not have caught my error either, because on a Mac the wrong fixture and the right fixture behave identically. The Linux run was the only thing that could distinguish them.
