### PR TITLE
test(dev-toolbox): drive the suite through the current action contract (#330)

### DIFF
--- a/packages/test/src/plugins/dev-toolbox.test.ts
+++ b/packages/test/src/plugins/dev-toolbox.test.ts
@@ -1,10 +1,23 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it, vi } from 'vitest'
-import { createPluginGlobals, loadPluginModule, withoutGlobal } from './plugin-loader'
+import { createPluginGlobals, loadPluginModule, loadPluginModuleWithSourceTransform, withoutGlobal } from './plugin-loader'
 
 const devToolboxUrl = new URL('../../../../plugins/touch-dev-toolbox/index.js', import.meta.url)
-const toolboxPlugin = loadPluginModule(devToolboxUrl)
-const { __test: toolboxTest } = toolboxPlugin
+
+// The plugin exports its lifecycle and nothing else: e37c92c8c removed the __test
+// export in the isolated-runtime migration. Both functions below still exist, they
+// are simply not exported, so they are re-exported at load time into this test's
+// copy of the module rather than adding a test-only export to the shipped file --
+// the same approach intelligence.test.ts takes.
+const TEST_EXPORT_NAMES = ['parseToolboxConfig', 'normalizeExternalUrl'] as const
+
+const toolboxTest = loadPluginModuleWithSourceTransform<{
+  __test: Record<(typeof TEST_EXPORT_NAMES)[number], (...args: any[]) => any>
+}>(
+  devToolboxUrl,
+  source => `${source}\nmodule.exports.__test={${TEST_EXPORT_NAMES.join(',')}}`,
+  createPluginGlobals(),
+).__test
 
 describe('dev toolbox config', () => {
   it('declares network permission for opening toolbox links', () => {
@@ -40,220 +53,125 @@ describe('dev toolbox config', () => {
     expect(toolboxTest.normalizeExternalUrl('not a url')).toBe('')
   })
 
-  it('blocks invalid link payloads before permission checks', async () => {
-    const openUrl = vi.fn()
-    const check = vi.fn(async () => true)
-    const request = vi.fn(async () => true)
-    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
-      openUrl,
-      permission: { check, request },
-    }))
+  // e37c92c8c moved the permission model host-side. This plugin no longer touches the
+  // permission SDK at all: onItemAction calls openUrl and reads the thrown error,
+  // where PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED means denied and anything else
+  // means the call failed (index.js:226-241). The tests below drove permission.check /
+  // permission.request, which nothing reads any more.
+  //
+  // They also passed actionId and payload inside meta. onItemAction resolves both from
+  // item.actions[0] (index.js:197-199), so action came back null, every branch was
+  // skipped, and the handler returned undefined -- which is why all eight reported
+  // "expected undefined to match object".
+  const HOST_DENIED = 'PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED'
 
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'file:///tmp/toolbox.json' },
-      },
-    })
+  function openLinkItem(url: string) {
+    return {
+      meta: { defaultAction: 'dev-toolbox' },
+      actions: [{ id: 'open-link', payload: { url } }],
+    }
+  }
+
+  it('rejects a non-HTTP link before reaching the host', async () => {
+    const openUrl = vi.fn()
+    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({ openUrl }))
+
+    const result = await pluginModule.onItemAction(openLinkItem('file:///tmp/toolbox.json'))
 
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
       reason: 'invalid-url',
+      message: '链接地址无效，仅支持 HTTP/HTTPS',
     })
-    expect(check).not.toHaveBeenCalled()
-    expect(request).not.toHaveBeenCalled()
     expect(openUrl).not.toHaveBeenCalled()
   })
 
-  it('blocks link opening when network permission is denied', async () => {
+  it('rejects a javascript: link before reaching the host', async () => {
     const openUrl = vi.fn()
-    const request = vi.fn(async () => false)
-    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
-      openUrl,
-      permission: {
-        check: async () => false,
-        request,
-      },
-    }))
+    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({ openUrl }))
 
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'https://example.com' },
-      },
+    const result = await pluginModule.onItemAction(openLinkItem('javascript:alert(1)'))
+
+    expect(result).toMatchObject({ status: 'blocked', reason: 'invalid-url' })
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+
+  it('blocks link opening when the host denies network permission', async () => {
+    const openUrl = vi.fn(async () => {
+      throw Object.assign(new Error('/private/open denied'), { code: HOST_DENIED })
     })
+    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({ openUrl }))
+
+    const result = await pluginModule.onItemAction(openLinkItem('https://example.com'))
 
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
       reason: 'permission-denied',
+      message: '缺少 network.internet 权限',
     })
-    expect(request).toHaveBeenCalledWith('network.internet', '需要 network.internet 权限以默认浏览器打开开发工具箱链接')
-    expect(openUrl).not.toHaveBeenCalled()
   })
 
-  it('blocks link opening when permission sdk is unavailable', async () => {
-    const openUrl = vi.fn()
-    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
-      openUrl,
-      permission: withoutGlobal(),
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'https://example.com' },
-      },
+  it('separates a failed host open from a denied one', async () => {
+    const openUrl = vi.fn(async () => {
+      throw new Error('open transport failed')
     })
+    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({ openUrl }))
 
+    const result = await pluginModule.onItemAction(openLinkItem('https://example.com'))
+
+    // A transport failure reported as a permission denial sends the user to a
+    // permission screen that has nothing to fix.
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-sdk-unavailable',
+      reason: 'open-url-failed',
+      message: '打开外部链接失败',
     })
