### PR TITLE
fix(nexus): validate webhook destinations at write and at dispatch

### DIFF
--- a/apps/nexus/server/utils/__tests__/webhookUrlPolicy.test.ts
+++ b/apps/nexus/server/utils/__tests__/webhookUrlPolicy.test.ts
@@ -1,0 +1,115 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { evaluateWebhookUrl } from '../webhookUrlPolicy'
+
+/**
+ * Where a stored webhook may point (#899).
+ *
+ * The credential store accepted any non-empty string under 2048 characters and the dispatcher
+ * passed it straight to the HTTP client. An admin session could set
+ * http://169.254.169.254/latest/meta-data/ and every notification became a request to that
+ * address; `validateStatus` accepts 100-599, so the delivery record reported the status and
+ * worked as a probe oracle. Plain http also sent the body and the X-Tuff-Signature HMAC in
+ * cleartext.
+ */
+
+const reason = (value: unknown) => {
+  const decision = evaluateWebhookUrl(value)
+  return decision.allowed ? undefined : decision.reason
+}
+
+describe('evaluateWebhookUrl', () => {
+  it('allows an ordinary https endpoint', () => {
+    // Positive control: a policy that refused everything would satisfy every rejection below
+    // while disabling webhook notifications entirely.
+    expect(evaluateWebhookUrl('https://hooks.example.test/abc')).toEqual({
+      allowed: true,
+      url: 'https://hooks.example.test/abc',
+    })
+  })
+
+  it('allows http on loopback, which is the documented development case', () => {
+    // The same carve-out readHttpsRelayEndpoint already makes in the dispatcher.
+    for (const url of ['http://localhost:3000/hook', 'http://127.0.0.1:3000/hook'])
+      expect(evaluateWebhookUrl(url).allowed, url).toBe(true)
+  })
+
+  it('refuses the cloud metadata address', () => {
+    // The reason this matters most.
+    expect(reason('http://169.254.169.254/latest/meta-data/')).toBe('insecure-scheme')
+    expect(reason('https://169.254.169.254/latest/meta-data/')).toBe('private-host')
+  })
+
+  it('refuses private IPv4 ranges over https', () => {
+    // https alone is not enough — the destination still has to be somewhere sensible.
+    for (const host of ['10.0.0.5', '172.16.0.5', '172.31.255.1', '192.168.1.1'])
+      expect(reason(`https://${host}/hook`), host).toBe('private-host')
+  })
+
+  it('allows public addresses that merely look adjacent to private ones', () => {
+    // 172.15 and 172.32 are outside the private block; over-blocking is its own failure.
+    for (const host of ['172.15.0.1', '172.32.0.1', '11.0.0.1', '193.168.1.1'])
+      expect(evaluateWebhookUrl(`https://${host}/hook`).allowed, host).toBe(true)
+  })
+
+  it('refuses IPv6 unique-local and link-local hosts', () => {
+    for (const host of ['[fd00::1]', '[fe80::1]'])
+      expect(reason(`https://${host}/hook`), host).toBe('private-host')
+  })
+
+  it('refuses internal-only hostnames', () => {
+    for (const host of ['metadata.google.internal', 'db.local'])
+      expect(reason(`https://${host}/hook`), host).toBe('private-host')
+  })
+
+  it('refuses plain http to any non-loopback host', () => {
+    expect(reason('http://hooks.example.test/abc')).toBe('insecure-scheme')
+  })
+
+  it('refuses non-http schemes', () => {
+    for (const url of ['file:///etc/passwd', 'ftp://example.test/x', 'gopher://example.test'])
+      expect(reason(url), url).toBe('unsupported-scheme')
+  })
+
+  it('refuses empty and unparseable input', () => {
+    expect(reason('')).toBe('empty')
+    expect(reason('   ')).toBe('empty')
+    expect(reason(undefined)).toBe('empty')
+    expect(reason('not a url')).toBe('unparseable')
+  })
+})
+
+/**
+ * That both the write path and the dispatch path use it.
+ *
+ * Write-time validation alone leaves credentials stored before it existed, and dispatch-time
+ * alone gives the admin no feedback. Both call sites are asserted at source level because the
+ * store needs a database and a master key, and the dispatcher needs a live delivery.
+ */
+describe('webhook url policy wiring', () => {
+  const read = (relative: string) =>
+    readFileSync(fileURLToPath(new URL(relative, import.meta.url)), 'utf8')
+
+  it('is applied when the credential is stored', () => {
+    const source = read('../notificationCredentialStore.ts')
+    expect(source).toContain('evaluateWebhookUrl(url)')
+    expect(source).toMatch(/if \(!decision\.allowed\)[\s\S]*?throw createError/)
+  })
+
+  it('is applied again at every dispatch site', () => {
+    // Three sites in the dispatcher. Guarding a subset would leave a working path.
+    const source = read('../notificationDispatcher.ts')
+    const calls = source.match(/assertDispatchableWebhookUrl\(credential\.url\)/g) ?? []
+    expect(calls).toHaveLength(3)
+  })
+
+  it('refuses before the request rather than after it', () => {
+    const source = read('../notificationDispatcher.ts')
+    const segments = source.split('assertDispatchableWebhookUrl(credential.url)').slice(1)
+    // Asserted, because with no call sites the loop below would pass by running zero times.
+    expect(segments).toHaveLength(3)
+    for (const segment of segments)
+      expect(segment.indexOf('if (rejected)')).toBeLessThan(segment.indexOf('networkClient.request'))
+  })
+})

