### PR TITLE
test(browser-bookmarks): drive the suite through the contracts the plugin actually has (#330)

### DIFF
--- a/packages/test/src/plugins/browser-bookmarks.test.ts
+++ b/packages/test/src/plugins/browser-bookmarks.test.ts
@@ -1,44 +1,89 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it, vi } from 'vitest'
-import { createPluginGlobals, loadPluginModule, withoutGlobal } from './plugin-loader'
+import { createPluginGlobals, loadPluginModule, loadPluginModuleWithSourceTransform, withoutGlobal } from './plugin-loader'
 
 const browserBookmarksUrl = new URL('../../../../plugins/touch-browser-bookmarks/index.js', import.meta.url)
-const browserBookmarksPlugin = loadPluginModule(browserBookmarksUrl)
-const { __test: browserBookmarksTest } = browserBookmarksPlugin
+// The plugin exports its lifecycle and nothing else. That is not an oversight to
+// route around: e37c92c8c removed the __test export in the isolated-runtime
+// migration, and the plugin's own suite asserts its absence ("exports lifecycle
+// only", plugins/touch-browser-bookmarks/index.test.cjs). Re-adding it to the
+// shipped file would break that contract to serve a test.
+//
+// So the internals are re-exported at load time instead, into this test's copy of
+// the module only -- the same approach intelligence.test.ts already takes.
+const TEST_EXPORT_NAMES = [
+  'normalizeUrlInput',
+  'upsertBookmark',
+  'cleanupRecent',
+  'mergeRecentForDisplay',
+] as const
 
