### PR TITLE
test(core-app): assert the redacted boundary error, and that the code cannot leak (#323)

### DIFF
--- a/apps/core-app/src/main/modules/ai/intelligence-agent-session-host-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-agent-session-host-boundary.test.ts
@@ -47,6 +47,9 @@ vi.mock('../sentry/sentry-service', () => {
 
 import { IntelligenceModule } from './intelligence-module'
 
+// Mirrors SAFE_HANDLER_PUBLIC_ERROR in src/main/utils/safe-handler.ts.
+const SAFE_PUBLIC_ERROR = 'The operation failed. Please retry.'
+
 type EventDefinition = { toEventName: () => string }
 type ApiResponse = { ok: boolean; result?: unknown; error?: string }
 type ApiHandler = (payload: unknown, context: HandlerContext) => Promise<ApiResponse>
@@ -148,10 +151,13 @@ describe('intelligenceModule agent session host boundary', () => {
     async ({ eventName, payload, operation }) => {
       const handler = getHandler(captureOrchestrationHandlers(), eventName)
 
-      await expect(handler(payload, pluginContext())).resolves.toEqual({
-        ok: false,
-        error: 'INTELLIGENCE_HOST_ONLY_CAPABILITY'
-      })
+      // safeApiHandler redacts every thrown error to one public string, so the
+      // internal INTELLIGENCE_HOST_ONLY_CAPABILITY code deliberately does not
+      // cross the boundary. Asserting the redaction, and that the code does not
+      // leak, is the contract -- the security half is the untouched service below.
+      const response = await handler(payload, pluginContext())
+      expect(response).toEqual({ ok: false, error: SAFE_PUBLIC_ERROR })
+      expect(JSON.stringify(response)).not.toContain('INTELLIGENCE_HOST_ONLY_CAPABILITY')
       expect(operation).not.toHaveBeenCalled()
     }
   )

--- a/apps/core-app/src/main/modules/ai/intelligence-workflow-host-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-workflow-host-boundary.test.ts
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import './intelligence-test-harness'
 import { IntelligenceModule } from './intelligence-module'
 
+// Mirrors SAFE_HANDLER_PUBLIC_ERROR in src/main/utils/safe-handler.ts.
+const SAFE_PUBLIC_ERROR = 'The operation failed. Please retry.'
+
 const workflowServiceMocks = vi.hoisted(() => ({
   listWorkflows: vi.fn(),
   getWorkflow: vi.fn(),
@@ -148,10 +151,13 @@ describe('intelligenceModule workflow control-plane host boundary', () => {
     async ({ eventName, payload }) => {
       const { handlers, waitForAgentRuntime } = captureWorkflowHandlers()
 
-      await expect(getHandler(handlers, eventName)(payload, pluginContext())).resolves.toEqual({
-        ok: false,
-        error: 'INTELLIGENCE_HOST_ONLY_CAPABILITY'
-      })
+      // safeApiHandler redacts every thrown error to one public string, so the
+      // internal INTELLIGENCE_HOST_ONLY_CAPABILITY code deliberately does not
+      // cross the boundary. Asserting the redaction, and that the code does not
+      // leak, is the contract -- the security half is the untouched service below.
+      const response = await getHandler(handlers, eventName)(payload, pluginContext())
+      expect(response).toEqual({ ok: false, error: SAFE_PUBLIC_ERROR })
+      expect(JSON.stringify(response)).not.toContain('INTELLIGENCE_HOST_ONLY_CAPABILITY')
       expect(waitForAgentRuntime).not.toHaveBeenCalled()
       expectWorkflowServiceUntouched()
     }


### PR DESCRIPTION
The workflow and agent-session host boundaries expected `error: 'INTELLIGENCE_HOST_ONLY_CAPABILITY'` and get `'The operation failed. Please retry.'` — **11 of #323's remaining 29 failures**.

## Not a regression

`assertHostOwnedIntelligenceControlPlane` throws an `Error` whose message is the code, and `safeApiHandler` catches every throw and returns one public string so internal detail cannot reach a plugin caller. That redaction is deliberate — it has its own test in `safe-handler.test.ts` — and the wrapping arrived in `ca2ee70e9`, after these assertions were written. This is category 2 in the issue's own triage: an intentional contract change needing an updated behaviour test.

## What the tests assert now

The redacted response, **plus** that the internal code does not appear anywhere in it:

```ts
expect(response).toEqual({ ok: false, error: SAFE_PUBLIC_ERROR })
expect(JSON.stringify(response)).not.toContain('INTELLIGENCE_HOST_ONLY_CAPABILITY')
```

That second line is the property the redaction exists for, and nothing was checking it. The security half was already covered — `waitForAgentRuntime` not called, workflow service untouched — and stays.

## On the acceptance criterion

#323 asks host-only tests to *"assert canonical error codes"*. At this boundary that is not possible without undoing the redaction, so I read it as the observable boundary contract rather than the internal string. Flagging that reading explicitly rather than quietly satisfying the letter of it.

Expected: **15 → 13 failing files, 29 → 18 failing tests.**

Refs #323