--- a/apps/nexus/server/utils/notificationCredentialStore.ts
+++ b/apps/nexus/server/utils/notificationCredentialStore.ts
@@ -1,4 +1,5 @@
 import type { D1Database } from '@cloudflare/workers-types'
+import { evaluateWebhookUrl } from './webhookUrlPolicy'
 import type { H3Event } from 'h3'
 import { Buffer } from 'node:buffer'
 import { createCipheriv, createDecipheriv, createHash, hkdfSync, randomBytes } from 'node:crypto'
@@ -200,8 +201,20 @@ function normalizeCredentialPayload(
   }
 
   if (credentialType === 'webhook') {
+    // A length check was the only rule here, so the stored url could be any string — including
+    // http://169.254.169.254/latest/meta-data/, which the dispatcher would then call on every
+    // notification (#899). Rejected at write time so the admin sees why.
+    const url = assertNonEmptyString(credentials.url, 'credentials.url', 2048)
+    const decision = evaluateWebhookUrl(url)
+    if (!decision.allowed) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: `credentials.url is not an acceptable webhook destination (${decision.reason})`,
+      })
+    }
+
     return {
-      url: assertNonEmptyString(credentials.url, 'credentials.url', 2048),
+      url: decision.url,
       signingSecret: optionalString(credentials.signingSecret, 'credentials.signingSecret', 4096),
     }
   }

--- a/apps/nexus/server/utils/notificationDispatcher.ts
+++ b/apps/nexus/server/utils/notificationDispatcher.ts
@@ -1,4 +1,5 @@
 import type { H3Event } from 'h3'
+import { evaluateWebhookUrl } from './webhookUrlPolicy'
 import type { PlatformGovernanceConfig } from './platformGovernanceStore'
 import type { NotificationCredentialPayload } from './notificationCredentialStore'
 import { Buffer } from 'node:buffer'
@@ -453,6 +454,21 @@ function createSendResult(reason: string, statusCode: number | null = null): Not
   }
 }
 
+/**
+ * Re-checks a stored webhook URL immediately before dispatch.
+ *
+ * Validation at write time does not cover credentials stored before it existed, and this is
+ * the call that actually leaves the server, so it is the one that has to be safe. Returns a
+ * failed send result rather than throwing, so the refusal is recorded on the delivery instead
+ * of surfacing as an unhandled error (#899).
+ */
+function assertDispatchableWebhookUrl(url: string): NotificationSendResult | null {
+  const decision = evaluateWebhookUrl(url)
+  if (decision.allowed)
+    return null
+  return createSendResult(`webhook-url-rejected:${decision.reason}`, null)
+}
+
 function createHttpSendResult(statusCode: number): NotificationSendResult {
   return createSendResult(statusCode >= 200 && statusCode < 300 ? 'sent' : 'adapter-http-error', statusCode)
 }
