### PR TITLE
fix(nexus): scope recovery to the matching device and bound guessing

### DIFF
--- a/apps/nexus/server/api/v1/keys/recover-device.post.ts
+++ b/apps/nexus/server/api/v1/keys/recover-device.post.ts
@@ -2,7 +2,7 @@ import { getHeader, readBody } from 'h3'
 import type { H3Event } from 'h3'
 import type { paths } from '../../../../types/sync-api'
 import { requireAppAuth } from '../../../utils/auth'
-import { consumeLoginToken, getDevice, listPasskeys, readDeviceId } from '../../../utils/authStore'
+import { consumeLoginToken, evaluateRecoveryRateLimit, getDevice, listPasskeys, readDeviceId, recordDeviceAuthAudit } from '../../../utils/authStore'
 import { createSyncError } from '../../../utils/syncErrors'
 import { recoverKeyrings } from '../../../utils/syncStoreV1'
 
@@ -40,7 +40,43 @@ export default defineEventHandler(async (event) => {
   if (!recoveryCode)
     throw createSyncError('SYNC_INVALID_PAYLOAD', 400, 'Invalid payload')
 
-  const keyrings = await recoverKeyrings(event, userId, { recoveryCode })
+  // Nothing bounded guessing before this: the route called recoverKeyrings on every request,
+  // and the step-up above returns early when the device is already trusted or the user has no
+  // passkeys, so an app token for the account was enough to try codes indefinitely (#904).
+  const rateLimit = await evaluateRecoveryRateLimit(event, { userId, deviceId })
+  if (!rateLimit.allowed) {
+    await recordDeviceAuthAudit(event, {
+      action: 'recover',
+      status: 'blocked',
+      userId,
+      deviceId,
+      reason: 'rate_limited',
+    })
+    throw createSyncError('DEVICE_NOT_AUTHORIZED', 429, 'Too many recovery attempts')
+  }
+
+  let keyrings
+  try {
+    keyrings = await recoverKeyrings(event, userId, { recoveryCode })
+  }
+  catch (error) {
+    // Only failures are counted, so a legitimate recovery never consumes anyone's budget.
+    await recordDeviceAuthAudit(event, {
+      action: 'recover',
+      status: 'failed',
+      userId,
+      deviceId,
+    })
+    throw error
+  }
+
+  await recordDeviceAuthAudit(event, {
+    action: 'recover',
+    status: 'success',
+    userId,
+    deviceId,
+  })
+
   const response: RecoverResponse = { keyrings }
   return response
 })

