### PR TITLE
fix(security): read the CF Access client secret from secrets only

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1270,8 +1270,13 @@ jobs:
     env:
       NEXUS_BASE_URL: ${{ vars.NEXUS_SYNC_BASE_URL || 'https://tuff.tagzxia.com' }}
       NEXUS_API_KEY: ${{ secrets.NEXUS_API_KEY }}
+      # The client ID is an identifier, so a variable is a reasonable place for it.
+      # The client secret is not: repository and organization variables are plaintext
+      # configuration, readable in the settings UI and the API, and never masked in Actions
+      # logs — so a `curl -v` printing the CF-Access-Client-Secret header would put standing
+      # access to the Nexus admin API into a public release log (#541). Secrets only.
       NEXUS_CF_ACCESS_CLIENT_ID: ${{ vars.ADMIN_CF_ACCESS_CLIENT_ID || secrets.ADMIN_CF_ACCESS_CLIENT_ID }}
-      NEXUS_CF_ACCESS_CLIENT_SECRET: ${{ vars.ADMIN_CF_ACCESS_CLIENT_SECRET || secrets.ADMIN_CF_ACCESS_CLIENT_SECRET }}
+      NEXUS_CF_ACCESS_CLIENT_SECRET: ${{ secrets.ADMIN_CF_ACCESS_CLIENT_SECRET }}
       TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sync_tag || github.ref_name }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -1279,6 +1284,23 @@ jobs:
         run: |
           if [ -z "${NEXUS_API_KEY}" ]; then
             echo "NEXUS_API_KEY is required for release sync."
+            exit 1
+          fi
+
+          # Cloudflare Access is optional — both empty means it is not in front of Nexus.
+          # Half-configured is not, and it is the state a setup that kept the client secret
+          # in a *variable* lands in, because this job now reads it from secrets only (#541).
+          # Saying so here beats an opaque 403 several steps later.
+          if [ -n "${NEXUS_CF_ACCESS_CLIENT_ID}" ] && [ -z "${NEXUS_CF_ACCESS_CLIENT_SECRET}" ]; then
+            echo "NEXUS_CF_ACCESS_CLIENT_ID is set but NEXUS_CF_ACCESS_CLIENT_SECRET is empty."
+            echo "The client secret is read from secrets.ADMIN_CF_ACCESS_CLIENT_SECRET only."
+            echo "If it is currently stored as a repository or organization *variable*, move it"
+            echo "to a secret — variables are plaintext and are never masked in workflow logs."
+            exit 1
+          fi
+
+          if [ -z "${NEXUS_CF_ACCESS_CLIENT_ID}" ] && [ -n "${NEXUS_CF_ACCESS_CLIENT_SECRET}" ]; then
+            echo "NEXUS_CF_ACCESS_CLIENT_SECRET is set but NEXUS_CF_ACCESS_CLIENT_ID is empty."
             exit 1
           fi
 


### PR DESCRIPTION
## What

```yaml
# before
NEXUS_CF_ACCESS_CLIENT_SECRET: ${{ vars.ADMIN_CF_ACCESS_CLIENT_SECRET || secrets.ADMIN_CF_ACCESS_CLIENT_SECRET }}
# after
NEXUS_CF_ACCESS_CLIENT_SECRET: ${{ secrets.ADMIN_CF_ACCESS_CLIENT_SECRET }}
```

Repository and organization variables are plaintext configuration — readable in the settings UI and the API, and **never masked in Actions logs**. An operator following the first branch would have put a Cloudflare Access service-token secret where a `curl -v` printing the `CF-Access-Client-Secret` header would leak standing access to the Nexus admin API into a public release log.

The **client ID** keeps its vars-first fallback: it is an identifier, not a credential. That distinction is now stated at the line instead of left to be inferred from which one has "SECRET" in the name.

## What I could and could not verify

```
repository variables : (none)
repository secrets   : 16, and ADMIN_CF_ACCESS_CLIENT_SECRET is not among them
organization scope   : 403 — this token lacks admin:org
```

So at repository level nothing breaks. **I cannot see the organization scope**, which means I cannot rule out that the value lives there as a variable today — in which case this change makes the sync fail.

## Which is why there is a guard, not just a deletion

The job's credential validation only checked `NEXUS_API_KEY`. Added a half-configured check:

```bash
if [ -n "${NEXUS_CF_ACCESS_CLIENT_ID}" ] && [ -z "${NEXUS_CF_ACCESS_CLIENT_SECRET}" ]; then
  echo "The client secret is read from secrets.ADMIN_CF_ACCESS_CLIENT_SECRET only."
  echo "If it is currently stored as a repository or organization *variable*, move it"
  echo "to a secret — variables are plaintext and are never masked in workflow logs."
  exit 1
fi
```

Cloudflare Access is optional — both values empty means it is not in front of Nexus — but ID-without-secret is precisely the state a vars-based setup lands in after this change. Without the guard it would surface as an opaque 403 several steps into a release. With it, the first failure says what to do.

## Repo-wide check

The only other `vars.*` match against `SECRET|TOKEN|PASSWORD|PRIVATE` is `AI_REVIEW_MAX_OUTPUT_TOKENS` — a token *count*, matched because "TOKENS" contains "TOKEN". Not a credential; flagged here so it does not look overlooked.

Fixes #541
