### PR TITLE
fix(core-app): stop an Everything query from being read as a CLI option

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/addon/files/everything-backend-service.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/everything-backend-service.ts
@@ -13,6 +13,27 @@ import {
 
 const execFileAsync = promisify(execFile)
 
+/**
+ * Makes a query safe to pass as an argv element to es.exe.
+ *
+ * es.exe treats any argument starting with `-` as an option, and the query sat in argv[0]
+ * unmodified, so `-export-csv C:\\Users\\Public\\out.csv` was consumed as the export switch
+ * and wrote index contents to a chosen path instead of searching. `-r`, `-path` and the rest
+ * of the option surface were reachable the same way (#903).
+ *
+ * This is argument injection, not shell injection — exec resolves to execFile with an args
+ * array, so no shell metacharacters are interpreted.
+ *
+ * A `--` end-of-options separator would be the conventional fix, but es.exe is a Windows
+ * binary this repo cannot exercise on other platforms, and it is not documented to honour
+ * `--`. Guessing wrong would turn every search on Windows into an unknown-option error, so
+ * the leading dashes are removed instead: strictly fewer assumptions, and a filename search
+ * beginning with `-` is the only thing it changes.
+ */
+export function sanitizeEverythingCliQuery(query: string): string {
+  return query.replace(/^[\s-]+/, '')
+}
+
 export interface EverythingSdkAddon {
   search?: (query: string, options?: { maxResults?: number }) => unknown
   query?: (query: string, options?: { maxResults?: number }) => unknown
@@ -105,7 +126,7 @@ export class EverythingBackendService {
     const { stdout } = await this.exec(
       esPath,
       [
-        query,
+        sanitizeEverythingCliQuery(query),
         '-n',
         String(maxResults),
         '-sort',

--- a/apps/core-app/src/main/modules/box-tool/addon/files/everything-cli-query.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/everything-cli-query.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeEverythingCliQuery } from './everything-backend-service'
+
+/**
+ * Option injection into the Everything CLI (#903).
+ *
+ * The raw query sat in argv[0], and es.exe reads any argument starting with `-` as an option.
+ * `-export-csv C:\Users\Public\out.csv` was therefore consumed as the export switch and wrote
+ * index contents to a chosen path instead of searching; `-r` and `-path` changed behaviour the
+ * same way.
+ *
+ * Argument injection, not shell injection — exec is execFile with an args array — but the
+ * option surface was reachable, and a query is not always typed by the user: a plugin or a
+ * recommendation flow can supply text it did not author.
+ */
+describe('sanitizeEverythingCliQuery', () => {
+  it('strips a leading dash so the query cannot become a switch', () => {
+    expect(sanitizeEverythingCliQuery('-export-csv C:\\Users\\Public\\out.csv')).toBe(
+      'export-csv C:\\Users\\Public\\out.csv'
+    )
+  })
+
+  it('strips repeated and spaced leading dashes', () => {
+    // `- -r`, `--path` and friends must not survive as options either.
+    expect(sanitizeEverythingCliQuery('--path C:\\')).toBe('path C:\\')
+    expect(sanitizeEverythingCliQuery('- -r evil')).toBe('r evil')
+    expect(sanitizeEverythingCliQuery('   -r')).toBe('r')
+  })
+
+  it('leaves an ordinary query untouched', () => {
+    // Positive control: a sanitiser that emptied everything would satisfy every assertion
+    // above while breaking search entirely.
+    for (const query of ['report.pdf', 'my file', 'C:\\Users\\me\\notes.txt', '2026-08 budget'])
+      expect(sanitizeEverythingCliQuery(query)).toBe(query)
+  })
+
+  it('keeps dashes that are not at the start', () => {
+    // The common real case — a hyphenated filename must still be searchable.
+    expect(sanitizeEverythingCliQuery('quarterly-report-2026.pdf')).toBe(
+      'quarterly-report-2026.pdf'
+    )
+    expect(sanitizeEverythingCliQuery('a -b')).toBe('a -b')
+  })
+
+  it('returns an empty string for input that is only dashes', () => {
+    // An empty query is a search that finds nothing, which is the right outcome for input
+    // that carried no search text to begin with.
+    expect(sanitizeEverythingCliQuery('---')).toBe('')
+    expect(sanitizeEverythingCliQuery('')).toBe('')
+  })
+})
+
+/**
+ * That searchCli actually calls it. The sanitiser is exported and unit-tested above; this
+ * pins the call site, which is what a refactor drops.
+ */
+describe('searchCli argv', () => {
+  it('passes the sanitised query, not the raw one', async () => {
+    const { EverythingBackendService } = await import('./everything-backend-service')
+    const calls: Array<{ args: string[] }> = []
+    const service = new (EverythingBackendService as unknown as new (runtime: unknown) => {
+      searchCli: (esPath: string, query: string, maxResults: number) => Promise<unknown>
+    })({
+      execFileAsync: async (_file: string, args: string[]) => {
+        calls.push({ args })
+        return { stdout: '', stderr: '' }
+      }
+    })
+
+    await service.searchCli('es.exe', '-export-csv out.csv', 10)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].args[0]).toBe('export-csv out.csv')
+    expect(calls[0].args[0].startsWith('-')).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #903.

## The defect

The raw query sat in `argv[0]`, and `es.exe` treats any argument starting with `-` as an option. `-export-csv C:\Users\Public\out.csv` was consumed as the **export switch** — writing index contents to a chosen path instead of searching. `-r` and `-path` changed behaviour the same way.

Argument injection, not shell injection: `exec` is `execFile` with an args array, so no shell metacharacters are interpreted. The report is right that impact is bounded when the user types their own query — it matters when a plugin or a recommendation flow forwards text it did not author.

## Why not `--`

The issue offered a `--` end-of-options separator first, and it is the conventional answer. I did not use it.

`es.exe` is a **Windows binary this repo cannot exercise on macOS or Linux**, and it is not documented to honour `--`. If it does not, every Windows search becomes an unknown-option error — and **no test in this repo would show that**, because the CLI path cannot run in CI here. Stripping the leading dashes makes strictly fewer assumptions.

The only behaviour it changes is a filename search that *begins* with a dash. Dashes anywhere else are untouched, which is the common real case (`quarterly-report-2026.pdf`).

## Tests

Six.

Five on the rule: a leading dash stripped; repeated and space-separated dashes (`--path`, `- -r`) stripped; **ordinary queries unchanged**; **hyphenated filenames still searchable**; an all-dashes input reduced to an empty query.

Those last two are the positive controls — a sanitiser that emptied everything would satisfy every negative assertion while breaking search entirely.

The sixth asserts `searchCli` passes the *sanitised* value. The helper being correct and the call site using it are separate facts, and only that test fails against the previous argv.

The 322 tests in the surrounding directory pass unchanged. Lint clean; `typecheck:node` shows zero errors in the changed files.