--- a/apps/nexus/server/utils/__tests__/recoverKeyrings.test.ts
+++ b/apps/nexus/server/utils/__tests__/recoverKeyrings.test.ts
@@ -1,0 +1,141 @@
+import type { H3Event } from 'h3'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { recoverKeyrings } from '../syncStoreV1'
+
+/**
+ * What a recovery code releases (#904).
+ *
+ * recoverKeyrings verified the submitted code against each device's stored hash, and on the
+ * first match returned `rows.map(...)` — every keyring row for the user, not the matching
+ * device's. One recovery code written down, screenshotted or leaked from an old machine
+ * therefore handed back the encrypted key material of the whole fleet, including devices with
+ * a different recovery code or none at all.
+ */
+
+// vi.hoisted, because the vi.mock factory below is hoisted above ordinary top-level
+// declarations and would otherwise read this before initialisation.
+const { verifyPassword } = vi.hoisted(() => ({ verifyPassword: vi.fn() }))
+
+vi.mock('../authCrypto', async () => {
+  const actual = await vi.importActual<typeof import('../authCrypto')>('../authCrypto')
+  return { ...actual, verifyPassword }
+})
+
+interface KeyringRow {
+  device_id: string
+  key_type: string
+  encrypted_key: string
+  rotated_at: string | null
+  created_at: string
+  recovery_code_hash: string | null
+}
+
+/**
+ * The narrowest database this function needs: schema setup runs and is ignored, and the one
+ * SELECT returns the rows under test. Deliberately not the full MockD1Database from
+ * syncStoreV1.test.ts — that fake models sync tables, not keyrings.
+ */
+function createEvent(rows: KeyringRow[]): H3Event {
+  const db = {
+    prepare(sql: string) {
+      const isKeyringSelect = sql.includes('FROM sync_keyrings') || sql.includes('recovery_code_hash')
+      return {
+        bind: () => ({
+          all: async () => ({ results: isKeyringSelect ? rows : [] }),
+          run: async () => ({}),
+          first: async () => null,
+        }),
+        all: async () => ({ results: [] }),
+        run: async () => ({}),
+        first: async () => null,
+      }
+    },
+    async batch() {
+      return []
+    },
+  }
+
+  return {
+    context: { cloudflare: { env: { DB: db } } },
+    node: { req: { headers: {} } },
+  } as unknown as H3Event
+}
+
+function row(deviceId: string, keyType: string, hash: string | null): KeyringRow {
+  return {
+    device_id: deviceId,
+    key_type: keyType,
+    encrypted_key: `enc-${deviceId}-${keyType}`,
+    rotated_at: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    recovery_code_hash: hash,
+  }
+}
+
+describe('recoverKeyrings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  /** Matches only the stored hash belonging to `deviceId`. */
+  function matchOnly(deviceId: string): void {
+    verifyPassword.mockImplementation(async (_code: string, _salt: string, hash: string) =>
+      hash === `hash-${deviceId}`,
+    )
+  }
+
+  const fleet = [
+    row('device-a', 'master', 'hash-device-a:salt'),
+    row('device-a', 'sync', 'hash-device-a:salt'),
+    row('device-b', 'master', 'hash-device-b:salt'),
+    row('device-c', 'master', null),
+  ]
+
+  it('returns only the matching device, not the whole fleet', async () => {
+    // The regression: this returned all four rows.
+    matchOnly('device-a')
+    const keyrings = await recoverKeyrings(createEvent(fleet), 'user-1', { recoveryCode: 'code' })
+
+    expect(keyrings.map(k => k.device_id)).toEqual(['device-a', 'device-a'])
+  })
+
+  it('returns every key type of the matching device', async () => {
+    // A device's keyring is only useful complete, and the code is stored per row, so the
+    // scoping is by device rather than by the single row that matched.
+    matchOnly('device-a')
+    const keyrings = await recoverKeyrings(createEvent(fleet), 'user-1', { recoveryCode: 'code' })
+
+    expect(keyrings.map(k => k.key_type).sort()).toEqual(['master', 'sync'])
+    expect(keyrings.map(k => k.keyring_id)).toContain('user-1:device-a:master')
+  })
+
+  it('never releases a device whose recovery code is different', async () => {
+    matchOnly('device-b')
+    const keyrings = await recoverKeyrings(createEvent(fleet), 'user-1', { recoveryCode: 'code' })
+
+    expect(keyrings.map(k => k.device_id)).toEqual(['device-b'])
+    expect(keyrings.some(k => k.device_id === 'device-a')).toBe(false)
+  })
+
+  it('never releases a device that has no recovery code at all', async () => {
+    // device-c is not even a candidate for matching, yet it used to be returned.
+    matchOnly('device-a')
+    const keyrings = await recoverKeyrings(createEvent(fleet), 'user-1', { recoveryCode: 'code' })
+
+    expect(keyrings.some(k => k.device_id === 'device-c')).toBe(false)
+  })
+
+  it('rejects a code that matches nothing', async () => {
+    verifyPassword.mockResolvedValue(false)
+    await expect(
+      recoverKeyrings(createEvent(fleet), 'user-1', { recoveryCode: 'nope' }),
+    ).rejects.toMatchObject({ statusCode: 403 })
+  })
+
+  it('rejects when the user has no keyrings', async () => {
+    verifyPassword.mockResolvedValue(false)
+    await expect(
+      recoverKeyrings(createEvent([]), 'user-1', { recoveryCode: 'code' }),
+    ).rejects.toMatchObject({ statusCode: 403 })
+  })
+})

