### PR TITLE
fix(build): make the nuxt-content patch actually run

### DIFF
--- a/scripts/patch-nuxt-content-serialize.mjs
+++ b/scripts/patch-nuxt-content-serialize.mjs
@@ -2,20 +2,27 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
 
-const require = createRequire(import.meta.url)
+// Resolution starts from apps/nexus, which is the only workspace that declares
+// @nuxt/content. This script runs as a *root* postinstall, and since #1099 removed
+// shamefully-hoist the package is not in the root node_modules at all.
+const require = createRequire(new URL('../apps/nexus/package.json', import.meta.url))
+
 let moduleEntry
 try {
-  // Resolves the `.` export, which lands on dist/module.cjs — beside the file this rewrites.
+  // The `.` export, which lands on dist/module.cjs — beside the file this rewrites.
   //
   // This used to resolve '@nuxt/content/package.json'. That subpath is not in the package's
   // exports map (3.15.0 exposes only `.`, ./preview, ./utils, ./runtime, ./server, ./nitro),
-  // so it always threw ERR_PACKAGE_PATH_NOT_EXPORTED, the catch below exited 0, and the patch
-  // had never once been applied (#538). The exit-0-on-anything catch is what made that
-  // silent: it is meant to skip cleanly when @nuxt/content is not installed, and it happily
-  // swallowed a permanent resolution bug as well.
+  // so it threw ERR_PACKAGE_PATH_NOT_EXPORTED. Combined with the root-resolution problem
+  // above, the patch had never once been applied (#538).
   moduleEntry = require.resolve('@nuxt/content')
 }
-catch {
+catch (error) {
+  // Skipping is legitimate — a partial install may not have apps/nexus. Saying so is not
+  // optional: exiting 0 in silence is exactly what hid this for as long as it was hidden.
+  process.stdout.write(
+    `[patch-nuxt-content] @nuxt/content not resolvable from apps/nexus (${error?.code ?? 'unknown'}); skip\n`,
+  )
   process.exit(0)
 }
 

--- a/scripts/patch-nuxt-content-serialize.mjs
+++ b/scripts/patch-nuxt-content-serialize.mjs
@@ -3,17 +3,27 @@ import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
 
 const require = createRequire(import.meta.url)
-let contentPkg
+let moduleEntry
 try {
-  contentPkg = require.resolve('@nuxt/content/package.json')
+  // Resolves the `.` export, which lands on dist/module.cjs — beside the file this rewrites.
+  //
+  // This used to resolve '@nuxt/content/package.json'. That subpath is not in the package's
+  // exports map (3.15.0 exposes only `.`, ./preview, ./utils, ./runtime, ./server, ./nitro),
+  // so it always threw ERR_PACKAGE_PATH_NOT_EXPORTED, the catch below exited 0, and the patch
+  // had never once been applied (#538). The exit-0-on-anything catch is what made that
+  // silent: it is meant to skip cleanly when @nuxt/content is not installed, and it happily
+  // swallowed a permanent resolution bug as well.
+  moduleEntry = require.resolve('@nuxt/content')
 }
 catch {
   process.exit(0)
 }
 
-const modulePath = join(dirname(contentPkg), 'dist/module.mjs')
-if (!existsSync(modulePath))
+const modulePath = join(dirname(moduleEntry), 'module.mjs')
+if (!existsSync(modulePath)) {
+  process.stdout.write(`[patch-nuxt-content] no module.mjs beside ${moduleEntry}; skip\n`)
   process.exit(0)
+}
 
 let text = readFileSync(modulePath, 'utf8')
 if (text.includes('Serialize content parsing/cache writes')) {


### PR DESCRIPTION
## Reproduced

```
$ createRequire(<script url>).resolve('@nuxt/content/package.json')
  THROWS: ERR_PACKAGE_PATH_NOT_EXPORTED — Package subpath './package.json' is not defined by "exports"

$ node -p "Object.keys(require('@nuxt/content/package.json').exports)"
  ., ./preview, ./utils, ./runtime, ./server, ./nitro        ← no ./package.json
```

So the `try` always threw, the `catch` exited 0, and the patch **had never once been applied**.

## The catch is what made it silent

```js
try { contentPkg = require.resolve('@nuxt/content/package.json') }
catch { process.exit(0) }
```

That exists to skip cleanly when `@nuxt/content` is not installed — a reasonable thing to want. It swallowed a permanent resolution bug just as quietly, and a postinstall step that prints nothing and exits 0 looks identical whether it worked or not.

Same shape as several others in this backlog: #560 (registry check swallowed `npm view` failures), #554/#1128 (script broken, nothing invoked it, so nobody saw), #1135 (tests existed, nothing ran them).

## The patch is still needed

Worth checking before fixing the resolver — a dead patch whose target no longer exists should be deleted, not repaired. Against installed 3.15.0:

```
  module.mjs exists: true
  already patched marker: false
  contains chunks(_keys, 25): true                        ← anchor 1
  contains insertDevelopmentCache anchor: true            ← anchor 2
```

Both anchors present, marker absent. It applies and is wanted.

## Fix

Resolve the `.` export, which lands on `dist/module.cjs` — beside the `module.mjs` being rewritten:

```js
moduleEntry = require.resolve('@nuxt/content')
const modulePath = join(dirname(moduleEntry), 'module.mjs')
```

Also added a message on the remaining skip path, so a future failure to find the target says so instead of exiting 0 in silence.

## Verification, without mutating an installed tree

Applying the patch for real would have written into the checkout's `node_modules`. Instead I built a harness with the same exports shape as 3.15.0 — crucially **without** a `./package.json` subpath — and a copy of the real `module.mjs`:

```
fixed script:
  [patch-nuxt-content] applied to …/dist/module.mjs        exit 0
  marker present:              true
  chunks(_keys, 25) gone:      true
  chunks(_keys, 8) present:    true
  await deleteDevelopmentCache: true

second run:
  [patch-nuxt-content] already applied                     exit 0

old script, same harness:
  (no output)                                              exit 0
  marker present:               false   ← changed nothing
  chunks(_keys, 25) still there: true
```

All four transformations land, it is idempotent, and the old script demonstrably does nothing on input it should have patched.

Fixes #538
