### PR TITLE
fix(utils): stop isAbsolutePath crashing in every window context

### DIFF
--- a/packages/utils/__tests__/safe-path.browser.test.ts
+++ b/packages/utils/__tests__/safe-path.browser.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest'
+import { isAbsolutePath, normalizeAbsolutePath } from '../common/utils/safe-path'
+import { hasWindow } from '../env'
+
+/**
+ * The window half of safe-path, which is where #580 lived.
+ *
+ * `safe-path` picks its path implementation once, at module load, from `hasWindow()`. Under
+ * the repo's default `environment: 'node'` it therefore picks `node:path`, whose `win32` is
+ * a real object — so the old `path.win32.isAbsolute(…)` worked and a node-environment test
+ * passed against the broken code. It has to be jsdom, and it has to be jsdom *before* the
+ * import above, which is what the pragma on line 1 arranges.
+ *
+ * With a window, `path` is path-browserify, whose `win32` is `null`.
+ */
+describe('isAbsolutePath in a window context', () => {
+  it('does not throw for a relative path', () => {
+    // This threw `Cannot read properties of null (reading 'isAbsolute')`.
+    expect(() => isAbsolutePath('foo/bar')).not.toThrow()
+    expect(isAbsolutePath('foo/bar')).toBe(false)
+  })
+
+  it('does not throw for the empty string', () => {
+    expect(() => isAbsolutePath('')).not.toThrow()
+    expect(isAbsolutePath('')).toBe(false)
+  })
+
+  it('recognises a windows drive path instead of throwing', () => {
+    expect(isAbsolutePath('C:\\Users\\me')).toBe(true)
+    expect(isAbsolutePath('c:/users/me')).toBe(true)
+  })
+
+  it('recognises a UNC path', () => {
+    expect(isAbsolutePath('\\\\server\\share\\x')).toBe(true)
+  })
+
+  it('still recognises posix absolute paths', () => {
+    expect(isAbsolutePath('/foo/bar')).toBe(true)
+  })
+
+  it('lets normalizeAbsolutePath reject relative input rather than crash', () => {
+    // normalizeAbsolutePath calls isAbsolutePath, so it crashed on the same inputs — for a
+    // renderer that meant an exception where a null was the documented answer.
+    expect(() => normalizeAbsolutePath('foo/bar')).not.toThrow()
+    expect(normalizeAbsolutePath('foo/bar')).toBeNull()
+  })
+
+  it('confirms the environment really is a window, so these assertions mean something', () => {
+    // Asserted through the same predicate safe-path branches on, not through `typeof window`
+    // directly. Without this the whole file would silently degrade into a duplicate of the
+    // node-side tests if the pragma on line 1 were ever dropped.
+    expect(hasWindow()).toBe(true)
+  })
+})

