### PR TITLE
test(quickops): restore the dropped contract coverage, and point the audit at it (#323)

### DIFF
--- a/apps/core-app/src/main/modules/quick-ops/quick-ops-flow-ai-adapter-audit.test.ts
+++ b/apps/core-app/src/main/modules/quick-ops/quick-ops-flow-ai-adapter-audit.test.ts
@@ -88,9 +88,8 @@ describe('QuickOps Flow and AI adapter audit', () => {
         {
           path: 'plugins/touch-quickops/index.test.cjs',
           source: [
-            'test("buildFlowAdapterTrace redacts request and payload values", () => {})',
-            'expect(trace).toMatchObject({ payloadKeys: [], sensitivePayloadRedacted: true })',
-            'test("onItemAction dispatches safe QuickOps Flow action", () => {})',
+            'test("projectItemsForHost publishes only whitelisted meta, so request detail cannot leak", () => {})',
+            'test("onItemAction dispatches only the fixed Flow payload and awaits the acknowledgement", () => {})',
             'assert.equal(items[0].meta.payload, undefined)',
             'assert.equal(resolveHighRiskFlowAction("kill port 3000").targetId, "quickops.port-kill")'
           ].join('\n')

--- a/apps/core-app/src/main/modules/quick-ops/quick-ops-flow-ai-adapter-audit.ts
+++ b/apps/core-app/src/main/modules/quick-ops/quick-ops-flow-ai-adapter-audit.ts
@@ -225,7 +225,7 @@ function detectAiAdapterSignals(aiSources: Array<{ path: string; source: string 
     sourceIncludes(
       aiSources,
       'plugins/touch-quickops/index.test.cjs',
-      'buildFlowAdapterTrace redacts request and payload values'
+      'publishes only whitelisted meta, so request detail cannot leak'
     )
   ) {
     signals.push('plugins/touch-quickops/index.test.cjs:contract')
@@ -261,8 +261,16 @@ function linksRequestTargetConfirmationResult(
     sourceIncludes(aiSources, 'plugins/touch-quickops/index.js', 'targetId') &&
     sourceIncludes(aiSources, 'plugins/touch-quickops/index.js', 'confirmation') &&
     sourceIncludes(aiSources, 'plugins/touch-quickops/index.js', 'result') &&
-    sourceIncludes(aiSources, 'plugins/touch-quickops/index.test.cjs', 'payloadKeys') &&
-    sourceIncludes(aiSources, 'plugins/touch-quickops/index.test.cjs', 'sensitivePayloadRedacted')
+    // Retargeted from the flowAdapterTrace's own payloadKeys / sensitivePayloadRedacted
+    // fields. That trace has no consumer anywhere in the repo and projectItemsForHost
+    // strips it before items reach the host, so asserting it proved a structure nothing
+    // reads. The protection that actually holds is the projection whitelist, so the
+    // evidence points there. See #323.
+    sourceIncludes(
+      aiSources,
+      'plugins/touch-quickops/index.test.cjs',
+      'publishes only whitelisted meta, so request detail cannot leak'
+    )
   )
 }
 
@@ -288,10 +296,12 @@ function hasRuntimeDispatchBridge(aiSources: Array<{ path: string; source: strin
     sourceIncludes(aiSources, 'plugins/touch-quickops/index.js', 'confirmationToken') &&
     sourceIncludes(aiSources, 'plugins/touch-quickops/index.js', 'runtimeDispatchBridge: true') &&
     sourceIncludes(aiSources, 'plugins/touch-quickops/index.js', 'runtimeDispatchBridge: false') &&
+    // The suite covers this under a more specific name than the marker used to expect;
+    // the test was never lost, only the marker went stale.
     sourceIncludes(
       aiSources,
       'plugins/touch-quickops/index.test.cjs',
-      'onItemAction dispatches safe QuickOps Flow action'
+      'onItemAction dispatches only the fixed Flow payload and awaits the acknowledgement'
     )
   )
 }

--- a/plugins/touch-quickops/index.test.cjs
+++ b/plugins/touch-quickops/index.test.cjs
@@ -218,3 +218,52 @@ test('onItemAction fails closed when the Flow facade is absent', async () => {
     reason: 'flow-sdk-unavailable',
   })
 })
+
+test('high-risk requests publish a blocked notice and nothing dispatchable', async () => {
+  const { plugin, state } = loadPlugin({
+    flow: {
+      async dispatch(payload, options) {
+        state.flowCalls.push({ payload, options })
+        return { sessionId: 'flow-1', state: 'ACKED' }
+      },
+    },
+  })
+
+  await plugin.onFeatureTriggered('quickops', { text: 'kill port 3000' })
+
+  // "kill port 3000" is the high-risk pattern the plugin refuses to carry out itself.
+  assert.equal(state.items.length, 1)
+  const [blocked] = state.items
+  assert.equal(blocked.id, 'quickops-high-risk-blocked-kill-port')
+  assert.equal(blocked.render.basic.title, '高风险端口释放已阻断')
+
+  // The point of the path: nothing the host could act on comes back. No flow item, no
+  // actions, no payload. A blocked action that still ships its payload is one careless
+  // dispatch away from running.
+  assert.equal(state.items.some(item => item.meta.defaultAction === 'quickops-flow-action'), false)
+  assert.equal(blocked.actions, undefined)
+  assert.equal(blocked.meta.defaultAction, undefined)
+  assert.equal(blocked.meta.payload, undefined)
+
+  // And acting on it anyway reaches no facade.
+  await plugin.onItemAction(blocked)
+  assert.deepEqual(state.flowCalls, [])
+})
+
+test('projectItemsForHost publishes only whitelisted meta, so request detail cannot leak', async () => {
+  const { plugin, state } = loadPlugin()
+
+  await plugin.onFeatureTriggered('quickops', { text: 'stop timer secret-token-abc123' })
+
+  // Every published item is projected down to a fixed meta shape before it leaves the
+  // plugin. This is what keeps request text and internal reasoning out of the host, and
+  // it is asserted here rather than assumed because it is invisible from the outside.
+  for (const item of state.items) {
+    assert.deepEqual(
+      Object.keys(item.meta).sort().filter(key => !['defaultAction', 'priority'].includes(key)),
+      ['featureId', 'pluginName'],
+    )
+  }
+
+  assert.doesNotMatch(JSON.stringify(state.items), /secret-token-abc123/)
+})


### PR DESCRIPTION
Refs #323. `quick-ops-flow-ai-adapter-audit` was the last failing CoreApp suite here.

All **16** implementation markers the audit looks for are present in
`plugins/touch-quickops/index.js`. All **6** test markers were gone — dropped when
`e37c92c8c` cut `index.test.cjs` from 1035 lines to 220.

### Two tests restore real coverage

- **High-risk blocking.** `kill port 3000` publishes the blocked notice and *nothing
  dispatchable* — no flow item, no actions, no payload — and acting on it anyway
  reaches no facade. A blocked action that still ships its payload is one careless
  dispatch away from running.
- **Host projection.** Every published item is projected down to a fixed meta shape
  before it leaves the plugin, and the request text does not survive it.

The second exists because of what the first turned up: `projectItemsForHost` strips
item meta to a **four-key whitelist**, so `mode`, `confirmation`, `result` and
`flowAdapterTrace` never reach the host at all. That's a real protection and nothing
was asserting it. My first attempt at these tests asserted the *pre*-projection shape
and failed — which is how I found it.

### `flowAdapterTrace` is dead data — reported, not deleted

It's built on three code paths, stripped before publication, and has **no consumer
anywhere in the repo** (`grep -rn flowAdapterTrace` outside the file that builds it:
nothing).

So two of the audit's markers were demanding test evidence of a structure nothing
reads. I've retargeted them at the projection test, which is where the protection
actually lives, and flagged the trace itself on #323 rather than quietly deleting it —
whether it should be published or removed is a maintainer call.

### One marker was never a coverage gap

`onItemAction dispatches safe QuickOps Flow action` is covered by a test with a
longer, more specific name (`…dispatches only the fixed Flow payload and awaits the
acknowledgement`). The test was never lost; only the marker went stale. Retargeted the
marker rather than renaming a good test to satisfy a grep.

### Verification

- `apps/core-app` quick-ops: **147 passing across 6 files** (was 1 failing).
- `plugins/touch-quickops/index.test.cjs`: **7/7**.
- The audit's synthetic fixture is updated to match, so it's still proven able to
  detect the signals it looks for — not just passing because it stopped looking.
- **No lint delta**: 112 pre-existing root-config errors in these files before and
  after (core-app's own config has opposite trailing-comma rules).

> CI red is #1194 (`node-pty` postinstall), fixed in #1197 — it fails on `master` too.