### PR TITLE
fix(utils): treat `/` as an attribute separator before href and src

### DIFF
--- a/packages/utils/__tests__/renderer/markdown-sanitizer.test.ts
+++ b/packages/utils/__tests__/renderer/markdown-sanitizer.test.ts
@@ -32,3 +32,57 @@ describe('markdown-sanitizer', () => {
     expect(html).toContain('href="#top"')
   })
 })
+
+/**
+ * The `/` attribute-name separator (#907).
+ *
+ * The handler and style strippers already used `[\s/]+`, because `<img/onerror=...>` is
+ * valid HTML.
+ * The href/src protocol allowlist still used `\s+`, so `<a/href="javascript:...">` was never
+ * inspected and came out of the sanitiser unchanged — while the ordinary `<a href=...>` form
+ * was correctly reduced to `<a>`. Release-note bodies and plugin READMEs reach v-html in the
+ * privileged renderer, so that anchor was one user click from ipcRenderer.
+ */
+describe('attribute separators before href/src', () => {
+  const dangerous = 'javascript:alert(1)'
+
+  it('strips a javascript: href introduced with a slash separator', () => {
+    expect(sanitizeMarkdownHtml(`<a/href="${dangerous}">x</a>`)).not.toContain('javascript:')
+  })
+
+  it('strips it with repeated slashes', () => {
+    expect(sanitizeMarkdownHtml(`<a//href="${dangerous}">x</a>`)).not.toContain('javascript:')
+  })
+
+  it('strips it with a slash after whitespace and vice versa', () => {
+    expect(sanitizeMarkdownHtml(`<a /href="${dangerous}">x</a>`)).not.toContain('javascript:')
+    expect(sanitizeMarkdownHtml(`<a/ href="${dangerous}">x</a>`)).not.toContain('javascript:')
+  })
+
+  it('strips the unquoted form too', () => {
+    // The second of the two regexes had the same defect and is easy to forget.
+    expect(sanitizeMarkdownHtml(`<a/href=${dangerous}>x</a>`)).not.toContain('javascript:')
+  })
+
+  it('strips a slash-separated src, not just href', () => {
+    expect(sanitizeMarkdownHtml(`<img/src="${dangerous}">`)).not.toContain('javascript:')
+  })
+
+  it('strips data: and vbscript: behind the same separator', () => {
+    expect(sanitizeMarkdownHtml('<a/href="data:text/html,<script>1</script>">x</a>')).not.toContain('data:')
+    expect(sanitizeMarkdownHtml('<a/href="vbscript:msgbox">x</a>')).not.toContain('vbscript:')
+  })
+
+  it('keeps a legitimate link written with a slash separator', () => {
+    // Positive control: the fix must inspect these attributes, not delete them wholesale.
+    const output = sanitizeMarkdownHtml('<a/href="https://example.test/docs">x</a>')
+    expect(output).toContain('href="https://example.test/docs"')
+    expect(output).not.toContain('/href')
+  })
+
+  it('still keeps an ordinary link untouched', () => {
+    expect(sanitizeMarkdownHtml('<a href="https://example.test">x</a>')).toContain(
+      'href="https://example.test"'
+    )
+  })
+})

--- a/packages/utils/renderer/shared/markdown-sanitizer.ts
+++ b/packages/utils/renderer/shared/markdown-sanitizer.ts
@@ -68,12 +68,16 @@ export function sanitizeMarkdownHtml(html: string): string {
     // URL-bearing attributes beyond href/src that can execute or navigate.
     .replace(/[\s/]+(?:formaction|xlink:href|action|srcdoc|background|ping)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '')
     // href/src with quotes — protocol-checked.
-    .replace(/\s+(href|src)\s*=\s*(["'])([\s\S]*?)\2/gi, (_match, name: string, quote: string, value: string) => {
+    //
+    // `[\s/]+`, not `\s+`, for the same reason the handlers above use it: `/` is a valid
+    // attribute-name separator, so `<a/href="javascript:...">` never reached the protocol
+    // allowlist and survived verbatim while the plain `<a href=...>` form was stripped (#907).
+    .replace(/[\s/]+(href|src)\s*=\s*(["'])([\s\S]*?)\2/gi, (_match, name: string, quote: string, value: string) => {
       if (!isAllowedUrl(value)) return ''
       return ` ${name.toLowerCase()}=${quote}${sanitizeAttributeValue(value.trim())}${quote}`
     })
     // href/src without quotes.
-    .replace(/\s+(href|src)\s*=\s*([^\s>"']+)/gi, (_match, name: string, value: string) => {
+    .replace(/[\s/]+(href|src)\s*=\s*([^\s>"']+)/gi, (_match, name: string, value: string) => {
       if (!isAllowedUrl(value)) return ''
       return ` ${name.toLowerCase()}="${sanitizeAttributeValue(value.trim())}"`
     })


### PR DESCRIPTION
Closes #907.

## The inconsistency

Three regexes in the same chain already used `[\s/]+`, with a comment explaining why — `/` is a legal attribute-name separator, so `<img/onerror=...>` is valid HTML. The two href/src regexes used `\s+`.

Reproduced before touching anything, by running the pair against both spellings:

```
<a href="javascript:alert(1)">x</a>   ->  <a>x</a>
<a/href="javascript:alert(1)">x</a>   ->  unchanged
```

The plain form was handled; the slash form never reached the protocol allowlist at all. That output feeds `v-html` in the privileged renderer through both `renderMarkdownToSafeHtml` callers — GitHub release-note bodies and plugin-store READMEs.

## Scope

The issue also proposed replacing the regex sanitiser with DOMPurify. That is a larger change with its own compatibility surface, and it is what **#900** tracks. This PR fixes the specific inconsistency between two regexes in one chain; it does not claim the sanitiser is now sound.

## Tests

Eight cases, **seven failing** against the previous version:

- slash separator; repeated slashes; slash-then-space and space-then-slash
- **the unquoted branch** — it had the identical defect, and fixing only the quoted one is the easy mistake
- `src` as well as `href`
- `data:` and `vbscript:` behind the same separator, not just `javascript:`
- **positive control:** a legitimate `https` link written with a slash separator is *kept* and rewritten to a normal attribute. A fix that deleted these attributes wholesale would pass every other assertion here.

Lint clean.

*(Note for the reader of the diff: the test file's doc comment originally contained `on*/style`, whose `*/` closed the block comment early and broke transform. Mentioning it because the fixed wording reads oddly otherwise.)*