--- a/apps/nexus/server/utils/__tests__/recoveryRateLimit.test.ts
+++ b/apps/nexus/server/utils/__tests__/recoveryRateLimit.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import type { H3Event } from 'h3'
+import { describe, expect, it } from 'vitest'
+import { evaluateRecoveryRateLimit } from '../authStore'
+
+/**
+ * Bounding recovery-code guesses (#904).
+ *
+ * Nothing counted attempts: the route called recoverKeyrings on every request, so an app
+ * token for the account was enough to submit codes indefinitely. The step-up in that route
+ * does not compensate — requireStepUpIfPasskeyEnabled returns early when the device is
+ * already trusted or the user has registered no passkeys.
+ */
+
+/** A database whose COUNT(*) answers with `count`, whatever is asked. */
+function createEvent(count: number, seen: string[][] = []): H3Event {
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind: (...args: unknown[]) => {
+          if (sql.includes('COUNT'))
+            seen.push(args.map(String))
+          return {
+            // countDeviceAuthAudits reads `total`, per `SELECT COUNT(*) AS total`.
+            first: async () => (sql.includes('COUNT') ? { total: count } : null),
+            all: async () => ({ results: [] }),
+            run: async () => ({}),
+          }
+        },
+        first: async () => null,
+        all: async () => ({ results: [] }),
+        run: async () => ({}),
+      }
+    },
+    async batch() {
+      return []
+    },
+  }
+
+  return {
+    context: { cloudflare: { env: { DB: db } } },
+    node: { req: { headers: {} } },
+  } as unknown as H3Event
+}
+
+describe('evaluateRecoveryRateLimit', () => {
+  it('allows an attempt when nothing has failed recently', async () => {
+    // Positive control: a limiter that refused everything would satisfy the assertions below
+    // while locking every user out of recovery entirely.
+    expect(await evaluateRecoveryRateLimit(createEvent(0), { userId: 'u1', deviceId: 'd1' }))
+      .toEqual({ allowed: true })
+  })
+
+  it('blocks once the per-device budget is spent', async () => {
+    const decision = await evaluateRecoveryRateLimit(createEvent(5), { userId: 'u1', deviceId: 'd1' })
+    expect(decision.allowed).toBe(false)
+    expect(decision.scope).toBe('device')
+  })
+
+  it('falls back to the per-user budget when no device id is known', async () => {
+    // Without this, dropping the device header would sidestep the limit entirely.
+    const decision = await evaluateRecoveryRateLimit(createEvent(10), { userId: 'u1' })
+    expect(decision.allowed).toBe(false)
+    expect(decision.scope).toBe('user')
+  })
+
+  it('counts only failed recovery attempts', async () => {
+    // A successful recovery must not consume anyone's budget, and other device-auth actions
+    // in the same audit table must not be mistaken for recovery guesses.
+    const seen: string[][] = []
+    await evaluateRecoveryRateLimit(createEvent(0, seen), { userId: 'u1', deviceId: 'd1' })
+    expect(seen.length).toBeGreaterThan(0)
+    for (const args of seen) {
+      expect(args).toContain('recover')
+      expect(args).toContain('failed')
+    }
+  })
+})
+
+/**
+ * That the route applies it. The handler needs app auth, a device id and a database, so the
+ * call sites are guarded at source level rather than by standing the whole route up.
+ */
+describe('recover-device route wiring', () => {
+  const source = readFileSync(
+    fileURLToPath(new URL('../../api/v1/keys/recover-device.post.ts', import.meta.url)),
+    'utf8',
+  )
+
+  it('evaluates the limit before recovering', () => {
+    const limitAt = source.indexOf('evaluateRecoveryRateLimit(')
+    const recoverAt = source.indexOf('recoverKeyrings(event')
+    expect(limitAt, 'rate limit call not found').toBeGreaterThan(-1)
+    expect(recoverAt).toBeGreaterThan(limitAt)
+  })
+
+  it('refuses with 429 rather than falling through', () => {
+    expect(source).toMatch(/if \(!rateLimit\.allowed\)[\s\S]*?429/)
+  })
+
+  it('records a failed attempt so the next call can count it', () => {
+    // Without this the limiter reads an always-empty table and never fires — the quiet way
+    // this kind of fix ends up doing nothing.
+    expect(source).toMatch(/status: 'failed'/)
+    expect(source).toMatch(/action: 'recover'/)
+  })
+})

