### PR TITLE
test(core-app): stop the transport-types mocks from dropping real exports (#323)

### DIFF
--- a/apps/core-app/src/main/modules/ai/intelligence-admin-surface-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-admin-surface-boundary.test.ts
@@ -72,7 +72,10 @@ vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', () => ({
   ...intelligenceEventMocks,
   intelligenceKnowledgeEvents: {}
 }))
-vi.mock('@talex-touch/utils/transport/events/types', () => ({
+// Spread the real module: a full replacement drops every export the
+// module later gains, which is how PRIVACY_DATA_CATEGORIES broke this.
+vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+  ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))
 vi.mock('./intelligence-sdk', () => ({

--- a/apps/core-app/src/main/modules/ai/intelligence-admin-surface-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-admin-surface-boundary.test.ts
@@ -72,9 +72,8 @@ const intelligenceEventMocks = vi.hoisted(() => {
 // from them called `undefined.toEventName()`. Only the api events are
 // overridden, which is all this suite looks up.
 vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', async (importOriginal) => {
-  const actual = await importOriginal<
-    typeof import('@talex-touch/utils/transport/sdk/domains/intelligence')
-  >()
+  const actual =
+    await importOriginal<typeof import('@talex-touch/utils/transport/sdk/domains/intelligence')>()
   return {
     ...actual,
     // Merged, not replaced. The hand-written list covers the events this suite

--- a/apps/core-app/src/main/modules/ai/intelligence-admin-surface-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-admin-surface-boundary.test.ts
@@ -63,18 +63,21 @@ const intelligenceEventMocks = vi.hoisted(() => {
       getMonthStats: event('intelligence:api:get-month-stats'),
       getUsageStats: event('intelligence:api:get-usage-stats'),
       getLocalEnvironment: event('intelligence:api:get-local-environment')
-    },
-    intelligenceContextEvents: {}
+    }
   }
 })
 
-vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', () => ({
-  ...intelligenceEventMocks,
-  intelligenceKnowledgeEvents: {}
+// Spread the real module rather than hand-listing namespaces: the context and
+// knowledge events were stubbed as `{}`, so every handler the module registers
+// from them called `undefined.toEventName()`. Only the api events are
+// overridden, which is all this suite looks up.
+vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@talex-touch/utils/transport/sdk/domains/intelligence')>()),
+  ...intelligenceEventMocks
 }))
 // Spread the real module: a full replacement drops every export the
 // module later gains, which is how PRIVACY_DATA_CATEGORIES broke this.
-vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+vi.mock('@talex-touch/utils/transport/events/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))

--- a/apps/core-app/src/main/modules/ai/intelligence-admin-surface-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-admin-surface-boundary.test.ts
@@ -71,10 +71,22 @@ const intelligenceEventMocks = vi.hoisted(() => {
 // knowledge events were stubbed as `{}`, so every handler the module registers
 // from them called `undefined.toEventName()`. Only the api events are
 // overridden, which is all this suite looks up.
-vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@talex-touch/utils/transport/sdk/domains/intelligence')>()),
-  ...intelligenceEventMocks
-}))
+vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('@talex-touch/utils/transport/sdk/domains/intelligence')
+  >()
+  return {
+    ...actual,
+    // Merged, not replaced. The hand-written list covers the events this suite
+    // looks up; replacing the namespace outright dropped the rest, and
+    // registerCapabilityChannels then called saveProviderConfig.toEventName()
+    // on undefined.
+    intelligenceApiEvents: {
+      ...actual.intelligenceApiEvents,
+      ...intelligenceEventMocks.intelligenceApiEvents
+    }
+  }
+})
 // Spread the real module: a full replacement drops every export the
 // module later gains, which is how PRIVACY_DATA_CATEGORIES broke this.
 vi.mock('@talex-touch/utils/transport/events/types', async (importOriginal) => ({

--- a/apps/core-app/src/main/modules/ai/intelligence-autonomous-permission-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-autonomous-permission-boundary.test.ts
@@ -42,7 +42,7 @@ vi.mock('./ai-cli-orchestrator', () => ({
 }))
 // Spread the real module: a full replacement drops every export the
 // module later gains, which is how PRIVACY_DATA_CATEGORIES broke this.
-vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+vi.mock('@talex-touch/utils/transport/events/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))

--- a/apps/core-app/src/main/modules/ai/intelligence-autonomous-permission-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-autonomous-permission-boundary.test.ts
@@ -40,7 +40,10 @@ vi.mock('./intelligence-workflow-service', () => ({
 vi.mock('./ai-cli-orchestrator', () => ({
   aiCliOrchestrator: orchestratorMocks
 }))
-vi.mock('@talex-touch/utils/transport/events/types', () => ({
+// Spread the real module: a full replacement drops every export the
+// module later gains, which is how PRIVACY_DATA_CATEGORIES broke this.
+vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+  ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))
 

--- a/apps/core-app/src/main/modules/ai/intelligence-invoke-actor-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-invoke-actor-boundary.test.ts
@@ -52,7 +52,10 @@ vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', () => ({
   ...intelligenceEventMocks,
   intelligenceKnowledgeEvents: {}
 }))
-vi.mock('@talex-touch/utils/transport/events/types', () => ({
+// Spread the real module: a full replacement drops every export the
+// module later gains, which is how PRIVACY_DATA_CATEGORIES broke this.
+vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+  ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))
 

--- a/apps/core-app/src/main/modules/ai/intelligence-invoke-actor-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-invoke-actor-boundary.test.ts
@@ -54,7 +54,7 @@ vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', () => ({
 }))
 // Spread the real module: a full replacement drops every export the
 // module later gains, which is how PRIVACY_DATA_CATEGORIES broke this.
-vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+vi.mock('@talex-touch/utils/transport/events/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))

--- a/apps/core-app/src/main/modules/ai/intelligence-knowledge-actor-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-knowledge-actor-boundary.test.ts
@@ -43,7 +43,7 @@ vi.mock('./intelligence-local-knowledge-engine', () => ({
 }))
 // Spread the real module: a full replacement drops every export the
 // module later gains, which is how PRIVACY_DATA_CATEGORIES broke this.
-vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+vi.mock('@talex-touch/utils/transport/events/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))

--- a/apps/core-app/src/main/modules/ai/intelligence-knowledge-actor-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-knowledge-actor-boundary.test.ts
@@ -41,7 +41,10 @@ const localKnowledgeEngineMocks = vi.hoisted(() => ({
 vi.mock('./intelligence-local-knowledge-engine', () => ({
   localKnowledgeEngine: localKnowledgeEngineMocks
 }))
-vi.mock('@talex-touch/utils/transport/events/types', () => ({
+// Spread the real module: a full replacement drops every export the
+// module later gains, which is how PRIVACY_DATA_CATEGORIES broke this.
+vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+  ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))
 

--- a/apps/core-app/src/main/modules/ai/intelligence-quota-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-quota-boundary.test.ts
@@ -47,7 +47,10 @@ vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', () => ({
   ...intelligenceEventMocks,
   intelligenceKnowledgeEvents: {}
 }))
-vi.mock('@talex-touch/utils/transport/events/types', () => ({
+// Spread the real module: a full replacement drops every export the
+// module later gains, which is how PRIVACY_DATA_CATEGORIES broke this.
+vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+  ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))
 

--- a/apps/core-app/src/main/modules/ai/intelligence-quota-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-quota-boundary.test.ts
@@ -49,7 +49,7 @@ vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', () => ({
 }))
 // Spread the real module: a full replacement drops every export the
 // module later gains, which is how PRIVACY_DATA_CATEGORIES broke this.
-vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+vi.mock('@talex-touch/utils/transport/events/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))

--- a/apps/core-app/src/main/modules/ai/intelligence-workflow-host-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-workflow-host-boundary.test.ts
@@ -18,7 +18,7 @@ vi.mock('./intelligence-workflow-service', () => ({
 }))
 // Spread the real module: a full replacement drops every export the
 // module later gains, which is how PRIVACY_DATA_CATEGORIES broke this.
-vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+vi.mock('@talex-touch/utils/transport/events/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))

--- a/apps/core-app/src/main/modules/ai/intelligence-workflow-host-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-workflow-host-boundary.test.ts
@@ -16,7 +16,10 @@ const workflowServiceMocks = vi.hoisted(() => ({
 vi.mock('./intelligence-workflow-service', () => ({
   intelligenceWorkflowService: workflowServiceMocks
 }))
-vi.mock('@talex-touch/utils/transport/events/types', () => ({
+// Spread the real module: a full replacement drops every export the
+// module later gains, which is how PRIVACY_DATA_CATEGORIES broke this.
+vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+  ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))
 vi.mock('../sentry/sentry-service', () => {

--- a/apps/core-app/src/renderer/src/views/base/settings/SettingUpdate.channel.test.ts
+++ b/apps/core-app/src/renderer/src/views/base/settings/SettingUpdate.channel.test.ts
@@ -50,7 +50,7 @@ vi.mock('@talex-touch/utils/transport/events', () => ({
 
 // Spread the real module: a full replacement drops every export the
 // module later gains, which is how PRIVACY_DATA_CATEGORIES broke this.
-vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+vi.mock('@talex-touch/utils/transport/events/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isBuildVerificationStatus: () => false
 }))

--- a/apps/core-app/src/renderer/src/views/base/settings/SettingUpdate.channel.test.ts
+++ b/apps/core-app/src/renderer/src/views/base/settings/SettingUpdate.channel.test.ts
@@ -48,7 +48,10 @@ vi.mock('@talex-touch/utils/transport/events', () => ({
   }
 }))
 
-vi.mock('@talex-touch/utils/transport/events/types', () => ({
+// Spread the real module: a full replacement drops every export the
+// module later gains, which is how PRIVACY_DATA_CATEGORIES broke this.
+vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+  ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isBuildVerificationStatus: () => false
 }))
 


### PR DESCRIPTION
Nineteen of #323's 41 failing tests are one message:

```
No "PRIVACY_DATA_CATEGORIES" export is defined on the
"@talex-touch/utils/transport/events/types" mock
```

Seven suites mock that module by **replacing it entirely** with a single override:

```ts
vi.mock('@talex-touch/utils/transport/events/types', () => ({
  isIntelligenceErrorCode: vi.fn(() => false)
}))
```

That holds until the real module gains an export the code under test imports — which `PRIVACY_DATA_CATEGORIES` did.

Each mock now spreads the real module through `importOriginal` and overrides only the one function it meant to, so the next added export does not break them again.

Six of the seven are in the failing set. `SettingUpdate.channel.test.ts` is not — it overrides `isBuildVerificationStatus` and has not yet touched a new export — but it carries the identical fault and would fail the same way, so it is converted rather than left as the next occurrence.

## Not verified locally

This worktree has no electron binary — its install was interrupted before postinstall — so these suites cannot run here at all. Locally they die on `Electron failed to install correctly`, which is my environment and not the bug; on CI they get past electron and fail only on the mock. **CI is the check for this one**, and I would rather say so than imply a local pass.

Expected: **20 → 14 failing files, 41 → 22 failing tests**, confirmed from the JUnit artifact.

Refs #323