+const browserBookmarksTest = loadPluginModuleWithSourceTransform<{
+  __test: Record<(typeof TEST_EXPORT_NAMES)[number], (...args: any[]) => any>
+}>(
+  browserBookmarksUrl,
+  source => `${source}\nmodule.exports.__test={${TEST_EXPORT_NAMES.join(',')}}`,
+  createPluginGlobals(),
+).__test
+
+// Mirrors the builder in plugins/touch-browser-bookmarks/index.test.cjs. This copy
+// had drifted from it in two ways that made every item come out wrong:
+// createAndAddAction was missing entirely (only the older addAction existed), so
+// every build threw; and setMeta overwrote rather than merged, while the plugin
+// calls it twice per item.
 class FakeBuilder {
   item: Record<string, unknown>
+  basic: Record<string, unknown>
 
   constructor(id: string) {
-    this.item = { id }
+    this.item = { id, meta: {}, actions: [] }
+    this.basic = {}
   }
 
-  setSource() {
+  setSource(type: string, id: string, name: string) {
+    this.item.source = { type, id, name }
     return this
   }
 
   setTitle(title: string) {
     this.item.title = title
+    this.basic.title = title
     return this
   }
 
   setSubtitle(subtitle: string) {
     this.item.subtitle = subtitle
+    this.basic.subtitle = subtitle
     return this
   }
 
-  setIcon() {
+  setIcon(icon: unknown) {
+    this.basic.icon = icon
     return this
   }
 
   setMeta(meta: Record<string, unknown>) {
-    this.item.meta = meta
+    this.item.meta = { ...(this.item.meta as Record<string, unknown>), ...meta }
+    return this
+  }
+
+  createAndAddAction(id: string, type: string, label: string, payload: unknown) {
+    ;(this.item.actions as unknown[]).push({ id, type, label, payload })
     return this
   }
 
   build() {
+    this.item.render = { mode: 'default', basic: { ...this.basic } }
     return this.item
   }
+}
+
+// buildActionItem (plugins/touch-browser-bookmarks/index.js:448-465) puts the
+// payload, sourceType and capability diagnostics in the item's *action*; item.meta
+// carries only pluginName / featureId / defaultAction. The assertions below read
+// the action, which is where the plugin actually writes them.
+function actionPayload(item: unknown): Record<string, any> | undefined {
+  return (item as { actions?: Array<{ payload?: Record<string, any> }> })?.actions?.[0]?.payload
 }
 
 describe('browser bookmarks plugin', () => {
@@ -133,7 +178,7 @@ describe('browser bookmarks plugin', () => {
 
     const openItem = items.find(item => item.title === '默认浏览器打开')
     expect(openItem?.subtitle).toContain('缺少 network.internet 权限')
-    expect(openItem?.meta?.capability).toMatchObject({
+    expect(actionPayload(openItem)?.capability).toMatchObject({
       id: 'network.internet',
       type: 'network',
       permission: 'network.internet',
@@ -172,22 +217,32 @@ describe('browser bookmarks plugin', () => {
 
     const openItem = items.find(item => item.title === '默认浏览器打开')
     expect(openItem?.subtitle).toContain('缺少 network.internet 权限')
-    expect(openItem?.meta?.capability).toMatchObject({
+    expect(actionPayload(openItem)?.capability).toMatchObject({
       status: 'permission-missing',
       reason: 'permission-sdk-unavailable',
       permission: 'network.internet',
     })
   })
 
-  it('blocks external URL opening when network permission is denied', async () => {
-    const openUrl = vi.fn()
-    const request = vi.fn(async () => false)
+  // e37c92c8c deleted ensurePermission and both permission.request calls: the
+  // plugin no longer prompts, the HOST enforces. It calls openUrl / clipboard.writeText
+  // and reads the thrown error -- PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED means denied,
+  // anything else means the call failed. The tests below asserted the deleted
+  // prompting contract (that `request` was called with a reason string, and that the
+  // capability was never invoked); they now drive the capability the way the host does.
+  // The intent of each is unchanged: denied / unavailable / failed / granted.
+  const HOST_DENIED = 'PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED'
+
+  function hostDenied(message: string) {
+    return Object.assign(new Error(message), { code: HOST_DENIED })
+  }
+
+  it('blocks external URL opening when the host denies network permission', async () => {
+    const openUrl = vi.fn(async () => {
+      throw hostDenied('/private/open denied')
+    })
     const pluginModule = loadPluginModule(browserBookmarksUrl, createPluginGlobals({
       openUrl,
-      permission: {
-        check: async () => false,
-        request,
-      },
       plugin: {
         storage: {
           async getFile() { return null },
@@ -197,11 +252,8 @@ describe('browser bookmarks plugin', () => {
     }))
 
     const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'browser-bookmarks',
-        actionId: 'open-url',
-        payload: { url: 'https://example.com', title: 'Example' },
-      },
+      meta: { defaultAction: 'browser-bookmarks' },
+      actions: [{ id: 'open-url', payload: { url: 'https://example.com', title: 'Example' } }],
     })
 
     expect(result).toMatchObject({
@@ -209,16 +261,13 @@ describe('browser bookmarks plugin', () => {
       success: false,
       status: 'blocked',
       reason: 'permission-denied',
+      message: '缺少 network.internet 权限',
     })
-    expect(request).toHaveBeenCalledWith('network.internet', '需要 network.internet 权限以默认浏览器打开网址')
-    expect(openUrl).not.toHaveBeenCalled()
   })
 
-  it('blocks external URL opening when permission sdk is unavailable', async () => {
-    const openUrl = vi.fn()
+  it('blocks external URL opening when the host exposes no openUrl capability', async () => {
     const pluginModule = loadPluginModule(browserBookmarksUrl, createPluginGlobals({
-      openUrl,
-      permission: withoutGlobal(),
+      openUrl: withoutGlobal(),
       plugin: {
         storage: {
           async getFile() { return null },
@@ -228,32 +277,24 @@ describe('browser bookmarks plugin', () => {
     }))
 
     const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'browser-bookmarks',
-        actionId: 'open-url',
-        payload: { url: 'https://example.com', title: 'Example' },
-      },
+      meta: { defaultAction: 'browser-bookmarks' },
+      actions: [{ id: 'open-url', payload: { url: 'https://example.com', title: 'Example' } }],
     })
 
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-sdk-unavailable',
+      reason: 'open-url-unavailable',
     })
-    expect(openUrl).not.toHaveBeenCalled()
   })
 
-  it('blocks external URL opening when network permission request fails', async () => {
-    const openUrl = vi.fn()
+  it('separates a failed host open from a denied one', async () => {
+    const openUrl = vi.fn(async () => {
+      throw new Error('open transport failed')
+    })
     const pluginModule = loadPluginModule(browserBookmarksUrl, createPluginGlobals({
       openUrl,
-      permission: {
-        check: async () => false,
-        request: async () => {
-          throw new Error('permission transport failed')
-        },
-      },
       plugin: {
         storage: {
           async getFile() { return null },
@@ -263,39 +304,32 @@ describe('browser bookmarks plugin', () => {
     }))
 
     const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'browser-bookmarks',
-        actionId: 'open-url',
-        payload: { url: 'https://example.com', title: 'Example' },
-      },
+      meta: { defaultAction: 'browser-bookmarks' },
+      actions: [{ id: 'open-url', payload: { url: 'https://example.com', title: 'Example' } }],
     })
 
+    // A transport failure must not be reported as a permission problem: it would
+    // send the user to a permission screen that has nothing to fix.
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-request-failed',
+      reason: 'open-url-failed',
+      message: '打开外部链接失败',
     })
-    expect(openUrl).not.toHaveBeenCalled()
   })
 
-  it('blocks URL copy when clipboard.write permission is denied', async () => {
-    const writeText = vi.fn()
-    const request = vi.fn(async () => false)
+  it('blocks URL copy when the host denies clipboard.write', async () => {
+    const writeText = vi.fn(async () => {
+      throw hostDenied('/private/clipboard denied')
+    })
     const pluginModule = loadPluginModule(browserBookmarksUrl, createPluginGlobals({
       clipboard: { writeText },
-      permission: {
-        check: async () => false,
-        request,
-      },
     }))
 
     const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'browser-bookmarks',
-        actionId: 'copy-url',
-        payload: { url: 'example.com' },
-      },
+      meta: { defaultAction: 'browser-bookmarks' },
+      actions: [{ id: 'copy-url', payload: { url: 'example.com' } }],
     })
 
     expect(result).toMatchObject({
@@ -303,97 +337,71 @@ describe('browser bookmarks plugin', () => {
       success: false,
       status: 'blocked',
       reason: 'permission-denied',
+      message: '复制失败：缺少 clipboard.write 权限',
     })
-    expect(request).toHaveBeenCalledWith('clipboard.write', '需要剪贴板写入权限以复制链接')
-    expect(writeText).not.toHaveBeenCalled()
   })
 
-  it('blocks URL copy when permission sdk is unavailable', async () => {
-    const writeText = vi.fn()
+  it('blocks URL copy when the host exposes no clipboard', async () => {
     const pluginModule = loadPluginModule(browserBookmarksUrl, createPluginGlobals({
-      clipboard: { writeText },
-      permission: withoutGlobal(),
+      clipboard: withoutGlobal(),
     }))
 
     const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'browser-bookmarks',
-        actionId: 'copy-url',
-        payload: { url: 'example.com' },
-      },
+      meta: { defaultAction: 'browser-bookmarks' },
+      actions: [{ id: 'copy-url', payload: { url: 'example.com' } }],
     })
 
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-sdk-unavailable',
+      reason: 'clipboard-unavailable',
+      message: '当前环境不支持写入剪贴板',
     })
-    expect(writeText).not.toHaveBeenCalled()
   })
 
-  it('blocks URL copy when clipboard permission request fails', async () => {
-    const writeText = vi.fn()
+  it('separates a failed clipboard write from a denied one', async () => {
+    const writeText = vi.fn(async () => {
+      throw new Error('clipboard transport failed')
+    })
     const pluginModule = loadPluginModule(browserBookmarksUrl, createPluginGlobals({
       clipboard: { writeText },
-      permission: {
-        check: async () => false,
-        request: async () => {
-          throw new Error('permission transport failed')
-        },
-      },
     }))
 
     const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'browser-bookmarks',
-        actionId: 'copy-url',
-        payload: { url: 'example.com' },
-      },
+      meta: { defaultAction: 'browser-bookmarks' },
+      actions: [{ id: 'copy-url', payload: { url: 'example.com' } }],
     })
 
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-request-failed',
+      reason: 'clipboard-write-failed',
+      message: '复制失败',
     })
-    expect(writeText).not.toHaveBeenCalled()
   })
 
-  it('copies URL after clipboard.write permission is granted', async () => {
-    const writeText = vi.fn()
-    const request = vi.fn(async () => true)
+  it('copies the normalized URL when the host allows clipboard.write', async () => {
+    const writeText = vi.fn(async () => undefined)
     const pluginModule = loadPluginModule(browserBookmarksUrl, createPluginGlobals({
       clipboard: { writeText },
-      permission: {
-        check: async () => false,
-        request,
-      },
     }))
 
     const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'browser-bookmarks',
-        actionId: 'copy-url',
-        payload: { url: 'example.com' },
-      },
+      meta: { defaultAction: 'browser-bookmarks' },
+      actions: [{ id: 'copy-url', payload: { url: 'example.com' } }],
     })
 
     expect(result).toMatchObject({ externalAction: true, status: 'started' })
-    expect(request).toHaveBeenCalledWith('clipboard.write', '需要剪贴板写入权限以复制链接')
     expect(writeText).toHaveBeenCalledWith('https://example.com/')
   })
 
-  it('opens external URL after network permission is granted and records recent URL', async () => {
+  it('opens the external URL and records it as recent when the host allows it', async () => {
     const openUrl = vi.fn(async () => undefined)
     const writes: Array<{ file: string, data: any }> = []
     const pluginModule = loadPluginModule(browserBookmarksUrl, createPluginGlobals({
       openUrl,
-      permission: {
-        check: async () => true,
-        request: async () => true,
-      },
       plugin: {
         storage: {
           async getFile() { return null },
@@ -403,11 +411,8 @@ describe('browser bookmarks plugin', () => {
     }))
 
     const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'browser-bookmarks',
-        actionId: 'open-url',
-        payload: { url: 'example.com', title: 'Example' },
-      },
+      meta: { defaultAction: 'browser-bookmarks' },
+      actions: [{ id: 'open-url', payload: { url: 'example.com', title: 'Example' } }],
     })
 
     expect(result).toMatchObject({ externalAction: true, status: 'started' })
@@ -424,6 +429,7 @@ describe('browser bookmarks plugin', () => {
       },
     })
   })
+
   it('renders manual, pinned, recent, and direct quicklinks with compatible source payloads', async () => {
     const items: Array<{ title?: string, subtitle?: string, meta?: Record<string, any> }> = []
     const files: Record<string, unknown> = {
@@ -483,59 +489,45 @@ describe('browser bookmarks plugin', () => {
     const pinned = items.find(item => item.title === '手动收藏 · Pinned manual bookmark')
     const recent = items.find(item => item.title === '手动最近 · Recent manual quicklink')
 
-    expect(regular?.meta).toMatchObject({
+    expect(actionPayload(regular)).toMatchObject({
       sourceType: 'manual-quicklink',
-      sourceKind: 'manual-quicklink',
-      payload: {
-        url: 'https://regular.example/',
-        title: 'Regular manual bookmark',
-        source: 'bookmark',
-        sourceType: 'manual-quicklink',
-      },
+      url: 'https://regular.example/',
+      title: 'Regular manual bookmark',
+      source: 'bookmark',
     })
-    expect(pinned?.meta).toMatchObject({
+    expect(actionPayload(pinned)).toMatchObject({
       sourceType: 'manual-pinned-quicklink',
-      sourceKind: 'manual-pinned-quicklink',
-      payload: {
-        url: 'https://pinned.example/',
-        title: 'Pinned manual bookmark',
-        source: 'bookmark',
-        sourceType: 'manual-pinned-quicklink',
-      },
+      url: 'https://pinned.example/',
+      title: 'Pinned manual bookmark',
+      source: 'bookmark',
     })
     expect(pinned?.subtitle).toContain('PINNED')
-    expect(recent?.meta).toMatchObject({
+    expect(actionPayload(recent)).toMatchObject({
       sourceType: 'manual-recent-quicklink',
-      sourceKind: 'manual-recent-quicklink',
-      payload: {
-        url: 'https://recent.example/',
-        title: 'Recent manual quicklink',
-        source: 'recent',
-        sourceType: 'manual-recent-quicklink',
-      },
+      url: 'https://recent.example/',
+      title: 'Recent manual quicklink',
+      source: 'recent',
     })
 
     await pluginModule.onFeatureTriggered('browser-bookmarks', 'https://direct.example')
 
+    // sourceType and the payload live in the action, not item.meta; sourceKind no
+    // longer exists in the plugin at all, so it is dropped rather than relocated.
     const directOpen = items.find(item => item.title === '默认浏览器打开')
     const directAdd = items.find(item => item.title === '添加到收藏')
     const directCopy = items.find(item => item.title === '复制 URL')
 
-    expect(directOpen?.meta).toMatchObject({
+    expect(actionPayload(directOpen)).toMatchObject({
       sourceType: 'manual-quicklink',
-      sourceKind: 'manual-quicklink',
-      payload: {
-        url: 'https://direct.example/',
-        source: 'quick',
-        sourceType: 'manual-quicklink',
-      },
+      url: 'https://direct.example/',
+      source: 'quick',
     })
-    expect(directAdd?.meta?.payload).toMatchObject({
+    expect(actionPayload(directAdd)).toMatchObject({
       url: 'https://direct.example/',
       sourceType: 'manual-quicklink',
     })
-    expect(directAdd?.meta?.payload?.source).toBeUndefined()
-    expect(directCopy?.meta?.payload).toEqual({
+    expect(actionPayload(directAdd)?.source).toBeUndefined()
+    expect(actionPayload(directCopy)).toEqual({
       url: 'https://direct.example/',
       sourceType: 'manual-quicklink',
     })

--- a/plugins/touch-browser-bookmarks/index.js
+++ b/plugins/touch-browser-bookmarks/index.js
@@ -678,8 +678,12 @@ const pluginLifecycle = {
       await plugin.feature.pushItems(items)
       return true
     }
-    catch {
-      logger?.error?.('[touch-browser-bookmarks] Failed to handle feature')
+    catch (error) {
+      // Carry the error. This catch turns any fault in the feature handler into a
+      // generic '浏览器收藏加载失败' item, so a message-only log leaves the user with
+      // a failure and nobody with a cause -- including whoever is looking at a test
+      // run, where every distinct fault in here presents as the same fallback item.
+      logger?.error?.('[touch-browser-bookmarks] Failed to handle feature', error)
       try {
         await plugin.feature.clearItems()
         await plugin.feature.pushItems([


### PR DESCRIPTION
Refs #330. `packages/test` browser-bookmarks: **15 failing → 0 of 16**.
No test removed, none downgraded to `it.todo`.

> Rebuilt on current `master`. The branch previously carried unrelated history —
> my earlier PRs were squash-merged, so the originals still sat on this branch and
> the diff showed dozens of unrelated files. It's now two files.

---

Four separate pieces of drift, all pointing the same way: the suite was written
against a plugin that `e37c92c8c` (isolated-runtime migration) replaced.

### 1. `__test` is gone — deliberately

The migration removed the `__test` export, and the plugin's own suite **asserts its
absence** (`"exports lifecycle only"`, `plugins/touch-browser-bookmarks/index.test.cjs`).
Re-adding it to the shipped file would break that contract to serve a test.

Instead the internals are re-exported *at load time*, into this suite's copy of the
module only, through the source-transform loader that `intelligence.test.ts` already
uses for exactly this. The shipped plugin is untouched.

### 2. `FakeBuilder` had drifted from the plugin's own

- `createAndAddAction` **missing entirely** — only the older `addAction` existed, so
  every item build threw and the handler's generic failure item came back instead.
- `setMeta` overwrote rather than merged, while the plugin calls it twice per item.

### 3. `onItemAction` reads `item.actions[0]`, not `item.meta`

The tests passed `actionId` and `payload` inside `meta`, so `action` came back null,
the handler fell through every branch, and returned `undefined`. Eight call sites.

### 4. The permission model moved host-side

`e37c92c8c` deleted `ensurePermission` and **both** `permission.request` calls. The
plugin doesn't prompt any more — it calls the capability and reads the thrown error:
`PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED` means denied, anything else means the call
failed. `permission.check` survives only to render diagnostics on the item.

The eight tests asserting the prompting contract now drive the capability the way the
host does. Intent unchanged — **denied / unavailable / failed / granted** — and two are
now specifically about *not* conflating a transport failure with a denial, which would
send a user to a permission screen that has nothing to fix.

### Assertion targets

`sourceType`, the payload and `capability` are written to the **action** by
`buildActionItem` (`index.js:448-465`); `item.meta` carries only `pluginName` /
`featureId` / `defaultAction`. The assertions read `item.meta`. `sourceKind` is
**dropped rather than relocated** — it doesn't exist anywhere in the plugin.

### The one plugin change

The `catch` in `onFeatureTriggered` logged the message and dropped the error. That
catch converts any fault into a generic `浏览器收藏加载失败` item, so the cause went
nowhere — which is why several unrelated faults in here all presented as the same
fallback item and stayed unexplained. It now carries the error.

### Verification

- `packages/test` browser-bookmarks: **16/16 passing** (was 1/16).
- The plugin's own `index.test.cjs`: still **5/5**, including the `__test`-absence assertion.
- ESLint clean on both changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging when browser bookmark actions fail, while preserving fallback behavior.
  * Enhanced handling of permission outcomes for opening URLs and copying to the clipboard.
  * Added support for retaining recently opened URLs.
  * Updated quicklink actions to use more reliable action payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->