### PR TITLE
fix(core-app): remove inline and wildcard script sources from the renderer CSP

### DIFF
--- a/apps/core-app/src/renderer/csp-policy.test.ts
+++ b/apps/core-app/src/renderer/csp-policy.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The renderer's Content-Security-Policy (#913).
+ *
+ * This is the privileged renderer: preload publishes ipcRenderer through contextBridge, and
+ * channel-guard grants every non-plugin caller all permissions. script-src used to be
+ * `* 'unsafe-inline' 'unsafe-eval'`, so a javascript: URL or inline handler that survived the
+ * markdown sanitiser — release notes are rendered here — executed with that authority.
+ *
+ * Asserted against the file because re-adding 'unsafe-inline' is a one-word edit that nothing
+ * else would catch.
+ */
+
+const html = readFileSync(fileURLToPath(new URL('./index.html', import.meta.url)), 'utf8')
+
+/**
+ * Comments are stripped before parsing. The file documents these directives in prose right
+ * above them, and the first version of this guard happily matched its own explanation of what
+ * script-src must not contain.
+ */
+const policy = html.replace(/<!--[\s\S]*?-->/g, '')
+
+function directive(name: string): string {
+  const match = policy.match(new RegExp(`(?:^|;)\\s*${name}\\s+([^;]+);`, 'm'))
+  expect(match, `directive ${name} not found — this guard is reading the wrong file`).not.toBeNull()
+  return match![1].replace(/\s+/g, ' ').trim()
+}
+
+describe('renderer content security policy', () => {
+  it('does not allow inline script', () => {
+    // The directive that made javascript: URLs and inline handlers executable.
+    expect(directive('script-src')).not.toContain("'unsafe-inline'")
+  })
+
+  it('does not allow script from an arbitrary origin', () => {
+    expect(directive('script-src').split(' ')).not.toContain('*')
+  })
+
+  it('restricts script to the app itself', () => {
+    expect(directive('script-src')).toContain("'self'")
+  })
+
+  it('still allows eval, which the plugin widget runtime requires', () => {
+    // Not an oversight. widget-registry.ts executes widget code through `new Function`, so
+    // dropping this removes plugin widgets rather than hardening anything. Asserted so the
+    // decision is visible rather than looking like an unfinished job.
+    expect(directive('script-src')).toContain("'unsafe-eval'")
+  })
+
+  it('keeps inline style, which Vue style bindings need', () => {
+    // Positive control in the other direction: a sweep that stripped 'unsafe-inline'
+    // everywhere would satisfy the script-src assertions above and break every :style binding.
+    expect(directive('style-src')).toContain("'unsafe-inline'")
+  })
+
+  it('has no inline script or event handler in the document itself', () => {
+    // The policy above only helps if the page it ships with obeys it.
+    expect(html).not.toMatch(/<script(?![^>]*\bsrc=)[^>]*>[\s\S]*?\S[\s\S]*?<\/script>/)
+    expect(html).not.toMatch(/\son[a-z]+\s*=\s*["']/i)
+  })
+})

--- a/apps/core-app/src/renderer/index.html
+++ b/apps/core-app/src/renderer/index.html
@@ -4,11 +4,26 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      script-src carries no 'unsafe-inline' and no wildcard: that combination is what let a
+      javascript: URL or an inline handler surviving the markdown sanitiser run inside the
+      privileged renderer, which holds the contextBridge ipcRenderer and is granted every
+      permission by channel-guard (#913).
+
+      'unsafe-eval' stays, and deliberately. The plugin widget runtime executes widget code
+      through `new Function` in widget-registry.ts, so removing it does not harden the
+      renderer — it removes plugin widgets. Replacing that executor is its own change.
+
+      default-src and connect-src are still wildcards. Narrowing them needs an inventory of
+      what the renderer actually reaches at runtime (user-configured AI provider origins,
+      the Vite dev server and its websocket) that a static reading cannot produce; tracked
+      on the issue rather than guessed at here.
+    -->
     <meta
       http-equiv="Content-Security-Policy"
       content="
     default-src * blob: data: tfile: remix:;
-    script-src * 'unsafe-inline' 'unsafe-eval' blob: data:;
+    script-src 'self' 'unsafe-eval' blob: data:;
     connect-src * ws: wss: blob: data: tfile:;
     img-src * data: blob: tfile: file: remix:;
     font-src * data: blob:;


### PR DESCRIPTION
Closes #913.

## What changed

```diff
- script-src * 'unsafe-inline' 'unsafe-eval' blob: data:;
+ script-src 'self' 'unsafe-eval' blob: data:;
```

`'unsafe-inline'` is what makes a `javascript:` URL or an inline handler executable. On **this** renderer — which publishes `ipcRenderer` through `contextBridge` and is granted every permission by `channel-guard` — markup surviving the markdown sanitiser (release notes render here) ran with that authority and could reach `system.openApp`, `terminal.session.create` and the download handlers.

## What I deliberately did not change

**`'unsafe-eval' stays.`** `widget-registry.ts` executes plugin widget code through `new Function`. Removing it does not harden the renderer — **it removes plugin widgets.** That is a different change with a different design, and shipping it here would have looked like a security fix while deleting a feature.

**`default-src` and `connect-src` stay wildcards.** The suggestion was to enumerate `connect-src` as "the Nexus origin", which assumes the renderer only talks to Nexus. What it actually reaches includes user-configured AI provider origins and, in development, the Vite dev server and its websocket. That list needs a runtime inventory, not a static reading — and guessing it wrong fails as a *silent network error*, which is the worst failure shape to ship.

Both decisions are recorded as a comment in `index.html` next to the policy, not only in this PR.

## Verification, and its limits

Established statically:

- no renderer Vite plugin injects HTML or script — `vue`, `Unocss`, `vueJsx`, `Components`, `generatorInformation`; none implement `transformIndexHtml`
- the document carries no inline script and no `on*` handler (asserted by test)

**Not established:** a full renderer build could not run in this worktree — `@talex-touch/tuffex/*` subpaths are unbuilt here, so `build:vite` fails before emitting HTML. The built `index.html` was therefore **not** inspected directly, and the app was not smoke-tested. CI's build is the check that the bundle still assembles; a dev-mode run is the check I could not perform.

## Tests

Six cases, three failing against the previous policy. Two are controls in the other direction:

- `'unsafe-eval'` **must still be present** — so the deliberate decision is visible rather than looking like an unfinished job
- `style-src` **must keep `'unsafe-inline'`** — every Vue `:style` binding depends on it, and a sweep that stripped the token everywhere would otherwise pass all the script-src assertions

The guard strips HTML comments before parsing. Its first version matched the prose comment explaining what `script-src` must not contain, and failed against the fixed file.