### PR TITLE
fix(publish): stop utils shipping catalog: to npm, and drop the guard that stood in for it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,9 +123,9 @@ jobs:
         run: pnpm check:plugin-lint-coverage && pnpm check:plugin-lint-coverage:self-test
 
       # 17 test files under scripts/ — the release machinery — that no workflow ran (#1135).
-      # Four are excluded, each with its reason named in the config: one needs a prior build, one
-      # fails on a real defect (#1137), and two exercise a macOS-only release-acceptance contract
-      # that a Linux runner cannot satisfy (#1139). The other 13 run here.
+      # Three are excluded, each with its reason named in the config: one needs a prior build, and
+      # two exercise a macOS-only release-acceptance contract a Linux runner cannot satisfy, so
+      # they run in job_release_acceptance instead (#1139). The other 14 run here.
       - name: Run repo-root tooling tests
         run: pnpm test:scripts
 

--- a/.github/workflows/package-utils-publish.yml
+++ b/.github/workflows/package-utils-publish.yml
@@ -102,44 +102,16 @@ jobs:
             exit 1
           fi
 
+      # Was a bare `npm publish` in packages/utils. npm does not understand pnpm's `catalog:`
+      # protocol, so it packed the specifier verbatim — `npm pack` here produces
+      # `"gsap": "catalog:"` and `"marked": "catalog:"`, which no consumer can resolve
+      # (#1137). publish-package.mjs packs with pnpm, which rewrites the protocol, then hands
+      # the finished tarball to `npm publish`; it also runs validate-publish-manifests --pack
+      # against that tarball, which every other package already got and this one did not
+      # (#551). Dist-tag selection is identical (`next` for prereleases) and the
+      # already-published check is built in.
       - name: Publish to npm
         if: steps.version_check.outputs.should_publish == 'true'
-        working-directory: packages/utils
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          version="${{ steps.version_check.outputs.current_version }}"
-          dist_tag="latest"
-          if [[ "${version}" == *"-"* ]]; then
-            dist_tag="next"
-          fi
-
-          if npm view "@talex-touch/utils@${version}" version >/dev/null 2>&1; then
-            echo "@talex-touch/utils@${version} already published. Skipping."
-            exit 0
-          fi
-
-          publish_log="$(mktemp)"
-          trap 'rm -f "${publish_log}"' EXIT
-
-          set +e
-          npm publish --access public --tag "${dist_tag}" >"${publish_log}" 2>&1
-          publish_status=$?
-          set -e
-
-          cat "${publish_log}"
-
-          if [ "${publish_status}" -eq 0 ]; then
-            exit 0
-          fi
-
-          if grep -Eqi 'previously published versions|cannot publish over the previously published version' "${publish_log}"; then
-            if npm view "@talex-touch/utils@${version}" version >/dev/null 2>&1; then
-              echo "@talex-touch/utils@${version} became available during publish. Treating duplicate publish as success."
-              exit 0
-            fi
-          fi
-
-          exit "${publish_status}"
+        run: node scripts/publish-package.mjs --filter "@talex-touch/utils" --skip-git-check --skip-tests

--- a/scripts/package-publish.config.mjs
+++ b/scripts/package-publish.config.mjs
@@ -67,8 +67,18 @@ export const dependencyFieldPaths = [
   'pnpm.overrides',
 ]
 
+/**
+ * `workspace:` was always allowed here and `catalog:` was not, which was never a difference
+ * in the protocols — pnpm rewrites both when it packs. The asymmetry was a guard against the
+ * one package that did not pack with pnpm: `packages/utils` published with a bare
+ * `npm publish`, and npm passes `catalog:` through verbatim (#1137, #551).
+ *
+ * That publish path now goes through publish-package.mjs like every other package, so the
+ * guard has nothing left to protect and was rejecting the supported way to use a catalog.
+ * `packedForbiddenProtocols` below still forbids `catalog:`, checked against the real
+ * tarball — a strictly stronger assertion than reading the source manifest.
+ */
 export const sourceForbiddenProtocols = [
-  'catalog:',
   'file:',
   'link:',
 ]

