### PR TITLE
test(core-app): recover four dead boundary suites and fix the mocks that killed them (#323)

### DIFF
--- a/apps/core-app/src/main/modules/ai/intelligence-admin-surface-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-admin-surface-boundary.test.ts
@@ -63,18 +63,32 @@ const intelligenceEventMocks = vi.hoisted(() => {
       getMonthStats: event('intelligence:api:get-month-stats'),
       getUsageStats: event('intelligence:api:get-usage-stats'),
       getLocalEnvironment: event('intelligence:api:get-local-environment')
-    },
-    intelligenceContextEvents: {}
+    }
   }
 })
 
-vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', () => ({
-  ...intelligenceEventMocks,
-  intelligenceKnowledgeEvents: {}
-}))
+// Spread the real module rather than hand-listing namespaces. intelligenceContextEvents
+// and intelligenceKnowledgeEvents were stubbed as {}, so every handler the module
+// registers from them called undefined.toEventName(). Only the api events are
+// overridden, which is all this suite looks up.
+vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@talex-touch/utils/transport/sdk/domains/intelligence')>()
+  return {
+    ...actual,
+    // Merged, not replaced. The hand-written list covers the events this suite looks
+    // up; replacing the namespace outright dropped the rest, and
+    // registerCapabilityChannels then called saveProviderConfig.toEventName() on
+    // undefined.
+    intelligenceApiEvents: {
+      ...actual.intelligenceApiEvents,
+      ...intelligenceEventMocks.intelligenceApiEvents
+    }
+  }
+})
 // Spread the real module: a full replacement drops every export the module later
 // gains, which is how PRIVACY_DATA_CATEGORIES broke this suite.
-vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+vi.mock('@talex-touch/utils/transport/events/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))

--- a/apps/core-app/src/main/modules/ai/intelligence-admin-surface-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-admin-surface-boundary.test.ts
@@ -72,7 +72,10 @@ vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', () => ({
   ...intelligenceEventMocks,
   intelligenceKnowledgeEvents: {}
 }))
