### PR TITLE
fix(core-app): actually confirm before handing a URL to the OS

### DIFF
--- a/apps/core-app/src/main/channel/common.test.ts
+++ b/apps/core-app/src/main/channel/common.test.ts
@@ -149,7 +149,8 @@ vi.mock('electron', () => ({
   },
   dialog: {
     showOpenDialog: vi.fn(),
-    showSaveDialog: vi.fn()
+    showSaveDialog: vi.fn(),
+    showMessageBox: vi.fn(async () => ({ response: 0 }))
   },
   screen: {
     getPrimaryDisplay: vi.fn(() => ({
@@ -468,7 +469,8 @@ vi.mock('../utils/common-util', () => ({
 }))
 
 vi.mock('../utils/i18n-helper', () => ({
-  setLocale: setLocaleMock
+  setLocale: setLocaleMock,
+  t: vi.fn((key: string) => key)
 }))
 
 vi.mock('../utils/logger', () => ({
@@ -504,6 +506,8 @@ vi.mock('../utils/storage-usage', () => ({
   getStorageUsageReport: vi.fn(async () => ({}))
 }))
 
+import { dialog, shell } from 'electron'
+import { APP_SCHEMA, FILE_SCHEMA } from '../config/default'
 import { CommonChannelModule } from './common'
 
 type CommonChannelModuleTestInstance = {
@@ -516,6 +520,7 @@ type CommonChannelModuleTestInstance = {
     event: { toEventName: () => string },
     handler: (payload: unknown, context: unknown) => Promise<unknown> | unknown
   ) => unknown
+  createOpenUrlHandler: () => (url: string) => Promise<void>
   readSystemFile: (payload: { source?: string; allowMissing?: boolean }) => Promise<string>
   buildTraySettingsFromAppSettings: (
     appSettings: Record<string, unknown>,
@@ -2103,5 +2108,83 @@ describe('CommonChannelModule private helpers', () => {
       (source) => source.descriptor.id === 'browser-bookmarks'
     )!
     expect(otherSource.health.lastError).toBe('raw other-source text')
+  })
+})
+
+/**
+ * What reaches shell.openExternal (#910).
+ *
+ * TouchWindow's will-navigate listener emits every blocked navigation as OPEN_EXTERNAL_URL,
+ * which lands here — so this receives renderer-controlled URLs. `file:` was decided as 'open'
+ * and handed straight to the OS, and the 'confirm' decision logged and then opened anyway, so
+ * nothing was ever actually confirmed.
+ */
+describe('createOpenUrlHandler', () => {
+  const openExternal = vi.mocked(shell.openExternal)
+  const showMessageBox = vi.mocked(dialog.showMessageBox)
+
+  function handler(): (url: string) => Promise<void> {
+    const module = new CommonChannelModule() as unknown as CommonChannelModuleTestInstance
+    return module.createOpenUrlHandler()
+  }
+
+  function answer(open: boolean): void {
+    // buttons are [Cancel, Open], so index 1 is approval.
+    showMessageBox.mockResolvedValue({ response: open ? 1 : 0 } as never)
+  }
+
+  it('asks before opening a file: URL instead of handing it straight to the OS', async () => {
+    // The regression. shell.openExternal on file: launches whatever the OS has registered,
+    // an executable included.
+    answer(false)
+    await handler()('file:///etc/passwd')
+    expect(showMessageBox).toHaveBeenCalledTimes(1)
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
+  it('opens a file: URL once the prompt is accepted', async () => {
+    answer(true)
+    await handler()('file:///etc/passwd')
+    expect(openExternal).toHaveBeenCalledWith('file:///etc/passwd')
+  })
+
+  it('does not open an http URL that the user declined', async () => {
+    answer(false)
+    await handler()('https://evil.test/payload')
+    expect(showMessageBox).toHaveBeenCalledTimes(1)
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
+  it('opens an http URL the user approved', async () => {
+    answer(true)
+    await handler()('https://example.test/docs')
+    expect(openExternal).toHaveBeenCalledWith('https://example.test/docs')
+  })
+
+  it('refuses when the confirmation dialog itself fails', async () => {
+    // Fail closed: a dialog that cannot be shown must not be read as approval.
+    showMessageBox.mockRejectedValue(new Error('no window'))
+    await handler()('https://evil.test/payload')
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
+  it('still skips the app and tfile schemes without prompting', async () => {
+    // Positive control on the other side: the fix must not start prompting for internal
+    // navigation, which would make the app unusable rather than safe.
+    answer(true)
+    // Read from the constants rather than hardcoded, so the assertion follows the schemes the
+    // app actually registers instead of drifting from them.
+    await handler()(`${APP_SCHEMA}://some/route`)
+    await handler()(`${FILE_SCHEMA}:///tmp/icon.png`)
+    expect(showMessageBox).not.toHaveBeenCalled()
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
+  it('still skips a relative path or fragment', async () => {
+    answer(true)
+    await handler()('/settings')
+    await handler()('#/settings')
+    expect(showMessageBox).not.toHaveBeenCalled()
+    expect(openExternal).not.toHaveBeenCalled()
   })
 })

--- a/apps/core-app/src/main/channel/common.ts
+++ b/apps/core-app/src/main/channel/common.ts
@@ -1093,23 +1093,30 @@ export class CommonChannelModule extends BaseModule {
      * Defaults to cancel, and a dialog that fails to show is treated as a refusal.
      */
     const confirmOpen = async (url: string): Promise<boolean> => {
-      const parent = BrowserWindow.getFocusedWindow() ?? undefined
+      const parent = BrowserWindow.getFocusedWindow()
       // Long URLs are truncated so the dialog cannot be pushed off screen, and the raw string
       // goes to `detail` rather than `message` so it is never mistaken for app-authored text.
       const shown = url.length > 320 ? `${url.slice(0, 320)}…` : url
+      const options = {
+        type: 'question' as const,
+        buttons: [t('common.cancel'), t('common.open')],
+        defaultId: 0,
+        cancelId: 0,
+        message: t('common.openExternalConfirm'),
+        detail: shown,
+        noLink: true
+      }
       try {
-        const { response } = await dialog.showMessageBox(parent, {
-          type: 'question',
-          buttons: [t('common.cancel'), t('common.open')],
-          defaultId: 0,
-          cancelId: 0,
-          message: t('common.openExternalConfirm'),
-          detail: shown,
-          noLink: true
-        })
+        // Two calls rather than passing `undefined`: the parented overload does not accept it,
+        // and a modal with no owner window is the correct shape when nothing is focused.
+        const { response } = parent
+          ? await dialog.showMessageBox(parent, options)
+          : await dialog.showMessageBox(options)
         return response === 1
       } catch (error) {
-        log.warn('open url confirmation failed, refusing', { meta: { url, error } })
+        log.warn('open url confirmation failed, refusing', {
+          meta: { url, error: error instanceof Error ? error.message : String(error) }
+        })
         return false
       }
     }

--- a/apps/core-app/src/main/channel/common.ts
+++ b/apps/core-app/src/main/channel/common.ts
@@ -122,7 +122,7 @@ import { getMainConfig, saveMainConfig, storageModule } from '../modules/storage
 import { getNetworkService } from '../modules/network'
 import { deviceIdleService } from '../service/device-idle-service'
 import { TalexTouch } from '../types'
-import { setLocale } from '../utils/i18n-helper'
+import { setLocale, t } from '../utils/i18n-helper'
 import { createLogger } from '../utils/logger'
 import { safeOpHandler, toErrorMessage } from '../utils/safe-handler'
 import { enterPerfContext } from '../utils/perf-context'
@@ -1071,7 +1071,6 @@ export class CommonChannelModule extends BaseModule {
       const protocol = parsed.protocol.replace(':', '')
 
       if (shouldSkipPromptProtocols.has(protocol)) return 'skip'
-      if (protocol === 'file') return 'open'
 
       if ((protocol === 'http' || protocol === 'https') && isLocalhostUrl(url)) {
         if (isFrontendLocalUrl(parsed)) {
@@ -1083,11 +1082,48 @@ export class CommonChannelModule extends BaseModule {
       return 'confirm'
     }
 
+    /**
+     * Asks before handing a URL to the OS.
+     *
+     * `will-navigate` on every TouchWindow forwards each blocked navigation here, so this
+     * receives renderer-controlled input. `shell.openExternal` on such a URL launches whatever
+     * the OS has registered for it — for `file:` that is an arbitrary local file, executable
+     * included. The 'confirm' decision existed for this and then opened anyway (#910).
+     *
+     * Defaults to cancel, and a dialog that fails to show is treated as a refusal.
+     */
+    const confirmOpen = async (url: string): Promise<boolean> => {
+      const parent = BrowserWindow.getFocusedWindow() ?? undefined
+      // Long URLs are truncated so the dialog cannot be pushed off screen, and the raw string
+      // goes to `detail` rather than `message` so it is never mistaken for app-authored text.
+      const shown = url.length > 320 ? `${url.slice(0, 320)}…` : url
+      try {
+        const { response } = await dialog.showMessageBox(parent, {
+          type: 'question',
+          buttons: [t('common.cancel'), t('common.open')],
+          defaultId: 0,
+          cancelId: 0,
+          message: t('common.openExternalConfirm'),
+          detail: shown,
+          noLink: true
+        })
+        return response === 1
+      } catch (error) {
+        log.warn('open url confirmation failed, refusing', { meta: { url, error } })
+        return false
+      }
+    }
+
     return async (url: string) => {
       const decision = getOpenUrlDecision(url)
       if (decision === 'skip') return
       if (decision === 'open') {
         shell.openExternal(url)
+        return
+      }
+
+      if (!(await confirmOpen(url))) {
+        log.debug('open url refused', { meta: { url, decision } })
         return
       }
 

--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -4297,6 +4297,7 @@
     "no": "No",
     "retry": "Retry",
     "cancel": "Cancel",
+    "openExternalConfirm": "Open this link outside Tuff?",
     "save": "Save",
     "confirm": "Confirm",
     "delete": "Delete",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -4249,6 +4249,7 @@
     "no": "否",
     "retry": "重试",
     "cancel": "取消",
+    "openExternalConfirm": "在 Tuff 之外打开此链接？",
     "save": "保存",
     "confirm": "确认",
     "delete": "删除",


### PR DESCRIPTION
Closes #910.

## Two defects in one handler

`touch-window.ts:93` emits **every** blocked navigation as `OPEN_EXTERNAL_URL`, which lands in `createOpenUrlHandler` — so this receives renderer-controlled URLs.

1. **`file:` was decided as `'open'`** and passed straight to `shell.openExternal`, which launches whatever the OS has registered for that path, an executable included.
2. **`'confirm'` never confirmed.** It logged the decision and called `shell.openExternal` on the next line.

## The fix

`file:` falls through to `'confirm'` like any other external scheme, and `'confirm'` now shows a message box defaulting to **Cancel**. A dialog that fails to show is treated as a refusal, not as approval.

## One detail worth flagging

The report's evidence quotes `shouldSkipPromptProtocols.has(protocol)` immediately above `if (protocol === 'file')`, which reads as though `file` might be skipped first and the line dead. It is not: `FILE_SCHEMA` is `'tfile'`, not `'file'`, so the skip set is `{tuff, tfile}` and the `'open'` branch was live. Checked before writing the fix.

## i18n

The dialog uses the main-process helper. `common.cancel` and `common.open` already existed; `common.openExternalConfirm` is new in both locale files.

`t()` returns **the key itself** when a key is missing, so an invented key would have rendered as literal `common.openExternalConfirm` in the dialog. The strings were verified against the locale JSON rather than assumed.

## Tests

Seven cases added to the existing `common.test.ts` harness:

- `file:` prompts instead of opening; opens only once approved
- an http URL declined is not opened; approved is
- **dialog throws → refuse** (fail closed)
- **other-direction control:** the internal app and `tfile` schemes, and relative paths / fragments, still skip *without* prompting — a fix that prompted for internal navigation would make the app unusable rather than safe. These read `APP_SCHEMA` / `FILE_SCHEMA` from the constants rather than hardcoding, since the test harness mocks `APP_SCHEMA` as `'app'`

Three of the seven fail against the pre-fix handler; the existing 19 in that file are unaffected. Lint clean under the core-app config.