### PR TITLE
fix(security): pass TUFF_ENCRYPTION_KEY through env instead of splicing it into bash

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -192,12 +192,19 @@ jobs:
 
       - name: Set Build Environment Variables
         shell: bash
+        env:
+          # Passed as an environment value rather than spliced into the script text below.
+          # A secret containing a quote or $(…) would otherwise be either a bash syntax error
+          # that fails every release build on all three runners, or a command substitution
+          # bash executes. Log masking does not help — the value is evaluated, not printed
+          # (#540). The same secret is already passed this way at the build step further down.
+          TUFF_ENCRYPTION_KEY: ${{ secrets.TUFF_ENCRYPTION_KEY }}
         run: |
           # GitHub Actions 自动提供 GITHUB_SHA
-          echo "GITHUB_SHA is set: ${{ github.sha }}"
+          echo "GITHUB_SHA is set: ${GITHUB_SHA}"
           echo "Setting Electron download/cache mirrors..."
           # TUFF_ENCRYPTION_KEY 从 secrets 中获取，如果不存在则为空（非官方构建）
-          if [ -n "${{ secrets.TUFF_ENCRYPTION_KEY }}" ]; then
+          if [ -n "${TUFF_ENCRYPTION_KEY}" ]; then
             echo "TUFF_ENCRYPTION_KEY is set (official build)"
           else
             echo "TUFF_ENCRYPTION_KEY is not set (unofficial build)"

--- a/scripts/check-workflow-injection.mjs
+++ b/scripts/check-workflow-injection.mjs
@@ -33,8 +33,16 @@ import { fileURLToPath } from 'node:url'
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const WORKFLOWS = path.join(ROOT, '.github', 'workflows')
 
-/** Contexts a caller can put arbitrary text into. */
+/**
+ * Contexts whose value must not become script text.
+ *
+ * `secrets.` is here for a different reason from the rest: it is not caller-controlled, but
+ * a secret containing a quote or `$(…)` is either a syntax error that fails every build or a
+ * command substitution bash executes — and log masking cannot help, because the value is
+ * evaluated rather than printed (#540).
+ */
 const UNSAFE = [
+  'secrets.',
   'github.event.inputs.',
   'inputs.',
   'github.event.issue.',
@@ -99,6 +107,16 @@ function selfTest() {
     {
       name: 'the same value in env: is allowed',
       text: '      env:\n        X: ${{ github.event.inputs.tag }}\n      run: |\n        echo "$X"\n',
+      expect: 0,
+    },
+    {
+      name: 'a secret inside run: is caught',
+      text: '      run: |\n        if [ -n "${{ secrets.API_KEY }}" ]; then :; fi\n',
+      expect: 1,
+    },
+    {
+      name: 'a secret in env: is allowed',
+      text: '      env:\n        API_KEY: ${{ secrets.API_KEY }}\n      run: |\n        echo "$API_KEY"\n',
       expect: 0,
     },
     {


### PR DESCRIPTION
## What

```bash
# before
if [ -n "${{ secrets.TUFF_ENCRYPTION_KEY }}" ]; then
```

The secret becomes part of the command text. A value containing a quote is a bash syntax error that fails **every release build on all three runners**; a value containing `$(…)` is a command substitution bash executes. Log masking protects neither — the value is evaluated, not printed.

## The fix is the file's own pattern

The step had **no `env:` block at all**. The same secret is already passed via `env:` at the build step further down (`:406`), so this restores consistency rather than introducing a convention.

```
env keys: TUFF_ENCRYPTION_KEY
run mentions secrets.: false
run uses $GITHUB_SHA: true
```

That last line: the neighbouring `echo "GITHUB_SHA is set: ${{ github.sha }}"` sits directly under a comment saying *「GitHub Actions 自动提供 GITHUB_SHA」*. Interpolating it contradicted the comment for no benefit, so it now reads the variable the comment describes.

## Only one site

Scanned all 18 workflows, with a positive control so an empty result could not read as clean:

```
secrets interpolated into a run: body — 1
  build-and-release.yml:200  if [ -n "${{ secrets.TUFF_ENCRYPTION_KEY }}" ]; then

positive control: 22 secrets. mentions in that file  ← the scanner does see them
```

## Guard extended

`check-workflow-injection.mjs` (added for #539) now treats `secrets.` as unsafe inside a `run:` body, with its own rationale recorded — unlike the caller-controlled contexts it already policed, a secret is not attacker text; the risk is that its *content* becomes script.

Two new self-test cases, one caught and one allowed:

```
ok   a secret inside run: is caught
ok   a secret in env: is allowed
```

Adversarially verified against the pre-fix file: exactly line 200. (The `github.event.inputs` findings are absent because #539 already fixed those — consistent with this branch's base.)

## Process note

I lint-checked **before** committing this time. In #539 I pushed twice on `eslint` exit 1 and only looked afterwards.

Fixes #540
