### PR TITLE
test(core-app): pin the accelerator platform before the module captures it (#323)

### DIFF
--- a/apps/core-app/src/main/modules/global-shortcon.test.ts
+++ b/apps/core-app/src/main/modules/global-shortcon.test.ts
@@ -3,7 +3,21 @@ import {
   ShortcutTriggerKind,
   ShortcutType
 } from '@talex-touch/utils/common/storage/entity/shortcut-settings'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest'
+
+// global-shortcon.ts computes `isMacPlatform` at module scope, so the Option/Alt
+// spelling is fixed the moment it is imported -- a beforeAll pin would be too
+// late. Hoisted so it runs before the import graph; the suite covers migration
+// of a persisted default, and only the token spelling is platform-specific.
+const originalPlatform = vi.hoisted(() => {
+  const previous = process.platform
+  Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+  return previous
+})
+
+afterAll(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+})
 
 const electronMocks = vi.hoisted(() => ({
   register: vi.fn(() => true),


### PR DESCRIPTION
The shortcut suite asserts `'CommandOrControl+Option+7'` and gets `'CommandOrControl+Alt+7'` on the Linux runner. `global-shortcon.ts` maps `OPTION`/`OPT` to `Option` on macOS and `Alt` elsewhere, so it passes on a macOS host and fails on CI — the same shape as the darwin suite in #1157.

## The pin has to be hoisted, not in `beforeAll`

`isMacPlatform` is a **module-scope const**, evaluated when `global-shortcon.ts` is imported. By the time a `beforeAll` hook runs, the spelling is already fixed.

That is the **opposite** of #1157, where the platform is read per call and `beforeAll` was early enough. Worth checking each time rather than copying the pattern across — I verified it here rather than assuming.

## Why pin rather than derive

The suite covers migration of a persisted default; only the token spelling is platform-specific. Pinning keeps the assertion a literal value. Deriving the expected token from the same mapping the code uses would make the test agree with the code even when the code is wrong.

## Two controls

| | |
|---|---|
| flip platform to `'linux'` above everything, before hoisting | **7/7** — the pin genuinely takes effect from a Linux host |
| hardcode `isMacPlatform = false` in the module | **1 failed** — the assertion still catches a real break |

Expected: **10 → 9 failing files and tests.**

Refs #323