### PR TITLE
fix(renderer): read file paths with either separator, not just '/'

### DIFF
--- a/apps/core-app/src/renderer/src/components/render/ItemSubtitle.vue
+++ b/apps/core-app/src/renderer/src/components/render/ItemSubtitle.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { FileType, TuffItem, TuffRender } from '@talex-touch/utils'
 import { getFileTypeFromPath } from '@talex-touch/utils'
+import { displayParentName } from '@talex-touch/utils/common/utils/safe-path'
 import dayjs from 'dayjs'
-import path from 'path-browserify'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { resolveI18nText } from '~/modules/lang/resolve-i18n-text'
@@ -17,7 +17,8 @@ const sourceType = computed(() => props.item.source.type)
 const { t } = useI18n()
 
 function formatBytes(bytes, decimals = 2) {
-  if (bytes === 0) return '0 Bytes'
+  if (bytes === 0)
+    return '0 Bytes'
   const k = 1024
   const dm = decimals < 0 ? 0 : decimals
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
@@ -25,7 +26,7 @@ function formatBytes(bytes, decimals = 2) {
   return `${Number.parseFloat((bytes / k ** i).toFixed(dm))} ${sizes[i]}`
 }
 
-type FileInfo = { path: string; size?: number; modified_at?: string | number }
+interface FileInfo { path: string, size?: number, modified_at?: string | number }
 
 const fileInfo = computed<FileInfo | null>(() => {
   if (sourceType.value !== 'file' && props.item.kind !== 'file') {
@@ -39,39 +40,40 @@ const fileInfo = computed<FileInfo | null>(() => {
   return file as FileInfo
 })
 
-const FILE_TYPE_META: Record<string, { icon: string; key: string }> = {
-  Image: { icon: 'i-ri-image-2-line', key: 'coreBox.fileTypes.image' },
-  Document: { icon: 'i-ri-file-text-line', key: 'coreBox.fileTypes.document' },
-  Audio: { icon: 'i-ri-music-2-line', key: 'coreBox.fileTypes.audio' },
-  Video: { icon: 'i-ri-video-line', key: 'coreBox.fileTypes.video' },
-  Archive: { icon: 'i-ri-archive-line', key: 'coreBox.fileTypes.archive' },
-  Code: { icon: 'i-ri-code-line', key: 'coreBox.fileTypes.code' },
-  Text: { icon: 'i-ri-file-list-3-line', key: 'coreBox.fileTypes.text' },
-  Design: { icon: 'i-ri-palette-line', key: 'coreBox.fileTypes.design' },
+const FILE_TYPE_META: Record<string, { icon: string, key: string }> = {
+  'Image': { icon: 'i-ri-image-2-line', key: 'coreBox.fileTypes.image' },
+  'Document': { icon: 'i-ri-file-text-line', key: 'coreBox.fileTypes.document' },
+  'Audio': { icon: 'i-ri-music-2-line', key: 'coreBox.fileTypes.audio' },
+  'Video': { icon: 'i-ri-video-line', key: 'coreBox.fileTypes.video' },
+  'Archive': { icon: 'i-ri-archive-line', key: 'coreBox.fileTypes.archive' },
+  'Code': { icon: 'i-ri-code-line', key: 'coreBox.fileTypes.code' },
+  'Text': { icon: 'i-ri-file-list-3-line', key: 'coreBox.fileTypes.text' },
+  'Design': { icon: 'i-ri-palette-line', key: 'coreBox.fileTypes.design' },
   '3D Model': { icon: 'i-ri-cube-line', key: 'coreBox.fileTypes.model3D' },
-  Font: { icon: 'i-ri-english-input', key: 'coreBox.fileTypes.font' },
-  Spreadsheet: { icon: 'i-ri-table-line', key: 'coreBox.fileTypes.spreadsheet' },
-  Presentation: { icon: 'i-ri-slideshow-line', key: 'coreBox.fileTypes.presentation' },
-  Ebook: { icon: 'i-ri-book-3-line', key: 'coreBox.fileTypes.ebook' },
-  Other: { icon: 'i-ri-more-2-line', key: 'coreBox.fileTypes.other' }
+  'Font': { icon: 'i-ri-english-input', key: 'coreBox.fileTypes.font' },
+  'Spreadsheet': { icon: 'i-ri-table-line', key: 'coreBox.fileTypes.spreadsheet' },
+  'Presentation': { icon: 'i-ri-slideshow-line', key: 'coreBox.fileTypes.presentation' },
+  'Ebook': { icon: 'i-ri-book-3-line', key: 'coreBox.fileTypes.ebook' },
+  'Other': { icon: 'i-ri-more-2-line', key: 'coreBox.fileTypes.other' },
 }
 
 const fileTypeMeta = computed(() => {
-  if (!fileInfo.value) return null
+  if (!fileInfo.value)
+    return null
   const type = getFileTypeFromPath(fileInfo.value.path) as FileType
   const meta = FILE_TYPE_META[type] || FILE_TYPE_META.Other
   const translated = t(meta.key)
   const label = translated === meta.key ? type : translated
   return {
     icon: meta.icon,
-    label
+    label,
   }
 })
 
 const recommendationBadge = computed(() => {
   const meta = props.item.meta as Record<string, unknown> | undefined
   const recommendation = meta?.recommendation as
-    | { badge?: { variant?: string; icon?: string; text?: string } }
+    | { badge?: { variant?: string, icon?: string, text?: string } }
     | undefined
   return recommendation?.badge
 })
@@ -118,7 +120,7 @@ const badgeStyle = computed(() => {
         <span class="opacity-50">&bull;</span>
         <span class="flex flex-1 items-center gap-1">
           <i class="i-carbon-folder" />
-          <span class="w-full truncate">{{ path.dirname(fileInfo.path).split('/').pop() }}</span>
+          <span class="w-full truncate">{{ displayParentName(fileInfo.path) }}</span>
         </span>
       </div>
     </template>

--- a/apps/core-app/src/renderer/src/components/render/ItemSubtitle.vue
+++ b/apps/core-app/src/renderer/src/components/render/ItemSubtitle.vue
@@ -17,8 +17,7 @@ const sourceType = computed(() => props.item.source.type)
 const { t } = useI18n()
 
 function formatBytes(bytes, decimals = 2) {
-  if (bytes === 0)
-    return '0 Bytes'
+  if (bytes === 0) return '0 Bytes'
   const k = 1024
   const dm = decimals < 0 ? 0 : decimals
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
@@ -26,7 +25,11 @@ function formatBytes(bytes, decimals = 2) {
   return `${Number.parseFloat((bytes / k ** i).toFixed(dm))} ${sizes[i]}`
 }
 
-interface FileInfo { path: string, size?: number, modified_at?: string | number }
+interface FileInfo {
+  path: string
+  size?: number
+  modified_at?: string | number
+}
 
 const fileInfo = computed<FileInfo | null>(() => {
   if (sourceType.value !== 'file' && props.item.kind !== 'file') {
@@ -40,40 +43,39 @@ const fileInfo = computed<FileInfo | null>(() => {
   return file as FileInfo
 })
 
-const FILE_TYPE_META: Record<string, { icon: string, key: string }> = {
-  'Image': { icon: 'i-ri-image-2-line', key: 'coreBox.fileTypes.image' },
-  'Document': { icon: 'i-ri-file-text-line', key: 'coreBox.fileTypes.document' },
-  'Audio': { icon: 'i-ri-music-2-line', key: 'coreBox.fileTypes.audio' },
-  'Video': { icon: 'i-ri-video-line', key: 'coreBox.fileTypes.video' },
-  'Archive': { icon: 'i-ri-archive-line', key: 'coreBox.fileTypes.archive' },
-  'Code': { icon: 'i-ri-code-line', key: 'coreBox.fileTypes.code' },
-  'Text': { icon: 'i-ri-file-list-3-line', key: 'coreBox.fileTypes.text' },
-  'Design': { icon: 'i-ri-palette-line', key: 'coreBox.fileTypes.design' },
+const FILE_TYPE_META: Record<string, { icon: string; key: string }> = {
+  Image: { icon: 'i-ri-image-2-line', key: 'coreBox.fileTypes.image' },
+  Document: { icon: 'i-ri-file-text-line', key: 'coreBox.fileTypes.document' },
+  Audio: { icon: 'i-ri-music-2-line', key: 'coreBox.fileTypes.audio' },
+  Video: { icon: 'i-ri-video-line', key: 'coreBox.fileTypes.video' },
+  Archive: { icon: 'i-ri-archive-line', key: 'coreBox.fileTypes.archive' },
+  Code: { icon: 'i-ri-code-line', key: 'coreBox.fileTypes.code' },
+  Text: { icon: 'i-ri-file-list-3-line', key: 'coreBox.fileTypes.text' },
+  Design: { icon: 'i-ri-palette-line', key: 'coreBox.fileTypes.design' },
   '3D Model': { icon: 'i-ri-cube-line', key: 'coreBox.fileTypes.model3D' },
-  'Font': { icon: 'i-ri-english-input', key: 'coreBox.fileTypes.font' },
-  'Spreadsheet': { icon: 'i-ri-table-line', key: 'coreBox.fileTypes.spreadsheet' },
-  'Presentation': { icon: 'i-ri-slideshow-line', key: 'coreBox.fileTypes.presentation' },
-  'Ebook': { icon: 'i-ri-book-3-line', key: 'coreBox.fileTypes.ebook' },
-  'Other': { icon: 'i-ri-more-2-line', key: 'coreBox.fileTypes.other' },
+  Font: { icon: 'i-ri-english-input', key: 'coreBox.fileTypes.font' },
+  Spreadsheet: { icon: 'i-ri-table-line', key: 'coreBox.fileTypes.spreadsheet' },
+  Presentation: { icon: 'i-ri-slideshow-line', key: 'coreBox.fileTypes.presentation' },
+  Ebook: { icon: 'i-ri-book-3-line', key: 'coreBox.fileTypes.ebook' },
+  Other: { icon: 'i-ri-more-2-line', key: 'coreBox.fileTypes.other' }
 }
 
 const fileTypeMeta = computed(() => {
-  if (!fileInfo.value)
-    return null
+  if (!fileInfo.value) return null
   const type = getFileTypeFromPath(fileInfo.value.path) as FileType
   const meta = FILE_TYPE_META[type] || FILE_TYPE_META.Other
   const translated = t(meta.key)
   const label = translated === meta.key ? type : translated
   return {
     icon: meta.icon,
-    label,
+    label
   }
 })
 
 const recommendationBadge = computed(() => {
   const meta = props.item.meta as Record<string, unknown> | undefined
   const recommendation = meta?.recommendation as
-    | { badge?: { variant?: string, icon?: string, text?: string } }
+    | { badge?: { variant?: string; icon?: string; text?: string } }
     | undefined
   return recommendation?.badge
 })

--- a/apps/core-app/src/renderer/src/views/box/tag/FileTag.vue
+++ b/apps/core-app/src/renderer/src/views/box/tag/FileTag.vue
@@ -1,5 +1,5 @@
 <script name="FileTag" setup lang="ts">
-import path from 'path-browserify'
+import { displayBasename } from '@talex-touch/utils/common/utils/safe-path'
 import { buildTfileUrl } from '~/utils/tfile-url'
 
 const props = defineProps<{
@@ -24,7 +24,7 @@ const image = computed(() => {
 const firstFileName = computed(() => {
   const [firstPath] = props.paths
 
-  return path.basename(firstPath || '')
+  return displayBasename(firstPath || '')
 })
 
 const fileLength = computed(() => props?.paths.length || 0)
@@ -32,7 +32,7 @@ const fileLength = computed(() => props?.paths.length || 0)
 
 <template>
   <div class="FileTag">
-    <img :src="image" alt="" />
+    <img :src="image" alt="">
     <span class="name">{{ firstFileName }}</span>
     <span v-if="fileLength - 1" class="badge" v-text="fileLength" />
   </div>

--- a/apps/core-app/src/renderer/src/views/box/tag/FileTag.vue
+++ b/apps/core-app/src/renderer/src/views/box/tag/FileTag.vue
@@ -32,7 +32,7 @@ const fileLength = computed(() => props?.paths.length || 0)
 
 <template>
   <div class="FileTag">
-    <img :src="image" alt="">
+    <img :src="image" alt="" />
     <span class="name">{{ firstFileName }}</span>
     <span v-if="fileLength - 1" class="badge" v-text="fileLength" />
   </div>

--- a/apps/core-app/src/renderer/src/views/box/tag/UnifiedFileTag.vue
+++ b/apps/core-app/src/renderer/src/views/box/tag/UnifiedFileTag.vue
@@ -1,14 +1,10 @@
 <script name="UnifiedFileTag" setup lang="ts">
-import path from 'path-browserify'
+import type { IClipboardItem } from '../../../modules/box/adapter/hooks/types'
+import { displayBasename, displayExtension } from '@talex-touch/utils/common/utils/safe-path'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { IClipboardItem } from '../../../modules/box/adapter/hooks/types'
 import { createRendererLogger } from '~/utils/renderer-log'
 import { buildTfileUrl } from '~/utils/tfile-url'
-
-const { t } = useI18n()
-const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'svg', 'webp', 'gif', 'bmp', 'ico'])
-const unifiedFileTagLog = createRendererLogger('UnifiedFileTag')
 
 /**
  * Unified file tag component that handles both FILE mode and clipboard files
@@ -22,16 +18,21 @@ const props = defineProps<{
   /** Clipboard data object (clipboard files) */
   clipboardData?: IClipboardItem | null
 }>()
+const { t } = useI18n()
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'svg', 'webp', 'gif', 'bmp', 'ico'])
+const unifiedFileTagLog = createRendererLogger('UnifiedFileTag')
 
 /**
  * Validate if a string is a valid file path
  * Filters out IDs, placeholders, and malformed paths
  */
 function isValidFilePath(str: string): boolean {
-  if (!str || typeof str !== 'string') return false
+  if (!str || typeof str !== 'string')
+    return false
 
   // Reject file IDs and placeholders
-  if (str.includes('file/id=') || str.includes('/.file/id=')) return false
+  if (str.includes('file/id=') || str.includes('/.file/id='))
+    return false
 
   // Must be an absolute path or valid relative path
   const trimmed = str.trim()
@@ -54,7 +55,8 @@ const filePaths = computed(() => {
       if (Array.isArray(parsed)) {
         return parsed.filter(isValidFilePath)
       }
-    } catch (error) {
+    }
+    catch (error) {
       unifiedFileTagLog.error('Failed to parse clipboard file data:', error)
     }
   }
@@ -65,12 +67,14 @@ const filePaths = computed(() => {
 const firstFilePath = computed(() => (filePaths.value.length > 0 ? filePaths.value[0] : null))
 
 function getFileExtension(value: string | null): string {
-  if (!value) return ''
-  return path.extname(value).replace(/^\./, '').toLowerCase()
+  if (!value)
+    return ''
+  return displayExtension(value)
 }
 
 function isImagePath(value: string | null): boolean {
-  if (!value) return false
+  if (!value)
+    return false
   const extension = getFileExtension(value)
   return IMAGE_EXTENSIONS.has(extension)
 }
@@ -84,8 +88,9 @@ const fileCount = computed(() => filePaths.value.length)
  * First file name for display
  */
 const firstFileName = computed(() => {
-  if (filePaths.value.length === 0) return t('boxTag.preparingFiles', '文件准备中...')
-  return path.basename(filePaths.value[0])
+  if (filePaths.value.length === 0)
+    return t('boxTag.preparingFiles', '文件准备中...')
+  return displayBasename(filePaths.value[0])
 })
 
 /**
@@ -129,14 +134,14 @@ const thumbnail = computed(() => {
         :src="thumbnail"
         class="file-icon thumbnail"
         alt="file thumbnail"
-      />
+      >
       <!-- Priority 2: File icon via tfile:// protocol -->
       <img
         v-else-if="fileIconUrl && !isLoading"
         :src="fileIconUrl"
         class="file-icon"
         alt="file icon"
-      />
+      >
       <!-- Priority 3: Fallback icon -->
       <i v-else class="i-ri-file-line file-icon-fallback" />
     </div>

--- a/apps/core-app/src/renderer/src/views/box/tag/UnifiedFileTag.vue
+++ b/apps/core-app/src/renderer/src/views/box/tag/UnifiedFileTag.vue
@@ -27,12 +27,10 @@ const unifiedFileTagLog = createRendererLogger('UnifiedFileTag')
  * Filters out IDs, placeholders, and malformed paths
  */
 function isValidFilePath(str: string): boolean {
-  if (!str || typeof str !== 'string')
-    return false
+  if (!str || typeof str !== 'string') return false
 
   // Reject file IDs and placeholders
-  if (str.includes('file/id=') || str.includes('/.file/id='))
-    return false
+  if (str.includes('file/id=') || str.includes('/.file/id=')) return false
 
   // Must be an absolute path or valid relative path
   const trimmed = str.trim()
@@ -55,8 +53,7 @@ const filePaths = computed(() => {
       if (Array.isArray(parsed)) {
         return parsed.filter(isValidFilePath)
       }
-    }
-    catch (error) {
+    } catch (error) {
       unifiedFileTagLog.error('Failed to parse clipboard file data:', error)
     }
   }
@@ -67,14 +64,12 @@ const filePaths = computed(() => {
 const firstFilePath = computed(() => (filePaths.value.length > 0 ? filePaths.value[0] : null))
 
 function getFileExtension(value: string | null): string {
-  if (!value)
-    return ''
+  if (!value) return ''
   return displayExtension(value)
 }
 
 function isImagePath(value: string | null): boolean {
-  if (!value)
-    return false
+  if (!value) return false
   const extension = getFileExtension(value)
   return IMAGE_EXTENSIONS.has(extension)
 }
@@ -88,8 +83,7 @@ const fileCount = computed(() => filePaths.value.length)
  * First file name for display
  */
 const firstFileName = computed(() => {
-  if (filePaths.value.length === 0)
-    return t('boxTag.preparingFiles', '文件准备中...')
+  if (filePaths.value.length === 0) return t('boxTag.preparingFiles', '文件准备中...')
   return displayBasename(filePaths.value[0])
 })
 
@@ -134,14 +128,14 @@ const thumbnail = computed(() => {
         :src="thumbnail"
         class="file-icon thumbnail"
         alt="file thumbnail"
-      >
+      />
       <!-- Priority 2: File icon via tfile:// protocol -->
       <img
         v-else-if="fileIconUrl && !isLoading"
         :src="fileIconUrl"
         class="file-icon"
         alt="file icon"
-      >
+      />
       <!-- Priority 3: Fallback icon -->
       <i v-else class="i-ri-file-line file-icon-fallback" />
     </div>

--- a/packages/utils/__tests__/safe-path.test.ts
+++ b/packages/utils/__tests__/safe-path.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { isAbsolutePath, isSafePathSegment, normalizeAbsolutePath } from '../common/utils/safe-path'
+import { displayBasename, displayExtension, displayParentName, isAbsolutePath, isSafePathSegment, normalizeAbsolutePath } from '../common/utils/safe-path'
 
 /**
  * These run under vitest, where `window` is undefined, so `safe-path` picks `node:path`.
@@ -89,5 +89,42 @@ describe('isSafePathSegment', () => {
 
   it('accepts an ordinary name', () => {
     expect(isSafePathSegment('plugin-name')).toBe(true)
+  })
+})
+
+describe('display helpers', () => {
+  it('reads a windows path the renderer would otherwise print whole', () => {
+    // path-browserify's sep is '/', so basename returned the entire string and dirname
+    // returned '.' — a file chip showed the full path where it meant the file name (#581).
+    const win = 'C:\\Users\\me\\Documents\\report.PDF'
+    expect(displayBasename(win)).toBe('report.PDF')
+    expect(displayParentName(win)).toBe('Documents')
+    expect(displayExtension(win)).toBe('pdf')
+  })
+
+  it('reads a posix path the same way', () => {
+    const posix = '/home/me/docs/report.pdf'
+    expect(displayBasename(posix)).toBe('report.pdf')
+    expect(displayParentName(posix)).toBe('docs')
+    expect(displayExtension(posix)).toBe('pdf')
+  })
+
+  it('handles a UNC path', () => {
+    expect(displayBasename('\\\\srv\\share\\a.txt')).toBe('a.txt')
+    expect(displayParentName('\\\\srv\\share\\a.txt')).toBe('share')
+  })
+
+  it('treats a leading dot as a hidden file, not an extension', () => {
+    expect(displayBasename('.gitignore')).toBe('.gitignore')
+    expect(displayExtension('.gitignore')).toBe('')
+  })
+
+  it('returns empty strings rather than throwing at the edges', () => {
+    for (const value of ['', '/', 'C:\\', 'report.pdf']) {
+      expect(() => displayBasename(value)).not.toThrow()
+      expect(typeof displayParentName(value)).toBe('string')
+    }
+    expect(displayParentName('report.pdf')).toBe('')
+    expect(displayBasename('')).toBe('')
   })
 })

--- a/packages/utils/common/utils/safe-path.ts
+++ b/packages/utils/common/utils/safe-path.ts
@@ -50,6 +50,42 @@ export function isAbsolutePath(value: string): boolean {
   return path.isAbsolute(value) || WIN32_ABSOLUTE_PATTERN.test(value)
 }
 
+/** Matches either separator, so these work on paths from either platform. */
+const ANY_SEPARATOR_PATTERN = /[\\/]/
+
+/**
+ * Display helpers for paths whose separator is not known at the call site.
+ *
+ * The renderer imports path-browserify, whose `sep` is `/`. Given a Windows path from the
+ * main process, `basename` returns the whole string and `dirname` returns `"."` — so a file
+ * chip showed `C:\Users\me\Documents\report.pdf` where it meant `report.pdf` (#581).
+ * These split on either separator instead of choosing a platform.
+ */
+function segments(value: string): string[] {
+  return String(value ?? '')
+    .split(ANY_SEPARATOR_PATTERN)
+    .filter(Boolean)
+}
+
+/** The final path segment. `''` when there is none. */
+export function displayBasename(value: string): string {
+  return segments(value).at(-1) ?? ''
+}
+
+/** The immediate parent directory's *name*, not the full parent path. `''` at the root. */
+export function displayParentName(value: string): string {
+  const parts = segments(value)
+  return parts.length >= 2 ? parts.at(-2)! : ''
+}
+
+/** Lowercased extension without the leading dot. `''` when there is none. */
+export function displayExtension(value: string): string {
+  const base = displayBasename(value)
+  const dot = base.lastIndexOf('.')
+  // A leading dot is a hidden file, not an extension: `.gitignore` has none.
+  return dot > 0 ? base.slice(dot + 1).toLowerCase() : ''
+}
+
 export function isSafePathSegment(value: string): boolean {
   const trimmed = value.trim()
   if (!trimmed || trimmed === '.' || trimmed === '..')


### PR DESCRIPTION
## Reproduced

path-browserify's `sep` is `/`. Given a Windows path from the main process:

```
sep:        "/"
basename → "C:\\Users\\me\\Documents\\report.pdf"    ← the entire string
dirname  → "."
extname  → ".pdf"                                    ← correct, by luck
posix control: basename("/a/b/c.pdf") → "c.pdf"
```

So a CoreBox file chip printed the whole path where it meant the file name, and `ItemSubtitle` printed `.` where it meant the parent folder — compounding it with a second posix assumption, `.split('/').pop()` on that `dirname`.

`extname` was correct because it only looks for the last dot; that call is a behaviour-preserving move, not a fix.

## Fix

`displayBasename` / `displayParentName` / `displayExtension` added to `safe-path`, splitting on either separator instead of choosing a platform. The three components now use them, and **path-browserify is absent from the renderer entirely**.

```
"C:\\Users\\me\\Documents\\report.PDF"  base="report.PDF"  parent="Documents"  ext="pdf"
"/home/me/docs/report.pdf"              base="report.pdf"  parent="docs"       ext="pdf"
"\\\\srv\\share\\a.txt"                 base="a.txt"       parent="share"      ext="txt"
".gitignore"                            base=".gitignore"  parent=""           ext=""
""                                      base=""            parent=""           ext=""
```

`displayParentName` returns the parent's *name*, not the parent path — that is what the only caller wanted and what its `.split('/').pop()` was reaching for. `displayExtension` treats a leading dot as a hidden file.

## Adversarially verified

Swapping the helpers back to path-browserify-backed implementations:

```
× reads a windows path the renderer would otherwise print whole
× handles a UNC path
× returns empty strings rather than throwing at the edges
  Tests  3 failed | 11 passed (14)
```

The posix and hidden-file cases pass either way — correctly, since path-browserify was never wrong about those. A test that failed on all five would have meant I was testing the helper's shape rather than the defect.

## Verification

```
packages/utils suite:  131 files, 1035 passed | 1 skipped
eslint (touched files): exit 0
path-browserify in apps/core-app/src/renderer: 0 matches
  (positive control: still 3 matches in safe-path.ts, so the scan works)
```

## Pre-existing lint debt, not touched

`ClipboardFileTag.vue`, `ClipboardImageTag.vue` and `TagSection.vue` in the same directory carry 26 lint errors between them. They are unchanged by this PR — I only noticed because I linted the directory glob rather than my two files, and briefly mistook them for mine. `lint:changed` will not flag them either, since they are unchanged. Flagging here rather than fixing, so the scope stays what the issue asked for.

Fixes #581
