### PR TITLE
ci(security): pin every third-party action to a commit SHA

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -78,7 +78,7 @@ jobs:
           python -m pip install setuptools
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           run_install: false
 
@@ -912,7 +912,7 @@ jobs:
           done
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           run_install: false
 
@@ -1227,7 +1227,7 @@ jobs:
 
       - name: Create Release
         id: create-release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ steps.release-info.outputs.tag }}
           name: ${{ steps.release-info.outputs.name }}
@@ -1296,7 +1296,7 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sync_tag || github.sha }}
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           run_install: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       nexus: ${{ steps.filter_not_allowed.outputs.nexus }}
     steps:
       - name: Check Not Allowed File Changes
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter_not_allowed
         with:
           list-files: json
@@ -51,13 +51,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v7
       - name: Setup mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           cache: true
           install: true
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -83,7 +83,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -127,6 +127,13 @@ jobs:
       - name: Verify plugin lint coverage
         run: pnpm check:plugin-lint-coverage && pnpm check:plugin-lint-coverage:self-test
 
+      # Third-party actions must be SHA-pinned (#546). dtolnay/rust-toolchain@stable was a
+      # *branch*, in workflows that also hold NPM_TOKEN, RELEASE_SIGNING_PRIVATE_KEY and the
+      # Apple notarization credentials — moving that ref is enough to run someone else's code
+      # next to the publishing keys. actions/* is exempt and the check says so.
+      - name: Verify action pins
+        run: pnpm check:action-pins && pnpm check:action-pins:self-test
+
       # 17 test files under scripts/ — the release machinery — that no workflow ran (#1135).
       # Three are excluded, each with its reason named in the config: one needs a prior build, and
       # two exercise a macOS-only release-acceptance contract a Linux runner cannot satisfy, so
@@ -147,7 +154,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -180,7 +187,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -230,7 +237,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -271,7 +278,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -340,7 +347,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/intelligence.yml
+++ b/.github/workflows/intelligence.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           cache: true
           install: true

--- a/.github/workflows/native-protocol.yml
+++ b/.github/workflows/native-protocol.yml
@@ -60,17 +60,17 @@ jobs:
           pkg-config
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
         with:
           components: rustfmt, clippy
 
       - name: Cache Rust workspace
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: packages/tuff-native
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           run_install: false
 

--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/package-tuff-cli-publish.yml
+++ b/.github/workflows/package-tuff-cli-publish.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/package-tuff-intelligence-publish.yml
+++ b/.github/workflows/package-tuff-intelligence-publish.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/package-tuffex-publish.yml
+++ b/.github/workflows/package-tuffex-publish.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/package-utils-publish.yml
+++ b/.github/workflows/package-utils-publish.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         with:
           config-name: release-drafter.yml

--- a/.github/workflows/windows-everything-production.yml
+++ b/.github/workflows/windows-everything-production.yml
@@ -47,7 +47,7 @@ jobs:
         run: python -m pip install setuptools
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
     "check:doc-metadata": "node scripts/check-doc-metadata.mjs",
     "check:doc-metadata:self-test": "node scripts/check-doc-metadata.mjs --self-test",
     "check:plugin-lint-coverage": "node scripts/check-plugin-lint-coverage.mjs",
