### PR TITLE
build(deps): drop the dead nodemailer catalog entry

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,7 +52,6 @@ catalog:
   marked: ^17.0.6
   mermaid: ^11.16.0
   next-auth: ~4.24.15
-  nodemailer: ^9.0.3
   ogl: ^1.0.11
   openapi-typescript: ^7.13.0
   qrcode: ^1.5.4


### PR DESCRIPTION
## Three claims, all confirmed

```
pnpm-workspace.yaml:55   nodemailer: ^9.0.3
package.json:212         "nodemailer": "^6.6.5 || ^7.0.0"   ← peerDependencyRules
declared in any manifest: none
```

## It was never installed, and the lockfile proves it

Removing the entry leaves `pnpm-lock.yaml` **byte-identical**. That is the evidence for "not installed at all" rather than an inference from the absence of a declaration.

The only two `nodemailer` mentions in the lockfile are inside **next-auth's own peerDependencies block**:

```yaml
nodemailer: ^7.0.7
…
nodemailer:
  optional: true
```

## Why the entry was worse than unused

It contradicted the one opinion about nodemailer that exists in this tree. next-auth wants `^7.0.7` as an optional peer; the root `peerDependencyRules.allowedVersions` allows `^6.6.5 || ^7.0.0` to satisfy it.

A catalog saying `^9.0.3` would have **violated that peer range the moment anyone wrote `catalog:` for nodemailer** — two majors past what next-auth accepts. So it was not a harmless leftover; it was a trap pointing at an incompatible version, sitting in the file people consult to answer "which version do we use".

## What stays

The `peerDependencyRules` entry. It is legitimate, it still matches next-auth's optional peer, and the issue's framing of it as part of the contradiction is right only in the sense that the *catalog* was the wrong side of it.

Fixes #570