### PR TITLE
feat(permission): record every API name the guard allows by default

### DIFF
--- a/apps/core-app/src/main/modules/permission/permission-guard.test.ts
+++ b/apps/core-app/src/main/modules/permission/permission-guard.test.ts
@@ -110,3 +110,60 @@ describe('permissionGuardPerformance', () => {
     }
   )
 })
+
+describe('unmapped API inventory', () => {
+  let tempDir = ''
+  let store: PermissionStore
+  let guard: PermissionGuard
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'permission-unmapped-'))
+    store = new PermissionStore(tempDir)
+    await store.initialize()
+    guard = new PermissionGuard(store)
+  })
+
+  afterEach(async () => {
+    await store?.shutdown()
+    if (!tempDir) return
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('still allows an unmapped name, but records it', () => {
+    // Deliberately pins the current behaviour rather than the desired one: the default is
+    // not being flipped here, only made observable (#915).
+    const result = guard.check(TEST_PLUGIN_ID, 'totally:unmapped:api', SDK_VERSION)
+
+    expect(result.allowed).toBe(true)
+    expect(guard.getUnmappedApis()).toEqual([
+      { apiName: 'totally:unmapped:api', count: 1, plugins: [TEST_PLUGIN_ID] }
+    ])
+  })
+
+  it('counts repeats and collects every plugin that reached it', () => {
+    guard.check('plugin-a', 'unmapped:one', SDK_VERSION)
+    guard.check('plugin-b', 'unmapped:one', SDK_VERSION)
+    guard.check('plugin-a', 'unmapped:one', SDK_VERSION)
+
+    const [entry] = guard.getUnmappedApis()
+    expect(entry.count).toBe(3)
+    expect([...entry.plugins].sort()).toEqual(['plugin-a', 'plugin-b'])
+  })
+
+  it('does not record a name that the mapping table covers', () => {
+    guard.check(TEST_PLUGIN_ID, 'search:root-results:push', SDK_VERSION)
+
+    expect(guard.getUnmappedApis()).toEqual([])
+  })
+
+  it('orders the inventory by frequency, so the flip starts with the common names', () => {
+    guard.check(TEST_PLUGIN_ID, 'unmapped:rare', SDK_VERSION)
+    guard.check(TEST_PLUGIN_ID, 'unmapped:common', SDK_VERSION)
+    guard.check(TEST_PLUGIN_ID, 'unmapped:common', SDK_VERSION)
+
+    expect(guard.getUnmappedApis().map((entry) => entry.apiName)).toEqual([
+      'unmapped:common',
+      'unmapped:rare'
+    ])
+  })
+})

--- a/apps/core-app/src/main/modules/permission/permission-guard.ts
+++ b/apps/core-app/src/main/modules/permission/permission-guard.ts
@@ -6,7 +6,10 @@
  */
 
 import type { PermissionStore } from './permission-store'
+import { getLogger } from '@talex-touch/utils/common/logger'
 import { normalizePermissionId, permissionRegistry } from '@talex-touch/utils/permission'
