### PR TITLE
test(core-app): pin the darwin scanner suite to the platform it covers (#323)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/addon/apps/darwin.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/darwin.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { execFileSafeMock, getElectronFileIconMock, writeDarwinAppIconMock } = vi.hoisted(() => ({
   execFileSafeMock: vi.fn(),
@@ -96,6 +96,21 @@ async function createTempAppBundle(
 
   return tmpRoot
 }
+
+// This suite covers the macOS app scanner, and the icon cache paths it asserts
+// come from app-icon-cache.ts, whose helpers default to process.platform. On a
+// Linux runner those resolve to a different directory and three tests fail as
+// if hydration broke. Pin the platform so the macOS behaviour is asserted
+// explicitly rather than inherited from whoever runs it.
+const originalPlatform = process.platform
+
+beforeAll(() => {
+  Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+})
+
+afterAll(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+})
 
 describe('darwin app info', () => {
   const tempRoots: string[] = []


### PR DESCRIPTION
The macOS app-scanner suite **passes on a macOS host** and fails three tests on the Linux runner.

The icon paths it asserts come from `app-icon-cache.ts`, whose `getAppIconCacheDir` / `getAppIconCachePath` default to `process.platform`. On Linux those resolve to a different directory, and the failures read as broken hydration rather than a wrong host:

```
.toMatch() expects to receive a string, but got object
AppKit path writer spy never called
expected '' to be null
```

## Confirmed by reproduction, not inference

Forcing `process.platform = 'linux'` on a macOS host produces **exactly those three failures and no others**.

The suite now pins the platform to `darwin` for its duration and restores it afterwards, so it asserts macOS behaviour explicitly instead of inheriting it from whoever runs it — #323's *"runnable on non-target-platform CI through explicit adapters/mocks without weakening real coverage"* applied to macOS.

## The pin is verified to be early enough

A pin in `beforeAll` is useless if a module read `process.platform` at import time. Checked rather than assumed: flipping platform to `'linux'` at **module scope**, before any import-time evaluation, still gives **8/8**.

Expected: **11 → 10 failing files, 13 → 10 failing tests.**

Refs #323