### PR TITLE
fix(tuff-native): expect the frozen-compose feature the capability always adds (#1125)

### DIFF
--- a/packages/tuff-native/scripts/verify-screenshot-production.js
+++ b/packages/tuff-native/scripts/verify-screenshot-production.js
@@ -35,7 +35,13 @@ try {
     else {
       assert.equal(capability.state, 'degraded')
       assert.equal(capability.reason, 'basic-backend-only')
-      assert.deepEqual(capability.features, ['display', 'region'])
+      // ScreenshotCapability::features() appends frozen-compose to whatever the
+      // backend reports, unconditionally (native-screenshot/src/capability.rs:35-39),
+      // so this list could never be just the backend's two. The Rust contract test
+      // already expects all three (backend_contract_tests.rs:377); this assertion was
+      // the outlier, and it made the Windows leg of native-protocol.yml red on every
+      // branch. macOS never noticed because its branch does not assert features.
+      assert.deepEqual(capability.features, ['display', 'region', 'frozen-compose'])
     }
   }
 }


### PR DESCRIPTION
Fixes the **Windows leg** of #1125.

`verify:screenshot-production` failed on every branch:

```
AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected
  [
    'display',
    'region',
+   'frozen-compose'
  ]
```

`ScreenshotCapability::features()` appends `frozen-compose` to whatever the backend
reports — **unconditionally** (`native-screenshot/src/capability.rs:35-39`):

```rust
fn features(&self) -> Vec<String> {
    let mut features = self.backend.support().features().to_vec();
    if !features.iter().any(|feature| feature == "frozen-compose") {
        features.push("frozen-compose".to_string());
    }
    features
}
```

So the win32/linux branch was asserting a list that **cannot occur**. This isn't
platform drift — the assertion was wrong from the moment `frozen-compose` was added
in `f184d0966`.

The Rust side already agrees on the three-feature list
(`backend_contract_tests.rs:377`: `vec!["display", "region", "frozen-compose"]`).
The JS verifier was the only place that disagreed.

**macOS never caught it** because its branch asserts `engine` and `state` only, never
`features` — which is also why this reads as a Windows-specific bug when it isn't.

### Verified

Built the production screenshot addon locally and ran
`verify-screenshot-production.js` on darwin: passes. That branch is untouched; this
only corrects the win32/linux expectation.

I can't execute the Windows path here, so the Windows leg of `native-protocol.yml` on
this PR is the real check.