### PR TITLE
fix(nexus): stop signing doc tokens with a constant on Cloudflare Pages

### DIFF
--- a/apps/nexus/server/api/docs/engagement.post.ts
+++ b/apps/nexus/server/api/docs/engagement.post.ts
@@ -119,7 +119,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Invalid payload' })
   }
 
-  const payload = verifyDocToken(token)
+  const payload = verifyDocToken(event, token)
   if (!payload || payload.sid !== sessionId || payload.cid !== clientId || payload.src !== sourceType) {
     throw createError({ statusCode: 403, statusMessage: 'Invalid token' })
   }

--- a/apps/nexus/server/api/docs/view.post.ts
+++ b/apps/nexus/server/api/docs/view.post.ts
@@ -116,7 +116,7 @@ export default defineEventHandler(async (event) => {
     ttlMs: SESSION_TTL_MS,
   })
 
-  const token = createDocToken({
+  const token = createDocToken(event, {
     sid: session.sessionId,
     path: session.path,
     cid: session.clientId,

--- a/apps/nexus/server/utils/__tests__/docAnalyticsTokenSecret.test.ts
+++ b/apps/nexus/server/utils/__tests__/docAnalyticsTokenSecret.test.ts
@@ -1,0 +1,52 @@
+import type { H3Event } from 'h3'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// useRuntimeConfig is a Nuxt auto-import, so it is a global here rather than a module.
+// Stubbing it as a module left it undefined, and the fail-closed cases then "passed" on a
+// ReferenceError instead of on the credential policy — a false green worth not repeating.
+vi.stubGlobal('useRuntimeConfig', () => ({}))
+
+const { createDocToken, verifyDocToken } = await import('../docAnalyticsStore')
+
+/** A Pages-shaped event: secrets arrive as bindings, never through process.env. */
+function eventWithBindings(env: Record<string, unknown>): H3Event {
+  return { context: { cloudflare: { env } } } as unknown as H3Event
+}
+
+const payload = { sid: 's', path: '/docs/x', cid: 'c', src: 'docs_page' as const, rl: 0 }
+
+describe('doc token signing secret', () => {
+  beforeEach(() => {
+    delete process.env.NUXT_DOC_TOKEN_SECRET
+    delete process.env.AUTH_SECRET
+  })
+
+  it('signs with the binding when Cloudflare supplies one', () => {
+    const event = eventWithBindings({ NUXT_DOC_TOKEN_SECRET: 'a'.repeat(40) })
+    const token = createDocToken(event, payload)
+
+    expect(verifyDocToken(event, token)).toMatchObject({ path: '/docs/x' })
+  })
+
+  it('does not accept a token signed under a different binding', () => {
+    const minted = createDocToken(eventWithBindings({ NUXT_DOC_TOKEN_SECRET: 'a'.repeat(40) }), payload)
+    const other = eventWithBindings({ NUXT_DOC_TOKEN_SECRET: 'b'.repeat(40) })
+
+    expect(verifyDocToken(other, minted)).toBeNull()
+  })
+
+  it('fails closed on a deployed runtime with no secret, instead of using a constant', () => {
+    // The defect: bindings present but no secret among them meant selectRuntimeCredential
+    // returned undefined, every process.env fallback was skipped by design, and the old code
+    // signed with a constant published in this repository (#920).
+    const event = eventWithBindings({ SOMETHING_ELSE: 'x' })
+
+    expect(() => createDocToken(event, payload)).toThrow(/NUXT_DOC_TOKEN_SECRET/)
+  })
+
+  it('rejects a secret that is too short rather than silently accepting it', () => {
+    const event = eventWithBindings({ NUXT_DOC_TOKEN_SECRET: 'short' })
+
+    expect(() => createDocToken(event, payload)).toThrow(/NUXT_DOC_TOKEN_SECRET/)
+  })
+})

--- a/apps/nexus/server/utils/__tests__/docAnalyticsTokenSecret.test.ts
+++ b/apps/nexus/server/utils/__tests__/docAnalyticsTokenSecret.test.ts
@@ -1,12 +1,12 @@
 import type { H3Event } from 'h3'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createDocToken, verifyDocToken } from '../docAnalyticsStore'
 
 // useRuntimeConfig is a Nuxt auto-import, so it is a global here rather than a module.
 // Stubbing it as a module left it undefined, and the fail-closed cases then "passed" on a
 // ReferenceError instead of on the credential policy — a false green worth not repeating.
 vi.stubGlobal('useRuntimeConfig', () => ({}))
 
-const { createDocToken, verifyDocToken } = await import('../docAnalyticsStore')
 
 /** A Pages-shaped event: secrets arrive as bindings, never through process.env. */
 function eventWithBindings(env: Record<string, unknown>): H3Event {

--- a/apps/nexus/server/utils/docAnalyticsStore.ts
+++ b/apps/nexus/server/utils/docAnalyticsStore.ts
@@ -1,6 +1,9 @@
 import type { D1Database } from '@cloudflare/workers-types'
+import type { H3Event } from 'h3'
 import { Buffer } from 'node:buffer'
 import { createHash, randomBytes, randomUUID } from 'node:crypto'
+import { readCloudflareBindings } from './cloudflare'
+import { assertRuntimeCredential, isLocalDevelopmentRuntime, selectRuntimeCredential } from './runtimeCredentialPolicy'
 
 const DOC_VIEWS_TABLE = 'doc_views'
 const DOC_VIEWS_DAILY_TABLE = 'doc_views_daily'
@@ -26,7 +29,6 @@ const CLEANUP_INTERVAL_MS = 6 * 60 * 60_000
 
 let analyticsSchemaInitialized = false
 let analyticsCleanupAt = 0
-let tokenSecretCache: string | null = null
 
 export type DocEngagementSourceType = 'docs_page' | 'doc_comments_admin'
 
@@ -210,30 +212,43 @@ function base64UrlDecode(value: string): string {
   return Buffer.from(normalized, 'base64').toString('utf8')
 }
 
-function getDocTokenSecret(): string {
-  if (tokenSecretCache)
-    return tokenSecretCache
+/** Only reachable when isLocalDevelopmentRuntime() is true; never on a deployed runtime. */
+const DEV_FALLBACK_DOC_TOKEN_SECRET = 'nexus-doc-analytics-local-development-secret'
 
+/**
+ * Resolves the doc-token signing secret the way every other credential here is resolved.
+ *
+ * This used to read only useRuntimeConfig() and process.env, and fell back to a hardcoded
+ * constant when neither produced 16 characters. On Cloudflare Pages secrets arrive as
+ * bindings on event.context.cloudflare.env, and selectRuntimeCredential deliberately ignores
+ * the process.env fallbacks once bindings exist (runtimeCredentialPolicy.ts:57) — so a
+ * deployed Pages runtime signed every doc token with a constant published in this repo,
+ * and anyone could mint one (#920).
+ *
+ * Fails closed off local development rather than substituting a constant: a signing secret
+ * that silently degrades to a known value is worse than an endpoint that stops working,
+ * because nothing observable distinguishes it from a working one.
+ */
+function getDocTokenSecret(event: H3Event): string {
+  const bindings = readCloudflareBindings(event)
   const config = useRuntimeConfig()
-  const candidates = [
-    config.appAuthJwtSecret,
-    config.auth?.secret,
-    process.env.NUXT_DOC_TOKEN_SECRET,
-    process.env.AUTH_SECRET,
-  ]
+  const configured = selectRuntimeCredential(
+    bindings,
+    bindings?.NUXT_DOC_TOKEN_SECRET ?? bindings?.AUTH_SECRET,
+    [config.appAuthJwtSecret, config.auth?.secret, process.env.NUXT_DOC_TOKEN_SECRET, process.env.AUTH_SECRET],
+  )
+  const localDevelopment = isLocalDevelopmentRuntime(bindings?.NEXUS_LOCAL_PAGES_PREVIEW, bindings)
 
-  for (const candidate of candidates) {
-    if (typeof candidate === 'string' && candidate.length >= 16) {
-      tokenSecretCache = candidate
-      return tokenSecretCache
-    }
-  }
+  if (configured !== undefined && configured !== null)
+    return assertRuntimeCredential('NUXT_DOC_TOKEN_SECRET', configured, { localDevelopment })
 
-  tokenSecretCache = 'nexus-doc-analytics-fallback-secret-v1'
-  return tokenSecretCache
+  if (!localDevelopment)
+    return assertRuntimeCredential('NUXT_DOC_TOKEN_SECRET', configured, { localDevelopment: false })
+
+  return DEV_FALLBACK_DOC_TOKEN_SECRET
 }
 
-export function createDocToken(payload: Omit<DocTokenPayload, 'iat' | 'exp' | 'typ'>, now = Date.now()): string {
+export function createDocToken(event: H3Event, payload: Omit<DocTokenPayload, 'iat' | 'exp' | 'typ'>, now = Date.now()): string {
   const issuedAt = Math.floor(now / 1000)
   const exp = issuedAt + TOKEN_TTL_SECONDS
   const tokenPayload: DocTokenPayload = {
@@ -249,14 +264,14 @@ export function createDocToken(payload: Omit<DocTokenPayload, 'iat' | 'exp' | 't
   const header = base64UrlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
   const body = base64UrlEncode(JSON.stringify(tokenPayload))
   const signingInput = `${header}.${body}`
-  const signature = createHash('sha256').update(`${signingInput}.${getDocTokenSecret()}`).digest('base64')
+  const signature = createHash('sha256').update(`${signingInput}.${getDocTokenSecret(event)}`).digest('base64')
     .replace(/\+/g, '-')
     .replace(/\//g, '_')
     .replace(/=+$/g, '')
   return `${signingInput}.${signature}`
 }
 
-export function verifyDocToken(token: string): DocTokenPayload | null {
+export function verifyDocToken(event: H3Event, token: string): DocTokenPayload | null {
   if (!token)
     return null
   const parts = token.split('.')
@@ -268,7 +283,7 @@ export function verifyDocToken(token: string): DocTokenPayload | null {
 
   try {
     const signingInput = `${headerPart}.${payloadPart}`
-    const expectedSignature = createHash('sha256').update(`${signingInput}.${getDocTokenSecret()}`).digest('base64')
+    const expectedSignature = createHash('sha256').update(`${signingInput}.${getDocTokenSecret(event)}`).digest('base64')
       .replace(/\+/g, '-')
       .replace(/\//g, '_')
       .replace(/=+$/g, '')

--- a/apps/nexus/types/cloudflare-env.d.ts
+++ b/apps/nexus/types/cloudflare-env.d.ts
@@ -11,6 +11,7 @@ declare global {
     PLUGIN_PACKAGES?: R2Bucket
     APP_AUTH_JWT_SECRET?: string
     AUTH_SECRET?: string
+    NUXT_DOC_TOKEN_SECRET?: string
     NUXT_INTELLIGENCE_ENCRYPT_KEY?: string
     RELEASE_SIGNATURE_PUBLIC_KEY?: string
     UPDATE_SIGNATURE_PUBLIC_KEY?: string


### PR DESCRIPTION
## The issue is tagged "lower confidence". It reproduces, and the repository's own code is the proof.

`getDocTokenSecret` read only `useRuntimeConfig()` and `process.env`, then fell back to a literal published in this repo. The question was whether a Cloudflare Pages deploy really leaves all four candidates undefined.

It does, and this codebase already knows it:

```ts
// server/utils/runtimeCredentialPolicy.ts:57
export function selectRuntimeCredential(platformBindings, platformValue, fallbackValues) {
  if (platformBindings) return platformValue      // ← process.env fallbacks are ignored, by design
  return fallbackValues.find(...)
}
```

Every other credential goes `readCloudflareBindings → selectRuntimeCredential → assertRuntimeCredential`. This one went nowhere near the bindings. So on Pages it took the fallback and signed **every doc token with a constant anyone can read here**.

## Fix

Rewritten on the pattern `intelligenceStore` already uses for `NUXT_INTELLIGENCE_ENCRYPT_KEY`, and **fails closed** off local development.

A signing secret that silently degrades to a known value is worse than an endpoint that stops working: nothing observable distinguishes the degraded state from a healthy one, which is how this survived.

`createDocToken`/`verifyDocToken` now take the `H3Event`; both call sites are handlers that already had one. The module-level cache is gone — it would have pinned whichever secret the first request resolved, including a dev fallback.

## The test that is the vulnerability

```
Tests  3 failed | 1 passed (4)      ← against the pre-fix resolution

× does not accept a token signed under a different binding
× fails closed on a deployed runtime with no secret, instead of using a constant
× rejects a secret that is too short rather than silently accepting it
```

The first one *is* the exploit: with the old code both events resolve to the same constant, so a token minted under one binding verifies under another. It failing is the forgery succeeding.

The fourth case passes either way — the old code also produced *a* usable token. Correct; that one is not about the defect.

## A false green I had to walk back

My first version stubbed `useRuntimeConfig` with `vi.mock('#imports')`. It is a Nuxt **auto-import**, so it is a global, and the stub did nothing — the fail-closed cases then "passed" on a `ReferenceError` rather than on the credential policy. Switched to `vi.stubGlobal` and tightened the matchers from bare `.toThrow()` to `.toThrow(/NUXT_DOC_TOKEN_SECRET/)`, so a crash can no longer satisfy them.

## Checks

```
eslint (nexus config): exit 0
server/utils tests:    36 files, 165 passed
vue-tsc server project: 58 errors, none in the files touched (pre-existing, all app-side)
```

Fixes #920
