### PR TITLE
fix(touch-image): use the workspace unplugin-export-plugin, not npm 0.2.13

### DIFF
--- a/plugins/touch-image/package.json
+++ b/plugins/touch-image/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@iconify-json/ri": "^1.2.10",
-    "@talex-touch/unplugin-export-plugin": "^0.2.13",
+    "@talex-touch/unplugin-export-plugin": "workspace:^",
     "@talex-touch/utils": "workspace:^",
     "@unocss/preset-icons": "^66.7.5",
     "@unocss/preset-uno": "^66.7.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1367,8 +1367,8 @@ importers:
         specifier: ^1.2.10
         version: 1.2.10
       '@talex-touch/unplugin-export-plugin':
-        specifier: ^0.2.13
-        version: 0.2.13
+        specifier: workspace:^
+        version: link:../../packages/unplugin-export-plugin
       '@talex-touch/utils':
         specifier: workspace:^
         version: link:../../packages/utils
@@ -5738,9 +5738,6 @@ packages:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
 
-  '@talex-touch/unplugin-export-plugin@0.2.13':
-    resolution: {integrity: sha512-Jh8jwvkcreTrKhua2xbqfWE+O+kwmzzG2L1/5OSyJDN+Yc6lYsD+xNqXzEwmHuRZx08tNa2RifeWPdCD6RPt8g==}
-
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
 
@@ -9100,9 +9097,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -18901,13 +18895,6 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@talex-touch/unplugin-export-plugin@0.2.13':
-    dependencies:
-      cli-progress: 3.12.0
-      compressing: 1.10.5
-      fs: 0.0.1-security
-      unplugin: 2.3.11
-
   '@tsconfig/node10@1.0.12': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -23013,8 +23000,6 @@ snapshots:
       - react-native-b4a
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true


### PR DESCRIPTION
## What

`plugins/touch-image` declared `^0.2.13` while the workspace package is at **1.2.16**, so it built against an npm copy from a much older API generation.

```
lockfile, before:  specifier: ^0.2.13   version: 0.2.13
lockfile, after:   specifier: workspace:^   version: link:../../packages/unplugin-export-plugin
```

## The sibling settles the risk

A 0.2 → 1.2 jump could have changed the API. It has not, for the usage here:

| | import | call |
|---|---|---|
| touch-image | `@talex-touch/unplugin-export-plugin/vite` | `TouchPluginExport()` |
| touch-translation | **identical** | **identical** |

and `touch-translation` has been on `workspace:^` all along. `touch-image` also already used `workspace:^` for `@talex-touch/utils` — this was the single line that had drifted, not a deliberate pin.

## What the lockfile drops

17 lines, two of them worth naming:

```
- '@talex-touch/unplugin-export-plugin@0.2.13':
-     dependencies:
-       cli-progress: 3.12.0
-       compressing: 1.10.5
-       fs: 0.0.1-security      ← the npm placeholder squatting a Node builtin
-       unplugin: 2.3.11
```

The old release depended on **`fs@0.0.1-security`**, the package npm publishes to squat the name of the `fs` builtin. It is inert, but it was in the tree solely because of this stale pin.

It also pulled `compressing 1.10.5`, which is one side of the split #572 is about — that issue is unaffected either way, since core-app pins `^2.1.1` directly.

Fixes #567