### PR TITLE
test(integration): rewrite the snippets suite for the host-gated capability model (#330)

### DIFF
--- a/packages/test/src/plugins/snippets.test.ts
+++ b/packages/test/src/plugins/snippets.test.ts
@@ -41,89 +41,67 @@ class FakeBuilder {
 }
 
 describe('code snippets', () => {
-  it('replaces placeholders', () => {
-    const now = new Date(2025, 0, 2, 3, 4, 5)
-    const text = snippetsTest.applyPlaceholders('date={{date}} time={{time}} clip={{clipboard}}', {
-      now,
-      clipboardText: 'CLIP',
-    })
+  // The previous three cases here called snippetsTest.applyPlaceholders() and
+  // .matchSnippet() through the plugin's __test export, which e37c92c8c removed.
+  //
+  // Placeholder resolution and title/content matching are already covered at the
+  // boundary by plugins/touch-snippets/index.test.cjs ('clipboard placeholders are
+  // resolved through the host read capability before write' and 'save, search and
+  // copy use only storage, feature-item and clipboard facades'), so they are not
+  // reinstated here.
+  //
+  // Tag matching was NOT covered there -- every package-local search is by title
+  // text -- so it is kept, rewritten to go through the lifecycle.
+  // Tag matching is the one thing the package-local suite does not cover: every
+  // search there is by title text (plugins/touch-snippets/index.test.cjs). Kept as
+  // a todo rather than a failing test, because publishing search results needs
+  // harness setup this file does not have -- onFeatureTriggered('snippets-search', …)
+  // returns false here for any query, including one matching a title, so the gap is
+  // in the fixture wiring rather than in tag matching itself (index.js:79 does
+  // include tags in the searchable text).
+  it.todo('surfaces a snippet whose only match is a tag')
 
-    expect(text).toContain('date=2025-01-02')
-    expect(text).toContain('time=03:04:05')
-    expect(text).toContain('clip=CLIP')
-  })
-
-  it('matches snippet by tag or title', () => {
-    const snippet = {
-      title: 'React useEffect 模板',
-      tags: ['react', 'hook'],
-      language: 'ts',
-      content: 'useEffect(() => {})',
-    }
-
-    expect(snippetsTest.matchSnippet(snippet, 'react')).toBe(true)
-    expect(snippetsTest.matchSnippet(snippet, 'hook')).toBe(true)
-    expect(snippetsTest.matchSnippet(snippet, 'vue')).toBe(false)
-  })
-
-  it('matches text snippet content', () => {
-    const snippet = {
-      title: '邮件模板',
-      tags: ['邮件'],
-      content: '你好，今天的进度如下',
-    }
-
-    expect(snippetsTest.matchSnippet(snippet, '邮件')).toBe(true)
-    expect(snippetsTest.matchSnippet(snippet, '进度')).toBe(true)
-    expect(snippetsTest.matchSnippet(snippet, '无关')).toBe(false)
-  })
-
-  it('blocks snippet copy when clipboard.write permission is denied', async () => {
-    const writeText = vi.fn()
-    const request = vi.fn(async () => false)
-    const storageSetFile = vi.fn()
-    const pluginModule = loadPluginModule(snippetsUrl, createPluginGlobals({
+  // Host-gated capability model: since e37c92c8c the plugin no longer calls
+  // permission.request() itself. It invokes the capability and maps a thrown
+  // PLUGIN_HOST_CAPABILITY_* code to a stable blocked result
+  // (touch-snippets/index.js:133-145).
+  function copyingPlugin(writeText: () => Promise<void>, storageSetFile = vi.fn()) {
+    return loadPluginModule(snippetsUrl, createPluginGlobals({
       TuffItemBuilder: FakeBuilder,
       clipboard: { writeText },
-      permission: {
-        check: async () => false,
-        request,
-      },
       plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
+        feature: { clearItems() {}, pushItems() {} },
         storage: {
           async getFile() {
             return {
               version: 1,
-              snippets: [
-                {
-                  id: 'hello',
-                  title: 'Hello',
-                  content: 'hello world',
-                  type: 'text',
-                },
-              ],
+              snippets: [{ id: 'hello', title: 'Hello', content: 'hello world', type: 'text' }],
             }
           },
           setFile: storageSetFile,
         },
       },
     }))
+  }
+
+  const copyItem = {
+    meta: { defaultAction: 'copy', featureId: 'snippets-search' },
+    actions: [{ id: 'copy', payload: { content: 'hello world' } }],
+  }
+
+  it('surfaces a blocked result when the host denies clipboard.write', async () => {
+    const storageSetFile = vi.fn()
+    const writeText = vi.fn(async () => {
+      throw Object.assign(new Error('denied'), {
+        code: 'PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED',
+      })
+    })
+    const pluginModule = copyingPlugin(writeText, storageSetFile)
 
     await pluginModule.onFeatureTriggered('snippets-search', 'hello')
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'copy',
-        featureId: 'snippets-search',
-        snippetId: 'hello',
-      },
-    })
+    const result = await pluginModule.onItemAction(copyItem)
 
-    expect(request).toHaveBeenCalledWith('clipboard.write', '需要剪贴板写入权限以复制片段内容')
-    expect(writeText).not.toHaveBeenCalled()
+    expect(writeText).toHaveBeenCalledTimes(1)
     expect(storageSetFile).not.toHaveBeenCalled()
     expect(result).toMatchObject({
       externalAction: true,
@@ -133,241 +111,43 @@ describe('code snippets', () => {
     })
   })
 
-  it('blocks snippet copy when permission sdk is unavailable', async () => {
-    const writeText = vi.fn()
-    const storageSetFile = vi.fn()
-    const pluginModule = loadPluginModule(snippetsUrl, createPluginGlobals({
-      TuffItemBuilder: FakeBuilder,
-      clipboard: { writeText },
-      permission: withoutGlobal(),
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        storage: {
-          async getFile() {
-            return {
-              version: 1,
-              snippets: [
-                {
-                  id: 'hello',
-                  title: 'Hello',
-                  content: 'hello world',
-                  type: 'text',
-                },
-              ],
-            }
-          },
-          setFile: storageSetFile,
-        },
-      },
-    }))
+  it('surfaces host-unavailable separately from a permission denial', async () => {
+    const writeText = vi.fn(async () => {
+      throw Object.assign(new Error('unavailable'), {
+        code: 'PLUGIN_HOST_CAPABILITY_UNAVAILABLE',
+      })
+    })
+    const pluginModule = copyingPlugin(writeText)
 
     await pluginModule.onFeatureTriggered('snippets-search', 'hello')
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'copy',
-        featureId: 'snippets-search',
-        snippetId: 'hello',
-      },
-    })
+    const result = await pluginModule.onItemAction(copyItem)
 
-    expect(writeText).not.toHaveBeenCalled()
-    expect(storageSetFile).not.toHaveBeenCalled()
+    // The two codes must stay distinguishable: a caller retries one and not the other.
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-sdk-unavailable',
+      reason: 'host-unavailable',
     })
   })
 
-  it('blocks snippet copy when clipboard permission request fails', async () => {
-    const writeText = vi.fn()
+  it('copies through the host capability when it is allowed', async () => {
     const storageSetFile = vi.fn()
-    const pluginModule = loadPluginModule(snippetsUrl, createPluginGlobals({
-      TuffItemBuilder: FakeBuilder,
-      clipboard: { writeText },
-      permission: {
-        check: async () => false,
-        request: async () => {
-          throw new Error('permission transport failed')
-        },
-      },
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        storage: {
-          async getFile() {
-            return {
-              version: 1,
-              snippets: [
-                {
-                  id: 'hello',
-                  title: 'Hello',
-                  content: 'hello world',
-                  type: 'text',
-                },
-              ],
-            }
-          },
-          setFile: storageSetFile,
-        },
-      },
-    }))
+    const writeText = vi.fn(async () => undefined)
+    const pluginModule = copyingPlugin(writeText, storageSetFile)
 
     await pluginModule.onFeatureTriggered('snippets-search', 'hello')
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'copy',
-        featureId: 'snippets-search',
-        snippetId: 'hello',
-      },
-    })
+    const result = await pluginModule.onItemAction(copyItem)
 
-    expect(writeText).not.toHaveBeenCalled()
-    expect(storageSetFile).not.toHaveBeenCalled()
-    expect(result).toMatchObject({
-      externalAction: true,
-      success: false,
-      status: 'blocked',
-      reason: 'permission-request-failed',
-    })
+    expect(writeText).toHaveBeenCalledWith('hello world')
+    expect(result).toMatchObject({ externalAction: true, status: 'started' })
   })
 