-vi.mock('@talex-touch/utils/transport/events/types', () => ({
+// Spread the real module: a full replacement drops every export the module later
+// gains, which is how PRIVACY_DATA_CATEGORIES broke this suite.
+vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+  ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))
 vi.mock('./intelligence-sdk', () => ({

--- a/apps/core-app/src/main/modules/ai/intelligence-agent-session-host-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-agent-session-host-boundary.test.ts
@@ -150,7 +150,13 @@ describe('intelligenceModule agent session host boundary', () => {
 
       await expect(handler(payload, pluginContext())).resolves.toEqual({
         ok: false,
-        error: 'INTELLIGENCE_HOST_ONLY_CAPABILITY'
+        // safeApiHandler returns a fixed public string so internal error detail does
+        // not cross the IPC boundary to a plugin (safe-handler.ts:5). The specific
+        // code still reaches the error reporter; it just is not handed to the caller.
+        // The boundary itself is asserted by the two expectations below, which check
+        // that nothing privileged ran -- that is the property worth pinning, not the
+        // wording of the rejection.
+        error: 'The operation failed. Please retry.'
       })
       expect(operation).not.toHaveBeenCalled()
     }

--- a/apps/core-app/src/main/modules/ai/intelligence-autonomous-permission-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-autonomous-permission-boundary.test.ts
@@ -42,7 +42,7 @@ vi.mock('./ai-cli-orchestrator', () => ({
 }))
 // Spread the real module: a full replacement drops every export the module later
 // gains, which is how PRIVACY_DATA_CATEGORIES broke this suite.
-vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+vi.mock('@talex-touch/utils/transport/events/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))

--- a/apps/core-app/src/main/modules/ai/intelligence-autonomous-permission-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-autonomous-permission-boundary.test.ts
@@ -40,7 +40,10 @@ vi.mock('./intelligence-workflow-service', () => ({
 vi.mock('./ai-cli-orchestrator', () => ({
   aiCliOrchestrator: orchestratorMocks
 }))
-vi.mock('@talex-touch/utils/transport/events/types', () => ({
+// Spread the real module: a full replacement drops every export the module later
+// gains, which is how PRIVACY_DATA_CATEGORIES broke this suite.
+vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+  ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))
 

--- a/apps/core-app/src/main/modules/ai/intelligence-invoke-actor-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-invoke-actor-boundary.test.ts
@@ -52,7 +52,10 @@ vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', () => ({
   ...intelligenceEventMocks,
   intelligenceKnowledgeEvents: {}
 }))
-vi.mock('@talex-touch/utils/transport/events/types', () => ({
+// Spread the real module: a full replacement drops every export the module later
+// gains, which is how PRIVACY_DATA_CATEGORIES broke this suite.
+vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+  ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))
 

--- a/apps/core-app/src/main/modules/ai/intelligence-invoke-actor-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-invoke-actor-boundary.test.ts
@@ -54,7 +54,7 @@ vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', () => ({
 }))
 // Spread the real module: a full replacement drops every export the module later
 // gains, which is how PRIVACY_DATA_CATEGORIES broke this suite.
-vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+vi.mock('@talex-touch/utils/transport/events/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))

--- a/apps/core-app/src/main/modules/ai/intelligence-knowledge-actor-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-knowledge-actor-boundary.test.ts
@@ -43,7 +43,7 @@ vi.mock('./intelligence-local-knowledge-engine', () => ({
 }))
 // Spread the real module: a full replacement drops every export the module later
 // gains, which is how PRIVACY_DATA_CATEGORIES broke this suite.
-vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+vi.mock('@talex-touch/utils/transport/events/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))

--- a/apps/core-app/src/main/modules/ai/intelligence-knowledge-actor-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-knowledge-actor-boundary.test.ts
@@ -41,7 +41,10 @@ const localKnowledgeEngineMocks = vi.hoisted(() => ({
 vi.mock('./intelligence-local-knowledge-engine', () => ({
   localKnowledgeEngine: localKnowledgeEngineMocks
 }))
-vi.mock('@talex-touch/utils/transport/events/types', () => ({
+// Spread the real module: a full replacement drops every export the module later
+// gains, which is how PRIVACY_DATA_CATEGORIES broke this suite.
+vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+  ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))
 

--- a/apps/core-app/src/main/modules/ai/intelligence-quota-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-quota-boundary.test.ts
@@ -49,7 +49,7 @@ vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', () => ({
 }))
 // Spread the real module: a full replacement drops every export the module later
 // gains, which is how PRIVACY_DATA_CATEGORIES broke this suite.
-vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+vi.mock('@talex-touch/utils/transport/events/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))

--- a/apps/core-app/src/main/modules/ai/intelligence-quota-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-quota-boundary.test.ts
@@ -47,7 +47,10 @@ vi.mock('@talex-touch/utils/transport/sdk/domains/intelligence', () => ({
   ...intelligenceEventMocks,
   intelligenceKnowledgeEvents: {}
 }))
-vi.mock('@talex-touch/utils/transport/events/types', () => ({
+// Spread the real module: a full replacement drops every export the module later
+// gains, which is how PRIVACY_DATA_CATEGORIES broke this suite.
+vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+  ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))
 

--- a/apps/core-app/src/main/modules/ai/intelligence-workflow-host-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-workflow-host-boundary.test.ts
@@ -16,7 +16,10 @@ const workflowServiceMocks = vi.hoisted(() => ({
 vi.mock('./intelligence-workflow-service', () => ({
   intelligenceWorkflowService: workflowServiceMocks
 }))
-vi.mock('@talex-touch/utils/transport/events/types', () => ({
+// Spread the real module: a full replacement drops every export the module later
+// gains, which is how PRIVACY_DATA_CATEGORIES broke this suite.
+vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+  ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))
 vi.mock('../sentry/sentry-service', () => {

--- a/apps/core-app/src/main/modules/ai/intelligence-workflow-host-boundary.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-workflow-host-boundary.test.ts
@@ -18,7 +18,7 @@ vi.mock('./intelligence-workflow-service', () => ({
 }))
 // Spread the real module: a full replacement drops every export the module later
 // gains, which is how PRIVACY_DATA_CATEGORIES broke this suite.
-vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+vi.mock('@talex-touch/utils/transport/events/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isIntelligenceErrorCode: vi.fn(() => false)
 }))
@@ -150,7 +150,13 @@ describe('intelligenceModule workflow control-plane host boundary', () => {
 
       await expect(getHandler(handlers, eventName)(payload, pluginContext())).resolves.toEqual({
         ok: false,
-        error: 'INTELLIGENCE_HOST_ONLY_CAPABILITY'
+        // safeApiHandler returns a fixed public string so internal error detail does
+        // not cross the IPC boundary to a plugin (safe-handler.ts:5). The specific
+        // code still reaches the error reporter; it just is not handed to the caller.
+        // The boundary itself is asserted by the two expectations below, which check
+        // that nothing privileged ran -- that is the property worth pinning, not the
+        // wording of the rejection.
+        error: 'The operation failed. Please retry.'
       })
       expect(waitForAgentRuntime).not.toHaveBeenCalled()
       expectWorkflowServiceUntouched()

--- a/apps/core-app/src/renderer/src/views/base/settings/SettingUpdate.channel.test.ts
+++ b/apps/core-app/src/renderer/src/views/base/settings/SettingUpdate.channel.test.ts
@@ -50,7 +50,7 @@ vi.mock('@talex-touch/utils/transport/events', () => ({
 
 // Spread the real module: a full replacement drops every export the module later
 // gains, which is how PRIVACY_DATA_CATEGORIES broke this suite.
-vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+vi.mock('@talex-touch/utils/transport/events/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isBuildVerificationStatus: () => false
 }))

--- a/apps/core-app/src/renderer/src/views/base/settings/SettingUpdate.channel.test.ts
+++ b/apps/core-app/src/renderer/src/views/base/settings/SettingUpdate.channel.test.ts
@@ -48,7 +48,10 @@ vi.mock('@talex-touch/utils/transport/events', () => ({
   }
 }))
 
-vi.mock('@talex-touch/utils/transport/events/types', () => ({
+// Spread the real module: a full replacement drops every export the module later
+// gains, which is how PRIVACY_DATA_CATEGORIES broke this suite.
+vi.mock('@talex-touch/utils/transport/events/types', async importOriginal => ({
+  ...(await importOriginal<typeof import('@talex-touch/utils/transport/events/types')>()),
   isBuildVerificationStatus: () => false
 }))
 


### PR DESCRIPTION
Refs #323. **CoreApp: 48 failing / 16 files → 28 failing / 8 files**, with 29 tests that
weren't running before.

---

## 1. Four suites had stopped running entirely

Seven suites mock `@talex-touch/utils/transport/events/types` by **replacing** the module
rather than spreading it, so every export it later gains disappears.
`PRIVACY_DATA_CATEGORIES` was that export.

Two failed loudly (`quota-boundary` 7, `invoke-actor-boundary` 8). **The other four died
during collection** — reported as a failed *file* with **zero failed tests**. Running
those five files together on `master`:

```
Test Files  4 failed | 1 passed (5)
Tests       4 passed (4)
```

Four boundary suites contributing nothing to the run **and nothing to the failure
count**. They'd stopped running without moving a number anyone watches — so the
48-failure figure was itself understating the problem.

## 2. Then they failed on the same mistake, one level down

Their mock of the intelligence transport domain hand-lists namespaces, so
`intelligenceContextEvents` and `intelligenceKnowledgeEvents` were stubbed as `{}` and
every handler registered from them called `undefined.toEventName()`.

`intelligenceApiEvents` needed the same treatment *nested inside it*: the hand-written
list covers what these suites look up, but replacing the namespace outright drops the
rest, and `registerCapabilityChannels` then called `saveProviderConfig.toEventName()` on
undefined.

## 3. One assertion was reading a leak that was deliberately closed

The host-only boundary tests expected `error: 'INTELLIGENCE_HOST_ONLY_CAPABILITY'`.
`safeApiHandler` returns a **fixed public string** so internal error detail doesn't cross
the IPC boundary to a plugin (`safe-handler.ts:5`) — the specific code still reaches the
error reporter, it just isn't handed to the caller.

They now assert the sanitized string. What they were really protecting — **that no
privileged work ran** — is asserted by the two expectations beside it, and those were
passing all along.

---

### Result

| | before | after |
|---|---|---|
| `admin-surface` | 11 failing | **0** |
| `workflow-host` | 7 failing | **0** |
| `agent-session-host` | 4 failing | **0** |
| `quota-boundary` | 7 failing | **0** |
| `invoke-actor-boundary` | 8 failing | **0** |
| CoreApp suite | 48 failing / 16 files | **28 failing / 8 files** |
| tests collected | 4710 | **4739** |

All 47 AI test files pass: **457 tests**.

### A correction on lint

`apps/core-app` has its own `eslint.config.mjs`, and `pnpm lint` runs eslint **from inside
the package** — so the root config I'd been measuring deltas against was the wrong gate
entirely. Under the real one my first commit left 8 prettier warnings, and
`--max-warnings=0` makes warnings fail. Fixed: **0 errors, 0 warnings** across every file
touched here.

### Still failing, reported not hidden

`intelligence-invoke-actor-boundary` has one test taking **5–6s** against vitest's 5s
default while its seven siblings take **9ms combined**. My hypothesis that it waits out
`options.timeout` is **wrong** — dropping 4000ms to 1000ms left it at 5.4s. It passes
under `--testTimeout=30000`, which is how the totals above were measured. I didn't raise
the timeout in-repo, because a 5-second unit test with immediately-resolving mocks is
worth understanding rather than accommodating.

> CI red is #1194 (`node-pty` postinstall), fixed in #1197 — it fails on `master` too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized error responses for rejected AI plugin operations, ensuring users receive a clear public-facing message rather than an internal error code.

- **Tests**
  - Updated AI boundary and settings tests to remain compatible with expanded event definitions.
  - Improved test coverage reliability for permission, workflow, quota, knowledge, invocation, and session scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->