### PR TITLE
build(deps): put every compressing consumer on the same major

### DIFF
--- a/packages/tuff-cli-core/package.json
+++ b/packages/tuff-cli-core/package.json
@@ -34,7 +34,7 @@
     "@vue/compiler-sfc": "^3.5.39",
     "chalk": "^5.6.2",
     "cli-progress": "^3.12.0",
-    "compressing": "^1.10.5",
+    "compressing": "^2.1.1",
     "esbuild": "^0.28.1",
     "fs-extra": "^11.3.6",
     "glob": "^10.5.0",

--- a/packages/tuff-cli/package.json
+++ b/packages/tuff-cli/package.json
@@ -33,7 +33,7 @@
     "@vue/compiler-sfc": "3.5.39",
     "chalk": "^5.6.2",
     "cli-progress": "^3.12.0",
-    "compressing": "^1.10.5",
+    "compressing": "^2.1.1",
     "debug": "^4.4.3",
     "esbuild": "^0.28.1",
     "fs-extra": "^11.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -912,8 +912,8 @@ importers:
         specifier: ^3.12.0
         version: 3.12.0
       compressing:
-        specifier: ^1.10.5
-        version: 1.10.5
+        specifier: ^2.1.1
+        version: 2.1.1
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@10.2.2)
@@ -973,8 +973,8 @@ importers:
         specifier: ^3.12.0
         version: 3.12.0
       compressing:
-        specifier: ^1.10.5
-        version: 1.10.5
+        specifier: ^2.1.1
+        version: 2.1.1
       esbuild:
         specifier: 0.28.1
         version: 0.28.1
@@ -7571,10 +7571,6 @@ packages:
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
-
-  compressing@1.10.5:
-    resolution: {integrity: sha512-kmVGoqpCTZLy36T8XeYexmyJ8YhZhgjGzkPr2iCGHdfZg7IkelF5DEf5Xyzeo7hwSSEW6ifZuv0IeRAkee5NcA==}
-    engines: {node: '>= 4.0.0'}
 
   compressing@2.1.1:
     resolution: {integrity: sha512-B/sIxBNB1SOY9GPo9nKk/R0K0q+27KdM3x3/LK/kV858UUWGbl9j0lqUvqQvaQrSJY9jSors4b3pbYc3dz+w4w==}
@@ -21287,18 +21283,6 @@ snapshots:
       is-stream: 2.0.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
-
-  compressing@1.10.5:
-    dependencies:
-      '@eggjs/yauzl': 2.11.0
-      flushwritable: 1.0.0
-      get-ready: 1.0.0
-      iconv-lite: 0.5.2
-      mkdirp: 0.5.6
-      pump: 3.0.3
-      streamifier: 0.1.1
-      tar-stream: 1.6.2
-      yazl: 2.5.1
 
   compressing@2.1.1:
     dependencies:


### PR DESCRIPTION
## What

`apps/core-app` declared `^2.1.1` while `packages/tuff-cli` and `packages/tuff-cli-core` declared `^1.10.5`, so **both majors resolved and shipped side by side**.

```
apps/core-app              ^2.1.1
packages/tuff-cli-core     ^1.10.5   → ^2.1.1
packages/tuff-cli          ^1.10.5   → ^2.1.1
```

## Compatibility checked before the bump, not after

`tuff-cli-core` touches a narrow surface — `new compressing.tar.Stream()`, then `.addEntry(path, { ignoreBase: true })` and `.pipe(…)`. `core-app` has been on `^2.1.1` all along using a **wider** one: `tar.compressDir`, `tar.uncompress`, `tgz.uncompress`, `zip.uncompress`.

Checked both installed majors directly rather than reading a changelog:

```
v1.10.5  tar.Stream=function  tar.compressDir=function  tar.uncompress=function  zip.uncompress=function
v2.1.1   tar.Stream=function  tar.compressDir=function  tar.uncompress=function  zip.uncompress=function

v1.10.5  new tar.Stream() → TarStream   addEntry=function  addEntry.length=2  pipe=function
v2.1.1   new tar.Stream() → TarStream   addEntry=function  addEntry.length=2  pipe=function
```

Identical top-level exports, the constructor builds on both, and `addEntry` keeps the same arity — so the `{ ignoreBase: true }` second argument is still accepted.

`packages/tuff-cli-core` suite: **11 files, 49 tests, all passing**.

## Result

```
lockfile: compressing@1.10.5  →  0 occurrences
          compressing@2.1.1   →  2 occurrences
          (positive control: 5 'compressing' mentions overall, so the file is being read)
```

−20/+4 lines: the whole `compressing@1.10.5` package entry and its dependency block are gone. One major in the tree instead of two.

## Not a duplicate of Dependabot #290

#290 proposes the same bump but targets **`master`**, not this integration branch, and has been open since 2026-07-21. It would not land here.

Fixes #572