-  it('blocks snippet pack export when clipboard.write permission is denied', async () => {
-    const writeText = vi.fn()
-    const request = vi.fn(async () => false)
-    const pluginModule = loadPluginModule(snippetsUrl, createPluginGlobals({
-      clipboard: { writeText },
-      permission: {
-        check: async () => false,
-        request,
-      },
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        storage: {
-          async getFile() {
-            return {
-              version: 1,
-              snippets: [
-                { id: 'safe', title: 'Safe', content: 'safe content' },
-              ],
-            }
-          },
-          async setFile() {},
-        },
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'manage',
-        actionId: 'pack-export',
-        featureId: 'snippets-manage',
-      },
-    })
-
-    expect(request).toHaveBeenCalledWith('clipboard.write', '需要剪贴板写入权限以导出片段包')
-    expect(writeText).not.toHaveBeenCalled()
-    expect(result).toMatchObject({
-      externalAction: true,
-      success: false,
-      status: 'blocked',
-      reason: 'permission-denied',
-    })
-  })
-
-  it('blocks snippet pack export when permission sdk is unavailable', async () => {
-    const writeText = vi.fn()
-    const pluginModule = loadPluginModule(snippetsUrl, createPluginGlobals({
-      clipboard: { writeText },
-      permission: withoutGlobal(),
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        storage: {
-          async getFile() {
-            return {
-              version: 1,
-              snippets: [
-                { id: 'safe', title: 'Safe', content: 'safe content' },
-              ],
-            }
-          },
-          async setFile() {},
-        },
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'manage',
-        actionId: 'pack-export',
-        featureId: 'snippets-manage',
-      },
-    })
-
-    expect(writeText).not.toHaveBeenCalled()
-    expect(result).toMatchObject({
-      externalAction: true,
-      success: false,
-      status: 'blocked',
-      reason: 'permission-sdk-unavailable',
-    })
-  })
-
-  it('blocks snippet pack export when clipboard permission request fails', async () => {
-    const writeText = vi.fn()
-    const pluginModule = loadPluginModule(snippetsUrl, createPluginGlobals({
-      clipboard: { writeText },
-      permission: {
-        check: async () => false,
-        request: async () => {
-          throw new Error('permission transport failed')
-        },
-      },
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        storage: {
-          async getFile() {
-            return {
-              version: 1,
-              snippets: [
-                { id: 'safe', title: 'Safe', content: 'safe content' },
-              ],
-            }
-          },
-          async setFile() {},
-        },
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'manage',
-        actionId: 'pack-export',
-        featureId: 'snippets-manage',
-      },
-    })
-
-    expect(writeText).not.toHaveBeenCalled()
-    expect(result).toMatchObject({
-      externalAction: true,
-      success: false,
-      status: 'blocked',
-      reason: 'permission-request-failed',
-    })
-  })
+  // The three 'blocks snippet pack export …' cases were removed rather than
+  // ported: touch-snippets no longer implements a 'pack-export' action at all.
+  // It was dropped in e37c92c8c alongside the prelude migration, and the plugin
+  // now handles add / clear / cloud-install / cloud-list / cloud-publish / copy /
+  // save. There is no replacement contract to link because there is no longer a
+  // feature -- keeping them would assert a permission gate on an action that
+  // cannot be invoked.
 })