-    expect(openUrl).not.toHaveBeenCalled()
   })
 
-  it('blocks link opening when network permission request fails', async () => {
-    const openUrl = vi.fn()
-    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
-      openUrl,
-      permission: {
-        check: async () => false,
-        request: async () => {
-          throw new Error('permission transport failed')
-        },
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'https://example.com' },
-      },
-    })
-
-    expect(result).toMatchObject({
-      externalAction: true,
-      success: false,
-      status: 'blocked',
-      reason: 'permission-request-failed',
-    })
-    expect(openUrl).not.toHaveBeenCalled()
-  })
-
-  it('blocks link opening when network permission check fails without requesting', async () => {
-    const openUrl = vi.fn()
-    const request = vi.fn(async () => true)
-    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
-      openUrl,
-      permission: {
-        check: async () => {
-          throw new Error('permission check failed')
-        },
-        request,
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'https://example.com' },
-      },
-    })
-
-    expect(result).toMatchObject({
-      externalAction: true,
-      success: false,
-      status: 'blocked',
-      reason: 'permission-request-failed',
-    })
-    expect(request).not.toHaveBeenCalled()
-    expect(openUrl).not.toHaveBeenCalled()
-  })
-
-  it('blocks link opening when the openUrl capability is unavailable', async () => {
+  it('blocks link opening when the host exposes no openUrl capability', async () => {
     const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
       openUrl: withoutGlobal(),
-      permission: {
-        check: async () => true,
-        request: async () => true,
-      },
     }))
 
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'https://example.com' },
-      },
-    })
+    const result = await pluginModule.onItemAction(openLinkItem('https://example.com'))
 
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
       reason: 'open-url-unavailable',
+      message: '当前运行时不支持打开外部链接',
     })
   })
 
-  it('returns an explicit blocked result when openUrl fails', async () => {
-    const openUrl = vi.fn(async () => {
-      throw new Error('host open failed')
-    })
-    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
-      openUrl,
-      permission: {
-        check: async () => true,
-        request: async () => true,
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'https://example.com' },
-      },
-    })
-
-    expect(result).toMatchObject({
-      externalAction: true,
-      success: false,
-      status: 'blocked',
-      reason: 'open-url-failed',
-    })
-    expect(openUrl).toHaveBeenCalledWith('https://example.com/')
-  })
-
-  it('opens link after network permission is granted', async () => {
+  it('opens a normalized link when the host allows it', async () => {
     const openUrl = vi.fn(async () => undefined)
-    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
-      openUrl,
-      permission: {
-        check: async () => true,
-        request: async () => true,
-      },
-    }))
+    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({ openUrl }))
 
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'https://example.com' },
-      },
-    })
+    const result = await pluginModule.onItemAction(openLinkItem('http://example.com'))
 
     expect(result).toMatchObject({ externalAction: true, status: 'started' })
-    expect(openUrl).toHaveBeenCalledWith('https://example.com/')
+    // normalizeExternalUrl runs before the host call, so the host receives the parsed
+    // form rather than the raw payload.
+    expect(openUrl).toHaveBeenCalledWith('http://example.com/')
+  })
+
+  it('ignores items whose default action is not the toolbox', async () => {
+    const openUrl = vi.fn()
+    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({ openUrl }))
+
+    const result = await pluginModule.onItemAction({
+      meta: { defaultAction: 'something-else' },
+      actions: [{ id: 'open-link', payload: { url: 'https://example.com' } }],
+    })
+
+    expect(result).toBeUndefined()
+    expect(openUrl).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Refs #330. `packages/test` dev-toolbox: **11 failing → 0 of 11**.

Eleven of twelve failed, in the two shapes this issue keeps producing.

### `__test` is gone — 3 tests

`parseToolboxConfig` and `normalizeExternalUrl` were reached through a `__test` export
that `e37c92c8c` removed. **Both functions still exist** — they're just not exported.
Re-exported at load time into this suite's copy of the module rather than adding a
test-only export back to the shipped plugin, using the source-transform loader
`intelligence.test.ts` already uses.

### The action shape moved — 8 tests

They passed `actionId` and `payload` inside `meta`. `onItemAction` resolves both from
`item.actions[0]` (`index.js:197-199`), so `action` came back null, every branch was
skipped, and the handler returned `undefined`.

That's why all eight reported the same `expected undefined to match object` — one
symptom, and it made eight distinct behaviours look like a single fault.

### The permission SDK isn't used any more

Those eight drove `permission.check` / `permission.request`. **This plugin doesn't
touch the permission SDK at all** — the only trace left is reading
`PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED` off a thrown error (`index.js:233`). It calls
`openUrl` and interprets what comes back.

They now drive that, keeping the same intent: **invalid / denied / failed /
unavailable / granted**.

### Two tests are new, not remapped

Covering ground the old set implied but never asserted:

- a **transport failure** is reported as `open-url-failed`, not `permission-denied` —
  conflating them sends a user to a permission screen with nothing to fix
- an item whose `defaultAction` belongs to another plugin is **ignored**, not acted on

### Verification

- `packages/test` dev-toolbox: **11/11 passing**.
- The plugin's own `index.test.cjs`: still **3/3**.
- ESLint clean.

> CI red on this branch is #1194 (`node-pty` postinstall), fixed in #1197.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for developer toolbox link-opening behavior, including invalid links, denied access, host failures, unavailable browser support, and successfully normalized links.
  * Added validation to ensure unrelated actions are ignored.
  * Updated test setup to reflect the current development-tool behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->