### PR TITLE
fix(core-app): narrow local-file roots from the whole home directory to scan paths

### DIFF
--- a/apps/core-app/src/main/utils/local-file-policy.test.ts
+++ b/apps/core-app/src/main/utils/local-file-policy.test.ts
@@ -1,0 +1,103 @@
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Which parts of the filesystem local-file access may reach (#914).
+ *
+ * getAllowedLocalFileRoots listed `app.getPath('home')`, so every file under the user's home
+ * was servable. The tfile: protocol is registered on the default session and whitelisted in
+ * the renderer CSP, which made that reachable from renderer script:
+ *
+ *   await (await fetch('tfile:///Users/victim/.ssh/id_rsa')).text()
+ *
+ * The roots are now the specific directories the app scans for installed applications and
+ * their icons — the only reason a home path was ever needed.
+ */
+
+const HOME = process.platform === 'win32' ? 'C:\\Users\\tester' : '/home/tester'
+const USER_DATA = path.join(HOME, '.config', 'tuff-userdata')
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn((name: string) => {
+      if (name === 'home') return HOME
+      if (name === 'userData') return USER_DATA
+      if (name === 'temp') return os.tmpdir()
+      throw new Error(`unexpected path ${name}`)
+    })
+  }
+}))
+
+const { getAllowedLocalFileRoots, isAllowedLocalFilePath } = await import('./local-file-policy')
+
+describe('getAllowedLocalFileRoots', () => {
+  let roots: string[]
+
+  beforeEach(() => {
+    roots = getAllowedLocalFileRoots()
+  })
+
+  it('no longer lists the home directory itself', () => {
+    // The regression. Any root equal to home makes every path below it servable.
+    expect(roots).not.toContain(path.normalize(HOME))
+  })
+
+  it('keeps userData and temp, which are the roots the protocol actually serves from', () => {
+    expect(roots).toContain(path.normalize(USER_DATA))
+    expect(roots).toContain(path.normalize(os.tmpdir()))
+  })
+
+  it('keeps a home-relative scan root for the current platform', () => {
+    // Positive control: narrowing must not have removed the app-icon paths outright, which
+    // would pass every assertion above while breaking the launcher's icons.
+    const expected =
+      process.platform === 'darwin'
+        ? path.join(HOME, 'Applications')
+        : process.platform === 'win32'
+          ? path.join(HOME, 'AppData', 'Local', 'Programs')
+          : path.join(HOME, '.local', 'share', 'applications')
+    expect(roots).toContain(path.normalize(expected))
+  })
+})
+
+describe('isAllowedLocalFilePath against the narrowed roots', () => {
+  const roots = getAllowedLocalFileRoots()
+
+  const secrets = [
+    path.join(HOME, '.ssh', 'id_rsa'),
+    path.join(HOME, '.aws', 'credentials'),
+    path.join(HOME, '.gnupg', 'secring.gpg'),
+    path.join(HOME, 'Documents', 'passwords.txt')
+  ]
+
+  it.each(secrets)('refuses %s', (filePath) => {
+    expect(isAllowedLocalFilePath(filePath, roots)).toBe(false)
+  })
+
+  it('still serves an application icon under the platform scan root', () => {
+    const icon =
+      process.platform === 'darwin'
+        ? path.join(HOME, 'Applications', 'Thing.app', 'Contents', 'Resources', 'icon.icns')
+        : process.platform === 'win32'
+          ? path.join(HOME, 'AppData', 'Local', 'Programs', 'thing', 'icon.ico')
+          : path.join(HOME, '.local', 'share', 'applications', 'thing.desktop')
+    expect(isAllowedLocalFilePath(icon, roots)).toBe(true)
+  })
+
+  it('still serves from userData', () => {
+    expect(isAllowedLocalFilePath(path.join(USER_DATA, 'cache', 'icon.png'), roots)).toBe(true)
+  })
+
+  it('refuses a sibling directory whose name merely starts with an allowed root', () => {
+    // A prefix comparison that forgets the separator would accept this.
+    const sibling =
+      process.platform === 'darwin'
+        ? path.join(HOME, 'ApplicationsPrivate', 'secret.txt')
+        : process.platform === 'win32'
+          ? path.join(HOME, 'AppData', 'Local', 'ProgramsPrivate', 'secret.txt')
+          : path.join(HOME, '.local', 'share', 'applications-private', 'secret.txt')
+    expect(isAllowedLocalFilePath(sibling, roots)).toBe(false)
+  })
+})

