### PR TITLE
test(nexus): unpin the login-history fixture before it detonates (#1210)

### DIFF
--- a/apps/nexus/app/pages/dashboard/notifications.test.ts
+++ b/apps/nexus/app/pages/dashboard/notifications.test.ts
@@ -51,7 +51,11 @@ describe('dashboard notification inbox UI contract', () => {
     expect(page).toContain('urlBase64ToArrayBuffer(browserPushPublicKey.value)')
     expect(page).toContain('runtimeConfig.public?.notificationWebPush?.publicKey')
     expect(page).toContain('browserPushStatusLabel')
-    expect(page).toContain('browserNotificationActionDisabled')
+    // The named browserNotificationActionDisabled computed was inlined into the
+    // template, so assert the condition itself rather than the identifier: the test
+    // cares that the action is gated on busy / denied / unsupported, not on where that
+    // expression lives.
+    expect(page).toMatch(/browserNotificationBusy \|\| browserNotificationPermission === .denied. \|\| browserNotificationPermission === .unsupported./)
     expect(page).toContain('browserNotificationPermissionLabel')
     expect(page).toContain('dashboard.notifications.browser.testSent')
     expect(page).toContain('dashboard.notifications.browser.webPushSubscribed')

--- a/apps/nexus/app/pages/store-page-performance.test.ts
+++ b/apps/nexus/app/pages/store-page-performance.test.ts
@@ -31,7 +31,10 @@ describe('store page remote search performance boundaries', () => {
     expect(storePage).toContain('const STORE_PLUGIN_PAGE_SIZE = 50')
     expect(storePage).toMatch(/function resolveStoreSearchQuery\(offset = 0\) \{[\s\S]*compact: 1,[\s\S]*q: activeSearch\.value \|\| undefined,[\s\S]*category: activeCategory\.value === 'all' \? undefined : activeCategory\.value,[\s\S]*limit: STORE_PLUGIN_PAGE_SIZE,[\s\S]*offset,[\s\S]*\}/)
     expect(storePage).toContain('const storeSearchQuery = computed(() => resolveStoreSearchQuery(0))')
-    expect(storePage).toMatch(/await useAsyncData\('store-plugins', \(\) =>\s*requestJson<StorePluginSearchResponse>\('\/api\/store\/search', \{\s*query: storeSearchQuery\.value,\s*\}\),\s*\{\s*watch: \[storeSearchQuery\],\s*\}\)/)
+    // The options object also carries lazy/server now, to keep first paint unblocked,
+    // so this no longer requires watch to be the only key -- only that the call targets
+    // /api/store/search and refreshes on the query.
+    expect(storePage).toMatch(/await useAsyncData\('store-plugins', \(\) =>\s*requestJson<StorePluginSearchResponse>\('\/api\/store\/search', \{\s*query: storeSearchQuery\.value,\s*\}\),\s*\{[\s\S]*?watch: \[storeSearchQuery\],[\s\S]*?\}\)/)
     expect(storePage).not.toMatch(/await useAsyncData\('store-plugins',[\s\S]*requestJson<[^>]*>\('\/api\/store\/plugins'/)
   })
 
@@ -75,13 +78,15 @@ describe('store page remote search performance boundaries', () => {
 
   it('keeps plugin detail overlay code out of the initial store page imports', () => {
     expect(storePage).toContain("const LazyFlipDialog = defineAsyncComponent(() => import('~/components/base/dialog/FlipDialog.vue'))")
-    expect(storePage).toContain("const LazyPluginMetaHeader = defineAsyncComponent(() => import('~/components/dashboard/PluginMetaHeader.vue'))")
+    // PluginMetaHeader moved from components/dashboard to components/plugin; the lazy
+    // boundary this test exists to protect is unchanged.
+    expect(storePage).toContain("const LazyPluginMetaHeader = defineAsyncComponent(() => import('~/components/plugin/PluginMetaHeader.vue'))")
     expect(storePage).toContain("const LazyTxTabs = defineAsyncComponent(() => import('@talex-touch/tuffex/tabs').then(module => module.TxTabs))")
     expect(storePage).toContain('v-if="selectedSlug || detailPending"')
     expect(storePage).toContain('<LazyFlipDialog')
     expect(storePage).toContain('<LazyTxTabs')
     expect(storePage).not.toContain("import FlipDialog from '~/components/base/dialog/FlipDialog.vue'")
-    expect(storePage).not.toContain("import PluginMetaHeader from '~/components/dashboard/PluginMetaHeader.vue'")
+    expect(storePage).not.toContain("import PluginMetaHeader from '~/components/plugin/PluginMetaHeader.vue'")
     expect(storePage).not.toContain("import { TxTabItem, TxTabs } from '@talex-touch/tuffex/tabs'")
     expect(storePage).not.toContain("import {\n  SharedPluginDetailReadme,\n  SharedPluginDetailVersions,\n} from '@talex-touch/utils/renderer/shared/components'")
   })

--- a/apps/nexus/build/check-worker-bundle.test.ts
+++ b/apps/nexus/build/check-worker-bundle.test.ts
@@ -380,27 +380,25 @@ describe('Nexus deploy asset budget', () => {
   })
 
   it('keeps public pricing and password-reset locale contracts complete', () => {
-    const pricingKeys = [
-      'freeTitle',
-      'freePrice',
-      'freeDesc',
-      'freeFeature1',
-      'freeFeature2',
-      'freeFeature3',
-      'plusTitle',
-      'plusPrice',
-      'plusDesc',
-      'plusFeature1',
-      'plusFeature2',
-      'plusFeature3',
-      'teamTitle',
-      'teamPrice',
-      'teamDesc',
-      'teamFeature1',
-      'teamFeature2',
-      'teamFeature3',
-      'cta',
+    // The pricing block was restructured from flat keys (freeTitle / freePrice /
+    // freeFeature1 …) into pricing.plans.<plan>.{name,desc,featureN}, and gained a
+    // fourth plan plus a set of top-level strings. The old flat list matched nothing,
+    // so this asserted an empty contract rather than a complete one. Walking the real
+    // shape also means a new plan cannot be added to one locale and not the other
+    // without failing here.
+    const pricingTopLevelKeys = [
+      'eyebrow',
+      'title',
+      'subtitle',
+      'popular',
+      'comingSoon',
+      'comingSoonHint',
+      'freeHint',
+      'perMonth',
+      'ctaFree',
+      'ctaWaitlist',
     ] as const
+    const pricingPlanKeys = ['name', 'desc', 'feature1', 'feature2', 'feature3', 'feature4'] as const
     const authKeys = [
       'forgotTitle',
       'forgotSubtitle',
@@ -409,11 +407,27 @@ describe('Nexus deploy asset budget', () => {
       'resetEmailSent',
     ] as const
 
-    for (const key of pricingKeys) {
+    for (const key of pricingTopLevelKeys) {
       expect(enLocale.pricing[key]).toBeTruthy()
       expect(enLocale.pricing[key]).not.toMatch(/\p{Script=Han}/u)
       expect(zhLocale.pricing[key]).toBeTruthy()
     }
+
+    expect(Object.keys(zhLocale.pricing.plans)).toEqual(Object.keys(enLocale.pricing.plans))
+
+    for (const plan of Object.keys(enLocale.pricing.plans) as Array<keyof typeof enLocale.pricing.plans>) {
+      for (const key of pricingPlanKeys) {
+        expect(enLocale.pricing.plans[plan][key], `en pricing.plans.${String(plan)}.${key}`).toBeTruthy()
+        expect(enLocale.pricing.plans[plan][key]).not.toMatch(/\p{Script=Han}/u)
+        expect(zhLocale.pricing.plans[plan][key], `zh pricing.plans.${String(plan)}.${key}`).toBeTruthy()
+      }
+    }
+
+    // Only the free plan carries a literal price; the rest are resolved at runtime or
+    // shown as coming soon.
+    expect(enLocale.pricing.plans.free.price).toBeTruthy()
+    expect(zhLocale.pricing.plans.free.price).toBeTruthy()
+
     for (const key of authKeys) {
       expect(enLocale.auth[key]).toBeTruthy()
       expect(enLocale.auth[key]).not.toMatch(/\p{Script=Han}/u)

--- a/apps/nexus/server/utils/__tests__/authStore-login-history.test.ts
+++ b/apps/nexus/server/utils/__tests__/authStore-login-history.test.ts
@@ -37,7 +37,11 @@ class MockD1Database {
     success: 1,
     reason: 'password',
     client_type: 'web',
-    created_at: '2026-06-21T10:00:00.000Z',
+    // Relative to now. listLoginHistory prunes rows older than its 90-day window
+    // before listing (authStore.ts:2804-2808), so a pinned created_at is a dated time
+    // bomb: this row was written 2026-06-21 and would have started failing on
+    // 2026-09-19, looking like a login-history regression rather than fixture rot.
+    created_at: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
     country_code: 'US',
     region_code: 'CA',
     region_name: 'California',

--- a/apps/nexus/server/utils/__tests__/authStore.sync-items-merge.test.ts
+++ b/apps/nexus/server/utils/__tests__/authStore.sync-items-merge.test.ts
@@ -40,6 +40,20 @@ class MockD1Database {
     return new MockStatement(this, sql)
   }
 
+  // mergeLegacySyncItemsForUsers moved its writes into a single db.batch() so they
+  // commit together or not at all (authStore.ts:2207, and the comment above it). This
+  // double only had prepare/first/run, so the merge threw "db.batch is not a function"
+  // before touching a row -- the test was failing on the shape of the call, not the
+  // merge. Runs the statements in order, which is the ordering guarantee the merge
+  // relies on; it does not simulate rollback, so a test that needs failure atomicity
+  // will need more than this.
+  async batch(statements: MockStatement[]) {
+    const results = []
+    for (const statement of statements)
+      results.push(await statement.run())
+    return results
+  }
+
   first(sql: string, args: any[]) {
     if (sql.includes('SELECT name FROM sqlite_master')) {
       const tableName = args[0]

--- a/apps/nexus/server/utils/__tests__/plugin-security-scan.test.ts
+++ b/apps/nexus/server/utils/__tests__/plugin-security-scan.test.ts
@@ -94,8 +94,11 @@ describe('TPEX authoritative security scan admission', () => {
       ruleId: 'PLUGIN_SCAN_DYNAMIC_EXECUTION',
       owner: 'nexus-security',
       reason: 'Approved compatibility exception',
-      createdAt: '2026-07-17T12:00:00.000Z',
-      expiresAt: '2026-07-19T12:00:00.000Z',
+      // Relative to now: pinned to 2026-07-17..19 this waiver expired on 2026-07-19 and
+      // the scan then blocked the package -- correctly. The expiry check working is
+      // what broke the test, so the fixture is the thing to fix, not the check.
+      createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
     }])
 
     expect(metadata.securityScan).toMatchObject({

--- a/apps/nexus/server/utils/__tests__/pluginsStore-security-scan.test.ts
+++ b/apps/nexus/server/utils/__tests__/pluginsStore-security-scan.test.ts
@@ -63,6 +63,31 @@ vi.mock('../platformGovernanceStore', () => ({
   }),
 }))
 
+// Publisher signing is a separate admission gate from the security scan this file
+// covers, and it has its own suite in ../pluginSigning.test.ts. Without this the publish
+// path rejects the fixture with PLUGIN_SIGNING_ENVELOPE_INVALID before any scan runs --
+// the fixture predates the signing envelope and carries only a legacy md5 _signature.
+// Mocked here for the same reason the seven collaborators around it are.
+vi.mock('../pluginSigning', () => ({
+  verifyPluginPublisherSignature: vi.fn(async (_event: unknown, input: any) => ({
+    envelope: {
+      algorithm: 'ed25519',
+      keyId: input?.publicKey?.keyId ?? 'test-key',
+      payload: {
+        pluginId: input?.pluginId,
+        pluginName: input?.pluginName,
+        version: input?.version,
+        channel: input?.channel,
+      },
+      payloadSha256: 'sha256-test',
+      signature: 'test-signature',
+    },
+    key: input?.publicKey ?? { keyId: 'test-key' },
+    verifiedAt: '2026-01-01T00:00:00.000Z',
+  })),
+  createPluginAdmissionAttestation: vi.fn(async () => null),
+}))
+
 vi.mock('../uploadGovernance', () => ({
   completeUploadGovernance: state.completeUploadGovernance,
   failUploadGovernance: state.failUploadGovernance,

--- a/apps/nexus/server/utils/platformGovernanceStore.test.ts
+++ b/apps/nexus/server/utils/platformGovernanceStore.test.ts
@@ -2630,17 +2630,33 @@ describe('platformGovernanceStore', () => {
     expect(serializedHealth).not.toContain(marker)
   })
 
+  // The analytics window is measured from Date.now() (platformGovernanceStore.ts:3309),
+  // so fixtures pinned to absolute dates silently fall out of it as the calendar moves.
+  // The two retention/queue tests below were pinned to 2026-05-20..22 and began failing
+  // once that was more than 30 days ago -- nothing about the code changed. Anchored to
+  // recent days instead so they stay inside any window they ask for.
+  function recentDay(daysAgo: number) {
+    const date = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10)
+    return { date, at: (time: string) => `${date}T${time}` }
+  }
+
+  const GOVERNANCE_DAY_1 = recentDay(5)
+  const GOVERNANCE_DAY_2 = recentDay(4)
+  const GOVERNANCE_DAY_3 = recentDay(3)
+
   it('builds anonymized private plugin retention analytics', async () => {
     const marker = crypto.randomUUID()
     const h3Event = event(`plugin-retention-${marker}`)
     const pluginId = `plugin_retention_${marker}`
 
     const records = [
-      ['retention-returning@example.com', 'download', 1, '2026-05-20T09:00:00.000Z'],
-      ['retention-returning@example.com', 'invoke', 2, '2026-05-21T09:00:00.000Z'],
-      ['retention-repeat@example.com', 'invoke', 1, '2026-05-20T10:00:00.000Z'],
-      ['retention-repeat@example.com', 'invoke', 1, '2026-05-22T10:00:00.000Z'],
-      ['retention-new@example.com', 'install', 1, '2026-05-22T11:00:00.000Z'],
+      ['retention-returning@example.com', 'download', 1, GOVERNANCE_DAY_1.at('09:00:00.000Z')],
+      ['retention-returning@example.com', 'invoke', 2, GOVERNANCE_DAY_2.at('09:00:00.000Z')],
+      ['retention-repeat@example.com', 'invoke', 1, GOVERNANCE_DAY_1.at('10:00:00.000Z')],
+      ['retention-repeat@example.com', 'invoke', 1, GOVERNANCE_DAY_3.at('10:00:00.000Z')],
+      ['retention-new@example.com', 'install', 1, GOVERNANCE_DAY_3.at('11:00:00.000Z')],
     ] as const
 
     for (const [actorId, action, quantity, occurredAt] of records) {
@@ -2678,7 +2694,7 @@ describe('platformGovernanceStore', () => {
     ]))
     expect(analytics.retention.trend).toEqual([
       expect.objectContaining({
-        date: '2026-05-20',
+        date: GOVERNANCE_DAY_1.date,
         newActors: 2,
         returningActors: 0,
         activeActors: 2,
@@ -2687,7 +2703,7 @@ describe('platformGovernanceStore', () => {
         retentionRate: 0,
       }),
       expect.objectContaining({
-        date: '2026-05-21',
+        date: GOVERNANCE_DAY_2.date,
         newActors: 0,
         returningActors: 1,
         activeActors: 1,
@@ -2696,7 +2712,7 @@ describe('platformGovernanceStore', () => {
         retentionRate: 100,
       }),
       expect.objectContaining({
-        date: '2026-05-22',
+        date: GOVERNANCE_DAY_3.date,
         newActors: 1,
         returningActors: 1,
         activeActors: 2,
@@ -2716,12 +2732,12 @@ describe('platformGovernanceStore', () => {
     const pluginId = `plugin_owner_action_${marker}`
 
     const records = [
-      [`owner-download-${marker}@example.com`, 'download', 80, '2026-05-20T09:00:00.000Z'],
-      [`owner-install-1-${marker}@example.com`, 'install', 1, '2026-05-21T09:00:00.000Z'],
-      [`owner-install-2-${marker}@example.com`, 'install', 1, '2026-05-21T10:00:00.000Z'],
-      [`owner-install-3-${marker}@example.com`, 'install', 1, '2026-05-21T11:00:00.000Z'],
-      [`owner-install-4-${marker}@example.com`, 'install', 1, '2026-05-21T12:00:00.000Z'],
-      [`owner-invoke-${marker}@example.com`, 'invoke', 5, '2026-05-22T09:00:00.000Z'],
+      [`owner-download-${marker}@example.com`, 'download', 80, GOVERNANCE_DAY_1.at('09:00:00.000Z')],
+      [`owner-install-1-${marker}@example.com`, 'install', 1, GOVERNANCE_DAY_2.at('09:00:00.000Z')],
+      [`owner-install-2-${marker}@example.com`, 'install', 1, GOVERNANCE_DAY_2.at('10:00:00.000Z')],
+      [`owner-install-3-${marker}@example.com`, 'install', 1, GOVERNANCE_DAY_2.at('11:00:00.000Z')],
+      [`owner-install-4-${marker}@example.com`, 'install', 1, GOVERNANCE_DAY_2.at('12:00:00.000Z')],
+      [`owner-invoke-${marker}@example.com`, 'invoke', 5, GOVERNANCE_DAY_3.at('09:00:00.000Z')],
     ] as const
 
     for (const [actorId, action, quantity, occurredAt] of records) {
@@ -2762,7 +2778,7 @@ describe('platformGovernanceStore', () => {
         retentionRate: 0,
         topCountryKey: 'us',
         topCountryShare: 100,
-        latestDate: '2026-05-22',
+        latestDate: GOVERNANCE_DAY_3.date,
       }),
       expect.objectContaining({
         key: 'low-install-conversion',

--- a/apps/nexus/test/api/app-auth/sign-in-token.post.test.ts
+++ b/apps/nexus/test/api/app-auth/sign-in-token.post.test.ts
@@ -26,8 +26,15 @@ describe('/api/app-auth/sign-in-token', () => {
     const result = await handler({ headers: {} })
 
     expect(result).toEqual({ appToken: 'app-token' })
+    // App tokens are now issued long-lived with an explicit grant type
+    // (LONG_TERM_APP_TOKEN_OPTIONS, appAuthToken.ts:5-8). Asserting the whole options
+    // object rather than just deviceId: grantType is the field the sibling test below
+    // relies on to refuse refreshing a short-term token, so silently issuing something
+    // other than 'long' here would defeat that check without failing anything.
     expect(authMocks.createAppToken).toHaveBeenCalledWith(expect.anything(), 'user-1', {
       deviceId: 'device-1',
+      grantType: 'long',
+      ttlSeconds: 30 * 24 * 60 * 60,
     })
   })
 

--- a/apps/nexus/test/api/auth/auth-email-channel-contract.test.ts
+++ b/apps/nexus/test/api/auth/auth-email-channel-contract.test.ts
@@ -16,7 +16,10 @@ describe('auth email notification channel contract', () => {
     for (const handler of handlers)
       expect(handler).toContain('}, event)')
 
-    expect(readAuthHandler('[...].ts')).toContain('}, tryCreateAuthEvent())')
+    // The magic-link call was reformatted across lines. What this test is protecting is
+    // that the auth event is still passed as sendEmail's second argument -- that is what
+    // notification channel routing reads -- not that it fits on one line.
+    expect(readAuthHandler('[...].ts')).toMatch(/\},\s*tryCreateAuthEvent\(\),?\s*\)/)
   })
 
   it('tags auth email actions for notification channel routing', () => {

--- a/apps/nexus/test/api/v1/intelligence/invoke.api.test.ts
+++ b/apps/nexus/test/api/v1/intelligence/invoke.api.test.ts
@@ -109,12 +109,19 @@ describe('/api/v1/intelligence/invoke', () => {
       }),
     )
 
+    // 7faea27bf canonicalised the error codes: intelligenceErrorContract maps the
+    // provider-level CREDITS_EXCEEDED onto QUOTA_EXHAUSTED, together with the two
+    // INTELLIGENCE_PROVIDER_*_QUOTA_EXCEEDED codes, so callers see one code for one
+    // condition instead of three. The provider still raises CREDITS_EXCEEDED -- that is
+    // what is thrown above -- and the boundary translates it.
+    //
+    // 402 is deliberately asserted unchanged: the canonicalisation moved the code, not
+    // the status, so anything switching on the HTTP status is unaffected.
     await expect(invokeHandler(makeEvent())).rejects.toMatchObject({
       statusCode: 402,
-      statusMessage: 'CREDITS_EXCEEDED',
       data: {
-        code: 'CREDITS_EXCEEDED',
-        reason: 'User credits exceeded.',
+        code: 'QUOTA_EXHAUSTED',
+        reason: 'The caller has exhausted its request, token, or cost quota.',
       },
     })
   })


### PR DESCRIPTION
Refs #1210. Contains #1212's commits plus one more.

Four of the thirteen failures in #1210 were **fixtures that aged out of a window
measured from `Date.now()`** — not code changes. That's a category, not a coincidence,
so I went looking for the rest of it.

### The method

If time is what breaks a test, time is the thing to vary. I ran each suite with the wall
clock advanced and diffed against its own baseline. Anything that fails only under the
shift is pinned to the calendar and will fail on its own eventually.

### What it found

| suite | +90d | verdict |
|---|---|---|
| `apps/nexus` | **1 new failure** | `authStore-login-history` — fixed here |
| `apps/core-app` | no change (47 failing before and after, same tests) | clean |
| `packages/test` | no change (60 failing before and after, same tests) | clean |

`listLoginHistory` prunes rows older than its 90-day window **before listing**
(`authStore.ts:2804-2808`). The fixture row was pinned to `2026-06-21` — inside that
window today, outside it from **2026-09-19**. It would have started failing then and
looked like a login-history regression rather than fixture rot.

### After the fix

`apps/nexus` is green at **+90d, +365d and +1095d**. A three-year horizon finds nothing
else of this kind.

### On the other 145 files

145 test files carry pinned ISO dates. Most are harmless — a fixed date only rots when
something compares it to *now*. I didn't touch them, and I don't think a blanket rule
against pinned dates is worth it; the clock-shift run is a better detector than a lint
rule, because it tests the actual comparison rather than the literal.

Worth considering as a periodic CI job rather than a one-off: it costs one extra suite
run and catches this whole class before it reaches a required gate.

> CI red is #1194 (`node-pty` postinstall), fixed in #1197 — it fails on `master` too.