### PR TITLE
test(core-app): stub the xdotool probe so the Linux case runs anywhere (#323)

### DIFF
--- a/apps/core-app/src/main/modules/system/active-app.test.ts
+++ b/apps/core-app/src/main/modules/system/active-app.test.ts
@@ -44,6 +44,15 @@ vi.mock('@talex-touch/utils/electron/env-tool', () => ({
   withOSAdapter: withOSAdapterMock
 }))
 
+// resolveActiveWindowLinux probes for xdotool before doing anything else, so
+// without this the Linux case depends on the runner having it installed and
+// returns null on CI. Spread the real module so only the probe is stubbed.
+vi.mock('./linux-desktop-tools', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./linux-desktop-tools')>()),
+  ensureXdotoolAvailable: vi.fn(async () => {}),
+  isXdotoolAvailable: vi.fn(async () => true)
+}))
+
 vi.mock('electron', () => ({
   app: {
     getFileIcon: getFileIconMock


### PR DESCRIPTION
`resolveActiveWindowLinux` calls `ensureXdotoolAvailable()` before its first command. The suite mocks `execFile` and `withOSAdapter` but **not that probe**, so the Linux test depended on the runner having xdotool installed.

On CI it throws, the resolver returns `null`, and the failure reads as a parsing regression:

```
expected null to match object { displayName: 'gnome-terminal', … }
```

It is a missing binary, not a parsing change. The probe is now stubbed, spreading the real module so only the availability check is replaced.

This is #323's *"runnable on non-target-platform CI through explicit adapters/mocks without weakening real coverage"* criterion applied to Linux rather than Windows: everything the test actually exercises — the xdotool/ps output parsing — is already fully mocked and never needed the binary present.

The other two failures in this file are macOS paths and are diagnosed separately; this PR does not touch them.

Refs #323