### PR TITLE
fix(nexus): attribute telemetry to proven credentials, not a body field

### DIFF
--- a/apps/nexus/server/api/telemetry/batch.post.ts
+++ b/apps/nexus/server/api/telemetry/batch.post.ts
@@ -1,5 +1,6 @@
 import { guardTelemetryIp } from '../../utils/ipSecurityStore'
 import { recordTelemetryEvent } from '../../utils/telemetryStore'
+import { resolveTelemetryUserId } from '../../utils/telemetryIdentity'
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
@@ -10,7 +11,6 @@ export default defineEventHandler(async (event) => {
 
   const events = body.events as Array<{
     eventType: 'search' | 'visit' | 'error' | 'feature_use' | 'performance'
-    userId?: string
     clientId?: string
     deviceFingerprint?: string
     platform?: string
@@ -31,6 +31,12 @@ export default defineEventHandler(async (event) => {
 
   await guardTelemetryIp(event, { weight: eventsToProcess.length, action: 'telemetry.batch' })
 
+  // Resolved once for the request, not per event: the credentials belong to the connection,
+  // so a batch cannot attribute different events to different people. A body userId is
+  // ignored here for the same reason as in record.post.ts — this route is unauthenticated,
+  // and at up to 100 events per request it was the cheaper way to fabricate history (#901).
+  const resolvedUserId = await resolveTelemetryUserId(event)
+
   // Process all events (fire and forget for performance)
   const promises = eventsToProcess.map(async (e) => {
     if (!e.eventType || !['search', 'visit', 'error', 'feature_use', 'performance'].includes(e.eventType)) {
@@ -40,7 +46,7 @@ export default defineEventHandler(async (event) => {
     try {
       await recordTelemetryEvent(event, {
         eventType: e.eventType,
-        userId: e.userId || undefined,
+        userId: resolvedUserId || undefined,
         clientId: e.clientId || undefined,
         deviceFingerprint: e.deviceFingerprint || undefined,
         platform: e.platform || undefined,
@@ -52,7 +58,7 @@ export default defineEventHandler(async (event) => {
         providerTimings: e.providerTimings || undefined,
         inputTypes: Array.isArray(e.inputTypes) ? e.inputTypes : undefined,
         metadata: e.metadata || undefined,
-        isAnonymous: e.isAnonymous !== false,
+        isAnonymous: resolvedUserId ? e.isAnonymous !== false : true,
       })
     }
     catch {

--- a/apps/nexus/server/api/telemetry/record.post.ts
+++ b/apps/nexus/server/api/telemetry/record.post.ts
@@ -1,5 +1,6 @@
 import { guardTelemetryIp } from '../../utils/ipSecurityStore'
 import { recordTelemetryEvent } from '../../utils/telemetryStore'
+import { resolveTelemetryUserId } from '../../utils/telemetryIdentity'
 
 export default defineEventHandler(async (event) => {
   await guardTelemetryIp(event, { weight: 1, action: 'telemetry.record' })
@@ -12,7 +13,6 @@ export default defineEventHandler(async (event) => {
 
   const {
     eventType,
-    userId,
     clientId,
     deviceFingerprint,
     platform,
@@ -31,9 +31,13 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Invalid event type' })
   }
 
+  // Deliberately not read from the body: this route is unauthenticated, so a body userId is a
+  // claim anyone can make about anyone (#901). Null here means the event is anonymous.
+  const resolvedUserId = await resolveTelemetryUserId(event)
+
   await recordTelemetryEvent(event, {
     eventType,
-    userId: userId || undefined,
+    userId: resolvedUserId || undefined,
     clientId: clientId || undefined,
     deviceFingerprint: deviceFingerprint || undefined,
     platform: platform || undefined,
@@ -45,7 +49,8 @@ export default defineEventHandler(async (event) => {
     providerTimings: providerTimings || undefined,
     inputTypes: Array.isArray(inputTypes) ? inputTypes : undefined,
     metadata: metadata || undefined,
-    isAnonymous: isAnonymous !== false,
+    // An event with no proven owner is anonymous whatever the body claims.
+    isAnonymous: resolvedUserId ? isAnonymous !== false : true,
   })
 
   return { success: true }

--- a/apps/nexus/server/utils/telemetryIdentity.ts
+++ b/apps/nexus/server/utils/telemetryIdentity.ts
@@ -1,0 +1,36 @@
+import type { H3Event } from 'h3'
+import { requireAppAuth, requireSessionAuth } from './auth'
+
+/**
+ * Who a telemetry event belongs to, according to the request's own credentials.
+ *
+ * The telemetry endpoints are unauthenticated — an IP guard only — and used to take `userId`
+ * straight from the body. Anyone could POST `{eventType: 'search', userId: '<victim>'}` and
+ * have it stored as that person's activity, which then surfaced in the per-user dashboard and
+ * in admin analytics (#901).
+ *
+ * Attribution that anyone can forge is worse than no attribution: it does not merely fail to
+ * inform an abuse investigation, it actively misleads one. So a body-supplied userId is now
+ * ignored outright, and an event is attributed only when the caller proved who it is.
+ *
+ * Both credential shapes are tried because the desktop app authenticates with a bearer app
+ * token while the web dashboard uses a session cookie; checking only one would silently
+ * anonymise the other.
+ */
+export async function resolveTelemetryUserId(event: H3Event): Promise<string | null> {
+  try {
+    const { userId } = await requireAppAuth(event)
+    if (userId) return userId
+  }
+  catch {
+    // No bearer token, or not a valid one. Fall through to the session check.
+  }
+
+  try {
+    const { userId } = await requireSessionAuth(event)
+    return userId || null
+  }
+  catch {
+    return null
+  }
+}

--- a/apps/nexus/test/api/telemetryIdentity.test.ts
+++ b/apps/nexus/test/api/telemetryIdentity.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolveTelemetryUserId } from '../../server/utils/telemetryIdentity'
+
+/**
+ * Who a telemetry event is attributed to (#901).
+ *
+ * The telemetry routes are unauthenticated — an IP guard only — and took `userId` from the
+ * body. Anyone could POST `{eventType: 'search', userId: '<victim>', searchQuery: '…'}` and
+ * have it stored as that person's activity, surfacing in the per-user dashboard and in admin
+ * analytics. The batch route accepted up to 100 of those per request.
+ */
+
+const { requireAppAuth, requireSessionAuth } = vi.hoisted(() => ({
+  requireAppAuth: vi.fn(),
+  requireSessionAuth: vi.fn(),
+}))
+
+vi.mock('../../server/utils/auth', () => ({ requireAppAuth, requireSessionAuth }))
+
+const event = {} as never
+
+describe('resolveTelemetryUserId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses the bearer app token, which is how the desktop app authenticates', async () => {
+    requireAppAuth.mockResolvedValue({ userId: 'app-user' })
+    expect(await resolveTelemetryUserId(event)).toBe('app-user')
+    expect(requireSessionAuth).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the session cookie, which is how the dashboard authenticates', async () => {
+    // Checking only one credential shape would silently anonymise the other.
+    requireAppAuth.mockRejectedValue(new Error('no bearer token'))
+    requireSessionAuth.mockResolvedValue({ userId: 'web-user' })
+    expect(await resolveTelemetryUserId(event)).toBe('web-user')
+  })
+
+  it('returns null when the caller proved nothing', async () => {
+    requireAppAuth.mockRejectedValue(new Error('no bearer token'))
+    requireSessionAuth.mockRejectedValue(new Error('no session'))
+    expect(await resolveTelemetryUserId(event)).toBeNull()
+  })
+
+  it('treats an authenticated context with no user id as anonymous', async () => {
+    requireAppAuth.mockResolvedValue({ userId: '' })
+    requireSessionAuth.mockRejectedValue(new Error('no session'))
+    expect(await resolveTelemetryUserId(event)).toBeNull()
+  })
+})
+
+/**
+ * That the routes use it and no longer read the body field.
+ *
+ * Both handlers need an IP guard, a database and a live request to stand up, so the call
+ * sites are guarded at source level. Without this the resolver could be correct and unused.
+ */
+describe('telemetry route wiring', () => {
+  const routes = ['record', 'batch'].map(name => ({
+    name,
+    source: readFileSync(
+      fileURLToPath(new URL(`../../server/api/telemetry/${name}.post.ts`, import.meta.url)),
+      'utf8',
+    ),
+  }))
+
+  it.each(routes)('$name resolves the user id from credentials', ({ source }) => {
+    expect(source).toContain('resolveTelemetryUserId(event)')
+    expect(source).toContain('userId: resolvedUserId || undefined')
+  })
+
+  it.each(routes)('$name no longer takes a user id from the body', ({ source }) => {
+    // The specific shapes that used to do it. A body still carrying `userId` is harmless as
+    // long as nothing reads it, which is what these assert.
+    expect(source).not.toContain('userId: userId || undefined')
+    expect(source).not.toContain('userId: e.userId || undefined')
+  })
+
+  it.each(routes)('$name marks an unattributed event anonymous whatever the body claims', ({ source }) => {
+    // Otherwise an event with no owner could still be stored as non-anonymous, which is the
+    // state the per-user dashboard reads.
+    expect(source).toMatch(/isAnonymous: resolvedUserId \?/)
+  })
+})


### PR DESCRIPTION
Closes #901.

## The defect

Both telemetry routes are unauthenticated — an IP guard only — and took `userId` from the request body, storing it as the event's owner. Anyone could POST `{eventType: "search", userId: "<victim>", searchQuery: "…"}` and have it appear as that person's activity in `dashboard/telemetry/me` and in admin analytics. The batch route accepted **100 such events per request**.

## The fix

`userId` is resolved from the request's own credentials; the body field is ignored.

**Both credential shapes are tried** — bearer app token first, then session cookie. The desktop app and the web dashboard authenticate differently, and checking only one would silently anonymise the other. In the batch route it is resolved **once per request**, not per event: credentials belong to the connection, so a batch cannot attribute different events to different people.

`isAnonymous` is derived too. An event with no proven owner is anonymous whatever the body claims, because that flag is what the per-user view reads.

## A consequence worth stating plainly

The desktop client sends `userId` in the telemetry body and **no Authorization header**, so identified events from it become anonymous until it starts sending its app token.

That is a real loss of attribution. It is still the right trade: attribution anyone can forge does not merely fail to inform an abuse investigation, **it actively misleads one**. Plumbing credentials into the client's telemetry path is a separate change — there is no app-token accessor in that part of the main process today.

## Tests

Ten.

Four on the resolver: app token used; **session fallback**; nothing proven → null; an authenticated context carrying an empty user id treated as anonymous.

Six are source-level guards across both routes — each needs an IP guard, a database and a live request to stand up, so the call sites are asserted directly. They cover: the resolver is called, `userId` comes from it, the old body reads are gone, and `isAnonymous` is derived. **All six fail against the previous handlers.**

Lint clean; `pnpm run typecheck` exits 0.