### PR TITLE
fix(core-app): stop renderer metadata from waiving the plugin install prompt

### DIFF
--- a/apps/core-app/src/main/modules/plugin/install-queue.test.ts
+++ b/apps/core-app/src/main/modules/plugin/install-queue.test.ts
@@ -45,12 +45,23 @@ describe('PluginInstallQueue permission confirmation', () => {
       discardPrepared: vi.fn().mockResolvedValue(undefined)
     } as unknown as PluginInstaller
 
+    // Permission confirmations, which is what these tests are about.
     const confirmRequests: PluginInstallConfirmRequest[] = []
+    // Source confirmations. These used to be skipped because the request carried
+    // `metadata.trusted`, which the renderer could forge (#902); the main process now always
+    // asks for a non-official plugin, so the harness answers on the user's behalf.
+    const sourceConfirmRequests: PluginInstallConfirmRequest[] = []
+    let queueRef: PluginInstallQueue | null = null
     const transport = {
       sendToWindow: vi.fn().mockImplementation(async (_windowId, event, payload) => {
-        if (event === PluginEvents.install.confirm) {
-          confirmRequests.push(payload as PluginInstallConfirmRequest)
+        if (event !== PluginEvents.install.confirm) return
+        const request = payload as PluginInstallConfirmRequest
+        if (request.kind === 'source') {
+          sourceConfirmRequests.push(request)
+          queueRef?.handleConfirmResponse({ taskId: request.taskId, decision: 'accept' })
+          return
         }
+        confirmRequests.push(request)
       })
     } as unknown as ITuffTransportMain
 
@@ -69,6 +80,7 @@ describe('PluginInstallQueue permission confirmation', () => {
       }),
       onPermissionConfirmed
     })
+    queueRef = queue
 
     return {
       queue,
@@ -76,6 +88,7 @@ describe('PluginInstallQueue permission confirmation', () => {
       installRequest,
       transport,
       confirmRequests,
+      sourceConfirmRequests,
       onPermissionConfirmed
     }
   }
@@ -310,8 +323,17 @@ describe('PluginInstallQueue permission confirmation', () => {
       discardPrepared: vi.fn().mockResolvedValue(undefined)
     } as unknown as PluginInstaller
 
+    // The source confirmation now runs for a non-official plugin (#902), so it has to be
+    // answered before the sdkapi check this test is actually about is reached.
+    let queueRef: PluginInstallQueue | null = null
     const transport = {
-      sendToWindow: vi.fn().mockResolvedValue(undefined)
+      sendToWindow: vi.fn().mockImplementation(async (_windowId, event, payload) => {
+        if (event !== PluginEvents.install.confirm) return
+        const request = payload as PluginInstallConfirmRequest
+        if (request.kind === 'source') {
+          queueRef?.handleConfirmResponse({ taskId: request.taskId, decision: 'accept' })
+        }
+      })
     } as unknown as ITuffTransportMain
 
     const queue = new PluginInstallQueue(installer, transport, 1, {
@@ -321,6 +343,7 @@ describe('PluginInstallQueue permission confirmation', () => {
         )
       }
     })
+    queueRef = queue
 
     const result = await queue.enqueue(installRequest)
 
@@ -330,5 +353,92 @@ describe('PluginInstallQueue permission confirmation', () => {
     }
     expect(installer.finalizeInstall).not.toHaveBeenCalled()
     expect(installer.discardPrepared).toHaveBeenCalledWith(prepared)
+  })
+})
+
+/**
+ * That renderer-supplied metadata cannot switch the consent prompt off (#902).
+ *
+ * `metadata.trusted` was read into a trustedHint and used to skip requestConfirmation, so any
+ * code running in the renderer could send `{trusted: true}` and install without a prompt.
+ * officialActual, the field next to it, was already recomputed in the main process — this one
+ * was the client-authoritative outlier.
+ */
+describe('install confirmation cannot be waived by the request', () => {
+  function createQueue(options: { official: boolean; metadata?: Record<string, unknown> }) {
+    const installRequest: PluginInstallRequest = {
+      source: 'https://example.com/plugin.tpex',
+      metadata: options.metadata
+    }
+
+    const prepared = {
+      request: installRequest,
+      providerResult: { provider: 'tpex', official: options.official, metadata: {} },
+      manifest: { name: 'touch-demo', version: '1.0.0' }
+    } as unknown as PreparedPluginInstall
+
+    const installer = {
+      prepareInstall: vi.fn().mockResolvedValue(prepared),
+      finalizeInstall: vi.fn().mockResolvedValue({
+        manifest: prepared.manifest,
+        providerResult: prepared.providerResult
+      }),
+      discardPrepared: vi.fn().mockResolvedValue(undefined)
+    } as unknown as PluginInstaller
+
+    const sourceConfirmRequests: PluginInstallConfirmRequest[] = []
+    let queueRef: PluginInstallQueue | null = null
+    const transport = {
+      sendToWindow: vi.fn().mockImplementation(async (_windowId, event, payload) => {
+        if (event !== PluginEvents.install.confirm) return
+        const request = payload as PluginInstallConfirmRequest
+        if (request.kind !== 'source') return
+        sourceConfirmRequests.push(request)
+        queueRef?.handleConfirmResponse({ taskId: request.taskId, decision: 'accept' })
+      })
+    } as unknown as ITuffTransportMain
+
+    const queue = new PluginInstallQueue(installer, transport, 1, {})
+    queueRef = queue
+    return { queue, installRequest, sourceConfirmRequests }
+  }
+
+  it('still asks when the request claims the user already trusted it', async () => {
+    // The regression: this installed with no prompt at all.
+    const { queue, installRequest, sourceConfirmRequests } = createQueue({
+      official: false,
+      metadata: { trusted: true }
+    })
+
+    const result = await queue.enqueue(installRequest)
+
+    expect(result.status).toBe('success')
+    expect(sourceConfirmRequests).toHaveLength(1)
+  })
+
+  it('asks for a plain untrusted request too', async () => {
+    const { queue, installRequest, sourceConfirmRequests } = createQueue({ official: false })
+    await queue.enqueue(installRequest)
+    expect(sourceConfirmRequests).toHaveLength(1)
+  })
+
+  it('does not ask when the main process itself established the plugin is official', async () => {
+    // Positive control, and the boundary that must not move: officialActual is recomputed from
+    // prepared.providerResult, not read from the request, so it is not forgeable the same way.
+    const { queue, installRequest, sourceConfirmRequests } = createQueue({ official: true })
+    await queue.enqueue(installRequest)
+    expect(sourceConfirmRequests).toHaveLength(0)
+  })
+
+  it('ignores a request claiming the plugin is official when the provider says otherwise', async () => {
+    // metadata.official is read into officialHint, which is a hint only; the skip is driven by
+    // officialActual. Asserted so that field cannot drift into being authoritative either.
+    const { queue, installRequest, sourceConfirmRequests } = createQueue({
+      official: false,
+      metadata: { official: true, trusted: true }
+    })
+
+    await queue.enqueue(installRequest)
+    expect(sourceConfirmRequests).toHaveLength(1)
   })
 })