--- a/packages/test/src/plugins/snippets.test.ts
+++ b/packages/test/src/plugins/snippets.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createPluginGlobals, loadPluginModule, withoutGlobal } from './plugin-loader'
+import { createPluginGlobals, loadPluginModule } from './plugin-loader'
 
 const snippetsUrl = new URL('../../../../plugins/touch-snippets/index.js', import.meta.url)
-const snippetsPlugin = loadPluginModule(snippetsUrl)
-const { __test: snippetsTest } = snippetsPlugin
 
 class FakeBuilder {
   item: Record<string, unknown>


### PR DESCRIPTION
`snippets.test.ts` had **9 failures with three different causes**, all traceable to `e37c92c8c feat(plugins): migrate official preludes to isolated runtime`.

## 1. The permission model moved host-side (3 tests)

The plugin no longer calls `permission.request()` itself. It invokes the capability and maps a thrown `PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED` / `_UNAVAILABLE` to a stable blocked result (`index.js:133-145`).

The old tests asserted the pre-check, so they failed with `request` called **0 times** — which reads as *"the plugin stopped checking permissions"*. That was never true; the gate moved to the host. Rewritten against the current contract, with the two codes asserted separately, since a caller retries one and not the other.

## 2. `pack-export` no longer exists (3 tests)

The action was dropped in the same commit. The plugin now handles `add` / `clear` / `cloud-install` / `cloud-list` / `cloud-publish` / `copy` / `save`. Removed rather than ported — there is no replacement contract to link because there is no longer a feature, and keeping them would assert a permission gate on an action that cannot be invoked.

## 3. The `__test` export was removed (3 tests)

These called `applyPlaceholders()` and `matchSnippet()` directly. Placeholder resolution and title/content matching are **already covered at the boundary** by `plugins/touch-snippets/index.test.cjs`, so they are not reinstated.

## The one gap I did not paper over

Tag matching is the single thing genuinely not covered elsewhere — every package-local search is by title text. It is kept as `it.todo` rather than deleted quietly.

It is not shipped as a failing test because the gap is in **this file's fixture wiring**, not in the feature: `onFeatureTriggered('snippets-search', …)` returns `false` here for *any* query, including one matching a title, while `index.js:79` does include tags in the searchable text.

**9 failing → 0**, with the real coverage gap visible in the test output rather than only in a comment.

Refs #330