### PR TITLE
ci: make the nexus suite blocking (#325)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,13 +301,15 @@ jobs:
       # only four hand-named core-app files were covered, inside a path-filtered
       # native-protocol job. See #924.
       #
-      # Non-blocking for now: both suites are red before this change — measured
-      # on CI at core-app 28 files / 68 tests and nexus 12 files / 15 tests.
-      # Running and visible beats not running; flip continue-on-error off once
-      # the counts reach zero, and until then use them as the regression
-      # baseline to compare against.
+      # nexus is now BLOCKING: 180 files / 963 tests, zero failures (#327 closed).
+      # core-app stays non-blocking at 2 failing files, down from 20 (#323). Both
+      # remaining failures there are product-side rather than test-side -- the
+      # packaged runtime closure shipping openai@6 against @langchain/openai's
+      # ^4.87.3, and plugins/touch-quickops having lost its contract tests -- so
+      # they need decisions, not an assertion edit, and blocking on them would
+      # stop every unrelated PR.
       #
-      # The counts above are the whole reason for the JUnit report below: a
+      # The counts are the whole reason for the JUnit report below: a
       # continue-on-error job reports success, so a jump like 20 -> 28 files is
       # invisible unless the numbers are an artifact rather than something you
       # have to scrape out of a 6000-line log.
@@ -319,7 +321,7 @@ jobs:
         run: pnpm -C packages/tuffex build
 
       - name: Run ${{ matrix.app }} suite
-        continue-on-error: true
+        continue-on-error: ${{ matrix.app != 'nexus' }}
         run: >-
           pnpm -C "apps/${{ matrix.app }}" exec vitest run
           --reporter=default


### PR DESCRIPTION
`apps/nexus` is green — **180 files, 963 tests, zero failures** — so the suite that was added non-blocking to make it *visible* can now hold the line.

```yaml
continue-on-error: ${{ matrix.app != 'nexus' }}
```

## core-app stays non-blocking, deliberately

It is down from **20 failing files to 2**, but both remaining failures are product-side rather than test-side:

- the packaged runtime closure carries `openai@6.26.0` through `langsmith`'s wildcard optional peer while `@langchain/openai@0.4.9` requires `^4.87.3`
- `plugins/touch-quickops` lost its contract tests when `__test` stopped being exported, so payload redaction and high-risk blocking have no coverage

Both need a decision rather than an assertion edit, and blocking on them would stop every unrelated pull request while that decision is pending.

## On the criterion

#325 asks that no global `continue-on-error` hide a failure. This meets it for the half that can meet it now, rather than waiting for both — and the comment in `ci.yml` now records exactly what the remaining exception is and why, so it cannot quietly become permanent.

Refs #325, #327, #323