### PR TITLE
fix(core-app): only let openApp launch an installed application

### DIFF
--- a/apps/core-app/src/main/channel/system-shell-handlers.test.ts
+++ b/apps/core-app/src/main/channel/system-shell-handlers.test.ts
@@ -1,3 +1,6 @@
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AppEvents } from '@talex-touch/utils/transport/events'
 import { registerSystemShellHandlers } from './system-shell-handlers'
@@ -374,5 +377,52 @@ describe('executeCommand path restriction', () => {
 
   it('still rejects an empty command', async () => {
     await expect(executeCommandHandler()({ command: '' })).rejects.toThrow('No command provided')
+  })
+})
+
+/**
+ * The openApp handler's side of the installed-application check (#908).
+ *
+ * evaluateInstalledAppPath is unit-tested next to itself; these two assert the handler
+ * consults it at all, which is the part a refactor can silently drop.
+ */
+describe('openApp target validation', () => {
+  function openAppHandler(): (payload: { appName?: string; path?: string }) => unknown {
+    const { transport, handlers } = createTransport()
+    registerSystemShellHandlers(transport as never, {
+      configRootPath: () => '/tmp/tuff/config',
+      appRootPath: () => '/tmp/tuff',
+      logger: { warn: vi.fn() },
+      registerSafeHandler: (() => vi.fn()) as never
+    })
+    const handler = handlers.get(AppEvents.system.openApp.toEventName())
+    if (!handler) throw new Error('openApp handler was not registered')
+    return handler as (payload: { appName?: string; path?: string }) => unknown
+  }
+
+  beforeEach(() => {
+    shellOpenPathMock.mockClear()
+  })
+
+  it('does not open a file the caller dropped outside the application roots', () => {
+    openAppHandler()({ path: `${os.homedir()}/Library/Caches/payload.command` })
+    expect(shellOpenPathMock).not.toHaveBeenCalled()
+  })
+
+  it('does not open a bare application name', () => {
+    openAppHandler()({ appName: 'Safari' })
+    expect(shellOpenPathMock).not.toHaveBeenCalled()
+  })
+
+  it('opens an installed application', () => {
+    // Platform-specific so the positive control is meaningful wherever CI runs.
+    const app =
+      process.platform === 'darwin'
+        ? '/Applications/Example.app'
+        : process.platform === 'win32'
+          ? path.join(os.homedir(), 'AppData', 'Local', 'Programs', 'x.exe')
+          : '/usr/share/applications/example.desktop'
+    openAppHandler()({ path: app })
+    expect(shellOpenPathMock).toHaveBeenCalledWith(app)
   })
 })

