### PR TITLE
test(core-app): stop pinning the migration chain to its current tail (#323)

### DIFF
--- a/apps/core-app/src/main/modules/privacy/retention-migration.test.ts
+++ b/apps/core-app/src/main/modules/privacy/retention-migration.test.ts
@@ -11,6 +11,7 @@ import {
 } from './retention-test-utils'
 
 const MIGRATIONS_URL = new URL('../../../../resources/db/migrations/', import.meta.url)
+const RETENTION_INDEXES_MIGRATION = '0034_privacy_retention_indexes.sql'
 const MIGRATIONS_FOLDER = fileURLToPath(MIGRATIONS_URL)
 
 interface MigrationJournal {
@@ -62,8 +63,13 @@ describe('privacy retention indexes migration', () => {
   it('extends the real migration chain without deleting existing rows', async () => {
     const { client } = await createPrivacyTestClient('migration')
     const migrations = await getPrivacyMigrationNames()
-    expect(migrations.at(-1)).toBe('0034_privacy_retention_indexes.sql')
-    await applyPrivacyMigrations(client, migrations.slice(0, -1))
+    // Target the retention-indexes migration by name rather than assuming it is
+    // last. Pinning it to the tail meant that once a later migration landed this
+    // suite would keep passing while exercising a different one entirely --
+    // worse than failing, which is what it did when 0035 and 0036 arrived.
+    const target = migrations.indexOf(RETENTION_INDEXES_MIGRATION)
+    expect(target, `${RETENTION_INDEXES_MIGRATION} is missing from the chain`).toBeGreaterThanOrEqual(0)
+    await applyPrivacyMigrations(client, migrations.slice(0, target))
 
     await client.execute(
       `INSERT INTO clipboard_history (type, content, timestamp, is_favorite)
@@ -75,7 +81,7 @@ describe('privacy retention indexes migration', () => {
        VALUES ('CANARY_CONTEXT_ROW', 'assistant', 'archived', 1, 1)`
     )
 
-    await applyPrivacyMigrations(client, migrations.slice(-1))
+    await applyPrivacyMigrations(client, [migrations[target]!])
 
     const indexes = await client.execute(
       `SELECT name FROM sqlite_master
@@ -224,7 +230,9 @@ describe('privacy retention indexes migration', () => {
     await migrate(drizzle(client), { migrationsFolder: MIGRATIONS_FOLDER })
 
     const journalRows = await client.execute('SELECT COUNT(*) AS count FROM __drizzle_migrations')
-    expect(Number(journalRows.rows[0]?.count)).toBe(35)
+    // Derived from the journal: a hardcoded count fails on every new migration
+    // while proving nothing about whether they all applied.
+    expect(Number(journalRows.rows[0]?.count)).toBe((await getPrivacyMigrationNames()).length)
     const clipboardColumns = await client.execute(`PRAGMA table_info('clipboard_history')`)
     expect(clipboardColumns.rows.some((row) => row.name === 'retention_protected')).toBe(true)
     const contextColumns = await client.execute(
@@ -262,7 +270,9 @@ describe('privacy retention indexes migration', () => {
     )
     expect(context.rows[0]?.is_pinned).toBe(0)
     const journalRows = await client.execute('SELECT COUNT(*) AS count FROM __drizzle_migrations')
-    expect(Number(journalRows.rows[0]?.count)).toBe(35)
+    // Derived from the journal: a hardcoded count fails on every new migration
+    // while proving nothing about whether they all applied.
+    expect(Number(journalRows.rows[0]?.count)).toBe((await getPrivacyMigrationNames()).length)
   })
 
   it('rolls back schema and journal state when 0034 fails mid-migration', async () => {

--- a/apps/core-app/src/main/modules/privacy/retention-migration.test.ts
+++ b/apps/core-app/src/main/modules/privacy/retention-migration.test.ts
@@ -68,7 +68,10 @@ describe('privacy retention indexes migration', () => {
     // suite would keep passing while exercising a different one entirely --
     // worse than failing, which is what it did when 0035 and 0036 arrived.
     const target = migrations.indexOf(RETENTION_INDEXES_MIGRATION)
-    expect(target, `${RETENTION_INDEXES_MIGRATION} is missing from the chain`).toBeGreaterThanOrEqual(0)
+    expect(
+      target,
+      `${RETENTION_INDEXES_MIGRATION} is missing from the chain`
+    ).toBeGreaterThanOrEqual(0)
     await applyPrivacyMigrations(client, migrations.slice(0, target))
 
     await client.execute(
@@ -244,7 +247,15 @@ describe('privacy retention indexes migration', () => {
   it('upgrades a journaled 0033 database while preserving existing rows', async () => {
     const { client, directory } = await createPrivacyTestClient('migration-upgrade')
     const stagedFolder = join(directory, 'migrations')
-    await stageMigrationChain(stagedFolder, 34)
+    // Both counts are derived from the chain: this test upgrades a database
+    // journaled at the migration before the retention indexes, up to and
+    // including them. Literal 34/35 silently drift as the chain grows.
+    const migrationNames = await getPrivacyMigrationNames()
+    const retentionIndex = migrationNames.indexOf(RETENTION_INDEXES_MIGRATION)
+    expect(retentionIndex).toBeGreaterThan(0)
+    const beforeRetention = retentionIndex
+    const throughRetention = retentionIndex + 1
+    await stageMigrationChain(stagedFolder, beforeRetention)
     await migrate(drizzle(client), { migrationsFolder: stagedFolder })
     await client.execute(
       `INSERT INTO clipboard_history (type, content, timestamp, is_favorite)
@@ -255,7 +266,7 @@ describe('privacy retention indexes migration', () => {
        VALUES ('journal-upgrade', 'assistant', 'archived', 1, 1)`
     )
 
-    await stageMigrationChain(stagedFolder, 35)
+    await stageMigrationChain(stagedFolder, throughRetention)
     await migrate(drizzle(client), { migrationsFolder: stagedFolder })
 
     const clipboard = await client.execute(
@@ -270,9 +281,9 @@ describe('privacy retention indexes migration', () => {
     )
     expect(context.rows[0]?.is_pinned).toBe(0)
     const journalRows = await client.execute('SELECT COUNT(*) AS count FROM __drizzle_migrations')
-    // Derived from the journal: a hardcoded count fails on every new migration
-    // while proving nothing about whether they all applied.
-    expect(Number(journalRows.rows[0]?.count)).toBe((await getPrivacyMigrationNames()).length)
+    // The staged folder holds only the chain through the retention indexes, so
+    // the journal reflects that subset rather than every migration on disk.
+    expect(Number(journalRows.rows[0]?.count)).toBe(throughRetention)
   })
 
   it('rolls back schema and journal state when 0034 fails mid-migration', async () => {


### PR DESCRIPTION
Two assertions in the privacy retention-migration suite encode today's migration set: that the last entry is `0034_privacy_retention_indexes.sql`, and that a fresh migrate journals exactly **35** rows. The chain is now **37** entries ending at `0036_recommendation_exposure_daily`.

## The tail assumption is the dangerous one

The suite applied `migrations.slice(0, -1)`, inserted canary rows, then applied `migrations.slice(-1)` — so it tested *whatever migration is last* rather than the one it is named after. **Once `0035` landed it would have kept passing while exercising a different migration entirely.** Failing is the better outcome, and it is what happened.

It now finds `0034_privacy_retention_indexes.sql` **by name**, applies everything before it, and applies exactly that one — so it keeps testing its own subject no matter what is added later.

## The count

Derived from `getPrivacyMigrationNames()` rather than hardcoded. A literal `35` breaks on every new migration while proving nothing about whether they all applied.

Same class as the fixtures with an expiry date in #327: an assertion that pins a moving value and fails on the calendar rather than on a defect.

**Not run locally** — this worktree has no electron binary, so the core-app suite cannot start here. Measured on CI.

Expected: **13 → 12 failing files, 18 → 16 failing tests.**

Refs #323