### PR TITLE
test(core-app): skip the native integrations loudly when their addon is absent (#323)

### DIFF
--- a/apps/core-app/src/main/modules/native-capabilities/native-screenshot-transport-napi.integration.test.ts
+++ b/apps/core-app/src/main/modules/native-capabilities/native-screenshot-transport-napi.integration.test.ts
@@ -45,7 +45,8 @@ if (!carrierLoad.carrier) {
 }
 
 function loadCarrier(): NapiCarrierInstance {
-  if (!carrierLoad.carrier) throw new Error(`Screenshot test carrier unavailable: ${carrierLoad.reason}`)
+  if (!carrierLoad.carrier)
+    throw new Error(`Screenshot test carrier unavailable: ${carrierLoad.reason}`)
   return carrierLoad.carrier
 }
 

--- a/apps/core-app/src/main/modules/native-capabilities/native-screenshot-transport-napi.integration.test.ts
+++ b/apps/core-app/src/main/modules/native-capabilities/native-screenshot-transport-napi.integration.test.ts
@@ -27,13 +27,29 @@ const screenshotProtocol = require('@talex-touch/tuff-native/screenshot-protocol
   loadScreenshotCarrier: (options?: { clientVersion?: string }) => ScreenshotCarrierLoadResult
 }
 
-function loadCarrier(): NapiCarrierInstance {
-  const loaded = screenshotProtocol.loadScreenshotCarrier({ clientVersion: '2.4.13' })
-  if (!loaded.carrier) throw new Error(`Screenshot test carrier unavailable: ${loaded.reason}`)
-  return loaded.carrier
+// Integration test against the compiled screenshot addon. It is run for real by
+// .github/workflows/native-protocol.yml, which builds the native package before
+// invoking this exact file. The general App-suites job builds nothing native, so
+// the carrier is unavailable there and the suite failed on a missing binding
+// rather than on behaviour.
+//
+// Skipped loudly rather than silently: the loader's own reason is printed, so an
+// unavailable carrier cannot be mistaken for passing coverage.
+const carrierLoad = screenshotProtocol.loadScreenshotCarrier({ clientVersion: '2.4.13' })
+
+if (!carrierLoad.carrier) {
+  console.warn(
+    `[native-screenshot-transport-napi] skipped: carrier unavailable (${carrierLoad.reason}). ` +
+      'CI covers this file in .github/workflows/native-protocol.yml, which builds the addon first.'
+  )
 }
 
-describe('nativeTransport screenshot N-API integration', () => {
+function loadCarrier(): NapiCarrierInstance {
+  if (!carrierLoad.carrier) throw new Error(`Screenshot test carrier unavailable: ${carrierLoad.reason}`)
+  return carrierLoad.carrier
+}
+
+describe.skipIf(!carrierLoad.carrier)('nativeTransport screenshot N-API integration', () => {
   it('runs refresh, PNG capture, frames, cancel, and dispose through the real addon', async () => {
     const carrier = loadCarrier()
     const transport = new NativeTransport({ carriers: [carrier] })

--- a/apps/core-app/src/main/modules/native-capabilities/native-transport-napi.integration.test.ts
+++ b/apps/core-app/src/main/modules/native-capabilities/native-transport-napi.integration.test.ts
@@ -3,6 +3,7 @@ import type {
   NativeProtocolBinding
 } from '@talex-touch/tuff-native/protocol'
 import { Buffer } from 'node:buffer'
+import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -17,15 +18,34 @@ const protocolModule = require('@talex-touch/tuff-native/protocol') as {
   }) => NapiCarrierInstance
 }
 
-function loadFixtureBinding(): NativeProtocolBinding {
-  const fixturePath = path.resolve(
-    process.cwd(),
-    '../../packages/tuff-native/build/fixtures/tuff_native_protocol_fixture.node'
+const FIXTURE_PATH = path.resolve(
+  process.cwd(),
+  '../../packages/tuff-native/build/fixtures/tuff_native_protocol_fixture.node'
+)
+
+// This is an integration test against a compiled Rust addon. It is run for real
+// by .github/workflows/native-protocol.yml, which builds the fixture
+// (`pnpm -C packages/tuff-native run build:protocol-fixture`) and then invokes
+// this exact file. The general App-suites job builds nothing native, so without
+// this guard the suite fails on a missing artifact rather than on behaviour.
+//
+// Skipped loudly rather than silently: the reason and the build command are
+// printed, so an absent fixture cannot be mistaken for passing coverage.
+const fixtureAvailable = existsSync(FIXTURE_PATH)
+
+if (!fixtureAvailable) {
+  console.warn(
+    `[native-transport-napi] skipped: fixture missing at ${FIXTURE_PATH}. ` +
+      'Build it with `pnpm -C packages/tuff-native run build:protocol-fixture`; ' +
+      'CI covers this file in .github/workflows/native-protocol.yml.'
   )
-  return require(fixturePath) as NativeProtocolBinding
 }
 
-describe('NativeTransport real N-API integration', () => {
+function loadFixtureBinding(): NativeProtocolBinding {
+  return require(FIXTURE_PATH) as NativeProtocolBinding
+}
+
+describe.skipIf(!fixtureAvailable)('NativeTransport real N-API integration', () => {
   it('runs unary attachments and credit-bounded streams through all three layers', async () => {
     const carrier = new protocolModule.NapiCarrier({
       id: 'fixture-napi',


### PR DESCRIPTION
Both N-API integration tests require a compiled Rust artifact that the general App-suites job never builds, so they failed on a missing binding rather than on behaviour:

```
Cannot find module packages/tuff-native/build/fixtures/tuff_native_protocol_fixture.node
Screenshot test carrier unavailable: binding-unavailable
```

## Neither is losing coverage

`.github/workflows/native-protocol.yml` builds the native package and the protocol fixture, then invokes **these two files by name** (lines 112 and 133). They run for real there. That is the *linked replacement contract* #323 requires — not a bare skip.

Both now skip when their prerequisite is missing and **print why**, naming the build command and the workflow that covers them. A silent skip would be worse than the failure, because it reads as passing coverage.

## Verified not dormant

Gating a test on something nobody provides is exactly the failure mode #927 describes, so I checked rather than assumed: **with a fixture file present the suite runs instead of skipping** — it then fails against the stub binding, which is the point. The gate is on the artifact's presence, not on an env var nobody sets.

Expected: **4 → 2 failing files and tests**, and the two remaining are the ones I have said should not be fixed by editing an assertion.

Refs #323