### PR TITLE
fix(core-app): refuse an unverified renderer override instead of installing it

### DIFF
--- a/apps/core-app/src/main/modules/update/renderer-override-verification.test.ts
+++ b/apps/core-app/src/main/modules/update/renderer-override-verification.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Verification of a renderer override bundle before it is installed (#912).
+ *
+ * An installed override runs as the app's renderer, which channel-guard grants unguarded
+ * system.shell along with the shell.openPath and download handlers. installRendererOverride
+ * used to verify the checksum only when the artifact happened to declare one, skip the
+ * signature entirely when no signatureUrl was present, and — when a signature *was* present
+ * and did not verify — log a warning and extract the bundle anyway.
+ *
+ * The sibling installer path, resolveVerifiedInstallTask, has always required both and thrown
+ * on either. These tests hold the override path to that same standard.
+ */
+
+const uncompress = vi.fn(async () => {})
+const verifyFileSignature = vi.fn(async () => ({
+  valid: true,
+  reason: undefined as string | undefined
+}))
+const messageAdd = vi.fn()
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp/tuff-test'),
+    getVersion: vi.fn(() => '2.4.9'),
+    isPackaged: true
+  }
+}))
+
+vi.mock('../../utils/release-signature', () => ({
+  SignatureVerifier: class SignatureVerifier {
+    verifyFileSignature = verifyFileSignature
+    verifyFileSignatureWithCache = vi.fn(async () => ({ valid: true }))
+  }
+}))
+
+vi.mock('../analytics/message-store', () => ({
+  getAnalyticsMessageStore: () => ({ add: messageAdd })
+}))
+vi.mock('../database', () => ({ databaseModule: { getDb: vi.fn() } }))
+vi.mock('../network', () => ({ getNetworkService: () => ({ request: vi.fn() }) }))
+vi.mock('compressing', () => ({ default: { zip: { uncompress } }, zip: { uncompress } }))
+
+vi.mock('fs-extra', () => {
+  const api = {
+    ensureDir: vi.fn(async () => {}),
+    copy: vi.fn(async () => {}),
+    remove: vi.fn(async () => {}),
+    // false everywhere, so bundle-root resolution finds no index.html. That is deliberate:
+    // the positive control only needs to prove extraction was reached, not to stage a bundle.
+    pathExists: vi.fn(async () => false),
+    readdir: vi.fn(async () => [])
+  }
+  return { default: api, ...api }
+})
+
+/**
+ * The module reads TUFF_ENABLE_RENDERER_OVERRIDE at load time, so the variable has to be set
+ * before the import — hence the dynamic import rather than a static one at the top.
+ */
+/** The private members these tests reach into; the class does not expose them. */
+type TestableUpdateSystem = {
+  installRendererOverride: (
+    task: unknown,
+    artifact: unknown,
+    release: unknown,
+    manifest: unknown
+  ) => Promise<void>
+  verifyChecksum: (filePath: string, expected: string) => Promise<boolean>
+}
+
+async function createSystem() {
+  const { UpdateSystem } = await import('./update-system')
+  const downloadCenter = {
+    getTask: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    createTask: vi.fn()
+  }
+  return new (UpdateSystem as unknown as new (dc: unknown, cfg: unknown) => TestableUpdateSystem)(
+    downloadCenter,
+    { rendererOverrideEnabled: true }
+  )
+}
+
+const release = { tag_name: 'v2.4.10' }
+const task = (signatureUrl?: string) => ({
+  destination: '/tmp/tuff-test',
+  filename: 'renderer.zip',
+  metadata: signatureUrl ? { signatureUrl } : {}
+})
+
+async function install(system: TestableUpdateSystem, artifact: unknown, signatureUrl?: string) {
+  return await system.installRendererOverride(task(signatureUrl), artifact, release, null)
+}
+
+describe('installRendererOverride verification', () => {
+  let system: TestableUpdateSystem
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.stubEnv('TUFF_ENABLE_RENDERER_OVERRIDE', '1')
+    vi.resetModules()
+    system = await createSystem()
+    // Checksum comparison is not what these tests are about; each case controls it directly.
+    system.verifyChecksum = vi.fn(async () => true)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('refuses an artifact that declares no checksum', async () => {
+    // Previously the `if (artifact.sha256)` guard meant no checksum was simply not checked.
+    await expect(install(system, {})).rejects.toThrow(/checksum is required but missing/i)
+    expect(uncompress).not.toHaveBeenCalled()
+  })
+
+  it('refuses an artifact whose checksum does not match', async () => {
+    system.verifyChecksum = vi.fn(async () => false)
+    await expect(install(system, { sha256: 'abc' }, 'https://example.test/r.sig')).rejects.toThrow(
+      /checksum verification failed/i
+    )
+    expect(uncompress).not.toHaveBeenCalled()
+  })
+
+  it('refuses when no signature URL is published', async () => {
+    await expect(install(system, { sha256: 'abc' })).rejects.toThrow(
+      /signature is required but missing/i
+    )
+    expect(uncompress).not.toHaveBeenCalled()
+  })
+
+  it('refuses an invalid signature instead of warning and installing anyway', async () => {
+    // The core of #912: this path logged a warning and fell through to extraction.
+    verifyFileSignature.mockResolvedValue({ valid: false, reason: 'bad-signature' })
+    await expect(install(system, { sha256: 'abc' }, 'https://example.test/r.sig')).rejects.toThrow(
+      /signature verification failed: bad-signature/i
+    )
+    expect(uncompress).not.toHaveBeenCalled()
+  })
+
+  it('reports every refusal at error severity, not warn', async () => {
+    // The warn severity was part of the defect: an operator reading the message stream saw a
+    // caution about a bundle that had already been installed.
+    verifyFileSignature.mockResolvedValue({ valid: false, reason: 'bad-signature' })
+    await expect(install(system, { sha256: 'abc' }, 'https://example.test/r.sig')).rejects.toThrow()
+    expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error' }))
+    expect(messageAdd).not.toHaveBeenCalledWith(expect.objectContaining({ severity: 'warn' }))
+  })
+
+  it('proceeds to extraction once checksum and signature both verify', async () => {
+    // Positive control. Without it every assertion above would still pass if the method threw
+    // unconditionally, which would "fix" the issue by breaking the feature.
+    verifyFileSignature.mockResolvedValue({ valid: true, reason: undefined })
+    await expect(install(system, { sha256: 'abc' }, 'https://example.test/r.sig')).rejects.toThrow(
+      /bundle missing index\.html/i
+    )
+    expect(uncompress).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/core-app/src/main/modules/update/update-system.ts
+++ b/apps/core-app/src/main/modules/update/update-system.ts
@@ -545,36 +545,63 @@ export class UpdateSystem {
     }
     const filePath = path.join(task.destination, task.filename)
 
-    if (artifact.sha256) {
-      const valid = await this.verifyChecksum(filePath, artifact.sha256)
-      if (!valid) {
-        this.reportRendererOverrideIssue(
-          'error',
-          'Renderer override checksum failed',
-          'Checksum verification failed',
-          { tag: release.tag_name }
-        )
-        throw new Error('Renderer override checksum verification failed')
-      }
+    // An installed override runs as the app's renderer, which channel-guard.ts grants
+    // unguarded system.shell along with the shell.openPath and download handlers. It is the
+    // same class of code execution as the installer package, so it is verified to the same
+    // standard as resolveVerifiedInstallTask: checksum and signature both required, and any
+    // failure aborts.
+    //
+    // Previously an absent sha256 or signatureUrl skipped the corresponding check entirely,
+    // and an *invalid* signature only logged a warning before extracting the bundle anyway
+    // (#912) — so an artifact published with neither field, or one whose signature did not
+    // verify, was installed exactly like a good one.
+    if (!artifact.sha256) {
+      this.reportRendererOverrideIssue(
+        'error',
+        'Renderer override checksum missing',
+        'Checksum is required but missing',
+        { tag: release.tag_name }
+      )
+      throw new Error('Renderer override checksum is required but missing')
+    }
+    if (!(await this.verifyChecksum(filePath, artifact.sha256))) {
+      this.reportRendererOverrideIssue(
+        'error',
+        'Renderer override checksum failed',
+        'Checksum verification failed',
+        { tag: release.tag_name }
+      )
+      throw new Error('Renderer override checksum verification failed')
     }
 
     const signatureUrl = task.metadata?.signatureUrl
-    if (typeof signatureUrl === 'string' && signatureUrl.length > 0) {
-      const verifyResult = await this.signatureVerifier.verifyFileSignature(filePath, signatureUrl)
-      if (!verifyResult.valid) {
-        updateSystemLog.warn('Renderer override signature verification failed', {
-          meta: {
-            tag: release.tag_name,
-            reason: verifyResult.reason
-          }
-        })
-        this.reportRendererOverrideIssue(
-          'warn',
-          'Renderer override signature invalid',
-          verifyResult.reason || 'Signature verification failed',
-          { tag: release.tag_name }
-        )
-      }
+    if (typeof signatureUrl !== 'string' || signatureUrl.length === 0) {
+      this.reportRendererOverrideIssue(
+        'error',
+        'Renderer override signature missing',
+        'Signature is required but missing',
+        { tag: release.tag_name }
+      )
+      throw new Error('Renderer override signature is required but missing')
+    }
+
+    const verifyResult = await this.signatureVerifier.verifyFileSignature(filePath, signatureUrl)
+    if (!verifyResult.valid) {
+      updateSystemLog.error('Renderer override signature verification failed', {
+        meta: {
+          tag: release.tag_name,
+          reason: verifyResult.reason
+        }
+      })
+      this.reportRendererOverrideIssue(
+        'error',
+        'Renderer override signature invalid',
+        verifyResult.reason || 'Signature verification failed',
+        { tag: release.tag_name }
+      )
+      throw new Error(
+        `Renderer override signature verification failed: ${verifyResult.reason ?? 'unknown'}`
+      )
     }
 
     const tempDir = path.join(os.tmpdir(), `talex-touch-renderer-${Date.now()}`)


### PR DESCRIPTION
Closes #912.

## The defect

`installRendererOverride` had three holes, all failing open:

| condition | before | now |
|---|---|---|
| artifact declares no `sha256` | check skipped entirely | refused |
| checksum mismatch | refused | refused |
| no `signatureUrl` published | check skipped entirely | refused |
| signature does not verify | **`warn` logged, bundle installed** | refused |

An artifact published with neither field was installed exactly like a good one, and an invalid signature produced a caution about a bundle that had *already* been installed.

## Why this standard

An installed override runs as the app's renderer, which `channel-guard.ts` grants unguarded `system.shell` along with the `shell.openPath` and download handlers — the same class of code execution as the installer package. The sibling path `resolveVerifiedInstallTask` has always required both a checksum and a signature and thrown on either. This just holds the override path to the standard already set next to it, rather than inventing one.

Every refusal is now reported at `error`; the `warn` severity was part of the defect.

## On the "high" severity

Worth stating plainly for whoever weighs it: **this was not reachable in a stock build.** The path is doubly opt-in — `TUFF_ENABLE_RENDERER_OVERRIDE=1` must be set at launch *and* `rendererOverrideEnabled` must be on, which defaults to `false`.

I fixed it anyway. An experimental feature that installs unverified code is better corrected before it ships than after, and the fix is a few lines against an existing in-file precedent.

## Tests

Six cases: one per refusal, the severity assertion, and a positive control that extraction is still reached when both checks pass.

The control is load-bearing. Without it every other assertion would also pass if the method simply threw unconditionally — which would "fix" the issue by breaking the feature outright. Four of the six fail against the pre-fix method.

## Verification

- `vitest run src/main/modules/update/renderer-override-verification.test.ts` — 6/6
- `eslint` (core-app config, where `lint:changed` runs) — clean; `update-system.ts` had zero warnings before and after
- `typecheck:node`: **CI is the verifier.** In this worktree `packages/utils` resolves twice and produces 42 pre-existing `Cannot redeclare` errors; none are in the changed files.