### PR TITLE
test(nexus): unpin the login-history fixture before it detonates (#1210)

### DIFF
--- a/apps/nexus/server/utils/__tests__/authStore-login-history.test.ts
+++ b/apps/nexus/server/utils/__tests__/authStore-login-history.test.ts
@@ -37,7 +37,11 @@ class MockD1Database {
     success: 1,
     reason: 'password',
     client_type: 'web',
-    created_at: '2026-06-21T10:00:00.000Z',
+    // Relative to now. listLoginHistory prunes rows older than its 90-day window
+    // before listing (authStore.ts:2804-2808), so a pinned created_at is a dated time
+    // bomb: this row was written 2026-06-21 and would have started failing on
+    // 2026-09-19, looking like a login-history regression rather than fixture rot.
+    created_at: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
     country_code: 'US',
     region_code: 'CA',
     region_name: 'California',


### PR DESCRIPTION
Refs #1210. Retarget of #1214 (opened against `master` by mistake).

`listLoginHistory` prunes rows older than its 90-day window **before listing**
(`authStore.ts:2804-2808`). The fixture row is pinned to `2026-06-21` — inside that window
today, outside it from **2026-09-19**. It would start failing then and read as a
login-history regression rather than fixture rot.

### Found by varying the thing that breaks it

Four of the thirteen failures I fixed in #1210 were fixtures that aged out of a
`Date.now()`-relative window. That's a category, not a coincidence — so rather than assume
I'd caught them all, I ran the suite with the wall clock advanced and diffed against its
own baseline.

**On this branch** (`app-shell-v2`), after this fix:

```
CLOCK_SHIFT_DAYS=365   →   Tests 1038 passed (1038)
```

The entire nexus suite survives a year of calendar drift. This was the only remaining
fixture of its kind.

### What I didn't do

145 test files carry pinned ISO dates. I left them — a fixed date only rots when something
compares it to *now*, and most never do. A lint rule against date literals would be noise;
the clock-shift run is the better detector because it tests the comparison rather than the
literal.

Worth considering as a periodic CI job. It costs one extra suite run and catches this whole
class before it reaches a required gate — but it doubles a suite's runtime on whatever
schedule it runs, so that's a call for you rather than something to slip in.