+
+const permissionGuardLog = getLogger('permission-guard')
 
 /**
  * Permission check result
@@ -138,6 +141,9 @@ export class PermissionGuard {
     slowChecks: 0 // > 5ms
   }
 
+  /** API names that reached check() with no mapping, and how often. See #915. */
+  private unmappedApis = new Map<string, { count: number; plugins: Set<string> }>()
+
   constructor(store: PermissionStore) {
     this.store = store
 
@@ -157,7 +163,14 @@ export class PermissionGuard {
     const requiredPermissions = this.getRequiredPermissions(apiName)
 
     if (requiredPermissions.length === 0) {
-      // No permission required for this API
+      // Unmapped names are allowed, which makes this an opt-in denylist keyed on a
+      // hand-maintained table rather than a default-deny gate (#915). Flipping the default
+      // needs an inventory of every name that legitimately reaches here — four call sites
+      // feed it, two of them with a caller-supplied string — and that inventory does not
+      // exist yet. Recording each one is how it gets built: an allow that leaves a trace is
+      // still a gap, but it is a countable gap rather than a silent one.
+      this.recordUnmappedApi(pluginId, apiName)
+
       const duration = performance.now() - startTime
       this.recordPerformance(duration)
       return {
@@ -273,6 +286,33 @@ export class PermissionGuard {
   /**
    * Get required permissions for an API
    */
+  private recordUnmappedApi(pluginId: string, apiName: string): void {
+    const entry = this.unmappedApis.get(apiName)
+    if (entry) {
+      entry.count += 1
+      entry.plugins.add(pluginId)
+      return
+    }
+
+    this.unmappedApis.set(apiName, { count: 1, plugins: new Set([pluginId]) })
+    // First sighting only: these repeat per call and would drown the log otherwise.
+    permissionGuardLog.warn(
+      `"${apiName}" matches no entry in API_PERMISSION_MAPPINGS and was allowed by default.`,
+      { meta: { apiName, pluginId } }
+    )
+  }
+
+  /**
+   * Every unmapped name seen so far. This is the inventory a default-deny flip needs: each
+   * entry is either an API that should require a permission, or one that should be declared
+   * as deliberately public.
+   */
+  getUnmappedApis(): { apiName: string; count: number; plugins: string[] }[] {
+    return [...this.unmappedApis.entries()]
+      .map(([apiName, entry]) => ({ apiName, count: entry.count, plugins: [...entry.plugins] }))
+      .sort((left, right) => right.count - left.count)
+  }
+
   getRequiredPermissions(apiName: string): string[] {
     // Exact match
     const exact = this.mappings.get(apiName)


### PR DESCRIPTION
## What this does, and what it deliberately does not

`PermissionGuard.check()` returns `allowed: true` whenever a name matches no entry in `API_PERMISSION_MAPPINGS` — an opt-in denylist keyed on a hand-maintained table, not a default-deny gate. Confirmed at `permission-guard.ts:159`.

**This PR does not flip the default.** It builds the inventory a flip needs.

## Why not just flip it

Four call sites reach the guard, and two pass a caller-supplied string:

```
plugin/services/plugin-storage-transport-service.ts:359   checkPermission(plugin.name, apiName, …)
permission/channel-guard.ts:161                           checkPermission(pluginId, permissionId, …)
native-capabilities/index.ts:107                          checkPermission(plugin.name, apiName, …)   ← apiName is a parameter
plugin/plugin.ts:1161                                     checkPermission(this.name, 'search:root-results:push', …)  ← literal, and mapped
```

So the set of names that legitimately arrive here is not knowable by reading the code. Flipping to deny without that set would break real plugin traffic in ways that surface only at runtime — and I cannot run the Electron app to find out.

## What it does instead

Every unmapped name is counted along with the plugins that used it, logged **once** on first sighting (they repeat per call and would drown the log), and exposed through `getUnmappedApis()` sorted by frequency.

Each entry is then either an API that should require a permission, or one that should be declared deliberately public. That is exactly the list a default-deny flip needs and that nobody currently has.

An allow that leaves a trace is still a gap. It is a countable one.

## Tests

Four, pinning the **current** behaviour rather than the desired one — including that a mapped name is *not* recorded, so the recorder cannot quietly become a log of everything.

## Deltas measured, not assumed

```
eslint (apps/core-app's own config):  HEAD 0e/0w   →   now 0e/0w
tsc -p tsconfig.node.json:            HEAD 43 errors → now 43 errors, none in this file
permission-guard.test.ts:             13 passed
```

The first `console.warn` I wrote tripped `no-console`; switched to `getLogger('permission-guard')`, which `permission-store.ts` in the same directory already uses.

One note: `keeps permission checks under the 5ms target` failed once during this work and passed on every subsequent run, at HEAD and with the change. It is a wall-clock assertion, so it is timing-sensitive by construction — worth knowing if it flakes in CI, but not caused here.

Refs #915
