### PR TITLE
test(core-app): pin the Spotlight icon-cache test to macOS (#323)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/addon/files/native-file-search-provider.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/native-file-search-provider.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { execFileMock, getMainConfigMock, getPathMock, iconCacheEnsureMock, statMock } = vi.hoisted(
   () => ({
@@ -73,6 +73,20 @@ interface SearchableSpotlightProvider {
     signal: AbortSignal
   ) => Promise<Array<{ path: string; name: string; extension: string; isDir: boolean }>>
 }
+
+// The Spotlight path is macOS-only: the provider gates on
+// `process.platform !== this.capabilities.platform`, so on a Linux runner it
+// reports unavailable and warms no icons, and the failure reads as a broken
+// icon cache. Pinned so the macOS behaviour is asserted explicitly.
+const originalPlatform = process.platform
+
+beforeAll(() => {
+  Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+})
+
+afterAll(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+})
 
 describe('native-file-search-provider', () => {
   beforeEach(() => {


### PR DESCRIPTION
`uses cached file icons and warms missing icons for Spotlight results` passes on a macOS host and fails on the Linux runner:

```
expected [] to have a length of 2 but got 0
```

Spotlight is macOS-only, and the provider gates on `process.platform !== this.capabilities.platform` — so on Linux it reports unavailable and warms nothing. The failure reads as a broken icon cache; it is a wrong host.

**Confirmed by reproduction:** forcing `process.platform = 'linux'` on a macOS host produces exactly that failure and no others.

## `beforeAll` is early enough here — checked, not assumed

`process.platform` is read per call in the provider and through default parameters in `app-icon-cache`, with no module-scope capture. Same as the darwin suite in #1157, and **unlike** the shortcut suite in #1162 where `isMacPlatform` is a module-scope const and the pin had to be hoisted. Worth verifying each time rather than copying the pattern.

## Two controls

| | |
|---|---|
| flip platform to `'linux'` above everything | **5/5** — the pin takes effect |
| force `isAvailable()` to false in the provider | **1 failed** — the assertion still catches a real break |

Expected: **6 → 5 failing files and tests.**

Refs #323