### PR TITLE
fix(nexus): mint activation codes with a CSPRNG

### DIFF
--- a/apps/nexus/server/utils/__tests__/subscriptionActivationCode.test.ts
+++ b/apps/nexus/server/utils/__tests__/subscriptionActivationCode.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+import { generateActivationCode } from '../subscriptionStore'
+
+const ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+
+describe('generateActivationCode', () => {
+  it('keeps the TUFF-<plan>-<8>-<4> shape', () => {
+    const code = generateActivationCode('PRO')
+    expect(code).toMatch(/^TUFF-PRO-[A-Z2-9]{8}-[A-Z2-9]{4}$/)
+  })
+
+  it('uses only the unambiguous alphabet', () => {
+    // No I, O, 0 or 1 — a code read off a screen must not be mistypeable.
+    for (let i = 0; i < 200; i++) {
+      const body = generateActivationCode('PLUS').replace('TUFF-PLUS-', '').replace('-', '')
+      for (const ch of body)
+        expect(ALPHABET, `unexpected character ${ch}`).toContain(ch)
+    }
+  })
+
+  it('does not derive from Math.random', () => {
+    // The defect: V8's xorshift128+ state is recoverable from a few consecutive outputs, so
+    // two codes from one isolate exposed every other code it minted (#918). Pinning
+    // Math.random to a constant would have made the old generator emit one repeated
+    // character; a CSPRNG is unaffected.
+    const spy = vi.spyOn(Math, 'random').mockReturnValue(0)
+    try {
+      const codes = new Set(Array.from({ length: 50 }, () => generateActivationCode('PRO')))
+      expect(codes.size).toBe(50)
+      expect(spy).not.toHaveBeenCalled()
+    }
+    finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('does not repeat across a large batch', () => {
+    const codes = new Set(Array.from({ length: 2000 }, () => generateActivationCode('TEAM')))
+    expect(codes.size).toBe(2000)
+  })
+
+  it('spreads across the alphabet rather than favouring a prefix', () => {
+    // A biased modulo over a non-power-of-two alphabet would skew the low characters. This
+    // alphabet is 32 long so a mask would be fine too, but the assertion guards the choice.
+    const seen = new Set<string>()
+    for (let i = 0; i < 500; i++)
+      for (const ch of generateActivationCode('PRO').slice(-4)) seen.add(ch)
+
+    expect(seen.size).toBeGreaterThan(ALPHABET.length * 0.8)
+  })
+})

--- a/apps/nexus/server/utils/subscriptionStore.ts
+++ b/apps/nexus/server/utils/subscriptionStore.ts
@@ -1,6 +1,6 @@
 import type { D1Database } from '@cloudflare/workers-types'
 import type { H3Event } from 'h3'
-import { randomUUID } from 'node:crypto'
+import { randomInt, randomUUID } from 'node:crypto'
 import { createError } from 'h3'
 import { readCloudflareBindings } from './cloudflare'
 
@@ -109,17 +109,33 @@ function mapCodeRow(row: D1ActivationCodeRow): ActivationCode {
   }
 }
 
-function generateActivationCode(plan: SubscriptionPlan): string {
-  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
-  let random = ''
-  for (let i = 0; i < 8; i++) {
-    random += chars.charAt(Math.floor(Math.random() * chars.length))
-  }
-  let check = ''
-  for (let i = 0; i < 4; i++) {
-    check += chars.charAt(Math.floor(Math.random() * chars.length))
-  }
-  return `TUFF-${plan}-${random}-${check}`
+/**
+ * Crockford-style alphabet: no I, O, 0 or 1, so a code read aloud or off a screen cannot be
+ * mistyped between visually similar characters.
+ */
+const ACTIVATION_CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+
+/**
+ * These grant paid plans, so they have to be unguessable.
+ *
+ * This used Math.random, which is V8's xorshift128+ — not a CSPRNG and not meant to be one.
+ * Its internal state is recoverable from a handful of consecutive outputs, so an attacker
+ * holding two codes minted in the same isolate could reconstruct every other code that
+ * isolate produced and redeem them against /api/subscription/activate (#918).
+ *
+ * randomInt is rejection-sampled and unbiased. The alphabet is 32 characters, a power of
+ * two, so a mask over randomBytes would also have been unbiased — randomInt is used because
+ * it stays correct if the alphabet ever changes length.
+ */
+function randomCodeSegment(length: number): string {
+  let out = ''
+  for (let i = 0; i < length; i++)
+    out += ACTIVATION_CODE_ALPHABET.charAt(randomInt(ACTIVATION_CODE_ALPHABET.length))
+  return out
+}
+
+export function generateActivationCode(plan: SubscriptionPlan): string {
+  return `TUFF-${plan}-${randomCodeSegment(8)}-${randomCodeSegment(4)}`
 }
 
 export async function createActivationCode(


### PR DESCRIPTION
## The defect

```js
// before
const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
random += chars.charAt(Math.floor(Math.random() * chars.length))
```

`Math.random` is V8's xorshift128+. It is not a CSPRNG and does not claim to be — its internal state is recoverable from a handful of consecutive outputs. An attacker holding two codes minted by the same isolate could reconstruct **every other code that isolate produced** and redeem them at `/api/subscription/activate`, which requires only a verified email.

## Fix

`randomInt` from `node:crypto` — rejection-sampled and unbiased.

The alphabet is 32 characters, a power of two, so a mask over `randomBytes` would have been unbiased as well. `randomInt` is used because it stays correct if the alphabet ever changes length, which a mask would not.

**Format unchanged**: `TUFF-<plan>-<8>-<4>` over the same I/O/0/1-free alphabet. Nothing parses it — `activateCode` uppercases the input and looks it up — so no caller is affected.

## The test that matters

```js
const spy = vi.spyOn(Math, 'random').mockReturnValue(0)
const codes = new Set(Array.from({ length: 50 }, () => generateActivationCode('PRO')))
expect(codes.size).toBe(50)
expect(spy).not.toHaveBeenCalled()
```

Pinning `Math.random` to a constant would have made the old generator emit one repeated character. Against the pre-fix implementation:

```
× generateActivationCode > does not derive from Math.random
  Tests  1 failed | 4 passed (5)
```

Exactly that one case fails. The other four — format, alphabet, batch uniqueness, spread — pass either way, correctly: those properties held under `Math.random` too in ordinary conditions. A test that failed on all five would have meant I was testing the rewrite's shape rather than the vulnerability.

With the fix, 5/5.

## Scope

`Math.random` remains elsewhere in `apps/nexus/server`: provider load-balancing selection (`assistant.post.ts`, `admin/intelligence/chat.ts`) and internal ids prefixed with `Date.now()` (`docAssistantStore`, `intelligenceAgentGraphRunner`, the LangChain adapters). None is a secret and none is this issue; flagged rather than swept in.

Fixes #918