-    "check:plugin-lint-coverage:self-test": "node scripts/check-plugin-lint-coverage.mjs --self-test"
+    "check:plugin-lint-coverage:self-test": "node scripts/check-plugin-lint-coverage.mjs --self-test",
+    "check:action-pins": "node scripts/check-action-pins.mjs",
+    "check:action-pins:self-test": "node scripts/check-action-pins.mjs --self-test"
   },
   "dependencies": {
     "@sentry/vite-plugin": "^4.9.1",

--- a/scripts/check-action-pins.mjs
+++ b/scripts/check-action-pins.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Requires every third-party GitHub Action to be pinned to a full commit SHA.
+ *
+ * A tag is mutable and a branch doubly so. `dtolnay/rust-toolchain@stable` was a *branch*,
+ * used in a workflow that also holds NPM_TOKEN, RELEASE_SIGNING_PRIVATE_KEY and the Apple
+ * notarization credentials (#546). If that repo is compromised, moving the ref is enough to
+ * run attacker code inside a job holding publishing keys — no release, no review, no diff.
+ *
+ * `actions/*` is exempt: it is GitHub's own namespace, published from the same platform that
+ * runs the workflow, and pinning it buys nothing that trusting the runner does not already
+ * concede. Everything else must be a SHA.
+ *
+ * Read-only. `--self-test` proves the detector fires, because a pin checker that matches
+ * nothing looks exactly like a fully pinned repository.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const WORKFLOWS = path.join(ROOT, '.github', 'workflows')
+
+/** Owners whose actions may stay on a major tag, with the reason. */
+const EXEMPT_OWNERS = {
+  actions: 'GitHub\'s own namespace, served by the same platform that runs the workflow.',
+}
+
+const USES = /^\s*(?:-\s*)?uses:\s*([A-Za-z0-9._-]+)\/([A-Za-z0-9._/-]+)@(\S+)/
+const FULL_SHA = /^[0-9a-f]{40}$/
+
+export function findUnpinned(files, readFile, exempt = EXEMPT_OWNERS) {
+  const problems = []
+  for (const file of files) {
+    const text = readFile(file)
+    if (!text) continue
+    text.split('\n').forEach((line, index) => {
+      const match = USES.exec(line)
+      if (!match) return
+      const [, owner, repo, ref] = match
+      if (owner in exempt) return
+      // A local composite action (./.github/workflows/x.yml) never matches USES.
+      if (FULL_SHA.test(ref)) return
+      problems.push({ file, line: index + 1, action: `${owner}/${repo}`, ref })
+    })
+  }
+  return problems
+}
+
+function listWorkflows() {
+  return readdirSync(WORKFLOWS)
+    .filter(name => name.endsWith('.yml') || name.endsWith('.yaml'))
+    .sort()
+}
+
+function readWorkflow(file) {
+  try {
+    return readFileSync(path.join(WORKFLOWS, file), 'utf8')
+  }
+  catch {
+    return null
+  }
+}
+
+function selfTest() {
+  const cases = [
+    {
+      name: 'a third-party action on a major tag is caught',
+      text: '      - uses: pnpm/action-setup@v6\n',
+      expect: 1,
+    },
+    {
+      name: 'a third-party action on a branch is caught',
+      text: '      - uses: dtolnay/rust-toolchain@stable\n',
+      expect: 1,
+    },
+    {
+      name: 'a full SHA is accepted',
+      text: '      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10\n',
+      expect: 0,
+    },
+    {
+      name: 'a short SHA is not accepted as a pin',
+      text: '      - uses: pnpm/action-setup@0977fd9\n',
+      expect: 1,
+    },
+    {
+      name: 'the actions/ namespace is exempt',
+      text: '      - uses: actions/checkout@v7\n',
+      expect: 0,
+    },
+    {
+      name: 'a reusable local workflow is not an action reference',
+      text: '    uses: ./.github/workflows/package-ci.yml\n',
+      expect: 0,
+    },
+  ]
+
+  let failures = 0
+  for (const testCase of cases) {
+    const found = findUnpinned(['fixture.yml'], () => testCase.text)
+    const ok = found.length === testCase.expect
+    console.log(`${ok ? 'ok  ' : 'FAIL'} ${testCase.name}`)
+    if (!ok) {
+      failures += 1
+      console.log(`     expected ${testCase.expect}, got ${found.length}: ${JSON.stringify(found)}`)
+    }
+  }
+
+  const real = findUnpinned(listWorkflows(), readWorkflow)
+  console.log(`${real.length === 0 ? 'ok  ' : 'FAIL'} the real workflows are fully pinned`)
+  if (real.length > 0) {
+    failures += 1
+    for (const p of real) console.log(`     ${p.file}:${p.line} ${p.action}@${p.ref}`)
+  }
+  return failures
+}
+
+function main() {
+  if (process.argv.includes('--self-test'))
+    process.exit(selfTest() > 0 ? 1 : 0)
+
+  const files = listWorkflows()
+  const problems = findUnpinned(files, readWorkflow)
+  if (problems.length > 0) {
+    console.error('[action-pins] third-party actions on a mutable ref:\n')
+    for (const p of problems)
+      console.error(`  - ${p.file}:${p.line}  ${p.action}@${p.ref}`)
+    console.error(
+      '\nPin to a full commit SHA and keep the version in a trailing comment, so Dependabot'
+      + '\nstill updates it:\n'
+      + '\n    uses: owner/action@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10\n'
+      + '\nResolve one with:  gh api /repos/<owner>/<action>/commits/<ref> --jq .sha',
+    )
+    process.exit(1)
+  }
+
+  const exempt = Object.keys(EXEMPT_OWNERS).join(', ')
+  console.log(
+    `[action-pins] ${files.length} workflows: every third-party action is SHA-pinned `
+    + `(${exempt}/* exempt)`,
+  )
+}
+
+// Guarded so findUnpinned can be imported without running the check — without this, an
+// `import` of this module prints a verdict, which is exactly how my own adversarial test
+// of it produced a misleading pass.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url))
+  main()

--- a/scripts/check-action-pins.mjs
+++ b/scripts/check-action-pins.mjs
@@ -28,21 +28,25 @@ const EXEMPT_OWNERS = {
   actions: 'GitHub\'s own namespace, served by the same platform that runs the workflow.',
 }
 
-const USES = /^\s*(?:-\s*)?uses:\s*([A-Za-z0-9._-]+)\/([A-Za-z0-9._/-]+)@(\S+)/
+const USES = /^\s*(?:-\s*)?uses:\s*([\w.-]+)\/([\w./-]+)@(\S+)/
 const FULL_SHA = /^[0-9a-f]{40}$/
 
 export function findUnpinned(files, readFile, exempt = EXEMPT_OWNERS) {
   const problems = []
   for (const file of files) {
     const text = readFile(file)
-    if (!text) continue
+    if (!text)
+      continue
     text.split('\n').forEach((line, index) => {
       const match = USES.exec(line)
-      if (!match) return
+      if (!match)
+        return
       const [, owner, repo, ref] = match
-      if (owner in exempt) return
+      if (owner in exempt)
+        return
       // A local composite action (./.github/workflows/x.yml) never matches USES.
-      if (FULL_SHA.test(ref)) return
+      if (FULL_SHA.test(ref))
+        return
       problems.push({ file, line: index + 1, action: `${owner}/${repo}`, ref })
     })
   }


### PR DESCRIPTION
## What

24 third-party action references across 11 workflow files, pinned to full commit SHAs. Plus a guard so the next one cannot slip in.

```
17  pnpm/action-setup@v6                → 0977fd99…  # v6.0.10
 2  jdx/mise-action@v4                  → 7e36c90d…  # v4.2.4
 1  softprops/action-gh-release@v3      → 3d0d9888…  # v3.0.2
 1  release-drafter/release-drafter@v7  → 34d80673…  # v7.7.0
 1  Swatinem/rust-cache@v2              → 6323deb1…  # v2.9.2
 1  dorny/paths-filter@v4               → ceb8a2b8…  # v4.0.3
 1  dtolnay/rust-toolchain@stable       → 4360b525…  # stable branch
```

That last one is a **branch**, not even a tag — a force-push upstream is enough. All of these run in workflows that also hold `NPM_TOKEN`, `RELEASE_SIGNING_PRIVATE_KEY`, `NEXUS_API_KEY` and the Apple notarization credentials. Nothing about such a change appears in a diff here.

Pure substitution: **+24 / −24**, and all 18 workflows still parse. Each pin keeps its version in a trailing comment, which is the form Dependabot understands, so `github-actions` updates keep working.

## `actions/*` deliberately not pinned

It is GitHub's own namespace, served by the same platform already executing the job. Pinning it buys nothing that trusting the runner does not already concede. The check encodes that exemption with its reason rather than leaving it as an unexplained gap — 46 references across 6 actions stay on major tags.

## The guard

`scripts/check-action-pins.mjs`, wired into PR Quality. Six self-test cases, including two that matter more than they look:

- **a short SHA is not accepted as a pin** — `@0977fd9` looks pinned and is not
- **a reusable local workflow is not an action reference** — `uses: ./.github/workflows/package-ci.yml` must not be flagged

## Adversarially verified, after a false pass

Running it against the pre-fix workflows reports **exactly the 24 refs this PR pinned**:

```
pre-fix workflows staged: 18
unpinned refs found: 24
   17  pnpm/action-setup@v6
    2  jdx/mise-action@v4
    1  softprops/action-gh-release@v3
    …
```

My first attempt at that check reported **0**, because the fixture directory was empty — `git ls-tree` without `-r` had staged nothing. An empty input reports zero and is indistinguishable from success, so the staging count is now asserted before the result is believed.

The same attempt also revealed the script ran its check on `import`, which made the import-based test print the *current* tree's verdict rather than the fixture's. Added the entry guard the repo's other scripts use, and said so in the comment.

Fixes #546