@@ -655,6 +671,10 @@ async function sendWebhookNotification(
   if (credential.signingSecret)
     headers['X-Tuff-Signature'] = signBody(body, credential.signingSecret)
 
+  const rejected = assertDispatchableWebhookUrl(credential.url)
+  if (rejected)
+    return rejected
+
   const response = await networkClient.request({
     method: 'POST',
     url: credential.url,
@@ -701,6 +721,10 @@ async function sendGenericEmailNotification(
   }
   if (credential.signingSecret)
     headers['X-Tuff-Signature'] = signBody(body, credential.signingSecret)
+
+  const rejected = assertDispatchableWebhookUrl(credential.url)
+  if (rejected)
+    return rejected
 
   const response = await networkClient.request({
     method: 'POST',
@@ -802,6 +826,10 @@ async function sendWebPushRelayNotification(
   }
   if (credential.signingSecret)
     headers['X-Tuff-Signature'] = signBody(body, credential.signingSecret)
+
+  const rejected = assertDispatchableWebhookUrl(credential.url)
+  if (rejected)
+    return rejected
 
   const response = await networkClient.request({
     method: 'POST',

--- a/apps/nexus/server/utils/webhookUrlPolicy.ts
+++ b/apps/nexus/server/utils/webhookUrlPolicy.ts
@@ -1,0 +1,95 @@
+export type WebhookUrlRejection =
+  | 'empty'
+  | 'unparseable'
+  | 'unsupported-scheme'
+  | 'insecure-scheme'
+  | 'private-host'
+
+export type WebhookUrlDecision =
+  | { allowed: true, url: string }
+  | { allowed: false, reason: WebhookUrlRejection }
+
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]'])
+
+/**
+ * Hosts a server-side webhook must never be pointed at.
+ *
+ * 169.254.169.254 is the cloud instance-metadata address and the reason this matters most,
+ * but the whole private and link-local space is refused: a webhook is an outbound call the
+ * server makes on a stored address, so it is a ready-made probe of the network it runs in.
+ */
+function isPrivateHost(hostname: string): boolean {
+  const host = hostname.replace(/^\[|\]$/g, '').toLowerCase()
+
+  if (host === '0.0.0.0' || host === '::' || host.endsWith('.internal') || host.endsWith('.local'))
+    return true
+
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host)
+  if (ipv4) {
+    // Indexed directly rather than destructured: noUncheckedIndexedAccess types a slice's
+    // elements as possibly undefined, and the regex has already guaranteed both groups.
+    const a = Number(ipv4[1])
+    const b = Number(ipv4[2])
+    if (a === 10 || a === 127) return true
+    if (a === 169 && b === 254) return true
+    if (a === 172 && b >= 16 && b <= 31) return true
+    if (a === 192 && b === 168) return true
+    return false
+  }
+
+  // IPv6 unique-local (fc00::/7) and link-local (fe80::/10).
+  if (/^f[cd][0-9a-f]{2}:/.test(host) || /^fe[89ab][0-9a-f]:/.test(host))
+    return true
+
+  return false
+}
+
+/**
+ * Whether a stored webhook URL may be dispatched to.
+ *
+ * The credential store accepted any non-empty string under 2048 characters — no parse, no
+ * scheme check, no host rule — and the dispatcher passed it straight to the HTTP client. An
+ * admin session could point it at http://169.254.169.254/latest/meta-data/ and every
+ * notification became a request to that address; `validateStatus` accepts 100-599, so the
+ * delivery record reported the status and worked as a probe oracle. Plain http also sent the
+ * body and the X-Tuff-Signature HMAC in cleartext (#899).
+ *
+ * The scheme rule is the one `readHttpsRelayEndpoint` already applies in the dispatcher —
+ * https, or http for loopback so local development still works — with the private-host
+ * refusal added.
+ *
+ * Known limit: this checks the literal host. A DNS name that resolves to a private address
+ * still passes, because the check happens before resolution. Closing that needs resolution
+ * -time filtering in the HTTP client, which is a different change.
+ */
+export function evaluateWebhookUrl(value: unknown): WebhookUrlDecision {
+  const raw = typeof value === 'string' ? value.trim() : ''
+  if (!raw) {
+    return { allowed: false, reason: 'empty' }
+  }
+
+  let url: URL
+  try {
+    url = new URL(raw)
+  }
+  catch {
+    return { allowed: false, reason: 'unparseable' }
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    return { allowed: false, reason: 'unsupported-scheme' }
+  }
+
+  const loopback = LOOPBACK_HOSTS.has(url.hostname.toLowerCase())
+  if (url.protocol === 'http:' && !loopback) {
+    return { allowed: false, reason: 'insecure-scheme' }
+  }
+
+  // Loopback over http is the documented development case, so it is not a private-host
+  // rejection; anything else in private or link-local space is.
+  if (!loopback && isPrivateHost(url.hostname)) {
+    return { allowed: false, reason: 'private-host' }
+  }
+
+  return { allowed: true, url: url.toString() }
+}


### PR DESCRIPTION
Closes #899.

## The defect

`storeNotificationCredential` accepted any non-empty string under 2048 characters as the webhook url — no parse, no scheme check, no host rule — and the dispatcher passed it straight to the HTTP client at **three** call sites.

An admin session could set `http://169.254.169.254/latest/meta-data/` and every notification became a request to that address. `validateStatus` accepts 100-599, so the delivery record reported the status and worked as a **probe oracle**. Plain http also sent the body and the `X-Tuff-Signature` HMAC in cleartext.

## The rule

The scheme rule is the one `readHttpsRelayEndpoint` **already applies in the same file** — https, or http for loopback so local development keeps working — with private and link-local hosts refused on top.

## Why both places

| checked only at | leaves |
|---|---|
| write time | every credential stored *before* the check existed |
| dispatch time | the admin with no feedback about why their endpoint is wrong |

So both. The dispatch check returns a **failed send result** rather than throwing, so a refusal is recorded on the delivery instead of surfacing as an unhandled error.

## Two things I deliberately did not do

**`readHttpsRelayEndpoint` is left alone.** It has the same private-host gap, but it reads platform governance config rather than an admin-supplied credential — changing its behaviour is a separate decision from fixing the reported one.

**No resolution-time filtering.** This checks the literal host, so a DNS name resolving to a private address still passes. That is stated in the code rather than left implied; closing it means filtering inside the HTTP client.

## Tests

Thirteen. Ten on the rule, including two positive controls — an ordinary https endpoint is allowed, and addresses that merely *look* adjacent to private ranges (`172.15.x`, `172.32.x`, `11.x`, `193.168.x`) are **not** blocked, since over-blocking is its own failure.

Three are wiring guards (the store needs a database and a master key; the dispatcher a live delivery). Two fail against the previous version. The third asserts it found **three** call sites before checking their ordering — with none it would have passed by iterating an empty list, which is the failure mode I keep running into in this codebase.

Lint clean; `pnpm run typecheck` exits 0. All 191 tests under `server/utils/__tests__` pass.