### PR TITLE
fix(nexus): stop LinuxDO's unverified email from adopting an existing account

### DIFF
--- a/apps/nexus/server/api/auth/[...].ts
+++ b/apps/nexus/server/api/auth/[...].ts
@@ -20,6 +20,7 @@ import {
 import { readCloudflareBindings } from '../../utils/cloudflare'
 import { sendEmail } from '../../utils/email'
 import { normalizeAuthOrigin, shouldTrustForwardedAuthHost } from '../../utils/authOrigin'
+import { oauthEmailProvesMailboxControl } from '../../utils/oauthEmailTrust'
 import {
   assertRuntimeCredential,
   isLocalDevelopmentRuntime,
@@ -614,9 +615,14 @@ function getAuthOptions(authSecret: string): AuthOptions {
       type: 'oauth',
       clientId: linuxdoClientId,
       clientSecret: linuxdoClientSecret,
-      // Keep LinuxDO behavior consistent with GitHub: when OAuth email matches an existing
-      // local account, allow linking instead of returning without creating provider linkage.
-      allowDangerousEmailAccountLinking: true,
+      // GitHub resolves its email through /user/emails and keeps only entries the issuer
+      // marks `verified === true`, so an email from GitHub is proof of mailbox control.
+      // LinuxDO's /api/user carries no equivalent claim: the address is whatever the account
+      // has set. Auto-linking on it let anyone who set a victim's address at the issuer sign
+      // straight into the victim's Nexus account, admin included (#916). Linking to a
+      // pre-existing local account is therefore off here, and the signIn callback below
+      // refuses to adopt one unless the profile carries an explicit `email_verified` claim.
+      allowDangerousEmailAccountLinking: false,
       authorization: {
         url: `${linuxdoIssuer}/oauth2/authorize`,
         params: { scope: 'profile email' },
@@ -699,6 +705,11 @@ function getAuthOptions(authSecret: string): AuthOptions {
           if (!email) return true
           const existing = await getUserByEmail(authEvent, email)
           if (!existing) return true
+          // Checked before restoreForInteractiveSignIn, not after: that call un-deletes an
+          // account inside its pending-deletion window, so letting an untrusted email reach
+          // it would let a stranger resurrect someone else's account even when the sign-in
+          // that follows is refused.
+          if (!oauthEmailProvesMailboxControl(account.provider, profile)) return false
           return Boolean(await restoreForInteractiveSignIn(authEvent, existing.id))
         }
         if (account.provider === 'email') {

--- a/apps/nexus/server/utils/oauthEmailTrust.test.ts
+++ b/apps/nexus/server/utils/oauthEmailTrust.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import type { Profile } from 'next-auth'
+import { describe, expect, it } from 'vitest'
+import { EMAIL_VERIFYING_OAUTH_PROVIDERS, oauthEmailProvesMailboxControl } from './oauthEmailTrust'
+
+/**
+ * The rule that decides whether an OAuth email may be used to sign in as an account that
+ * already exists (#916).
+ *
+ * LinuxDO's /api/user returns an address with no verification claim attached, and the
+ * provider had allowDangerousEmailAccountLinking on, so setting a victim's address at the
+ * issuer was enough to be handed their Nexus account.
+ */
+describe('oauthEmailProvesMailboxControl', () => {
+  const profile = (value: unknown): Profile => ({ email_verified: value }) as unknown as Profile
+
+  it('trusts github, whose userinfo hook keeps only issuer-verified addresses', () => {
+    expect(oauthEmailProvesMailboxControl('github')).toBe(true)
+  })
+
+  it('does not trust linuxdo, which sends no verification claim', () => {
+    expect(oauthEmailProvesMailboxControl('linuxdo')).toBe(false)
+    expect(oauthEmailProvesMailboxControl('linuxdo', profile(undefined))).toBe(false)
+  })
+
+  it('accepts an explicit email_verified claim from any provider', () => {
+    // Kept so a provider that does assert verification is not punished for not being github.
+    expect(oauthEmailProvesMailboxControl('linuxdo', profile(true))).toBe(true)
+  })
+
+  it('rejects the truthy shapes that are not a verification claim', () => {
+    // An issuer emitting "false" as a string would otherwise read as verified, which is the
+    // classic way a strict-equality check gets loosened into a vulnerability.
+    for (const value of ['true', 'false', 1, 0, 'yes', {}, [], null])
+      expect(oauthEmailProvesMailboxControl('linuxdo', profile(value)), String(value)).toBe(false)
+  })
+
+  it('fails closed for an unknown provider', () => {
+    expect(oauthEmailProvesMailboxControl('some-new-idp')).toBe(false)
+  })
+
+  it('keeps the trusted set to providers that actually verify', () => {
+    // A guard on the allowlist itself: adding an entry here silently re-opens #916 for that
+    // provider, so growing it should require editing this assertion too.
+    expect([...EMAIL_VERIFYING_OAUTH_PROVIDERS]).toEqual(['github'])
+  })
+})
+
+/**
+ * The other half of the fix lives in provider config, where re-enabling the hole is a
+ * one-word edit. Asserted against the source text because the auth route builds its provider
+ * list inside a Nuxt request handler and cannot be imported in isolation.
+ */
+describe('linuxdo provider configuration', () => {
+  const source = readFileSync(
+    fileURLToPath(new URL('../api/auth/[...].ts', import.meta.url)),
+    'utf8',
+  )
+
+  function linuxdoBlock(): string {
+    const start = source.indexOf('const linuxdoProvider')
+    expect(start, 'linuxdo provider block not found — this guard is reading the wrong file').toBeGreaterThan(-1)
+    const end = source.indexOf('providers.push(linuxdoProvider', start)
+    expect(end).toBeGreaterThan(start)
+    return source.slice(start, end)
+  }
+
+  it('does not allow dangerous email account linking', () => {
+    expect(linuxdoBlock()).toContain('allowDangerousEmailAccountLinking: false')
+    expect(linuxdoBlock()).not.toContain('allowDangerousEmailAccountLinking: true')
+  })
+
+  it('confirms the guard can see a true value, so the assertion above means something', () => {
+    // Positive control. Without it, a block() that silently returned '' would pass the
+    // not.toContain above and report a fixed provider forever.
+    const github = source.slice(source.indexOf('GitHubProvider({'))
+    expect(github).toContain('allowDangerousEmailAccountLinking: true')
+  })
+})

--- a/apps/nexus/server/utils/oauthEmailTrust.ts
+++ b/apps/nexus/server/utils/oauthEmailTrust.ts
@@ -1,0 +1,28 @@
+import type { Profile } from 'next-auth'
+
+/**
+ * OAuth providers whose email claim is itself proof that the signer controls the mailbox.
+ *
+ * Only GitHub qualifies today: its userinfo hook resolves the address through /user/emails
+ * and keeps entries the issuer marks `verified === true`. (That selection still has an
+ * unverified last-resort branch — tracked separately in #917 — which is why this is a
+ * deliberate allowlist rather than "every provider except LinuxDO".)
+ */
+export const EMAIL_VERIFYING_OAUTH_PROVIDERS = new Set(['github'])
+
+/**
+ * Whether an OAuth email may be used to sign in as a **pre-existing** local account.
+ *
+ * Creating a fresh account from an unverified address is harmless — the address simply
+ * becomes that new account's email. Adopting an account that already exists is not: it hands
+ * over someone else's identity on the strength of a string the attacker chose. LinuxDO's
+ * /api/user carries no verification claim at all, so anyone who set a victim's address at
+ * the issuer could sign straight into the victim's Nexus account, admin included (#916).
+ */
+export function oauthEmailProvesMailboxControl(provider: string, profile?: Profile): boolean {
+  if (EMAIL_VERIFYING_OAUTH_PROVIDERS.has(provider)) return true
+  // Absent an explicit claim this is false, so a provider that sends no verification signal
+  // fails closed rather than being trusted by default. Only a real boolean `true` counts —
+  // the string "true", 1 and "1" are all shapes an issuer can emit for an unverified state.
+  return (profile as { email_verified?: unknown } | undefined)?.email_verified === true
+}


### PR DESCRIPTION
Closes #916.

## The defect

LinuxDO ran with `allowDangerousEmailAccountLinking: true` while `profile()` took `profile.email` straight from `/api/user`. That response carries **no verification claim** — the address is simply whatever the LinuxDO account has set. Claiming a victim's address at the issuer and clicking *Sign in with LinuxDO* was enough to be handed the victim's Nexus account, admin role included, without ever proving control of the mailbox.

## Why the suggested fix needed adjusting

The issue proposed requiring `email_verified === true`. That field does not exist in LinuxDO's response, so requiring it alone would have been asserting a claim the issuer never makes. Instead the check **fails closed on its absence**: a provider that sends no verification signal is untrusted, and one that does send `email_verified: true` is honoured. Nothing is invented.

## The distinction the fix draws

| situation | before | now |
|---|---|---|
| unverified email, **no** existing account | new account created | unchanged — the address just becomes that account's email |
| unverified email, **existing** account | signed in as that user | refused |
| github (issuer-verified email) | signed in | unchanged |

Creating a new account from an unverified address is not someone else's identity. Adopting an account that already exists is. Only the second is blocked.

## One thing the issue did not mention

The check sits **before** `restoreForInteractiveSignIn`, not after. That call un-deletes an account inside its pending-deletion window, so an untrusted email reaching it would let a stranger resurrect someone else's account even when the sign-in that follows is refused.

## Behaviour change, stated plainly

A LinuxDO user who also has a local account under the same address will now get `OAuthAccountNotLinked` instead of being signed in. **That path was the vulnerability**, so no version of this fix keeps it working — those users need to sign in locally and link deliberately. Flagging it because it is a real support-facing change, not a silent one.

## Scope

GitHub is untouched. Its userinfo hook already filters on the issuer's `verified === true`; the unverified last-resort branch still in that selection is #917 and is deliberately left for that issue. The trusted-provider set is an explicit allowlist rather than "everything except LinuxDO" for exactly that reason.

## Tests

`server/utils/oauthEmailTrust.test.ts`, 8 cases:

- github trusted; linuxdo not; explicit `email_verified: true` honoured from any provider
- the truthy-but-not-a-claim shapes rejected — `'true'`, `'false'`, `1`, `0`, `'yes'`, `{}`, `[]`, `null` (loosening strict equality here is the classic regression)
- unknown provider fails closed
- the allowlist itself is pinned, so adding a provider to it requires editing the assertion
- a source-level guard that the linuxdo block does not carry `allowDangerousEmailAccountLinking: true`, since re-opening the hole is a one-word edit

Against the pre-fix `HEAD` the config guard **fails**; the remaining 7 pass. The guard also carries a positive control asserting it can still *see* a `true` value (on the GitHub block) — without that, a selector returning `''` would report a fixed provider forever.

Lint clean.