### PR TITLE
fix(nexus): drop the unverified last-resort branch in GitHub email selection

### DIFF
--- a/apps/nexus/server/api/auth/[...].ts
+++ b/apps/nexus/server/api/auth/[...].ts
@@ -20,7 +20,7 @@ import {
 import { readCloudflareBindings } from '../../utils/cloudflare'
 import { sendEmail } from '../../utils/email'
 import { normalizeAuthOrigin, shouldTrustForwardedAuthHost } from '../../utils/authOrigin'
-import { oauthEmailProvesMailboxControl } from '../../utils/oauthEmailTrust'
+import { oauthEmailProvesMailboxControl, selectVerifiedGitHubEmail } from '../../utils/oauthEmailTrust'
 import {
   assertRuntimeCredential,
   isLocalDevelopmentRuntime,
@@ -576,24 +576,19 @@ function getAuthOptions(authSecret: string): AuthOptions {
               if (emailResponse.status >= 200 && emailResponse.status < 300) {
                 const emails = Array.isArray(emailResponse.data) ? emailResponse.data : []
                 if (Array.isArray(emails)) {
-                  const primary =
-                    emails.find(item => {
-                      return (
-                        item &&
-                        typeof item.email === 'string' &&
-                        item.email.length > 0 &&
-                        item.verified === true &&
-                        item.primary === true
-                      )
-                    }) ??
-                    emails.find(item => {
-                      return item && typeof item.email === 'string' && item.email.length > 0 && item.verified === true
-                    }) ??
-                    emails.find(item => {
-                      return item && typeof item.email === 'string' && item.email.length > 0
-                    })
-
-                  if (primary && typeof primary.email === 'string') profile.email = primary.email
+                  // Verified addresses only. There used to be a further branch taking any
+                  // address at all when neither matched, and GitHub returns addresses a user
+                  // has merely *added* (`verified: false`), so it could hand back one the
+                  // signer never proved they own (#917).
+                  //
+                  // This matters more than it looks: oauthEmailProvesMailboxControl trusts
+                  // 'github' unconditionally, and the reason it may is precisely that this
+                  // selection yields verified addresses only. The fallback contradicted the
+                  // premise the rest of the account-linking rule rests on. Left unset when
+                  // nothing is verified — sign-in still works, it just cannot resolve to a
+                  // pre-existing account, which is the outcome worth protecting.
+                  const selected = selectVerifiedGitHubEmail(emails)
+                  if (selected) profile.email = selected
                 }
               }
             }

--- a/apps/nexus/server/utils/oauthEmailTrust.test.ts
+++ b/apps/nexus/server/utils/oauthEmailTrust.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import type { Profile } from 'next-auth'
 import { describe, expect, it } from 'vitest'
-import { EMAIL_VERIFYING_OAUTH_PROVIDERS, oauthEmailProvesMailboxControl } from './oauthEmailTrust'
+import { EMAIL_VERIFYING_OAUTH_PROVIDERS, oauthEmailProvesMailboxControl, selectVerifiedGitHubEmail } from './oauthEmailTrust'
 
 /**
  * The rule that decides whether an OAuth email may be used to sign in as an account that
@@ -76,5 +76,58 @@ describe('linuxdo provider configuration', () => {
     // not.toContain above and report a fixed provider forever.
     const github = source.slice(source.indexOf('GitHubProvider({'))
     expect(github).toContain('allowDangerousEmailAccountLinking: true')
+  })
+})
+
+/**
+ * Which address GitHub's /user/emails contributes (#917).
+ *
+ * The selection had a last-resort branch that took any address when no verified one matched.
+ * GitHub returns addresses a user has merely *added*, so that branch could yield one the
+ * signer never proved they own — and oauthEmailProvesMailboxControl above trusts 'github'
+ * unconditionally on the premise that this selection is verified-only.
+ */
+describe('selectVerifiedGitHubEmail', () => {
+  const entry = (email: string, verified: boolean, primary = false) => ({ email, verified, primary })
+
+  it('prefers the verified primary address', () => {
+    expect(selectVerifiedGitHubEmail([
+      entry('other@example.com', true),
+      entry('me@example.com', true, true),
+    ])).toBe('me@example.com')
+  })
+
+  it('takes a verified non-primary when no verified primary exists', () => {
+    expect(selectVerifiedGitHubEmail([
+      entry('unverified@example.com', false, true),
+      entry('me@example.com', true),
+    ])).toBe('me@example.com')
+  })
+
+  it('returns nothing when the only addresses are unverified', () => {
+    // The regression. This used to return victim@example.com, which then matched an existing
+    // Nexus account and linked the attacker's GitHub identity to it.
+    expect(selectVerifiedGitHubEmail([
+      entry('victim@example.com', false, true),
+      entry('attacker@example.com', false),
+    ])).toBeUndefined()
+  })
+
+  it('never prefers an unverified primary over a verified non-primary', () => {
+    expect(selectVerifiedGitHubEmail([
+      entry('victim@example.com', false, true),
+      entry('attacker@example.com', true),
+    ])).toBe('attacker@example.com')
+  })
+
+  it('treats a non-boolean verified value as unverified', () => {
+    for (const value of ['true', 1, 'yes', {}])
+      expect(selectVerifiedGitHubEmail([{ email: 'x@example.com', verified: value, primary: true }]), String(value)).toBeUndefined()
+  })
+
+  it('handles the shapes a failed API call can produce', () => {
+    for (const value of [[], null, undefined, {}, 'nope'])
+      expect(selectVerifiedGitHubEmail(value)).toBeUndefined()
+    expect(selectVerifiedGitHubEmail([null, { email: '' , verified: true }, { verified: true }])).toBeUndefined()
   })
 })

--- a/apps/nexus/server/utils/oauthEmailTrust.ts
+++ b/apps/nexus/server/utils/oauthEmailTrust.ts
@@ -26,3 +26,29 @@ export function oauthEmailProvesMailboxControl(provider: string, profile?: Profi
   // the string "true", 1 and "1" are all shapes an issuer can emit for an unverified state.
   return (profile as { email_verified?: unknown } | undefined)?.email_verified === true
 }
+
+/**
+ * Picks the address to use from GitHub's /user/emails, preferring the verified primary.
+ *
+ * Only entries GitHub reports as `verified: true` are eligible. The selection used to fall
+ * back to any address when no verified one matched, which defeated the point: GitHub returns
+ * addresses a user has merely *added*, so the fallback could yield one the signer never
+ * proved they own (#917). Returning undefined is the correct answer when nothing is
+ * verified — the caller leaves profile.email unset, and a sign-in with no email cannot
+ * resolve to a pre-existing account.
+ */
+export function selectVerifiedGitHubEmail(emails: unknown): string | undefined {
+  if (!Array.isArray(emails)) return undefined
+
+  const usable = (item: unknown): item is { email: string; verified: true; primary?: unknown } => {
+    if (!item || typeof item !== 'object') return false
+    const record = item as { email?: unknown; verified?: unknown }
+    return typeof record.email === 'string' && record.email.length > 0 && record.verified === true
+  }
+
+  const found =
+    emails.find(item => usable(item) && (item as { primary?: unknown }).primary === true) ??
+    emails.find(usable)
+
+  return usable(found) ? found.email : undefined
+}


### PR DESCRIPTION
Closes #917.

## The defect

The `/user/emails` selection tried three branches in order:

1. `verified === true && primary === true`
2. `verified === true`
3. **any address at all**

GitHub returns addresses a user has merely *added* (`verified: false`), so branch 3 could hand back an address the signer never proved they own — which then matched an existing Nexus account through `allowDangerousEmailAccountLinking`.

## On the "plausible" flag

The report was filed as needing verification, and it is right to be cautious: branch 3 only runs when the public profile email is `null` **and** no verified address comes back at all, which is an unusual account state.

I fixed it anyway, for a reason that did not exist when the issue was filed. #916 introduced `oauthEmailProvesMailboxControl`, which trusts `'github'` **unconditionally** — and the justification for that is precisely that this selection yields verified addresses only. Branch 3 contradicted the premise the rest of the account-linking rule now rests on. Narrow reachability, but it undercut a guarantee stated elsewhere in the code.

## Behaviour when nothing is verified

`profile.email` is left unset. The issue suggested failing the sign-in outright; leaving it unset reaches the same security outcome — a sign-in with no email cannot resolve to a pre-existing account — without turning a GitHub account that has no verified address into a hard error.

## Tests

The selection moved to `server/utils/oauthEmailTrust.ts`, beside the rule it underpins, so it can be tested at all — it was inline in a Nitro `userinfo` hook. The extraction is faithful with branch 3 removed.

Six new cases (14 in the file):

- verified primary preferred; verified non-primary used when no verified primary exists
- **unverified-only input returns nothing** — the regression
- an unverified *primary* never beats a verified non-primary
- `verified` values of `'true'`, `1`, `'yes'`, `{}` treated as unverified
- the shapes a failed API call produces: `[]`, `null`, `undefined`, `{}`, `'nope'`, and entries missing/empty `email`

**Discrimination check:** reinstating branch 3 in the extracted function fails 2 of the 14. Restoring the route file alone would not have exercised these tests, since the logic was inline before — so the check was run against the reinstated behaviour rather than against a file revert.

Lint clean.