--- a/apps/core-app/src/main/channel/system-shell-handlers.ts
+++ b/apps/core-app/src/main/channel/system-shell-handlers.ts
@@ -5,6 +5,7 @@ import { shell } from 'electron'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { validateExternalUrl } from '../utils/external-url-policy'
+import { evaluateInstalledAppPath } from '../utils/installed-app-policy'
 import type { LogOptions } from '../utils/logger'
 
 export interface SystemShellCapabilities {
@@ -94,10 +95,18 @@ export function registerSystemShellHandlers(
       shell.showItemInFolder(target)
     }),
     transport.on(AppEvents.system.openApp, (payload) => {
+      // shell.openPath launches by OS association, so this handler was a way for any caller —
+      // transport.on registers on the plugin channel too — to execute a file it had dropped
+      // elsewhere, e.g. through the download handler (#908). The target must now be an
+      // application this machine actually has installed.
       const target = payload?.appName || payload?.path
-      if (target) {
-        void shell.openPath(target)
+      const decision = evaluateInstalledAppPath(target)
+      if (!decision.allowed) {
+        options.logger.warn('Blocked openApp request', { meta: { reason: decision.reason } })
+        return undefined
       }
+
+      void shell.openPath(target as string)
       return undefined
     }),
     transport.on(AppEvents.system.openPromptsFolder, async () => {

--- a/apps/core-app/src/main/utils/installed-app-policy.test.ts
+++ b/apps/core-app/src/main/utils/installed-app-policy.test.ts
@@ -1,0 +1,73 @@
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { describe, expect, it } from 'vitest'
+import { evaluateInstalledAppPath } from './installed-app-policy'
+
+/**
+ * What system.openApp may launch (#908).
+ *
+ * The handler passed `payload.appName || payload.path` straight to shell.openPath, which asks
+ * the OS to open it — on macOS and Windows that means execution, outside the Electron sandbox.
+ * transport.on registers on the plugin channel as well, so any plugin could drop a file via
+ * the download handler and then have the main process run it.
+ */
+
+const HOME = os.homedir()
+
+/** An application path that is valid on the platform the test is running on. */
+function installedApp(): string {
+  if (process.platform === 'darwin') return '/Applications/Example.app'
+  if (process.platform === 'win32') return path.join(HOME, 'AppData', 'Local', 'Programs', 'x.exe')
+  return '/usr/share/applications/example.desktop'
+}
+
+/** A payload inside an application root but not itself an application. */
+function scriptInAppRoot(): string {
+  if (process.platform === 'darwin') return '/Applications/payload.command'
+  if (process.platform === 'win32') return path.join(HOME, 'AppData', 'Local', 'Programs', 'p.bat')
+  return '/usr/share/applications/payload.sh'
+}
+
+describe('evaluateInstalledAppPath', () => {
+  it('allows an installed application', () => {
+    // Positive control. Every rejection below would also pass if this returned false for
+    // everything, which would "fix" the issue by disabling the feature.
+    expect(evaluateInstalledAppPath(installedApp())).toEqual({ allowed: true })
+  })
+
+  it('rejects a path outside the application roots', () => {
+    const dropped = path.join(HOME, 'Library', 'Caches', 'payload.command')
+    expect(evaluateInstalledAppPath(dropped).reason).toBe('outside-application-roots')
+  })
+
+  it('rejects a script that merely sits in an application root', () => {
+    // Being in the right folder is not enough: openPath runs a .command or .bat just as
+    // readily as it opens an app.
+    expect(evaluateInstalledAppPath(scriptInAppRoot()).reason).toBe('not-an-application')
+  })
+
+  it('rejects a traversal that climbs out of an application root', () => {
+    const escaped = `${installedApp()}/../../../tmp/payload.app`
+    expect(evaluateInstalledAppPath(escaped).allowed).toBe(false)
+  })
+
+  it('rejects a sibling directory sharing an application root prefix', () => {
+    const sibling =
+      process.platform === 'win32'
+        ? path.join(`${HOME}\\AppData\\Local\\ProgramsEvil`, 'x.exe')
+        : `${installedApp().replace(/\/[^/]+$/, '')}Evil/x.app`
+    expect(evaluateInstalledAppPath(sibling).allowed).toBe(false)
+  })
+
+  it('rejects a bare application name', () => {
+    // Not a regression: shell.openPath takes a filesystem path and never resolved 'Safari'.
+    expect(evaluateInstalledAppPath('Safari').reason).toBe('not-absolute')
+  })
+
+  it('rejects empty and undefined input', () => {
+    expect(evaluateInstalledAppPath('').reason).toBe('empty')
+    expect(evaluateInstalledAppPath(undefined).reason).toBe('empty')
+    expect(evaluateInstalledAppPath('   ').reason).toBe('empty')
+  })
+})

--- a/apps/core-app/src/main/utils/installed-app-policy.ts
+++ b/apps/core-app/src/main/utils/installed-app-policy.ts
@@ -1,0 +1,89 @@
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+
+/**
+ * Where installed applications live, per platform.
+ *
+ * Taken from the directories the launcher already indexes (app-scanner's WATCH_PATHS) plus
+ * the system application folders, so "an application this machine has installed" means the
+ * same thing to the opener as it does to search.
+ */
+function applicationRoots(): string[] {
+  const home = os.homedir()
+
+  if (process.platform === 'darwin') {
+    return ['/Applications', '/System/Applications', path.join(home, 'Applications')]
+  }
+
+  if (process.platform === 'win32') {
+    return [
+      process.env.PROGRAMFILES,
+      process.env['PROGRAMFILES(X86)'],
+      path.join(home, 'AppData', 'Local', 'Programs'),
+      path.join(home, 'AppData', 'Roaming', 'Microsoft', 'Windows', 'Start Menu', 'Programs'),
+      'C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs'
+    ].filter((value): value is string => Boolean(value))
+  }
+
+  return [
+    '/usr/share/applications',
+    '/var/lib/snapd/desktop/applications',
+    path.join(home, '.local', 'share', 'applications')
+  ]
+}
+
+/**
+ * Extensions that name an application rather than a document.
+ *
+ * The point of the check is that shell.openPath launches by OS association, so a `.command`,
+ * `.bat` or `.sh` sitting in an application directory would run just as readily as an app.
+ */
+function applicationExtensions(): string[] {
+  if (process.platform === 'darwin') return ['.app']
+  if (process.platform === 'win32') return ['.exe', '.lnk']
+  return ['.desktop']
+}
+
+export interface InstalledAppDecision {
+  allowed: boolean
+  reason?: 'empty' | 'not-absolute' | 'outside-application-roots' | 'not-an-application'
+}
+
+/**
+ * Whether a path may be handed to shell.openPath as "open this installed application".
+ *
+ * The handler used to pass `payload.appName || payload.path` straight through, so any caller
+ * could name a file it had dropped elsewhere — via the download handler, for instance — and
+ * have the OS execute it outside the sandbox (#908).
+ *
+ * A bare application *name* is rejected along with every other relative value. That is not a
+ * regression: shell.openPath takes a filesystem path and never resolved a name like 'Safari'
+ * to begin with.
+ */
+export function evaluateInstalledAppPath(target: string | undefined): InstalledAppDecision {
+  const value = typeof target === 'string' ? target.trim() : ''
+  if (!value) {
+    return { allowed: false, reason: 'empty' }
+  }
+
+  if (!path.isAbsolute(value)) {
+    return { allowed: false, reason: 'not-absolute' }
+  }
+
+  const resolved = path.resolve(value)
+  const withinRoot = applicationRoots().some((root) => {
+    const resolvedRoot = path.resolve(root)
+    return resolved === resolvedRoot || resolved.startsWith(resolvedRoot + path.sep)
+  })
+  if (!withinRoot) {
+    return { allowed: false, reason: 'outside-application-roots' }
+  }
+
+  const extension = path.extname(resolved).toLowerCase()
+  if (!applicationExtensions().includes(extension)) {
+    return { allowed: false, reason: 'not-an-application' }
+  }
+
+  return { allowed: true }
+}


### PR DESCRIPTION
Closes #908.

## The defect

```ts
const target = payload?.appName || payload?.path
if (target) void shell.openPath(target)
```

`shell.openPath` asks the OS to open the target — on macOS and Windows, to **execute** it, outside the Electron sandbox. `transport.on` registers on the plugin channel too, so any plugin could drop a file via the download handler and then have the main process run it. Nothing consulted the permission module, and `withPermission` would not have helped a renderer caller: `channel-guard` returns early when there is no plugin id.

## The rule

The target must be an application the machine has installed — **inside a platform application root** *and* **carrying an application extension**.

Both are needed. A `.command` or `.bat` sitting in `/Applications` would otherwise launch exactly as readily as an app, and the report's own scenario is a dropped file.

Roots come from the directories the launcher already indexes (`app-scanner`'s `WATCH_PATHS`) plus the system application folders, so *installed application* means the same thing to the opener as it does to search.

## Two decisions

**A bare `appName` is now rejected**, along with every other relative value. Not a regression: `shell.openPath` takes a filesystem path and never resolved `'Safari'`, so that branch of the payload was already dead.

**No confirmation prompt for anything outside the allowlist**, which the suggested direction proposed. A prompt that can authorise launching an arbitrary dropped file converts a code-execution bug into a social-engineering one rather than closing it, and no caller needs the capability — there is no in-app caller at all, only SDK surface.

## Tests

Ten. Seven on the policy:

- installed application allowed (**positive control** — every rejection below would also pass if it returned false for everything)
- a file dropped outside the roots; a script *inside* a root; a traversal climbing out; a sibling directory sharing a root prefix
- a bare name; empty/undefined/whitespace

Three on the handler's use of it, because a refactor can drop the call and no policy test would notice. Two of those fail against the pre-fix handler.

The platform-specific paths are computed per-platform so the positive control is meaningful wherever CI runs. Lint clean.