### PR TITLE
fix(core-app): guard the Windows 7 GPU workaround with a platform check (#323)

### DIFF
--- a/apps/core-app/src/main/core/precore.ts
+++ b/apps/core-app/src/main/core/precore.ts
@@ -206,8 +206,11 @@ if (parseBooleanEnv(process.env.TUFF_V8_JITLESS)) {
 
 app.commandLine.appendSwitch('js-flags', v8JsFlags.join(' '))
 
-// Disable GPU Acceleration for Windows 7
-if (release().startsWith('6.1')) app.disableHardwareAcceleration()
+// Disable GPU Acceleration for Windows 7 (NT 6.1).
+// The platform guard is load-bearing: os.release() returns the kernel version on
+// Linux, and 6.1 is an LTS line (Debian 12), so without it every such machine
+// silently loses hardware acceleration on the strength of a Windows check.
+if (process.platform === 'win32' && release().startsWith('6.1')) app.disableHardwareAcceleration()
 
 // Set application name for Windows 10+ notifications
 if (process.platform === 'win32') app.setAppUserModelId(app.getName())


### PR DESCRIPTION
```ts
// Disable GPU Acceleration for Windows 7
if (release().startsWith('6.1')) app.disableHardwareAcceleration()
```

The comment says Windows 7 (NT 6.1). The condition **never checks the platform**.

`os.release()` returns the *kernel* version on Linux, and **6.1 is an LTS line** — Debian 12 ships 6.1.0. On any such machine the app silently disables hardware acceleration on the strength of a Windows version test.

The very next line already shows the intended shape:

```ts
if (process.platform === 'win32') app.setAppUserModelId(app.getName())
```

## How it surfaced

Two #323 failures on the Ubuntu runner — `app.disableHardwareAcceleration is not a function` and `Cannot read properties of undefined (reading 'commandLine')` — because `precore` reached those calls on electron mocks that do not provide them.

It would be easy to read those as incomplete mocks and extend them. They are **symptoms of the missing guard**: on a correctly-guarded build the branch is never taken off Windows, so the mocks were never wrong.

Category 1 in this issue's triage: a product regression, not a test problem. It is also user-facing — the runner is not special here, any Linux 6.1 host loses GPU acceleration.

## Not verified locally

This worktree has no electron binary, so both suites die before running (`Electron failed to install correctly`). CI is the check for this one; I would rather say so than imply a local pass.

Expected: **9 → 7 failing files and tests.**

Refs #323