### PR TITLE
fix(publish): stop the registry check reporting clean when it could not read

### DIFF
--- a/scripts/publish-package.mjs
+++ b/scripts/publish-package.mjs
@@ -158,18 +158,43 @@ function packPackage(packageInfo, tempRoot) {
   return packedFiles[0]
 }
 
-function verifyRegistryManifest(packageInfo, version) {
-  const fields = ['dependencies', 'peerDependencies', 'optionalDependencies']
-  for (const field of fields) {
+export const REGISTRY_MANIFEST_FIELDS = [
+  'dependencies',
+  'peerDependencies',
+  'optionalDependencies',
+]
+
+function readRegistryField(packageName, version, field) {
+  return runOutput(`npm view "${packageName}@${version}" ${field} --json`)
+}
+
+/**
+ * Post-publish check that the registry copy carries no catalog:/workspace:/file:/link: spec.
+ *
+ * The throw used to live inside a try whose catch rethrew only its own message, so any
+ * failure of `npm view` itself — rate limit, auth, proxy, a registry hiccup — was swallowed
+ * and the check reported success (#560). That is the worst possible default for this
+ * particular check: it is the last line between a forbidden protocol and consumers, and the
+ * conditions that break `npm view` are exactly the ones around a release.
+ *
+ * `readField` is injectable so the failure path can be tested without a registry.
+ */
+export function verifyRegistryManifest(packageInfo, version, readField = readRegistryField) {
+  for (const field of REGISTRY_MANIFEST_FIELDS) {
+    let value
     try {
-      const value = runOutput(`npm view "${packageInfo.name}@${version}" ${field} --json`)
-      if (/"(?:catalog|workspace|file|link):/.test(value)) {
-        throw new Error(`Registry manifest still contains forbidden protocol in ${field}: ${value}`)
-      }
+      value = readField(packageInfo.name, version, field)
     }
     catch (error) {
-      if (String(error?.message || error).includes('Registry manifest still contains'))
-        throw error
+      throw new Error(
+        `Could not read the published manifest for ${packageInfo.name}@${version} (${field}): `
+        + `${String(error?.message || error)}. Refusing to treat an unreadable manifest as `
+        + `clean — this check is what stops a forbidden protocol reaching consumers.`,
+      )
+    }
+
+    if (/"(?:catalog|workspace|file|link):/.test(value)) {
+      throw new Error(`Registry manifest still contains forbidden protocol in ${field}: ${value}`)
     }
   }
 }
@@ -220,10 +245,13 @@ function main() {
   }
 }
 
-try {
-  main()
-}
-catch (error) {
-  console.error('[publish-package] Failed:', error instanceof Error ? error.message : String(error))
-  process.exit(1)
+// Guarded so the tests can import verifyRegistryManifest without running a publish.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    main()
+  }
+  catch (error) {
+    console.error('[publish-package] Failed:', error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
 }

--- a/scripts/publish-package.test.mjs
+++ b/scripts/publish-package.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'vitest'
+import { REGISTRY_MANIFEST_FIELDS, verifyRegistryManifest } from './publish-package.mjs'
+
+const pkg = { name: '@talex-touch/utils' }
+
+describe('verifyRegistryManifest', () => {
+  it('accepts a registry manifest with fully resolved specifiers', () => {
+    const readField = () => '{"marked":"^17.0.6","gsap":"^3.15.0"}'
+
+    assert.doesNotThrow(() => verifyRegistryManifest(pkg, '1.0.51', readField))
+  })
+
+  it('rejects a forbidden protocol that reached the registry', () => {
+    const readField = (_name, _version, field) =>
+      field === 'dependencies' ? '{"gsap":"catalog:"}' : '{}'
+
+    assert.throws(
+      () => verifyRegistryManifest(pkg, '1.0.51', readField),
+      /Registry manifest still contains forbidden protocol in dependencies/,
+    )
+  })
+
+  it('fails when npm view fails, instead of reporting the manifest clean', () => {
+    // The regression: the old catch rethrew only its own message, so a rate limit, auth
+    // failure or registry hiccup made the check pass silently (#560).
+    const readField = () => {
+      throw new Error('npm ERR! 429 Too Many Requests')
+    }
+
+    assert.throws(
+      () => verifyRegistryManifest(pkg, '1.0.51', readField),
+      /Could not read the published manifest .* 429 Too Many Requests/s,
+    )
+  })
+
+  it('fails on the first unreadable field rather than continuing through the rest', () => {
+    const seen = []
+    const readField = (_name, _version, field) => {
+      seen.push(field)
+      throw new Error('ENOTFOUND registry.npmjs.org')
+    }
+
+    assert.throws(() => verifyRegistryManifest(pkg, '1.0.51', readField))
+    assert.deepEqual(seen, [REGISTRY_MANIFEST_FIELDS[0]])
+  })
+
+  it('checks every declared field when they are all readable', () => {
+    const seen = []
+    const readField = (_name, _version, field) => {
+      seen.push(field)
+      return '{}'
+    }
+
+    verifyRegistryManifest(pkg, '1.0.51', readField)
+    assert.deepEqual(seen, REGISTRY_MANIFEST_FIELDS)
+  })
+
+  it('treats an absent field as clean, since npm prints nothing for one', () => {
+    // `npm view <pkg> peerDependencies --json` exits 0 with empty output when the field is
+    // absent. That is genuinely clean and must stay distinguishable from a failed call.
+    const readField = () => ''
+
+    assert.doesNotThrow(() => verifyRegistryManifest(pkg, '1.0.51', readField))
+  })
+
+  it('catches each forbidden protocol, not just catalog:', () => {
+    for (const spec of ['workspace:^1.0.0', 'file:../utils', 'link:../utils']) {
+      const readField = () => `{"dep":"${spec}"}`
+      assert.throws(
+        () => verifyRegistryManifest(pkg, '1.0.51', readField),
+        /forbidden protocol/,
+        `expected ${spec} to be rejected`,
+      )
+    }
+  })
+})


### PR DESCRIPTION
## What

`verifyRegistryManifest` is the post-publish check that the registry copy carries no `catalog:`/`workspace:`/`file:`/`link:` spec. Its throw sat inside a try whose catch rethrew only its own message:

```js
catch (error) {
  if (String(error?.message || error).includes('Registry manifest still contains'))
    throw error
  // everything else: swallowed, loop continues, function returns normally
}
```

So a rate limit, auth failure, proxy error or registry hiccup made the check **report success**.

## Why this one matters more than its severity label

It is the last line between a forbidden protocol and consumers — and #1137 just showed that line was load-bearing: `packages/utils` was one version bump away from publishing `"gsap": "catalog:"`. If that had gone out during a registry wobble, this check would have said clean.

The conditions that break `npm view` — rate limits, auth, network — are exactly the ones that cluster around a release.

## Fix

The forbidden-protocol throw moves out of the `try`, which removes the need to re-detect it by message string at all. A read failure now fails loudly, naming the field and the underlying error:

> Could not read the published manifest for @talex-touch/utils@1.0.51 (dependencies): npm ERR! 429 Too Many Requests. Refusing to treat an unreadable manifest as clean — this check is what stops a forbidden protocol reaching consumers.

An **absent** field stays clean: `npm view <pkg> peerDependencies --json` exits 0 with empty output when there is none, which is genuinely different from a failed call. There is a case for that.

## Testability

`publish-package.mjs` had no tests, and could not have any: `main()` ran at import, so importing the module would have started a publish. Added the entry guard the repo already uses in `run-eslint-changed.mjs`, and made the registry reader injectable.

```
$ node --input-type=module -e "await import('./scripts/publish-package.mjs')"
  imported without publishing; exports: REGISTRY_MANIFEST_FIELDS,verifyRegistryManifest
```

## Adversarial verification

Seven cases. Rather than only checking them against the old file — where they fail merely because the export did not exist — I built a variant that keeps the **new API** and restores only the **old swallow**:

```
   ✓ accepts a registry manifest with fully resolved specifiers
   ✓ rejects a forbidden protocol that reached the registry
   × fails when npm view fails, instead of reporting the manifest clean
   × fails on the first unreadable field rather than continuing through the rest
   ✓ checks every declared field when they are all readable
   ✓ treats an absent field as clean, since npm prints nothing for one
   ✓ catches each forbidden protocol, not just catalog:
      Tests  2 failed | 5 passed (7)
```

Exactly the two swallow cases fail. They are pinned to the behaviour, not to the refactor.

## Local note

`scripts/check-release-gates/local-checks.test.mjs > validates packed publish manifests` fails in my worktree with `ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL`, because the worktree symlinks the main checkout's `node_modules` and pnpm cannot see the workspace links. It **passed in CI** on #1144. Unrelated to this change; CI is the arbiter.

Fixes #560
