### PR TITLE
test(snippets): rebuild the suite on the plugin's surviving surface (#330)

### DIFF
--- a/packages/test/src/plugins/snippets.test.ts
+++ b/packages/test/src/plugins/snippets.test.ts
@@ -1,18 +1,22 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createPluginGlobals, loadPluginModule, withoutGlobal } from './plugin-loader'
+import { createPluginGlobals, loadPluginModule } from './plugin-loader'
 
 const snippetsUrl = new URL('../../../../plugins/touch-snippets/index.js', import.meta.url)
-const snippetsPlugin = loadPluginModule(snippetsUrl)
-const { __test: snippetsTest } = snippetsPlugin
 
+// Mirrors the builder in plugins/touch-snippets/index.test.cjs. This copy had
+// drifted: createAndAddAction was missing entirely, and setMeta overwrote instead
+// of merging. buildItem (index.js:116-131) puts the payload in the ACTION, and
+// onItemAction reads it back from item.actions -- so without the action the
+// payload never survives the round trip a test is trying to exercise.
 class FakeBuilder {
   item: Record<string, unknown>
 
   constructor(id: string) {
-    this.item = { id }
+    this.item = { id, meta: {}, actions: [] }
   }
 
-  setSource() {
+  setSource(type: string, id: string, name: string) {
+    this.item.source = { type, id, name }
     return this
   }
 
@@ -31,7 +35,12 @@ class FakeBuilder {
   }
 
   setMeta(meta: Record<string, unknown>) {
-    this.item.meta = meta
+    this.item.meta = { ...(this.item.meta as Record<string, unknown>), ...meta }
+    return this
+  }
+
+  createAndAddAction(id: string, type: string, label: string, payload: unknown) {
+    ;(this.item.actions as unknown[]).push({ id, type, label, payload })
     return this
   }
 
@@ -40,334 +49,211 @@ class FakeBuilder {
   }
 }
 
-describe('code snippets', () => {
-  it('replaces placeholders', () => {
-    const now = new Date(2025, 0, 2, 3, 4, 5)
-    const text = snippetsTest.applyPlaceholders('date={{date}} time={{time}} clip={{clipboard}}', {
-      now,
-      clipboardText: 'CLIP',
-    })
+type Item = Record<string, any>
 
-    expect(text).toContain('date=2025-01-02')
-    expect(text).toContain('time=03:04:05')
-    expect(text).toContain('clip=CLIP')
+interface HarnessOptions {
+  snippets?: Array<Record<string, unknown>>
+  clipboard?: Record<string, unknown> | null
+}
+
+// e37c92c8c moved the permission model host-side: the plugin no longer prompts, it
+// calls the capability and reads the thrown error. actionFailure (index.js:133-147)
+// maps PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED to 'permission-denied' and
+// PLUGIN_HOST_CAPABILITY_UNAVAILABLE to 'host-unavailable', with everything else
+// falling through to the caller's fallback reason.
+const HOST_DENIED = 'PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED'
+
+function hostDenied(message: string) {
+  return Object.assign(new Error(message), { code: HOST_DENIED })
+}
+
+function createHarness(options: HarnessOptions = {}) {
+  const items: Item[] = []
+  const writes: string[] = []
+  const stored: Array<Record<string, unknown>> = []
+
+  const clipboard = options.clipboard === null
+    ? undefined
+    : options.clipboard ?? {
+      async readText() {
+        return 'CLIP'
+      },
+      async writeText(value: string) {
+        writes.push(value)
+      },
+    }
+
+  const module = loadPluginModule(snippetsUrl, createPluginGlobals({
+    TuffItemBuilder: FakeBuilder,
+    ...(clipboard ? { clipboard } : {}),
+    plugin: {
+      feature: {
+        clearItems() {
+          items.length = 0
+        },
+        pushItems(next: Item[]) {
+          items.push(...next)
+        },
+      },
+      storage: {
+        async getFile() {
+          return { version: 1, snippets: options.snippets ?? [] }
+        },
+        async setFile(_name: string, value: Record<string, unknown>) {
+          stored.push(value)
+        },
+      },
+    },
+  }))
+
+  return { module, items, writes, stored }
+}
+
+// onItemAction resolves the payload from item.actions by matching the action id
+// (index.js:356-358); the tests used to pass it inside meta, where nothing reads it.
+function copyItem(content: string) {
+  return {
+    meta: { defaultAction: 'copy', featureId: 'snippets-search' },
+    actions: [{ id: 'copy', payload: { content } }],
+  }
+}
+
+describe('code snippets', () => {
+  // applyPlaceholders and matchSnippet were both deleted in e37c92c8c, so the tests
+  // that called them through a __test export had no subject left. The surviving
+  // behaviour is reached the way the plugin exposes it: placeholders through the
+  // copy action, matching through the search feature.
+  //
+  // The reduction is real and is reported on #330 rather than pinned here: the old
+  // applyPlaceholders also substituted {{date}}, {{time}} and {{uuid}}, and only
+  // {{clipboard}} survives. Those three were never advertised in the manifest, which
+  // still documents {{clipboard}} alone, so this asserts what the plugin promises
+  // and does not assert the absence of what it dropped.
+  it('resolves the clipboard placeholder through the host read capability', async () => {
+    const harness = createHarness()
+
+    const result = await harness.module.onItemAction(copyItem('before {{clipboard}} after'))
+
+    expect(result).toMatchObject({ externalAction: true, status: 'started' })
+    expect(harness.writes).toEqual(['before CLIP after'])
   })
 
-  it('matches snippet by tag or title', () => {
+  it('leaves content without placeholders untouched', async () => {
+    const harness = createHarness()
+
+    await harness.module.onItemAction(copyItem('plain content'))
+
+    expect(harness.writes).toEqual(['plain content'])
+  })
+
+  it('matches snippet by tag or title', async () => {
     const snippet = {
+      id: 'react',
       title: 'React useEffect 模板',
       tags: ['react', 'hook'],
       language: 'ts',
       content: 'useEffect(() => {})',
     }
 
-    expect(snippetsTest.matchSnippet(snippet, 'react')).toBe(true)
-    expect(snippetsTest.matchSnippet(snippet, 'hook')).toBe(true)
-    expect(snippetsTest.matchSnippet(snippet, 'vue')).toBe(false)
+    for (const keyword of ['react', 'hook']) {
+      const harness = createHarness({ snippets: [snippet] })
+      await harness.module.onFeatureTriggered('snippets-search', keyword)
+      expect(harness.items.map(item => item.title)).toEqual(['React useEffect 模板'])
+    }
+
+    const miss = createHarness({ snippets: [snippet] })
+    await miss.module.onFeatureTriggered('snippets-search', 'vue')
+    expect(miss.items.map(item => item.title)).toEqual(['没有匹配的片段'])
   })
 
-  it('matches text snippet content', () => {
+  it('matches text snippet content', async () => {
     const snippet = {
+      id: 'mail',
       title: '邮件模板',
       tags: ['邮件'],
       content: '你好，今天的进度如下',
     }
 
-    expect(snippetsTest.matchSnippet(snippet, '邮件')).toBe(true)
-    expect(snippetsTest.matchSnippet(snippet, '进度')).toBe(true)
-    expect(snippetsTest.matchSnippet(snippet, '无关')).toBe(false)
+    for (const keyword of ['邮件', '进度']) {
+      const harness = createHarness({ snippets: [snippet] })
+      await harness.module.onFeatureTriggered('snippets-search', keyword)
+      expect(harness.items.map(item => item.title)).toEqual(['邮件模板'])
+    }
+
+    const miss = createHarness({ snippets: [snippet] })
+    await miss.module.onFeatureTriggered('snippets-search', '无关')
+    expect(miss.items.map(item => item.title)).toEqual(['没有匹配的片段'])
   })
 
-  it('blocks snippet copy when clipboard.write permission is denied', async () => {
-    const writeText = vi.fn()
-    const request = vi.fn(async () => false)
-    const storageSetFile = vi.fn()
-    const pluginModule = loadPluginModule(snippetsUrl, createPluginGlobals({
-      TuffItemBuilder: FakeBuilder,
-      clipboard: { writeText },
-      permission: {
-        check: async () => false,
-        request,
-      },
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        storage: {
-          async getFile() {
-            return {
-              version: 1,
-              snippets: [
-                {
-                  id: 'hello',
-                  title: 'Hello',
-                  content: 'hello world',
-                  type: 'text',
-                },
-              ],
-            }
-          },
-          setFile: storageSetFile,
-        },
-      },
-    }))
-
-    await pluginModule.onFeatureTriggered('snippets-search', 'hello')
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'copy',
-        featureId: 'snippets-search',
-        snippetId: 'hello',
-      },
+  it('blocks snippet copy when the host denies clipboard.write', async () => {
+    const writeText = vi.fn(async () => {
+      throw hostDenied('/private/clipboard denied')
     })
+    const harness = createHarness({ clipboard: {
+      async readText() {
+        return 'CLIP'
+      },
+      writeText,
+    } })
 
-    expect(request).toHaveBeenCalledWith('clipboard.write', '需要剪贴板写入权限以复制片段内容')
-    expect(writeText).not.toHaveBeenCalled()
-    expect(storageSetFile).not.toHaveBeenCalled()
+    const result = await harness.module.onItemAction(copyItem('hello world'))
+
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
       reason: 'permission-denied',
+      message: '缺少执行此操作所需的权限',
     })
+    expect(harness.stored).toEqual([])
   })
 
-  it('blocks snippet copy when permission sdk is unavailable', async () => {
+  it('blocks snippet copy when the host exposes no clipboard reader', async () => {
     const writeText = vi.fn()
-    const storageSetFile = vi.fn()
-    const pluginModule = loadPluginModule(snippetsUrl, createPluginGlobals({
-      TuffItemBuilder: FakeBuilder,
-      clipboard: { writeText },
-      permission: withoutGlobal(),
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        storage: {
-          async getFile() {
-            return {
-              version: 1,
-              snippets: [
-                {
-                  id: 'hello',
-                  title: 'Hello',
-                  content: 'hello world',
-                  type: 'text',
-                },
-              ],
-            }
-          },
-          setFile: storageSetFile,
-        },
-      },
-    }))
+    // resolveClipboardPlaceholders raises PLUGIN_HOST_CAPABILITY_UNAVAILABLE rather
+    // than substituting an empty string, so an absent host reader cannot silently
+    // put a half-resolved template on the user's clipboard.
+    const harness = createHarness({ clipboard: { writeText } })
 
-    await pluginModule.onFeatureTriggered('snippets-search', 'hello')
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'copy',
-        featureId: 'snippets-search',
-        snippetId: 'hello',
-      },
-    })
+    const result = await harness.module.onItemAction(copyItem('before {{clipboard}} after'))
 
-    expect(writeText).not.toHaveBeenCalled()
-    expect(storageSetFile).not.toHaveBeenCalled()
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-sdk-unavailable',
+      reason: 'host-unavailable',
+      message: '宿主服务暂不可用',
     })
+    expect(writeText).not.toHaveBeenCalled()
   })
 
-  it('blocks snippet copy when clipboard permission request fails', async () => {
-    const writeText = vi.fn()
-    const storageSetFile = vi.fn()
-    const pluginModule = loadPluginModule(snippetsUrl, createPluginGlobals({
-      TuffItemBuilder: FakeBuilder,
-      clipboard: { writeText },
-      permission: {
-        check: async () => false,
-        request: async () => {
-          throw new Error('permission transport failed')
-        },
-      },
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        storage: {
-          async getFile() {
-            return {
-              version: 1,
-              snippets: [
-                {
-                  id: 'hello',
-                  title: 'Hello',
-                  content: 'hello world',
-                  type: 'text',
-                },
-              ],
-            }
-          },
-          setFile: storageSetFile,
-        },
-      },
-    }))
-
-    await pluginModule.onFeatureTriggered('snippets-search', 'hello')
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'copy',
-        featureId: 'snippets-search',
-        snippetId: 'hello',
-      },
+  it('separates a failed clipboard write from a denied one', async () => {
+    const writeText = vi.fn(async () => {
+      throw new Error('clipboard transport failed')
     })
+    const harness = createHarness({ clipboard: {
+      async readText() {
+        return 'CLIP'
+      },
+      writeText,
+    } })
 
-    expect(writeText).not.toHaveBeenCalled()
-    expect(storageSetFile).not.toHaveBeenCalled()
+    const result = await harness.module.onItemAction(copyItem('hello world'))
+
+    // A transport failure must not be reported as a permission problem: it would send
+    // the user to a permission screen that has nothing to fix.
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-request-failed',
+      reason: 'action-failed',
+      message: '操作失败',
     })
   })
 
-  it('blocks snippet pack export when clipboard.write permission is denied', async () => {
-    const writeText = vi.fn()
-    const request = vi.fn(async () => false)
-    const pluginModule = loadPluginModule(snippetsUrl, createPluginGlobals({
-      clipboard: { writeText },
-      permission: {
-        check: async () => false,
-        request,
-      },
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        storage: {
-          async getFile() {
-            return {
-              version: 1,
-              snippets: [
-                { id: 'safe', title: 'Safe', content: 'safe content' },
-              ],
-            }
-          },
-          async setFile() {},
-        },
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'manage',
-        actionId: 'pack-export',
-        featureId: 'snippets-manage',
-      },
-    })
-
-    expect(request).toHaveBeenCalledWith('clipboard.write', '需要剪贴板写入权限以导出片段包')
-    expect(writeText).not.toHaveBeenCalled()
-    expect(result).toMatchObject({
-      externalAction: true,
-      success: false,
-      status: 'blocked',
-      reason: 'permission-denied',
-    })
-  })
-
-  it('blocks snippet pack export when permission sdk is unavailable', async () => {
-    const writeText = vi.fn()
-    const pluginModule = loadPluginModule(snippetsUrl, createPluginGlobals({
-      clipboard: { writeText },
-      permission: withoutGlobal(),
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        storage: {
-          async getFile() {
-            return {
-              version: 1,
-              snippets: [
-                { id: 'safe', title: 'Safe', content: 'safe content' },
-              ],
-            }
-          },
-          async setFile() {},
-        },
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'manage',
-        actionId: 'pack-export',
-        featureId: 'snippets-manage',
-      },
-    })
-
-    expect(writeText).not.toHaveBeenCalled()
-    expect(result).toMatchObject({
-      externalAction: true,
-      success: false,
-      status: 'blocked',
-      reason: 'permission-sdk-unavailable',
-    })
-  })
-
-  it('blocks snippet pack export when clipboard permission request fails', async () => {
-    const writeText = vi.fn()
-    const pluginModule = loadPluginModule(snippetsUrl, createPluginGlobals({
-      clipboard: { writeText },
-      permission: {
-        check: async () => false,
-        request: async () => {
-          throw new Error('permission transport failed')
-        },
-      },
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        storage: {
-          async getFile() {
-            return {
-              version: 1,
-              snippets: [
-                { id: 'safe', title: 'Safe', content: 'safe content' },
-              ],
-            }
-          },
-          async setFile() {},
-        },
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'manage',
-        actionId: 'pack-export',
-        featureId: 'snippets-manage',
-      },
-    })
-
-    expect(writeText).not.toHaveBeenCalled()
-    expect(result).toMatchObject({
-      externalAction: true,
-      success: false,
-      status: 'blocked',
-      reason: 'permission-request-failed',
-    })
-  })
+  // The three 'snippet pack export' tests that stood here were removed: e37c92c8c
+  // deleted the pack-export action outright, so onItemAction has no branch for it and
+  // returns undefined. There is nothing left to re-target them at. The cloud-share
+  // flow that took over that ground is covered by the plugin's own suite
+  // (plugins/touch-snippets/index.test.cjs), including its denial path.
 })


### PR DESCRIPTION
Refs #330. `packages/test` snippets: **9 failing → 0**. Seven tests, from nine.

All nine failed for three different reasons, all introduced by `e37c92c8c`
(isolated-runtime migration).

### Deleted subjects — 3 tests

| gone | where the behaviour lives now |
|---|---|
| `applyPlaceholders` | `resolveClipboardPlaceholders`, reached through the **copy action**. Only `{{clipboard}}` survives. |
| `matchSnippet` | inlined into `showSearch` as a filter over `[title, content, ...tags]`, reached through the **search feature**. Both old assertions still hold under it. |

Rather than re-export deleted functions, these are driven through the surface the
plugin does expose — closer to what a user hits, and not dependent on internals at all.

### Deleted feature — 3 tests removed

`e37c92c8c` deleted the `pack-export` action outright. `onItemAction` has no branch
for it and returns `undefined`; there is nothing left to re-target those tests at.
The cloud-share flow that took over that ground is covered by the plugin's own suite
(`plugins/touch-snippets/index.test.cjs`), denial path included.

### Replaced model — 3 tests

The plugin no longer prompts. The host enforces and throws, and `actionFailure`
(`index.js:133-147`) maps `PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED` →
`permission-denied` and `PLUGIN_HOST_CAPABILITY_UNAVAILABLE` → `host-unavailable`.
The three copy tests now drive that. One of them specifically separates a **transport
failure** from a **denial** — conflating them sends a user to a permission screen
that has nothing to fix.

### Same fixture drift as browser-bookmarks

`FakeBuilder` had no `createAndAddAction`, and `setMeta` overwrote instead of merging.
`buildItem` puts the payload in the **action** and `onItemAction` reads it back from
`item.actions`, so without it the payload never survived the round trip the test was
trying to exercise. The call sites also passed the payload in `meta`, where nothing
reads it.

### One thing reported rather than asserted

`applyPlaceholders` also substituted `{{date}}`, `{{time}}` and `{{uuid}}` — only
`{{clipboard}}` survived. I did **not** pin their absence. The manifest documents
`{{clipboard}}` alone and always did (checked at `e37c92c8c^`), so the three were
undocumented; the suite asserts what the plugin promises rather than freezing a loss
someone may want to undo. Flagged on #330 for a maintainer call.

### Verification

- `packages/test` snippets: **7/7 passing**.
- The plugin's own `index.test.cjs`: still **7/7**.
- ESLint clean.

> CI red on this branch is #1194 (`node-pty` postinstall), which fails on `master` too.