### PR TITLE
fix(core-app): restrict executeCommand to directories inside the app root

### DIFF
--- a/apps/core-app/src/main/channel/common.ts
+++ b/apps/core-app/src/main/channel/common.ts
@@ -1501,6 +1501,7 @@ export class CommonChannelModule extends BaseModule {
       }),
       ...registerSystemShellHandlers(transport, {
         configRootPath: () => storageModule.filePath,
+        appRootPath: () => touchApp.rootPath,
         logger: log,
         registerSafeHandler
       }),

--- a/apps/core-app/src/main/channel/system-shell-handlers.test.ts
+++ b/apps/core-app/src/main/channel/system-shell-handlers.test.ts
@@ -63,6 +63,7 @@ describe('registerSystemShellHandlers', () => {
 
     registerSystemShellHandlers(transport as never, {
       configRootPath: () => '/tmp/tuff',
+      appRootPath: () => '/tmp/tuff',
       logger,
       registerSafeHandler: vi.fn(() => vi.fn()) as never
     })
@@ -84,6 +85,7 @@ describe('registerSystemShellHandlers', () => {
 
     registerSystemShellHandlers(transport as never, {
       configRootPath: () => '/tmp/tuff',
+      appRootPath: () => '/tmp/tuff',
       logger: { warn: vi.fn() },
       registerSafeHandler: vi.fn(() => vi.fn()) as never
     })
@@ -102,6 +104,7 @@ describe('registerSystemShellHandlers', () => {
 
     registerSystemShellHandlers(transport as never, {
       configRootPath: () => '/tmp/tuff',
+      appRootPath: () => '/tmp/tuff',
       logger: { warn: vi.fn() },
       registerSafeHandler: vi.fn(() => vi.fn()) as never
     })
@@ -121,6 +124,7 @@ describe('registerSystemShellHandlers', () => {
 
     registerSystemShellHandlers(transport as never, {
       configRootPath: () => '/tmp/tuff',
+      appRootPath: () => '/tmp/tuff',
       logger: { warn: vi.fn() },
       registerSafeHandler: vi.fn(() => vi.fn()) as never
     })
@@ -140,6 +144,7 @@ describe('registerSystemShellHandlers', () => {
 
     registerSystemShellHandlers(transport as never, {
       configRootPath: () => '/tmp/tuff',
+      appRootPath: () => '/tmp/tuff',
       logger: { warn: vi.fn() },
       registerSafeHandler: vi.fn(() => vi.fn()) as never
     })
@@ -158,6 +163,7 @@ describe('registerSystemShellHandlers', () => {
 
     registerSystemShellHandlers(transport as never, {
       configRootPath: () => '/tmp/tuff',
+      appRootPath: () => '/tmp/tuff',
       logger: { warn: vi.fn() },
       registerSafeHandler: vi.fn(() => vi.fn()) as never
     })
@@ -174,6 +180,7 @@ describe('registerSystemShellHandlers', () => {
 
     registerSystemShellHandlers(transport as never, {
       configRootPath: () => '/tmp/tuff',
+      appRootPath: () => '/tmp/tuff',
       logger: { warn: vi.fn() },
       registerSafeHandler: vi.fn(() => vi.fn()) as never
     })
@@ -193,6 +200,7 @@ describe('registerSystemShellHandlers', () => {
 
     registerSystemShellHandlers(transport as never, {
       configRootPath: () => '/tmp/tuff',
+      appRootPath: () => '/tmp/tuff',
       logger: { warn: vi.fn() },
       registerSafeHandler: vi.fn(() => vi.fn()) as never
     })
@@ -212,6 +220,7 @@ describe('registerSystemShellHandlers', () => {
 
     registerSystemShellHandlers(transport as never, {
       configRootPath: () => '/tmp/tuff/config',
+      appRootPath: () => '/tmp/tuff',
       logger: { warn: vi.fn() },
       registerSafeHandler: vi.fn(() => vi.fn()) as never
     })
@@ -230,6 +239,7 @@ describe('registerSystemShellHandlers', () => {
 
     registerSystemShellHandlers(transport as never, {
       configRootPath: () => '/tmp/tuff/config',
+      appRootPath: () => '/tmp/tuff',
       logger: { warn: vi.fn() },
       registerSafeHandler: vi.fn(() => vi.fn()) as never
     })
@@ -245,6 +255,7 @@ describe('registerSystemShellHandlers', () => {
 
     registerSystemShellHandlers(transport as never, {
       configRootPath: () => '/tmp/tuff',
+      appRootPath: () => '/tmp/tuff',
       logger: { warn: vi.fn() },
       registerSafeHandler: registerSafeHandler as never
     })
@@ -253,5 +264,115 @@ describe('registerSystemShellHandlers', () => {
       AppEvents.system.executeCommand,
       expect.any(Function)
     )
+  })
+})
+
+/**
+ * What executeCommand is allowed to open (#909).
+ *
+ * shell.openPath does not run a command — it hands the path to the OS association, so a
+ * .command, .bat or .app is executed. The handler accepted any caller-supplied string, which
+ * meant a plugin could write a script through the download handler and then ask the main
+ * process to launch it.
+ *
+ * The only caller in the app is Settings > About opening the application folder, so the
+ * surface it needs is a directory inside the app's own root.
+ */
+describe('executeCommand path restriction', () => {
+  const APP_ROOT = '/tmp/tuff'
+
+  function executeCommandHandler(): (payload: { command?: string }) => Promise<void> {
+    const { transport } = createTransport()
+    let captured: ((payload: { command?: string }) => Promise<void>) | null = null
+    registerSystemShellHandlers(transport as never, {
+      configRootPath: () => '/tmp/tuff/config',
+      appRootPath: () => APP_ROOT,
+      logger: { warn: vi.fn() },
+      registerSafeHandler: ((event: { toEventName: () => string }, handler: unknown) => {
+        if (event.toEventName() === AppEvents.system.executeCommand.toEventName()) {
+          captured = handler as (payload: { command?: string }) => Promise<void>
+        }
+        return vi.fn()
+      }) as never
+    })
+    if (!captured) throw new Error('executeCommand handler was not registered')
+    return captured
+  }
+
+  beforeEach(() => {
+    fsStatMock.mockReset()
+    shellOpenPathMock.mockReset()
+    shellOpenPathMock.mockResolvedValue('')
+  })
+
+  function asDirectory(): void {
+    fsStatMock.mockResolvedValue({ isDirectory: () => true } as never)
+  }
+
+  function asFile(): void {
+    fsStatMock.mockResolvedValue({ isDirectory: () => false } as never)
+  }
+
+  it('opens the application folder, which is the one real caller', async () => {
+    // Positive control: Settings > About sends touchApp.rootPath verbatim.
+    asDirectory()
+    await executeCommandHandler()({ command: APP_ROOT })
+    expect(shellOpenPathMock).toHaveBeenCalledWith(APP_ROOT)
+  })
+
+  it('opens a directory beneath the app root', async () => {
+    asDirectory()
+    await executeCommandHandler()({ command: `${APP_ROOT}/plugins` })
+    expect(shellOpenPathMock).toHaveBeenCalledWith(`${APP_ROOT}/plugins`)
+  })
+
+  it('refuses a path outside the app root', async () => {
+    asDirectory()
+    await expect(executeCommandHandler()({ command: '/tmp/evil' })).rejects.toThrow(
+      'SYSTEM_SHELL_PATH_OUTSIDE_APP_ROOT'
+    )
+    expect(shellOpenPathMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses a sibling directory that merely shares the root prefix', async () => {
+    asDirectory()
+    await expect(executeCommandHandler()({ command: `${APP_ROOT}-backup/x` })).rejects.toThrow(
+      'SYSTEM_SHELL_PATH_OUTSIDE_APP_ROOT'
+    )
+  })
+
+  it('refuses a traversal that climbs out of the root', async () => {
+    asDirectory()
+    await expect(
+      executeCommandHandler()({ command: `${APP_ROOT}/../../etc/passwd` })
+    ).rejects.toThrow('SYSTEM_SHELL_PATH_OUTSIDE_APP_ROOT')
+  })
+
+  it('refuses a script file even inside the app root', async () => {
+    // The download handler can write into app storage, so "inside the root" alone is not safe.
+    asFile()
+    await expect(
+      executeCommandHandler()({ command: `${APP_ROOT}/payload.command` })
+    ).rejects.toThrow('SYSTEM_SHELL_PATH_NOT_A_DIRECTORY')
+    expect(shellOpenPathMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses a .app bundle inside the app root, which is a directory that executes', async () => {
+    asDirectory()
+    await expect(executeCommandHandler()({ command: `${APP_ROOT}/Evil.app` })).rejects.toThrow(
+      'SYSTEM_SHELL_PATH_NOT_A_DIRECTORY'
+    )
+    expect(shellOpenPathMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses a path that does not exist', async () => {
+    fsStatMock.mockRejectedValue(new Error('ENOENT'))
+    await expect(executeCommandHandler()({ command: `${APP_ROOT}/missing` })).rejects.toThrow(
+      'SYSTEM_SHELL_PATH_UNAVAILABLE'
+    )
+  })
+
+  it('still rejects an empty command', async () => {
+    await expect(executeCommandHandler()({ command: '' })).rejects.toThrow('No command provided')
   })
 })

--- a/apps/core-app/src/main/channel/system-shell-handlers.ts
+++ b/apps/core-app/src/main/channel/system-shell-handlers.ts
@@ -18,9 +18,28 @@ export const systemShellCapabilities: SystemShellCapabilities = {
 const SYSTEM_SHELL_PATH_REQUIRED = 'SYSTEM_SHELL_PATH_REQUIRED'
 const SYSTEM_SHELL_PATH_UNAVAILABLE = 'SYSTEM_SHELL_PATH_UNAVAILABLE'
 const SYSTEM_SHELL_OPEN_PATH_FAILED = 'SYSTEM_SHELL_OPEN_PATH_FAILED'
+const SYSTEM_SHELL_PATH_OUTSIDE_APP_ROOT = 'SYSTEM_SHELL_PATH_OUTSIDE_APP_ROOT'
+const SYSTEM_SHELL_PATH_NOT_A_DIRECTORY = 'SYSTEM_SHELL_PATH_NOT_A_DIRECTORY'
+
+/**
+ * Whether `target` is the app root itself or a path beneath it.
+ *
+ * Compared after path.resolve so that '..' segments cannot climb out, and with a trailing
+ * separator so a sibling like `<root>-backup` does not match the prefix.
+ */
+function isWithinAppRoot(target: string, appRoot: string): boolean {
+  const resolvedRoot = path.resolve(appRoot)
+  const resolvedTarget = path.resolve(target)
+  if (resolvedTarget === resolvedRoot) {
+    return true
+  }
+  return resolvedTarget.startsWith(resolvedRoot + path.sep)
+}
 
 export interface SystemShellHandlerOptions {
   configRootPath: () => string | null | undefined
+  /** The app's own data root. executeCommand may not open anything outside it. */
+  appRootPath: () => string | null | undefined
   logger: { warn: (message: unknown, options?: LogOptions) => void }
   registerSafeHandler: <TReq, TExtra extends Record<string, unknown> = Record<string, never>>(
     event: TuffEvent<TReq, unknown> & { toEventName: () => string },
@@ -107,6 +126,41 @@ export function registerSystemShellHandlers(
         const command = typeof payload?.command === 'string' ? payload.command : ''
         if (!command) {
           throw new Error('No command provided')
+        }
+
+        // shell.openPath does not "run a command" — it hands the path to the OS association,
+        // which for a .command, .bat or .app means execution. The event accepted any string,
+        // so a plugin could write a script through the download handler and then ask the main
+        // process to launch it (#909).
+        //
+        // The one caller in the app is Settings > About opening the application folder, so
+        // the surface it actually needs is: a directory, inside the app's own root. Both
+        // conditions matter — restricting to the root alone would still allow launching a
+        // .app bundle or a script that a plugin had written into its own storage.
+        const appRoot = options.appRootPath()
+        if (!appRoot) {
+          throw new Error(SYSTEM_SHELL_PATH_UNAVAILABLE)
+        }
+        if (!isWithinAppRoot(command, appRoot)) {
+          options.logger.warn('Blocked executeCommand outside the app root', {
+            meta: { reason: SYSTEM_SHELL_PATH_OUTSIDE_APP_ROOT }
+          })
+          throw new Error(SYSTEM_SHELL_PATH_OUTSIDE_APP_ROOT)
+        }
+
+        let stats: Awaited<ReturnType<typeof fs.stat>>
+        try {
+          stats = await fs.stat(command)
+        } catch {
+          throw new Error(SYSTEM_SHELL_PATH_UNAVAILABLE)
+        }
+        // A macOS .app bundle is a directory that executes, so the directory check alone is
+        // not enough even inside the root.
+        if (!stats.isDirectory() || path.extname(command).toLowerCase() === '.app') {
+          options.logger.warn('Blocked executeCommand on a non-directory target', {
+            meta: { reason: SYSTEM_SHELL_PATH_NOT_A_DIRECTORY }
+          })
+          throw new Error(SYSTEM_SHELL_PATH_NOT_A_DIRECTORY)
         }
 
         const error = await shell.openPath(command)


### PR DESCRIPTION
Closes #909.

## The defect

`AppEvents.system.executeCommand` took any string and passed it to `shell.openPath`. That call does not "run a command" — it hands the path to the **OS association**, so a `.command`, `.bat` or `.app` is executed. Nothing constrained the path, and `createSafeOperationHandler` only reports errors.

## Why neither suggested direction fits

The issue offered *delete the event* or *reduce it to an enum of internal actions*. Checking the callers ruled both out:

- there is exactly **one** caller in the app — `SettingAbout.vue:241`, opening the application folder
- it is also **public SDK surface**: `touch-sdk`'s `executeCommand`, the `app.executeCommand` domain method, and the documented `app:system:execute-command` event

Deleting it breaks that button and an advertised API. But what the one caller needs is narrow enough to state directly: **a directory, inside the app's own data root.**

## Both halves of that check matter

| check alone | still allows |
|---|---|
| inside the app root | a `.app` bundle or a script a plugin wrote into its own storage — plugin data lives under the root |
| is a directory | any folder anywhere on the machine |

A `.app` bundle is a *directory that executes*, so it is rejected by extension too.

## A wiring detail

The handler had no access to the app root. Options carried `configRootPath`, which is `storageModule.filePath` — a **child** of the root — so restricting to that would have rejected the About page's own path. `appRootPath` is now passed alongside it.

## Tests

Nine cases; six fail against the pre-fix handler:

- outside the root; a **sibling sharing the root prefix** (`/tmp/tuff-backup/x`); a **traversal** climbing out (`<root>/../../etc/passwd`)
- a script file inside the root; a `.app` bundle inside the root
- a path that does not exist

Two are positive controls: the About page's exact path and a directory below it still open. Without those, a handler that rejected everything would pass every refusal assertion.

The 11 existing tests in that file pass (they needed the new option field). Lint clean; `typecheck:node` shows zero errors in the changed files.