### PR TITLE
docs(roadmap): drop three finished tasks from the active table

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,7 @@
 
 ---
 
-## 📁 活跃 Trellis 任务全景（27 个）
+## 📁 活跃 Trellis 任务全景（24 个）
 
 优先级与状态以各任务 `task.json` / `prd.md` 为准。父子任务缩进展示。
 
@@ -61,8 +61,6 @@
 | ├ [gate-search-on-storage-hydration](.trellis/tasks/07-09-gate-search-on-storage-hydration/prd.md) | P1 | planning |
 | ├ [establish-single-search-index-writer](.trellis/tasks/07-09-establish-single-search-index-writer/prd.md) | P1 | planning |
 | └ [unify-search-provider-lifecycle](.trellis/tasks/07-09-unify-search-provider-lifecycle/prd.md) | P2 | planning |
-| [batch-commit-release-v2-4-14-beta-1](.trellis/tasks/07-27-batch-commit-release-v2-4-14-beta-1/prd.md) | P1 | 🔄 planning [1/2] |
-| └ [release-v2-4-14-beta-1](.trellis/tasks/07-27-release-v2-4-14-beta-1/prd.md) | P1 | planning |
 | [catalog-service-mvp](.trellis/tasks/07-13-catalog-service-mvp/prd.md) | P1 | planning |
 | [optimize-core-utility-plugins](.trellis/tasks/07-27-optimize-core-utility-plugins/prd.md) | P1 | 🔄 planning [0/3] |
 | ├ [optimize-intelligence-plugin](.trellis/tasks/07-27-optimize-intelligence-plugin/prd.md) | P1 | planning |
@@ -80,7 +78,6 @@
 | [base-anchor-liquid-animation](.trellis/tasks/07-27-base-anchor-liquid-animation/prd.md) | P2 | 🔄 in_progress（AC 验收中） |
 | [fix-plugin-folder-button](.trellis/tasks/07-27-fix-plugin-folder-button/prd.md) | P2 | 🔄 in_progress |
 | [tuffex-docs-audit](.trellis/tasks/07-28-tuffex-docs-audit/prd.md) | P2 | 🔄 审计进行中 |
-| [fix-file-index-update-redaction-476](.trellis/tasks/07-30-fix-file-index-update-redaction-476/prd.md) | P2 | 🔄 in_progress |
 | [docs-roadmap-consolidation-cleanup](.trellis/tasks/07-30-docs-roadmap-consolidation-cleanup/prd.md) | P2 | 🔄 in_progress（本任务） |
 | [expose-plugin-search-sdk](.trellis/tasks/07-27-expose-plugin-search-sdk/prd.md) | P3 | planning |
 


### PR DESCRIPTION
Item 3 of the split proposed on #1125 — the part with no Trellis task-system contention.

## What was wrong

`ROADMAP.md`'s table lives under 「活跃 Trellis 任务全景」 and contains no `archive/` links at all, so it is the active view. Three rows point at tasks archived weeks ago **and report them as unfinished**:

| row | ROADMAP says | archived record says |
|---|---|---|
| batch-commit-release-v2-4-14-beta-1 | 🔄 planning [1/2] | completed 2026-07-31 |
| release-v2-4-14-beta-1 | planning | completed 2026-07-31 |
| fix-file-index-update-redaction-476 | 🔄 in_progress | completed 2026-07-30 |

Statuses read from each task's archived `task.json`.

## Removed, not repointed

The section is explicitly the active list, and 「已完成关键里程碑」 further down is where finished work belongs. Repointing the links at `archive/` would have satisfied the linter while leaving three completed tasks presented as in-flight.

Heading count 27 → 24, checked against the table rather than assumed: exactly 27 rows before, exactly 24 after.

## Verified

```
before: DOC-LINK-UNTRACKED=4 … total 147
after:  DOC-LINK-UNTRACKED=1 … total 144
```

The remaining one is `07-26-install-launch-v2-4-13-beta-23`, whose task directory exists **only in the maintainer's unpushed local checkout** — the same premise failure recorded on #354. Nothing in this repository can fix that link; it resolves when that work is pushed.

Progresses #1125