--- a/packages/utils/__tests__/safe-path.test.ts
+++ b/packages/utils/__tests__/safe-path.test.ts
@@ -1,0 +1,93 @@
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { isAbsolutePath, isSafePathSegment, normalizeAbsolutePath } from '../common/utils/safe-path'
+
+/**
+ * These run under vitest, where `window` is undefined, so `safe-path` picks `node:path`.
+ * The bug they cover only appeared when `window` existed and path-browserify was chosen —
+ * its `win32` property is `null`, and the old implementation dereferenced it (#580).
+ *
+ * Rather than fake a window, the browser half is covered by asserting the win32 rule the
+ * fix now implements inline is the same rule `node:path.win32.isAbsolute` applies. If the
+ * two ever diverge, a renderer and the main process would disagree about whether a path is
+ * absolute, which is the failure mode worth pinning.
+ */
+describe('isAbsolutePath', () => {
+  it('accepts posix absolute paths', () => {
+    expect(isAbsolutePath('/foo/bar')).toBe(true)
+    expect(isAbsolutePath('/')).toBe(true)
+  })
+
+  it('accepts windows drive and UNC paths on any platform', () => {
+    expect(isAbsolutePath('C:\\Users\\me')).toBe(true)
+    expect(isAbsolutePath('c:/users/me')).toBe(true)
+    expect(isAbsolutePath('\\\\server\\share\\x')).toBe(true)
+  })
+
+  it('returns false rather than throwing for the inputs that used to crash', () => {
+    // Every one of these threw `Cannot read properties of null (reading 'isAbsolute')` in a
+    // window context, because they are exactly the inputs the posix check answers false to.
+    for (const value of ['foo/bar', '', '../x', './x', 'C:', 'C:foo'])
+      expect(isAbsolutePath(value)).toBe(false)
+  })
+
+  it('agrees with node:path.win32.isAbsolute on the whole surface', () => {
+    const cases = [
+      'C:\\Users\\me',
+      'c:/users/me',
+      'C:',
+      'C:foo',
+      'C:/',
+      '\\\\server\\share\\x',
+      '//server/share/x',
+      '\\\\server',
+      '\\\\',
+      '/foo',
+      '\\foo',
+      '/',
+      '\\',
+      'foo',
+      '',
+      '../x',
+      './x',
+      '.',
+      '..',
+      'Z:\\',
+      '1:\\x',
+      'a',
+    ]
+
+    for (const value of cases) {
+      // isAbsolutePath is posix-OR-win32, so it may be true where win32 alone is false.
+      // What must never happen is win32 saying true while isAbsolutePath says false.
+      if (path.win32.isAbsolute(value))
+        expect(isAbsolutePath(value), `win32 absolute: ${JSON.stringify(value)}`).toBe(true)
+    }
+  })
+})
+
+describe('normalizeAbsolutePath', () => {
+  it('returns null for relative input instead of throwing', () => {
+    expect(normalizeAbsolutePath('foo/bar')).toBeNull()
+    expect(normalizeAbsolutePath('')).toBeNull()
+  })
+
+  it('rejects a null byte', () => {
+    expect(normalizeAbsolutePath('/foo\0bar')).toBeNull()
+  })
+
+  it('normalizes an absolute path', () => {
+    expect(normalizeAbsolutePath('/foo/./bar')).toBe(path.normalize('/foo/./bar'))
+  })
+})
+
+describe('isSafePathSegment', () => {
+  it('rejects separators, traversal and empty input', () => {
+    for (const value of ['', ' ', '.', '..', 'a/b', 'a\\b', 'a\0b'])
+      expect(isSafePathSegment(value)).toBe(false)
+  })
+
+  it('accepts an ordinary name', () => {
+    expect(isSafePathSegment('plugin-name')).toBe(true)
+  })
+})

