### PR TITLE
test(core-app): stub talex-mica-electron in the division-box session suite (#323)

### DIFF
--- a/apps/core-app/src/main/modules/division-box/session.test.ts
+++ b/apps/core-app/src/main/modules/division-box/session.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it, vi } from 'vitest'
 import { DivisionBoxSession } from './session'
 import { resolveDivisionBoxHeaderHeight, resolveDivisionBoxInitialWindowBounds } from './layout'
 
+// talex-mica-electron reads app.commandLine in its module body, so importing
+// ./session transitively crashes at collection with 'Cannot read properties of
+// undefined' before a single test runs. Same stub the intelligence harness uses.
+vi.mock('talex-mica-electron', () => ({
+  IS_WINDOWS_11: false,
+  WIN10: false,
+  MicaBrowserWindow: class MicaBrowserWindow {},
+  useMicaElectron: vi.fn()
+}))
+
 vi.mock('../plugin/plugin-module', () => ({
   pluginModule: { pluginManager: null }
 }))


### PR DESCRIPTION
`session.test.ts` imports `./session`, which transitively loads `talex-mica-electron`. That module reads `app.commandLine` **in its body**, and in a vitest process `require('electron')` yields a path string rather than the API — so `app` is undefined and the file dies at collection:

```
TypeError: Cannot read properties of undefined (reading 'commandLine')
  at talex-mica-electron/main.js
```

No test ran, which is why this suite reported a single failure with no test name attached. Stubbed with the same shape `intelligence-test-harness.ts` already uses.

Worth separating from #1164: that failure looked identical (`commandLine` on an undefined `app`) but had a different cause — an unguarded Windows check in `precore`. Two failures with the same message, two unrelated fixes.

**Not verified locally** — this worktree has no electron binary, so the suite cannot start here. CI is the check.

Refs #323