--- a/apps/core-app/src/main/modules/plugin/install-queue.ts
+++ b/apps/core-app/src/main/modules/plugin/install-queue.ts
@@ -35,8 +35,6 @@ interface InstallTask {
   prepared?: PreparedPluginInstall
   officialHint?: boolean
   officialActual?: boolean
-  /** Whether the user already confirmed installation on the client side */
-  trustedHint?: boolean
   /** Force update existing plugin */
   forceUpdate?: boolean
   /** Auto re-enable plugin after update */
@@ -118,8 +116,6 @@ export class PluginInstallQueue {
         lastProgress: -1,
         officialHint:
           typeof request.metadata?.official === 'boolean' ? request.metadata.official : undefined,
-        trustedHint:
-          typeof request.metadata?.trusted === 'boolean' ? request.metadata.trusted : undefined,
         forceUpdate:
           typeof request.metadata?.forceUpdate === 'boolean'
             ? request.metadata.forceUpdate
@@ -207,10 +203,19 @@ export class PluginInstallQueue {
         this.emitProgress(task, 'verifying', { progress: 100 })
       }
 
-      // Skip confirmation if:
-      // 1. Plugin is official (from provider result)
-      // 2. User already confirmed on client side (trustedHint)
-      const needsConfirmation = !task.officialActual && !task.trustedHint
+      // Confirmation is skipped only when the main process itself established the plugin is
+      // official — officialActual is recomputed here from prepared.providerResult, not taken
+      // from the request.
+      //
+      // It used to also skip on a `trustedHint` read straight off `metadata.trusted` in the IPC
+      // payload. Any code running in the renderer could send `{trusted: true}` and install with
+      // no prompt (#902); the renderer's own dialog is not evidence the main process can check.
+      // The field is gone rather than merely unused, so it cannot be quietly rewired.
+      //
+      // The renderer still shows its own confirmation, so an ordinary store install now asks
+      // twice. That is worth it until the two prompts are merged: the alternative is a control
+      // anything in the renderer can switch off.
+      const needsConfirmation = !task.officialActual
       if (needsConfirmation) {
         await this.requestConfirmation(task, {
           taskId: task.id,


### PR DESCRIPTION
Closes #902.

## The defect

`metadata.trusted` was read off the IPC payload into `trustedHint` and used to skip `requestConfirmation`. Any code in the renderer could send `{source: "<url>", metadata: {trusted: true}}` and install with **no prompt**.

Signature verification does not compensate: `requiresRegistryTrust` is only set for an official provider result or a registry source, so a non-registry source skips the trust check entirely.

The field right next to it already showed the intended pattern — `officialActual` is **recomputed in the main process** from `prepared.providerResult`. `trustedHint` was the client-authoritative outlier. The skip now depends on `officialActual` alone, and the field is **deleted** rather than left unused, so it cannot be quietly rewired.

## Two consequences I want stated rather than discovered

**1. Store installs now prompt twice.** `useStoreInstall` confirms in the renderer and then sets `trusted` — via `plugin.trusted === true || true`, i.e. unconditionally — and that dialog is still there. Merging the two prompts is the right follow-up, but it changes what *official* plugins prompt for, so it is a product decision rather than something to fold in here.

**2. This does not make the prompt unforgeable.** The main-process confirmation is rendered by the renderer and answered over IPC by task id, so injected renderer script can still answer it. What this removes is a flag that skipped the prompt outright. A native `dialog.showMessageBox` would close the rest; that is a separate change with its own UX consequences.

## Tests

Three existing tests passed `metadata: {trusted: true}` to skip past the source confirmation and reach the *permission* confirmation they were actually about. They hung once the source prompt started running. Their harnesses now answer it — a faithful update to the new behaviour, not a workaround.

Four new tests, **two failing** against the previous condition:

- still asks when the request claims `trusted: true`
- asks for a plain untrusted request
- **positive control:** does *not* ask when the main process itself established the plugin is official — that boundary must not move
- ignores `metadata.official: true` when the provider says otherwise, so `officialHint` cannot drift into being authoritative either

All 1183 tests under `src/main/modules/plugin` pass. Lint clean; `typecheck:node` reports zero errors in the changed files.