--- a/packages/utils/common/utils/safe-path.ts
+++ b/packages/utils/common/utils/safe-path.ts
@@ -10,7 +10,8 @@ const path = (() => {
   if (nodeRequire) {
     try {
       return nodeRequire('node:path')
-    } catch {
+    }
+    catch {
       return pathBrowserify
     }
   }
@@ -30,30 +31,51 @@ export interface SafePathOptions {
 
 const NULL_BYTE_PATTERN = /\0/
 
+/**
+ * `node:path.win32.isAbsolute` without `node:path`.
+ *
+ * In any window context `path` above is path-browserify, whose `win32` property is `null`.
+ * Dereferencing it threw a TypeError for every input the POSIX check answered `false` to —
+ * which is every relative path, every Windows path and the empty string, i.e. the whole
+ * "no" half of a predicate whose job is to answer yes or no (#580).
+ *
+ * Verified equivalent to `node:path.win32.isAbsolute` across 23 cases including drive
+ * letters, UNC prefixes, bare `\\`, single leading separators and `C:foo`. A leading
+ * separator alone counts, which is what an earlier drive-letter-or-UNC form of this regex
+ * got wrong on four of them.
+ */
+const WIN32_ABSOLUTE_PATTERN = /^(?:[\\/]|[a-z]:[\\/])/i
+
 export function isAbsolutePath(value: string): boolean {
-  return path.isAbsolute(value) || path.win32.isAbsolute(value)
+  return path.isAbsolute(value) || WIN32_ABSOLUTE_PATTERN.test(value)
 }
 
 export function isSafePathSegment(value: string): boolean {
   const trimmed = value.trim()
-  if (!trimmed || trimmed === '.' || trimmed === '..') return false
-  if (NULL_BYTE_PATTERN.test(trimmed)) return false
-  if (trimmed.includes('/') || trimmed.includes('\\')) return false
+  if (!trimmed || trimmed === '.' || trimmed === '..')
+    return false
+  if (NULL_BYTE_PATTERN.test(trimmed))
+    return false
+  if (trimmed.includes('/') || trimmed.includes('\\'))
+    return false
   return true
 }
 
 export function normalizeAbsolutePath(value: string): string | null {
   const trimmed = value.trim()
-  if (!trimmed) return null
-  if (!isAbsolutePath(trimmed)) return null
-  if (NULL_BYTE_PATTERN.test(trimmed)) return null
+  if (!trimmed)
+    return null
+  if (!isAbsolutePath(trimmed))
+    return null
+  if (NULL_BYTE_PATTERN.test(trimmed))
+    return null
   return path.normalize(trimmed)
 }
 
 export function resolveSafePath(
   baseDir: string,
   targetPath: string,
-  options: SafePathOptions = {}
+  options: SafePathOptions = {},
 ): SafePathResult {
   const allowAbsolute = options.allowAbsolute ?? false
   const allowRoot = options.allowRoot ?? false
@@ -93,7 +115,7 @@ export function resolveSafePath(
 export function assertSafePath(
   baseDir: string,
   targetPath: string,
-  options: SafePathOptions = {}
+  options: SafePathOptions = {},
 ): string {
   const result = resolveSafePath(baseDir, targetPath, options)
   if (!result.resolvedPath) {


### PR DESCRIPTION
## The crash

`safe-path` picks path-browserify whenever `window` exists — **every renderer, preload and plugin Surface** — and path-browserify sets `win32` to `null`. So `path.win32.isAbsolute(value)` threw for every input the posix check answered false to:

```
"/foo/bar"        → true
"C:\\Users\\me"   → THROWS  TypeError: Cannot read properties of null (reading 'isAbsolute')
"foo/bar"         → THROWS
""                → THROWS
"../x"            → THROWS
```

That is the **entire "no" half** of a predicate whose job is to answer yes or no. `normalizeAbsolutePath` calls it, so a renderer got an exception where `null` was the documented answer.

## Fix

Replaced the dereference with the rule `node:path.win32.isAbsolute` applies, verified equivalent across 23 inputs.

**My first regex was wrong on four of them.** It required a drive letter or a full UNC prefix; win32 also treats a *single* leading separator as absolute, so `\foo` and bare `\\` are true. Checking against the real implementation rather than against my model of it is what caught that.

## Two test files, because one would have been useless

`safe-path.test.ts` (node environment) **passes against the broken implementation** — under `environment: 'node'` safe-path picks `node:path`, whose `win32` is a real object, so the old code works there. I wrote that file first, ran the adversarial check, and got 9/9 both ways. It proved nothing.

`safe-path.browser.test.ts` carries `// @vitest-environment jsdom` on line 1, so `window` exists *before* the import and the module resolves path-browserify at load time. Against the pre-fix code:

```
× does not throw for a relative path        → 'TypeError: Cannot read properties of null…'
× does not throw for the empty string       → same
× recognises a windows drive path           → Cannot read properties of null (reading 'isAbsolute')
× recognises a UNC path                     → same
× lets normalizeAbsolutePath reject relative input rather than crash
  Tests  5 failed | 2 passed (7)
```

With the fix, 7/7. The two that pass either way are the posix case and the environment assertion — correctly, since neither touches `win32`.

That last one asserts `hasWindow()` is true rather than `typeof window`, both because the repo lints against the latter and because it is the exact predicate `safe-path` branches on. Without it the file would silently degrade into a duplicate of the node-side tests if the pragma were ever dropped — which is how I got a meaningless green the first time.

## Verification

```
packages/utils full suite:  131 files, 1030 passed | 1 skipped
eslint:                     exit 0
collection confirmed:       16 safe-path entries in `vitest list`
```

Fixes #580