--- a/apps/nexus/server/utils/authStore.ts
+++ b/apps/nexus/server/utils/authStore.ts
@@ -543,7 +543,7 @@ export type DeviceAuthStatus = 'pending' | 'approved' | 'cancelled' | 'rejected'
 export type DeviceAuthGrantType = 'short' | 'long'
 export type DeviceAuthRejectReason = 'ip_mismatch' | 'permission_denied' | 'rate_limited' | 'cooldown' | 'unknown'
 export type DeviceAuthBrowserState = 'unknown' | 'opened' | 'closed'
-export type DeviceAuthAuditAction = 'request' | 'approve' | 'reject' | 'cancel' | 'revoke' | 'trust' | 'untrust'
+export type DeviceAuthAuditAction = 'request' | 'approve' | 'reject' | 'cancel' | 'revoke' | 'trust' | 'untrust' | 'recover'
 export type DeviceAuthAuditStatus = 'success' | 'blocked' | 'failed'
 
 export interface DeviceAuthAuditRecord {
@@ -1190,7 +1190,7 @@ function normalizeDeviceAuthAuditAction(value: unknown): DeviceAuthAuditAction {
   if (typeof value !== 'string')
     return 'request'
   const normalized = value.trim().toLowerCase()
-  if (normalized === 'request' || normalized === 'approve' || normalized === 'reject' || normalized === 'cancel' || normalized === 'revoke' || normalized === 'trust' || normalized === 'untrust')
+  if (normalized === 'request' || normalized === 'approve' || normalized === 'reject' || normalized === 'cancel' || normalized === 'revoke' || normalized === 'trust' || normalized === 'untrust' || normalized === 'recover')
     return normalized
   return 'request'
 }
@@ -1373,6 +1373,63 @@ export async function listDeviceAuthAudits(
     LIMIT ?
   `).bind(...params, limit).all<Record<string, any>>()
   return (result.results ?? []).map(row => mapDeviceAuthAuditRow(row))
+}
+
+/** Failed recovery attempts tolerated per device, then per user, inside the window. */
+const RECOVERY_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000
+const RECOVERY_RATE_LIMIT_MAX_BY_DEVICE = 5
+const RECOVERY_RATE_LIMIT_MAX_BY_USER = 10
+
+export interface RecoveryRateLimitDecision {
+  allowed: boolean
+  scope?: 'device' | 'user'
+  retryAfterMs?: number
+}
+
+/**
+ * Bounds guessing of a device recovery code.
+ *
+ * Nothing counted attempts before: the recovery route called recoverKeyrings on every
+ * request, so anyone holding an app token for the account could submit codes indefinitely,
+ * and the step-up in that route demands nothing when the device is already trusted or the
+ * user has no passkeys registered (#904).
+ *
+ * Counts only failures, so a legitimate recovery does not consume anyone's budget, and counts
+ * per device before per user, so one noisy device cannot lock the account out of every other
+ * device it owns.
+ */
+export async function evaluateRecoveryRateLimit(event: H3Event, payload: {
+  userId: string
+  deviceId?: string | null
+}): Promise<RecoveryRateLimitDecision> {
+  const db = requireDatabase(event)
+  await ensureAuthSchema(db)
+  const since = new Date(Date.now() - RECOVERY_RATE_LIMIT_WINDOW_MS).toISOString()
+
+  const checks: Array<{ scope: 'device' | 'user', limit: number, whereSql: string, params: Array<string | number | null> }> = []
+  if (payload.deviceId) {
+    checks.push({
+      scope: 'device',
+      limit: RECOVERY_RATE_LIMIT_MAX_BY_DEVICE,
+      whereSql: 'action = ? AND status = ? AND device_id = ? AND created_at >= ?',
+      params: ['recover', 'failed', payload.deviceId, since],
+    })
+  }
+  checks.push({
+    scope: 'user',
+    limit: RECOVERY_RATE_LIMIT_MAX_BY_USER,
+    whereSql: 'action = ? AND status = ? AND user_id = ? AND created_at >= ?',
+    params: ['recover', 'failed', payload.userId, since],
+  })
+
+  for (const check of checks) {
+    const count = await countDeviceAuthAudits(db, check.whereSql, check.params)
+    if (count >= check.limit) {
+      return { allowed: false, scope: check.scope, retryAfterMs: RECOVERY_RATE_LIMIT_WINDOW_MS }
+    }
+  }
+
+  return { allowed: true }
 }
 
 export async function evaluateDeviceAuthRateLimit(event: H3Event, payload: {

--- a/apps/nexus/server/utils/syncStoreV1.ts
+++ b/apps/nexus/server/utils/syncStoreV1.ts
@@ -1606,19 +1606,28 @@ export async function recoverKeyrings(
   const rows = result.results ?? []
   const candidates = rows.filter(row => typeof row.recovery_code_hash === 'string' && row.recovery_code_hash.length > 0)
 
-  let verified = false
+  let matchedDeviceId: string | null = null
   for (const row of candidates) {
     if (await verifyRecoveryCode(payload.recoveryCode, row.recovery_code_hash!)) {
-      verified = true
+      matchedDeviceId = row.device_id
       break
     }
   }
 
-  if (!verified) {
+  if (!matchedDeviceId) {
     throw createSyncError('DEVICE_NOT_AUTHORIZED', 403, 'Invalid recovery code')
   }
 
-  return rows.map(row => ({
+  // Only the device whose code matched. This used to map over every row for the user, so
+  // knowing one device's recovery code — written down, screenshotted, or leaked from an old
+  // machine — handed back the encrypted key material of the entire fleet, including devices
+  // with a different recovery code or none at all (#904).
+  //
+  // Every key_type of the matched device is returned, because the code is stored per keyring
+  // row and a device's keyring is only useful complete.
+  return rows
+    .filter(row => row.device_id === matchedDeviceId)
+    .map(row => ({
     keyring_id: `${userId}:${row.device_id}:${row.key_type}`,
     device_id: row.device_id,
     key_type: row.key_type,


### PR DESCRIPTION
Closes #904.

## Two defects

**1. The success path mapped over `rows`, not the match.** Proving knowledge of one device's recovery code released the encrypted key material of **every** device the user owns — including devices with a different recovery code, and devices with `recovery_code_hash` null that were never even candidates for matching.

Now scoped to the device whose code matched, and to **every `key_type` of that device** — the code is stored per keyring row, and a device's keyring is only useful complete.

**2. Nothing counted attempts.** The route called `recoverKeyrings` on every request. The step-up does not compensate: `requireStepUpIfPasskeyEnabled` returns early when the device is already trusted **or** when the user has registered no passkeys. An app token for the account was enough to submit codes indefinitely.

`evaluateRecoveryRateLimit` allows 5 failures per device and 10 per user in a 15-minute window.

## Why no new storage

It reuses the existing device-auth audit table. `'recover'` joins the `DeviceAuthAuditAction` union and its normalizer; the `action` column is plain `TEXT` with **no CHECK constraint**, so there is no migration.

Three choices inside the limiter that are easy to get wrong:

- **only failures are counted** — a legitimate recovery must not consume anyone's budget
- **device budget before user budget** — otherwise one noisy device locks the account out of every other device it owns
- **the per-user check still applies with no device id** — otherwise dropping the header sidesteps the limit entirely

## Tests

Thirteen.

Six on scoping, **four failing** against the previous version: only the matching device returned; all of its key types; a device with a *different* code never released; a device with *no* code never released.

Seven on rate limiting, three of which are source-level guards on the route — the handler needs app auth, a device id and a database, so standing it up is not worth it. One of the three asserts the **failed attempt is recorded**: without that the limiter reads an always-empty table and never fires, which is the quiet way this class of fix ends up doing nothing.

## Verification notes

Existing `syncStoreV1` suite green (13 tests). `pnpm run typecheck` — zero errors in the changed files.

Two self-inflicted detours worth mentioning since they shaped the test file: nexus forbids top-level `await` (core-app does not), and the `vi.mock` factory referenced a plain top-level `const`, which fails with *"Cannot access 'verifyPassword' before initialization"* once a static import is used — `vi.hoisted` fixes it.