### PR TITLE
fix(core-app): stop the node-pty postinstall check from failing every install (#1194)

### DIFF
--- a/apps/core-app/scripts/ensure-node-pty-helper.cjs
+++ b/apps/core-app/scripts/ensure-node-pty-helper.cjs
@@ -1,17 +1,60 @@
+/**
+ * node-pty ships `spawn-helper` as a separate executable and can lose its
+ * executable bit through some install paths, which then fails at runtime when a
+ * PTY is spawned rather than at install time. This restores it.
+ *
+ * It must not be able to fail an install. This runs from core-app's postinstall,
+ * so throwing here does not degrade the terminal -- it stops the repo from
+ * installing at all, on every workflow whose first step is `pnpm install`.
+ */
+
 const fs = require('node:fs')
 const path = require('node:path')
 
-if (process.platform !== 'win32') {
-  const entry = require.resolve('node-pty')
-  const helper = path.resolve(
-    path.dirname(entry),
-    '..',
-    'prebuilds',
-    `${process.platform}-${process.arch}`,
-    'spawn-helper'
-  )
-  if (!fs.existsSync(helper)) {
-    throw new Error(`node-pty spawn-helper is missing for ${process.platform}-${process.arch}`)
+function ensureHelperExecutable() {
+  if (process.platform === 'win32') {
+    return
   }
-  fs.chmodSync(helper, 0o755)
+
+  let packageRoot
+  try {
+    packageRoot = path.dirname(path.dirname(require.resolve('node-pty')))
+  }
+  catch {
+    // A filtered or partial install may not have node-pty at all. Nothing to fix.
+    return
+  }
+
+  // Two layouts, depending on how node-pty installed itself. `prebuilds/` is
+  // populated when it downloads a prebuild; when it finds none it falls back to
+  // `node-gyp rebuild`, which writes to `build/Release/` and leaves no `prebuilds/`
+  // directory behind. The original check knew only the first, so a perfectly good
+  // source build looked like a broken install.
+  const candidates = [
+    path.join(packageRoot, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper'),
+    path.join(packageRoot, 'build', 'Release', 'spawn-helper')
+  ]
+
+  const helper = candidates.find(candidate => fs.existsSync(candidate))
+
+  if (!helper) {
+    // Not necessarily a fault: on Linux the gyp build produces pty.node alone and no
+    // spawn-helper target runs at all. Say so and carry on. If a platform does need
+    // it and it is genuinely missing, node-pty reports that when a PTY is spawned,
+    // which is a better place to find out than a failed install of the whole repo.
+    console.warn(
+      `[ensure-node-pty-helper] no spawn-helper found for ${process.platform}-${process.arch}; `
+      + `skipping chmod. Looked in:\n  ${candidates.join('\n  ')}`
+    )
+    return
+  }
+
+  try {
+    fs.chmodSync(helper, 0o755)
+  }
+  catch (error) {
+    console.warn(`[ensure-node-pty-helper] could not chmod ${helper}:`, error)
+  }
 }
+
+ensureHelperExecutable()


### PR DESCRIPTION
Fixes #1194. **Unblocks CI repo-wide** — not just my branches.

Since 2026-08-05 every workflow whose first step is `pnpm install` has failed on
Linux, on `master` as well as on PRs:

```
apps/core-app postinstall: Error: node-pty spawn-helper is missing for linux-x64
 ELIFECYCLE  Command failed with exit code 1.
```

### What was wrong

The check asserted a file at `prebuilds/<platform>-<arch>/spawn-helper`. That path is
populated when node-pty **downloads a prebuild**. When it finds none it falls back to
`node-gyp rebuild`, which writes `build/Release/` and leaves **no `prebuilds/`
directory at all** — so the check fired on a build that had just succeeded.

The install log shows both halves plainly
([run 30965683079](https://github.com/talex-touch/tuff/actions/runs/30965683079)):

```
> Rebuilding because directory .../node-pty/prebuilds/linux-x64 does not exist
  CXX(target) Release/obj.target/pty/src/unix/pty.o
  SOLINK_MODULE(target) Release/obj.target/pty.node
  COPY Release/pty.node
gyp info ok
```

node-pty reports the prebuild directory missing, works around it, succeeds — and the
guard then checks the very path node-pty had just told it wasn't there.

### The fix — two changes, one per failure mode

| | |
|---|---|
| **layout** | Look in `build/Release/` as well as `prebuilds/`, so a source build is recognised rather than mistaken for a broken one. |
| **severity** | **Warn instead of throwing.** This runs from `postinstall`: throwing doesn't degrade the terminal, it stops the whole repo from installing. If a platform genuinely needs the helper and it's genuinely absent, node-pty says so when a PTY is spawned — a much better place to find out. |

The `chmod 0o755`, which is the actual point of the script, is unchanged and now
reaches the source-build layout it previously couldn't see.

Also guards `require.resolve('node-pty')` — a filtered or partial install may not have
node-pty at all, which was a second way for this to throw out of `postinstall`.

### Verified

Ran the script against all three layouts:

- `prebuilds/<platform>-<arch>/spawn-helper` present → chmod 644 → **755**, exit 0
- `build/Release/spawn-helper` present → chmod 644 → **755**, exit 0 *(the case that used to throw)*
- neither present → warns naming both paths, **exit 0**

### One thing I could not verify here

I claim in the commit message that no `spawn-helper` target runs on Linux. That is
read off the gyp output above — it compiles `pty.o` and `pty.node` and nothing else —
**not** from node-pty's `binding.gyp`, which I couldn't fetch (no registry access in
this environment). Worth a second pair of eyes if you want that stated as fact.

It does not affect the fix: the new behaviour is to warn rather than throw regardless
of platform, so the fix is correct either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of native helper permissions during setup.
  * Supports both prebuilt and source-built helper locations.
  * Setup now continues gracefully when the helper is unavailable or permissions cannot be restored.
  * Windows environments are handled without unnecessary permission checks.
  * When found, the helper’s executable permissions are automatically restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->