### PR TITLE
fix(utils): stop shipping vue as a hard dependency beside its own peer

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -69,12 +69,12 @@
     "fs-extra": "^11.3.6",
     "gsap": "catalog:",
     "marked": "catalog:",
-    "path-browserify": "^1.0.1",
-    "vue": "^3.5.39"
+    "path-browserify": "^1.0.1"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
     "@vitest/coverage-v8": "^3.2.7",
-    "vitest": "^3.2.7"
+    "vitest": "^3.2.7",
+    "vue": "^3.5.39"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1304,9 +1304,6 @@ importers:
       path-browserify:
         specifier: ^1.0.1
         version: 1.0.1
-      vue:
-        specifier: ^3.5.39
-        version: 3.5.39(typescript@5.9.3)
     devDependencies:
       '@types/fs-extra':
         specifier: ^11.0.4
@@ -1317,6 +1314,9 @@ importers:
       vitest:
         specifier: ^3.2.7
         version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.2)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(sass@1.101.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
+      vue:
+        specifier: ^3.5.39
+        version: 3.5.39(typescript@5.9.3)
 
   plugins/clipboard-history:
     dependencies:


### PR DESCRIPTION
## Confirmed on the published artifact

```
$ npm view @talex-touch/utils@1.0.50 dependencies.vue peerDependencies.vue
dependencies.vue     = '^3.5.33'
peerDependencies.vue = '^3.5.27'
```

Both shipped. A consumer installs a second Vue nested under `node_modules/@talex-touch/utils`, so the composables in `packages/utils/renderer` run against it rather than the host's — reactivity created inside utils is invisible to the app that imported it.

## Moved, not deleted

21 files in this package import `vue`, and `.npmrc` sets `auto-install-peers=false`, so a peer alone is not installed for a workspace importer — utils' own tests would stop resolving it. `electron` gets away with peer-only because nothing in the test path imports it.

`devDependencies` keeps vue available here and out of what consumers install. That is the usual shape for a library with a peer dependency.

## Verified on the tarball, not the source manifest

```
packed dependencies.vue     : (absent)
packed peerDependencies.vue : ^3.5.27
```

`devDependencies` remains in the packed manifest — npm does not strip it — but a consumer installing `@talex-touch/utils` does not install its devDependencies, so no nested Vue appears. Checking the source manifest alone would not have shown this either way.

Suite unaffected: **131 files, 1035 passed | 1 skipped**, with vue still resolving.

## Lockfile

```
before  dependencies: @vueuse/core, chalk, chokidar, dayjs, fs-extra, gsap, marked, path-browserify, vue
after   dependencies: @vueuse/core, chalk, chokidar, dayjs, fs-extra, gsap, marked, path-browserify
        devDependencies: @types/fs-extra, @vitest/coverage-v8, vitest, vue
```

Three lines changed, no version moved.

## Not touched

`@vueuse/core` is a dependency with **no** peer — arguably the same shape one step removed, since it is a Vue-ecosystem package that will pull its own Vue expectations along. Different package, different decision; flagged rather than folded in.

Fixes #582
