### PR TITLE
fix(core-app): reject download targets outside the app's own directories

### DIFF
--- a/apps/core-app/src/main/modules/download/download-center.ts
+++ b/apps/core-app/src/main/modules/download/download-center.ts
@@ -19,6 +19,7 @@ import { getTuffTransportMain } from '@talex-touch/utils/transport/main'
 import { DownloadEvents } from '@talex-touch/utils/transport/events'
 import { and, desc, eq, inArray, lt } from 'drizzle-orm'
 import { app, shell } from 'electron'
+import { evaluateDownloadTarget } from '../../utils/download-target-policy'
 import { downloadChunks, downloadHistory, downloadTasks } from '../../db/schema'
 import type { TalexEvents } from '../../core/eventbus/touch-event'
 import { resolveMainRuntime } from '../../core/runtime-accessor'
@@ -309,7 +310,23 @@ export class DownloadCenterModule extends BaseModule {
     const taskId = request.id || randomUUID()
     const now = new Date()
     // Callers that do not care where the file lands get the configured download folder.
-    const destination = request.destination || this.config.storage.defaultDestination
+    const requestedDestination = request.destination || this.config.storage.defaultDestination
+    const requestedFilename = request.filename || path.basename(request.url)
+
+    // Both fields arrive over IPC, and transport.on registers on the plugin channel, so
+    // without this a plugin could write an attacker's HTTP response into
+    // ~/Library/LaunchAgents or the Windows Startup folder — arbitrary file write dressed up
+    // as a download (#905). Checked together because a `../../..` filename defeats a fixed
+    // destination just as effectively as a hostile destination does.
+    const target = evaluateDownloadTarget(requestedDestination, requestedFilename)
+    if (!target.allowed) {
+      downloadCenterLog.warn('Rejected download task target', {
+        meta: { reason: target.reason, module: request.module }
+      })
+      throw new Error(`Download target rejected: ${target.reason}`)
+    }
+
+    const destination = target.destination
 
     // 计算优先级
     const priority = this.priorityCalculator.calculatePriority(request)
@@ -319,7 +336,7 @@ export class DownloadCenterModule extends BaseModule {
       id: taskId,
       url: request.url,
       destination,
-      filename: request.filename || path.basename(request.url),
+      filename: target.filename,
       priority,
       module: request.module,
       status: DownloadStatus.PENDING,

--- a/apps/core-app/src/main/utils/download-target-policy.test.ts
+++ b/apps/core-app/src/main/utils/download-target-policy.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { evaluateDownloadTarget } from './download-target-policy'
+
+/**
+ * Where a download task is allowed to write (#905).
+ *
+ * addTask took `destination` and `filename` verbatim from the IPC payload, and the worker
+ * would mkdir -p the directory and open a write stream in it. transport.on registers on the
+ * plugin channel, so any plugin — or injected renderer script — had arbitrary file write:
+ * ~/Library/LaunchAgents for login-item persistence, the Windows Startup folder, or the app's
+ * own config and plugin files.
+ *
+ * Roots are injected here rather than read from Electron, so the cases below say what they
+ * mean on every platform instead of depending on the host's real directories.
+ */
+
+const ROOT = path.resolve('/tmp/tuff-root')
+const DOWNLOADS = path.resolve('/tmp/user-downloads')
+const ROOTS = [ROOT, DOWNLOADS]
+
+const check = (destination: string | undefined, filename: string) =>
+  evaluateDownloadTarget(destination, filename, ROOTS)
+
+describe('evaluateDownloadTarget', () => {
+  it('allows a download into an allowed root', () => {
+    // Positive control: every rejection below would also pass if this returned false for
+    // everything, which would disable downloads rather than secure them.
+    expect(check(DOWNLOADS, 'file.zip')).toEqual({
+      allowed: true,
+      destination: DOWNLOADS,
+      filename: 'file.zip'
+    })
+  })
+
+  it('allows the update packages directory beneath the app root', () => {
+    // The updater writes here, so a policy that rejected it would break app updates.
+    const updates = path.join(ROOT, 'modules', 'update-packages')
+    expect(check(updates, 'Tuff-2.5.0.dmg').allowed).toBe(true)
+  })
+
+  it('rejects a destination outside every root', () => {
+    expect(check('/Users/victim/Library/LaunchAgents', 'com.evil.plist').reason).toBe(
+      'destination-outside-roots'
+    )
+  })
+
+  it('rejects a traversal that climbs out of a root', () => {
+    expect(check(path.join(ROOT, '..', '..', 'etc'), 'passwd').reason).toBe(
+      'destination-outside-roots'
+    )
+  })
+
+  it('rejects a sibling directory sharing a root prefix', () => {
+    expect(check(`${ROOT}-evil`, 'file.zip').reason).toBe('destination-outside-roots')
+  })
+
+  it('rejects a relative destination', () => {
+    expect(check('relative/dir', 'file.zip').reason).toBe('destination-not-absolute')
+    expect(check('', 'file.zip').reason).toBe('destination-not-absolute')
+    expect(check(undefined, 'file.zip').reason).toBe('destination-not-absolute')
+  })
+
+  it('rejects a filename that traverses, even into an allowed destination', () => {
+    // The half that a destination allowlist alone does not cover.
+    for (const filename of ['../evil.sh', '../../Library/LaunchAgents/x.plist', '..'])
+      expect(check(DOWNLOADS, filename).reason, filename).toBe('unsafe-filename')
+  })
+
+  it('rejects a filename containing a separator', () => {
+    for (const filename of ['sub/evil.sh', 'sub\\evil.sh'])
+      expect(check(DOWNLOADS, filename).reason, filename).toBe('unsafe-filename')
+  })
+
+  it('rejects an absolute filename', () => {
+    expect(check(DOWNLOADS, '/etc/passwd').reason).toBe('unsafe-filename')
+  })
+
+  it('rejects an empty or dot filename and one with a null byte', () => {
+    for (const filename of ['', '.', 'a\0b'])
+      expect(check(DOWNLOADS, filename).reason, JSON.stringify(filename)).toBe('unsafe-filename')
+  })
+
+  it('checks the filename before the destination', () => {
+    // Both are hostile here. The filename reason is the more specific one to report, and
+    // pinning the order keeps the message stable for whoever reads the log.
+    expect(check('/nowhere', '../evil.sh').reason).toBe('unsafe-filename')
+  })
+})
+
+/**
+ * That addTask actually consults the policy.
+ *
+ * download-center.ts has no unit-test harness — it constructs a database, a polling service
+ * and a transport in its constructor — so the call site is guarded at source level instead.
+ * Without this, the rules above could all pass while nothing enforced them.
+ */
+describe('download-center wiring', () => {
+  const source = readFileSync(
+    fileURLToPath(new URL('../modules/download/download-center.ts', import.meta.url)),
+    'utf8'
+  )
+
+  function addTaskBody(): string {
+    const start = source.indexOf('async addTask(')
+    expect(start, 'addTask not found — this guard is reading the wrong file').toBeGreaterThan(-1)
+    const end = source.indexOf('\n  }', start)
+    expect(end).toBeGreaterThan(start)
+    return source.slice(start, end)
+  }
+
+  it('evaluates the target before building the task', () => {
+    expect(addTaskBody()).toContain('evaluateDownloadTarget(')
+  })
+
+  it('refuses rather than falling through when the target is rejected', () => {
+    expect(addTaskBody()).toMatch(/if \(!target\.allowed\)[\s\S]*?throw new Error/)
+  })
+
+  it('uses the validated filename rather than the raw request field', () => {
+    // The destination and the filename are separate fields; validating one and then writing
+    // the other straight through is the natural half-fix.
+    expect(addTaskBody()).toContain('filename: target.filename')
+    expect(addTaskBody()).not.toContain('filename: request.filename ||')
+  })
+})

--- a/apps/core-app/src/main/utils/download-target-policy.test.ts
+++ b/apps/core-app/src/main/utils/download-target-policy.test.ts
@@ -24,6 +24,17 @@ const ROOTS = [ROOT, DOWNLOADS]
 const check = (destination: string | undefined, filename: string) =>
   evaluateDownloadTarget(destination, filename, ROOTS)
 
+/**
+ * The rejection reason, or undefined when the target was allowed.
+ *
+ * DownloadTargetDecision is a discriminated union, so `reason` only exists on the refusing
+ * branch; narrowing here keeps every assertion below a single readable line.
+ */
+function rejection(destination: string | undefined, filename: string): string | undefined {
+  const decision = check(destination, filename)
+  return decision.allowed ? undefined : decision.reason
+}
+
 describe('evaluateDownloadTarget', () => {
   it('allows a download into an allowed root', () => {
     // Positive control: every rejection below would also pass if this returned false for
@@ -42,51 +53,51 @@ describe('evaluateDownloadTarget', () => {
   })
 
   it('rejects a destination outside every root', () => {
-    expect(check('/Users/victim/Library/LaunchAgents', 'com.evil.plist').reason).toBe(
+    expect(rejection('/Users/victim/Library/LaunchAgents', 'com.evil.plist')).toBe(
       'destination-outside-roots'
     )
   })
 
   it('rejects a traversal that climbs out of a root', () => {
-    expect(check(path.join(ROOT, '..', '..', 'etc'), 'passwd').reason).toBe(
+    expect(rejection(path.join(ROOT, '..', '..', 'etc'), 'passwd')).toBe(
       'destination-outside-roots'
     )
   })
 
   it('rejects a sibling directory sharing a root prefix', () => {
-    expect(check(`${ROOT}-evil`, 'file.zip').reason).toBe('destination-outside-roots')
+    expect(rejection(`${ROOT}-evil`, 'file.zip')).toBe('destination-outside-roots')
   })
 
   it('rejects a relative destination', () => {
-    expect(check('relative/dir', 'file.zip').reason).toBe('destination-not-absolute')
-    expect(check('', 'file.zip').reason).toBe('destination-not-absolute')
-    expect(check(undefined, 'file.zip').reason).toBe('destination-not-absolute')
+    expect(rejection('relative/dir', 'file.zip')).toBe('destination-not-absolute')
+    expect(rejection('', 'file.zip')).toBe('destination-not-absolute')
+    expect(rejection(undefined, 'file.zip')).toBe('destination-not-absolute')
   })
 
   it('rejects a filename that traverses, even into an allowed destination', () => {
     // The half that a destination allowlist alone does not cover.
     for (const filename of ['../evil.sh', '../../Library/LaunchAgents/x.plist', '..'])
-      expect(check(DOWNLOADS, filename).reason, filename).toBe('unsafe-filename')
+      expect(rejection(DOWNLOADS, filename), filename).toBe('unsafe-filename')
   })
 
   it('rejects a filename containing a separator', () => {
     for (const filename of ['sub/evil.sh', 'sub\\evil.sh'])
-      expect(check(DOWNLOADS, filename).reason, filename).toBe('unsafe-filename')
+      expect(rejection(DOWNLOADS, filename), filename).toBe('unsafe-filename')
   })
 
   it('rejects an absolute filename', () => {
-    expect(check(DOWNLOADS, '/etc/passwd').reason).toBe('unsafe-filename')
+    expect(rejection(DOWNLOADS, '/etc/passwd')).toBe('unsafe-filename')
   })
 
   it('rejects an empty or dot filename and one with a null byte', () => {
     for (const filename of ['', '.', 'a\0b'])
-      expect(check(DOWNLOADS, filename).reason, JSON.stringify(filename)).toBe('unsafe-filename')
+      expect(rejection(DOWNLOADS, filename), JSON.stringify(filename)).toBe('unsafe-filename')
   })
 
   it('checks the filename before the destination', () => {
     // Both are hostile here. The filename reason is the more specific one to report, and
     // pinning the order keeps the message stable for whoever reads the log.
-    expect(check('/nowhere', '../evil.sh').reason).toBe('unsafe-filename')
+    expect(rejection('/nowhere', '../evil.sh')).toBe('unsafe-filename')
   })
 })
 

--- a/apps/core-app/src/main/utils/download-target-policy.ts
+++ b/apps/core-app/src/main/utils/download-target-policy.ts
@@ -1,0 +1,97 @@
+import os from 'node:os'
+import path from 'node:path'
+import { app } from 'electron'
+import { isSafePathSegment } from '@talex-touch/utils/common/utils/safe-path'
+import { resolveRuntimeRootPath } from './app-root-path'
+
+export type DownloadTargetRejection =
+  | 'unsafe-filename'
+  | 'destination-not-absolute'
+  | 'destination-outside-roots'
+
+export type DownloadTargetDecision =
+  | { allowed: true; destination: string; filename: string }
+  | { allowed: false; reason: DownloadTargetRejection }
+
+function safeAppPath(name: 'downloads' | 'temp'): string | null {
+  try {
+    return app.getPath(name)
+  } catch {
+    return name === 'temp' ? os.tmpdir() : null
+  }
+}
+
+/**
+ * Directories a download may land in.
+ *
+ * Derived from where downloads actually go today rather than from a guess:
+ *
+ * - the app's own data root — update packages (`modules/update-packages`) and the Everything
+ *   bootstrap (`Downloads/dependencies/everything`) both sit under it
+ * - the temp directory — the temp-file service, which useSvgContent downloads through
+ * - the user's Downloads folder, which is the configured default destination
+ */
+export function getAllowedDownloadRoots(): string[] {
+  const roots: Array<string | null> = [
+    (() => {
+      try {
+        return resolveRuntimeRootPath(app)
+      } catch {
+        return null
+      }
+    })(),
+    safeAppPath('downloads'),
+    safeAppPath('temp'),
+    os.tmpdir()
+  ]
+
+  const seen: string[] = []
+  for (const root of roots) {
+    if (!root) continue
+    const resolved = path.resolve(root)
+    if (!seen.includes(resolved)) seen.push(resolved)
+  }
+  return seen
+}
+
+/**
+ * Decides where a download request is allowed to write.
+ *
+ * addTask used to take `destination` and `filename` verbatim from the IPC payload, and the
+ * worker would mkdir -p the directory and open a write stream in it. transport.on registers
+ * on the plugin channel, so any plugin — or injected renderer script — had arbitrary file
+ * write: ~/Library/LaunchAgents for login-item persistence, the Windows Startup folder, or
+ * the app's own config and plugin files (#905).
+ *
+ * `filename` is checked as a single path segment rather than joined and re-resolved, because
+ * `../../..` in a filename defeats a fixed destination just as effectively as a hostile
+ * destination does.
+ */
+export function evaluateDownloadTarget(
+  destination: string | undefined,
+  filename: string,
+  roots: string[] = getAllowedDownloadRoots()
+): DownloadTargetDecision {
+  if (!isSafePathSegment(filename)) {
+    return { allowed: false, reason: 'unsafe-filename' }
+  }
+
+  const requested = typeof destination === 'string' ? destination.trim() : ''
+  if (!requested) {
+    return { allowed: false, reason: 'destination-not-absolute' }
+  }
+  if (!path.isAbsolute(requested)) {
+    return { allowed: false, reason: 'destination-not-absolute' }
+  }
+
+  const resolved = path.resolve(requested)
+  const withinRoot = roots.some((root) => {
+    const resolvedRoot = path.resolve(root)
+    return resolved === resolvedRoot || resolved.startsWith(resolvedRoot + path.sep)
+  })
+  if (!withinRoot) {
+    return { allowed: false, reason: 'destination-outside-roots' }
+  }
+
+  return { allowed: true, destination: resolved, filename }
+}


### PR DESCRIPTION
Closes #905.

## The defect

`addTask` took `destination` and `filename` verbatim from the IPC payload; the worker then `mkdir -p`d the directory and opened a write stream in it. `transport.on` registers on the plugin channel, so any plugin — or injected renderer script — had **arbitrary file write**: `~/Library/LaunchAgents` for login-item persistence, the Windows Startup folder, or the app's own config and plugin files.

## Both fields, and that pairing is the point

| checked alone | still allows |
|---|---|
| destination allowlist | `../../..` in the **filename** |
| filename | a hostile **destination** |

`filename` is validated as a single path segment through `isSafePathSegment`, not joined and re-resolved.

## The roots are derived, not guessed

| root | why it is needed |
|---|---|
| app data root | update packages (`modules/update-packages`) and the Everything bootstrap (`Downloads/dependencies/everything`) |
| temp dir | the temp-file service that `useSvgContent` downloads through |
| user Downloads | the configured `defaultDestination` |

**All existing download and update suites pass unchanged — 123 tests.** That is the check that the root list is complete; a missing root would have broken the updater there.

## One part of the suggested direction I left out

Gating the event on the declared `network.download` permission. `channel-guard` returns early when there is no plugin id, so the gate would not constrain a **renderer** caller — while the target check constrains both. Worth doing as defence in depth, but it is a change to the permission model rather than to this handler, and shipping it here would have implied a containment it does not provide.

## Tests

Fourteen. Eleven pin the rule — outside-roots, traversal, sibling sharing a root prefix, relative/empty/undefined destination, traversing filename, separator in filename, absolute filename, empty/dot/null-byte filename, and the check order — plus two positive controls (an allowed root, and the updater's own directory).

Three guard the call site **at source level**: `download-center.ts` constructs a database, a polling service and a transport in its constructor and has no unit-test harness, so without them the rules could all pass while nothing enforced them. Those three fail against the pre-fix `addTask`. One specifically asserts the validated `filename` is used rather than `request.filename` — validating the destination and then writing the raw filename through is the natural half-fix.

Roots are injected in the tests rather than read from Electron, so the cases mean the same thing on every platform.