### PR TITLE
test(core-app): give the search-trace suite the app.getPath it resolves storage through (#323)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.trace.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.trace.test.ts
@@ -301,6 +301,12 @@ vi.mock('@talex-touch/utils/transport/main', () => ({
 vi.mock('electron', () => ({
   app: {
     getLocale: vi.fn(() => 'en-US'),
+    // The indexed-source runtime resolves its storage location through app.getPath;
+    // without it the whole trace suite failed with "app.getPath is not a function"
+    // before reaching anything it means to assert.
+    getPath: vi.fn((name: string) => `/tmp/tuff-test/${name}`),
+    getName: vi.fn(() => 'tuff-test'),
+    getVersion: vi.fn(() => '0.0.0-test'),
     commandLine: {
       appendSwitch: vi.fn()
     }


### PR DESCRIPTION
Refs #323. `search-core.trace`: **4 failing → 0**.

All four failed with `app.getPath is not a function` **before reaching anything they mean
to assert**. The indexed-source runtime resolves its storage location through
`app.getPath`, and the suite's electron mock stubs `getLocale` and `commandLine` only.

One line of mock. The four tests — transport handler registration, structured logging
without query plaintext, telemetry provider state, and the file-system event bridge — all
pass once the runtime can start.

### Also investigated here, not fixed

Three of CoreApp's remaining singles, classified rather than patched:

| test | verdict |
|---|---|
| `runtime-modules.contract` — `formdata-node` | **real**, and it's #323's known blocker — details below |
| `runtime-modules` — `node-pty` | environmental: node-pty isn't installed in this worktree at all |
| `native-transport-napi` | was a **stub file**, now builds — see below |
| `native-screenshot-transport-napi` | environmental: drives a real screen capture, needs macOS Screen Recording permission |

**`runtime-modules.contract` is a canary for the openai blocker.** It asserts the packaged
closure contains `formdata-node`. From the lockfile:

- `formdata-node@4.4.1` is a dependency of **`openai@4.104.0`**
- **`openai@6.26.0`** declares *no* `dependencies` at all — peer-only (`ws`, `zod`)
- the closure resolves **6.26.0**, so `formdata-node` isn't in it
- `apps/core-app` doesn't declare `openai` directly; it declares `@langchain/openai: ^0.4.9`, whose peer wants `openai@^4.87.3`

So this test isn't stale — it's the visible symptom of the exact conflict #323 already
names as its remaining blocker. **I did not touch it.** It should keep failing until the
closure resolves v4.

**`tuff_native_protocol_fixture.node` was a placeholder.** It contained the ASCII text
`module.exports = {}`, which is why `dlopen` reported *"slice is not valid mach-o file"* —
not an arch mismatch, an unbuilt artifact. Running `build:protocol-fixture` produces a real
`Mach-O arm64` library and `native-transport-napi` passes. Nothing to change in the repo;
worth knowing that the failure message points at architecture when the cause is that the
file was never built.

> CI red is #1194 (`node-pty` postinstall), fixed in #1197 — it fails on `master` too.