--- a/vitest.workspace-scripts.config.mjs
+++ b/vitest.workspace-scripts.config.mjs
@@ -29,12 +29,6 @@ export default defineConfig({
       // Not broken; wrong job. Run it after `pnpm -F @talex-touch/tuff-cli-core build`.
       'scripts/plugin-source-package-audit.test.ts',
 
-      // Fails on a real defect rather than a stale expectation: `pnpm publish:check` rejects
-      // the source manifests because `catalog:` specifiers reach them (#1137). Excluded so
-      // this gate can go green on the tests it *is* about, rather than being wired in red
-      // and immediately ignored. Remove this line when #1137 lands.
-      'scripts/check-release-gates/local-checks.test.mjs',
-
       // Exercise a contract that is macOS-only *by design*, so they cannot pass on
       // ubuntu-latest — and the fixtures are right to hardcode darwin/arm64:
       //

--- a/vitest.workspace-scripts.config.mjs
+++ b/vitest.workspace-scripts.config.mjs
@@ -16,6 +16,13 @@ import { defineConfig } from 'vitest/config'
  */
 export default defineConfig({
   test: {
+    // Several of these shell out to `pnpm pack` against real workspace packages, which is
+    // comfortably under a second locally and around six on a CI runner — past vitest's 5s
+    // default. A timeout there reads as a broken test rather than a slow one, so it gets a
+    // ceiling that reflects what the work costs instead of what a pure unit test costs.
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+
     include: [
       'scripts/**/*.test.mjs',
       'scripts/**/*.test.ts',


### PR DESCRIPTION
## A loaded gun, proved rather than inferred

`packages/utils` published with a bare `npm publish`. npm does not understand pnpm's `catalog:` protocol, so it packs the specifier **verbatim**. Against the current source:

```
$ npm pack   → gsap = catalog:     marked = catalog:     catalog: leaking → [["gsap","catalog:"],["marked","catalog:"]]
$ pnpm pack  → gsap = ^3.15.0      marked = ^17.0.6      catalog: leaking → NONE
```

The next version bump of `@talex-touch/utils` would have shipped two dependencies **no consumer can resolve**.

## Why nobody noticed

The artefact on npm is clean:

```
$ npm view @talex-touch/utils dependencies
  marked = ^17.0.4      ← concrete
  gsap   = (absent)
```

Because `1.0.50` was published *before* those specifiers became `catalog:` — `gsap` arrived in #1094 and `marked` in #1055, both after that release. Source version still equals published version, and the workflow skips when the version already exists. So the defect is real, latent, and invisible from the published artefact: checking npm would have said "fine".

Both of the mechanisms that should have caught it were themselves disabled — the release gate exited 0 on failure until #558, and its test ran nowhere until #1135.

## Fix — this is also #551

The publish step now goes through `publish-package.mjs`, like every other package. It packs with **pnpm** (which rewrites the protocol), hands the finished tarball to `npm publish`, and runs `validate-publish-manifests --pack` against that tarball — the gate every other package had and this one did not.

Behaviour preserved: dist-tag selection is the same logic (`next` for prereleases, `publish-package.mjs:91`), `access` comes from the package config, and the already-published check is built in (`:96`). The duplicate-publish grep is dropped because #564 gave these workflows a concurrency group, which prevents the race rather than recovering from it.

## And then the source-phase rule can go

```js
sourceForbiddenProtocols = ['catalog:', 'file:', 'link:']   // before
sourceForbiddenProtocols = ['file:', 'link:']               // after
```

That list allowed `workspace:` and forbade `catalog:`. There is no difference between those two protocols as far as packing goes — pnpm rewrites both. The asymmetry was a guard against the one package that did not pack with pnpm, and it was rejecting the supported way to use a catalog.

**`packedForbiddenProtocols` is untouched** and still contains `catalog:`:

```
  source forbidden: ["file:","link:"]
  packed forbidden: ["catalog:","workspace:","file:","link:"]
```

Checked against the real tarball, which is strictly stronger than reading the source manifest. This removes a proxy, not the check.

## Verification

```
$ pnpm publish:check
[publish-manifest] Validation passed (source): @talex-touch/tuffex, @talex-touch/utils,
  @talex-touch/tuff-core, @talex-touch/unplugin-export-plugin, @talex-touch/tuff-cli,
  @talex-touch/tuff-intelligence
exit 0
```

`scripts/check-release-gates/local-checks.test.mjs` comes out of the vitest exclusions — 14 of 17 now run on Linux, plus 2 on macOS.

I could **not** verify the packed path locally: my worktree symlinks the main checkout's `node_modules`, so `pnpm pack` there fails with `ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL` — an artefact of the symlink, not the change. **CI's `Run repo-root tooling tests` step is the real verification** for that file, since it does a proper `pnpm install --frozen-lockfile` first.

Fixes #1137
Fixes #551