--- a/apps/core-app/src/main/utils/local-file-policy.ts
+++ b/apps/core-app/src/main/utils/local-file-policy.ts
@@ -1,4 +1,5 @@
 import os from 'node:os'
+import path from 'node:path'
 import process from 'node:process'
 import { app } from 'electron'
 import { normalizeAbsolutePath, resolveSafePath } from '@talex-touch/utils/common/utils/safe-path'
@@ -13,6 +14,39 @@ function appPathSafe(name: AppPathName): string {
   }
 }
 
+/**
+ * The directories under the user's home that local-file access legitimately needs.
+ *
+ * This list used to be `app.getPath('home')` — the whole home directory. The tfile: protocol
+ * is registered on the default session and whitelisted in the renderer CSP, so any renderer
+ * script could read ~/.ssh/id_rsa, ~/.aws/credentials or a browser cookie database through it
+ * and exfiltrate the result (#914).
+ *
+ * Everything here is a scan root the app already uses to find installed applications and
+ * their icons, taken from app-scanner's WATCH_PATHS and the Steam provider. Nothing else
+ * under home was ever needed: userData and temp are separate roots below, and they stay.
+ */
+function getAllowedHomeSubRoots(): string[] {
+  const home = appPathSafe('home')
+  if (!home) {
+    return []
+  }
+
+  if (process.platform === 'darwin') {
+    return [path.join(home, 'Applications')]
+  }
+
+  if (process.platform === 'win32') {
+    return [
+      path.join(home, 'AppData', 'Roaming', 'Microsoft', 'Windows', 'Start Menu', 'Programs'),
+      path.join(home, 'AppData', 'Local', 'Programs'),
+      path.join(home, 'AppData', 'Local', 'Steam')
+    ]
+  }
+
+  return [path.join(home, '.local', 'share', 'applications')]
+}
+
 export function getAllowedLocalFileRoots(options: { includeCwd?: boolean } = {}): string[] {
   const winRoots =
     process.platform === 'win32'
@@ -24,7 +58,7 @@ export function getAllowedLocalFileRoots(options: { includeCwd?: boolean } = {})
 
   const candidates = [
     options.includeCwd ? process.cwd() : null,
-    appPathSafe('home'),
+    ...getAllowedHomeSubRoots(),
     appPathSafe('userData'),
     appPathSafe('temp'),
     os.tmpdir(),


### PR DESCRIPTION
Closes #914.

## The defect

`getAllowedLocalFileRoots` listed `app.getPath('home')`. The `tfile:` protocol is registered on the default session and whitelisted in the renderer CSP, so renderer script could do:

```js
await (await fetch('tfile:///Users/victim/.ssh/id_rsa')).text()
```

`isAllowedLocalFilePath` passed because the path sits under the home root. `~/.aws/credentials`, browser cookie databases and the app's own secure-store files were readable the same way.

## Why not simply delete the home root

Because something under home genuinely is needed: the launcher scans `~/Applications` for user-installed apps and serves their icons. Dropping the root outright would have satisfied every "secret file refused" assertion **while silently breaking app icons**.

So the replacement is the specific scan directories, read out of `app-scanner.ts` `WATCH_PATHS` and the Steam provider rather than guessed:

| platform | roots |
|---|---|
| darwin | `~/Applications` |
| win32 | `~/AppData/Roaming/…/Start Menu/Programs`, `~/AppData/Local/Programs`, `~/AppData/Local/Steam` |
| linux | `~/.local/share/applications` |

`userData` and `temp` were already separate roots and are untouched.

## Tests

Ten cases:

- home itself is no longer a root; `userData` and `temp` still are
- `~/.ssh/id_rsa`, `~/.aws/credentials`, `~/.gnupg/secring.gpg`, `~/Documents/passwords.txt` all refused
- **positive control** — a platform scan root is still present *and* still serves an icon path under it. This is the assertion that would have caught the "fix by deletion" version
- a sibling directory whose name merely starts with an allowed root (`~/ApplicationsPrivate`) is refused, since a prefix comparison that forgets the separator would accept it

Seven of the ten fail against the pre-fix roots.

## Regression check

The two existing consumers of this policy — `file-protocol/index.test.ts` and `network-service.test.ts`, 19 tests — pass unchanged. Lint clean under the core-app config.