### PR TITLE
fix(test): make packages/test independent of the electron binary, and recover two dead suites (#330)

### DIFF
--- a/packages/test/src/aisdk/provider-test.test.ts
+++ b/packages/test/src/aisdk/provider-test.test.ts
@@ -1,7 +1,62 @@
 import type { IntelligenceProviderConfig } from '@talex-touch/tuff-intelligence'
 import { IntelligenceProviderType } from '@talex-touch/tuff-intelligence'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { setIntelligenceProviderManager, tuffIntelligence } from '../../../../apps/core-app/src/main/modules/ai/intelligence-sdk'
+
+// This file's subject is the intelligence SDK, but importing it pulls in the
+// main-process bootstrap, which touches a wide slice of electron at module scope.
+// The stub that `electron` is aliased to throws by name on any unmocked surface,
+// which is the right default for a suite that means to assert electron behaviour
+// and the wrong one here: the boot path would have to be enumerated call by call,
+// and every future addition to it would break this file for no reason related to
+// what it tests.
+//
+// So the app-boot surfaces get a permissive auto-stub -- unknown members are
+// no-op functions -- while the handful of values the bootstrap actually reads are
+// given real answers. importOriginal is spread underneath so the surfaces nothing
+// here touches stay throwers rather than becoming undefined, which vitest rejects
+// outright when a factory omits an export.
+function autoStub(overrides: Record<string, unknown> = {}): any {
+  return new Proxy(overrides, {
+    get: (target, key) => key in target ? (target as any)[key] : () => undefined,
+  })
+}
+
+vi.mock('electron', async importOriginal => ({
+  ...(await importOriginal<typeof import('electron')>()),
+  app: autoStub({
+    isPackaged: false,
+    getPath: (name: string) => `/tmp/tuff-test/${name}`,
+    getLocale: () => 'en-US',
+    getVersion: () => '0.0.0-test',
+    getName: () => 'tuff-test',
+    requestSingleInstanceLock: () => true,
+    whenReady: async () => {},
+    commandLine: autoStub({ hasSwitch: () => false }),
+  }),
+  ipcMain: autoStub(),
+  crashReporter: autoStub(),
+  powerMonitor: autoStub(),
+  protocol: autoStub(),
+  nativeTheme: autoStub({ shouldUseDarkColors: false }),
+  session: autoStub({ defaultSession: autoStub({ webRequest: autoStub() }) }),
+  BrowserWindow: autoStub({ getAllWindows: () => [] }),
+}))
+
+vi.mock('@sentry/electron/main', () => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addBreadcrumb: vi.fn(),
+  setTag: vi.fn(),
+  setContext: vi.fn(),
+  setUser: vi.fn(),
+  withScope: vi.fn((fn: (scope: unknown) => void) =>
+    fn({ setTag: vi.fn(), setContext: vi.fn(), setUser: vi.fn() }),
+  ),
+  getCurrentScope: vi.fn(() => ({ setTag: vi.fn(), setContext: vi.fn(), setUser: vi.fn() })),
+  flush: vi.fn(async () => true),
+}))
 
 function setMockProviderManager(chatImpl: () => Promise<unknown>) {
   const provider = { chat: chatImpl } as any

--- a/packages/test/src/common/index.test.ts
+++ b/packages/test/src/common/index.test.ts
@@ -1,7 +1,5 @@
-import path from 'node:path'
 import { anyStr2Num, num2anyStr } from '@talex-touch/utils/common'
 import { describe, expect, it } from 'vitest'
-import { genFileTree } from '../../../help/tree-generator'
 
 describe('#Common', () => {
   it('serial str-num test', () => {
@@ -18,10 +16,8 @@ describe('#Common', () => {
   })
 })
 
-describe('#File tree', () => {
-  it('file tree generator test', () => {
-    const p = path.join(process.cwd(), '..', '..')
-
-    genFileTree(p)
-  })
-})
+// The '#File tree' suite was removed: help/tree-generator was pruned in 63c4f5022
+// (2026-07-14) and this was its only remaining caller, so the import failed and took
+// the whole file down with it -- including the str-num test above, which was never
+// reported as failing because the suite could not load at all. The test itself called
+// genFileTree(p) and asserted nothing, so there is no coverage to reinstate.

--- a/packages/test/src/download/notification-service.test.ts
+++ b/packages/test/src/download/notification-service.test.ts
@@ -169,19 +169,23 @@ describe('notificationService', () => {
     })
   })
 
-  describe('update Download Complete Notification', () => {
+  describe('update Ready Notification', () => {
+    // Was showUpdateDownloadCompleteNotification(version, taskId). It is now
+    // showUpdateReadyNotification({ version, platform, onClick }) and returns
+    // whether it notified, so the config gate can be asserted rather than merely
+    // smoke-tested with .not.toThrow().
+    function readyOptions() {
+      return { version: 'v2.0.0', platform: 'darwin' as NodeJS.Platform, onClick: () => {} }
+    }
+
     it('should show notification when update download completes', () => {
-      expect(() => {
-        notificationService.showUpdateDownloadCompleteNotification('v2.0.0', 'task-123')
-      }).not.toThrow()
+      expect(notificationService.showUpdateReadyNotification(readyOptions())).toBe(true)
     })
 
     it('should not show notification when disabled', () => {
       notificationService.updateConfig({ updateDownloadComplete: false })
 
-      expect(() => {
-        notificationService.showUpdateDownloadCompleteNotification('v2.0.0', 'task-123')
-      }).not.toThrow()
+      expect(notificationService.showUpdateReadyNotification(readyOptions())).toBe(false)
     })
   })
 

--- a/packages/test/src/stubs/electron.ts
+++ b/packages/test/src/stubs/electron.ts
@@ -12,51 +12,94 @@
  * environment for what is really a resolution mismatch.
  *
  * Aliasing gives both sides one identity, which is the thing `vi.mock` needs to
- * bind. Every export here throws: this file is a resolution target, not a
+ * bind. Every export here throws on use: this file is a resolution target, not a
  * substitute implementation. A test that reaches one of these has forgotten to
- * mock the surface it actually uses, and should be told so directly rather than
+ * mock the surface it actually uses, and should be told which one rather than
  * silently receiving an empty object.
+ *
+ * The export list mirrors what `apps/core-app/src/main` imports from 'electron'.
+ * A missing name is not a soft failure: an ES module namespace has no fallback,
+ * so an unlisted export makes the whole importing suite fail to collect -- which
+ * shows up as a failed *file* with zero failed *tests*, invisible in a summary
+ * that counts tests. Keep this list complete.
  */
 
 function unmocked(name: string): never {
   throw new Error(
     `electron.${name} was used without being mocked. packages/test aliases 'electron' to a stub; `
-    + `provide the surface you need via vi.mock('electron', () => ({ ${name}: ... })).`,
+    + `provide the surface you need via vi.mock('electron', () => ({ ... })).`,
   )
 }
 
-export const app = new Proxy({}, { get: (_t, key) => unmocked(`app.${String(key)}`) })
-export const shell = new Proxy({}, { get: (_t, key) => unmocked(`shell.${String(key)}`) })
-export const ipcMain = new Proxy({}, { get: (_t, key) => unmocked(`ipcMain.${String(key)}`) })
-export const ipcRenderer = new Proxy({}, { get: (_t, key) => unmocked(`ipcRenderer.${String(key)}`) })
-export const clipboard = new Proxy({}, { get: (_t, key) => unmocked(`clipboard.${String(key)}`) })
-export const nativeImage = new Proxy({}, { get: (_t, key) => unmocked(`nativeImage.${String(key)}`) })
-export const screen = new Proxy({}, { get: (_t, key) => unmocked(`screen.${String(key)}`) })
-export const dialog = new Proxy({}, { get: (_t, key) => unmocked(`dialog.${String(key)}`) })
-export const globalShortcut = new Proxy({}, { get: (_t, key) => unmocked(`globalShortcut.${String(key)}`) })
+function namespace(name: string): any {
+  return new Proxy({}, { get: (_target, key) => unmocked(`${name}.${String(key)}`) })
+}
 
-export class BrowserWindow {
-  constructor() {
-    unmocked('BrowserWindow')
+function constructible(name: string): any {
+  return class {
+    constructor() {
+      unmocked(`new ${name}()`)
+    }
+
+    static [Symbol.hasInstance](): boolean {
+      return false
+    }
   }
 }
 
-export class Notification {
-  constructor() {
-    unmocked('Notification')
-  }
-}
+export const app = namespace('app')
+export const clipboard = namespace('clipboard')
+export const crashReporter = namespace('crashReporter')
+export const dialog = namespace('dialog')
+export const globalShortcut = namespace('globalShortcut')
+export const ipcMain = namespace('ipcMain')
+export const ipcRenderer = namespace('ipcRenderer')
+export const nativeImage = namespace('nativeImage')
+export const nativeTheme = namespace('nativeTheme')
+export const net = namespace('net')
+export const powerMonitor = namespace('powerMonitor')
+export const powerSaveBlocker = namespace('powerSaveBlocker')
+export const protocol = namespace('protocol')
+export const screen = namespace('screen')
+export const session = namespace('session')
+export const shell = namespace('shell')
+export const systemPreferences = namespace('systemPreferences')
+export const utilityProcess = namespace('utilityProcess')
+export const webContents = namespace('webContents')
 
-export class Tray {
-  constructor() {
-    unmocked('Tray')
-  }
-}
+export const BrowserWindow = constructible('BrowserWindow')
+export const Menu = constructible('Menu')
+export const MessageChannelMain = constructible('MessageChannelMain')
+export const MessagePortMain = constructible('MessagePortMain')
+export const Notification = constructible('Notification')
+export const Tray = constructible('Tray')
+export const WebContentsView = constructible('WebContentsView')
 
-export class Menu {
-  constructor() {
-    unmocked('Menu')
-  }
+export default {
+  app,
+  clipboard,
+  crashReporter,
+  dialog,
+  globalShortcut,
+  ipcMain,
+  ipcRenderer,
+  nativeImage,
+  nativeTheme,
+  net,
+  powerMonitor,
+  powerSaveBlocker,
+  protocol,
+  screen,
+  session,
+  shell,
+  systemPreferences,
+  utilityProcess,
+  webContents,
+  BrowserWindow,
+  Menu,
+  MessageChannelMain,
+  MessagePortMain,
+  Notification,
+  Tray,
+  WebContentsView,
 }
-
-export default { app, shell, ipcMain, ipcRenderer, clipboard, nativeImage, screen, dialog, globalShortcut, BrowserWindow, Notification, Tray, Menu }

--- a/packages/test/src/stubs/electron.ts
+++ b/packages/test/src/stubs/electron.ts
@@ -1,0 +1,62 @@
+/**
+ * Resolution target for the bare `electron` specifier inside this package.
+ *
+ * `packages/test` exercises main-process code that imports `electron`, but does
+ * not (and should not) depend on the electron package itself -- it needs the
+ * module's shape, never its binary. Without an alias the specifier resolves to
+ * two different things: unresolvable from a test file, and the real
+ * `node_modules/.pnpm/electron/index.js` from the code under test. A
+ * `vi.mock('electron', ...)` registered in the test then keys off the former and
+ * never matches the latter, so the real package loads, runs its binary probe,
+ * and throws "Electron failed to install correctly" -- a message about the
+ * environment for what is really a resolution mismatch.
+ *
+ * Aliasing gives both sides one identity, which is the thing `vi.mock` needs to
+ * bind. Every export here throws: this file is a resolution target, not a
+ * substitute implementation. A test that reaches one of these has forgotten to
+ * mock the surface it actually uses, and should be told so directly rather than
+ * silently receiving an empty object.
+ */
+
+function unmocked(name: string): never {
+  throw new Error(
+    `electron.${name} was used without being mocked. packages/test aliases 'electron' to a stub; `
+    + `provide the surface you need via vi.mock('electron', () => ({ ${name}: ... })).`,
+  )
+}
+
+export const app = new Proxy({}, { get: (_t, key) => unmocked(`app.${String(key)}`) })
+export const shell = new Proxy({}, { get: (_t, key) => unmocked(`shell.${String(key)}`) })
+export const ipcMain = new Proxy({}, { get: (_t, key) => unmocked(`ipcMain.${String(key)}`) })
+export const ipcRenderer = new Proxy({}, { get: (_t, key) => unmocked(`ipcRenderer.${String(key)}`) })
+export const clipboard = new Proxy({}, { get: (_t, key) => unmocked(`clipboard.${String(key)}`) })
+export const nativeImage = new Proxy({}, { get: (_t, key) => unmocked(`nativeImage.${String(key)}`) })
+export const screen = new Proxy({}, { get: (_t, key) => unmocked(`screen.${String(key)}`) })
+export const dialog = new Proxy({}, { get: (_t, key) => unmocked(`dialog.${String(key)}`) })
+export const globalShortcut = new Proxy({}, { get: (_t, key) => unmocked(`globalShortcut.${String(key)}`) })
+
+export class BrowserWindow {
+  constructor() {
+    unmocked('BrowserWindow')
+  }
+}
+
+export class Notification {
+  constructor() {
+    unmocked('Notification')
+  }
+}
+
+export class Tray {
+  constructor() {
+    unmocked('Tray')
+  }
+}
+
+export class Menu {
+  constructor() {
+    unmocked('Menu')
+  }
+}
+
+export default { app, shell, ipcMain, ipcRenderer, clipboard, nativeImage, screen, dialog, globalShortcut, BrowserWindow, Notification, Tray, Menu }

--- a/packages/test/src/stubs/sentry-electron-main.ts
+++ b/packages/test/src/stubs/sentry-electron-main.ts
@@ -1,0 +1,49 @@
+/**
+ * Resolution target for `@sentry/electron/main` inside this package.
+ *
+ * Same problem as src/stubs/electron.ts: packages/test does not depend on
+ * @sentry/electron, so the specifier is unresolvable from a test file while the
+ * main-process code under test resolves it to the real package. A
+ * vi.mock('@sentry/electron/main', ...) in the test therefore never binds, the
+ * real module loads, and it calls parseSemver(process.versions.electron) at
+ * module scope -- undefined outside an Electron runtime. The suite dies during
+ * collection, which surfaces as a failed file with *zero* failed tests: invisible
+ * in a summary line that only counts tests.
+ *
+ * Unlike the electron stub, these are no-ops rather than throwers. Sentry calls
+ * are fire-and-forget telemetry that production code makes freely and no test
+ * asserts; throwing here would break working tests to no purpose. A test that
+ * wants to assert telemetry should still install its own vi.mock, which now binds
+ * correctly because both sides resolve to this file.
+ */
+
+function noop(): void {}
+
+export const init = noop
+export const captureException = noop
+export const captureMessage = noop
+export const addBreadcrumb = noop
+export const setTag = noop
+export const setContext = noop
+export const setUser = noop
+export const setExtra = noop
+
+const scope = {
+  setTag: noop,
+  setContext: noop,
+  setUser: noop,
+  setExtra: noop,
+  setLevel: noop,
+}
+
+export function withScope(callback: (s: typeof scope) => void): void {
+  callback(scope)
+}
+
+export function getCurrentScope(): typeof scope {
+  return scope
+}
+
+export async function flush(): Promise<boolean> {
+  return true
+}

--- a/packages/test/src/stubs/talex-mica-electron.ts
+++ b/packages/test/src/stubs/talex-mica-electron.ts
@@ -1,0 +1,27 @@
+/**
+ * Resolution target for `talex-mica-electron` inside this package.
+ *
+ * A CJS package whose main.js calls `require('electron')` at module scope. Two
+ * things make it unusable here: packages/test cannot resolve it, so a
+ * vi.mock('talex-mica-electron', ...) in a test never binds (see
+ * src/stubs/electron.ts for why); and inlining it does not help either, because
+ * vite's CJS interop routes its `require` through Node rather than the alias map,
+ * so it still fails to find electron under pnpm's strict layout.
+ *
+ * The package applies Windows Mica/Acrylic window effects. It has nothing to say
+ * on any other platform and nothing at all outside a real Electron runtime, so
+ * the stub reports "not Windows 11" and hands back inert shapes -- the same
+ * answers core-app's own suites give it via vi.mock (see
+ * apps/core-app/src/main/channel/common.test.ts).
+ */
+
+export const IS_WINDOWS_11 = false
+export const WIN10 = false
+
+export class MicaBrowserWindow {}
+
+export function useMicaElectron(_path?: string): void {}
+export function setMicaEffect(): void {}
+export function disableMicaEffect(): void {}
+
+export default { IS_WINDOWS_11, WIN10, MicaBrowserWindow, useMicaElectron, setMicaEffect, disableMicaEffect }

--- a/packages/test/vitest.config.ts
+++ b/packages/test/vitest.config.ts
@@ -1,6 +1,16 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/dist/config'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Give `electron` a single identity across this package. Test files and the
+      // main-process code they import otherwise resolve the bare specifier
+      // differently, which stops vi.mock('electron', ...) from ever binding.
+      // See src/stubs/electron.ts for the full reasoning.
+      electron: fileURLToPath(new URL('./src/stubs/electron.ts', import.meta.url)),
+    },
+  },
   test: {
     include: ['src/**/*.test.ts'],
     environment: 'node',

--- a/packages/test/vitest.config.ts
+++ b/packages/test/vitest.config.ts
@@ -8,11 +8,30 @@ export default defineConfig({
       // main-process code they import otherwise resolve the bare specifier
       // differently, which stops vi.mock('electron', ...) from ever binding.
       // See src/stubs/electron.ts for the full reasoning.
-      electron: fileURLToPath(new URL('./src/stubs/electron.ts', import.meta.url)),
+      'electron': fileURLToPath(new URL('./src/stubs/electron.ts', import.meta.url)),
+      // Same reason, same fix: @sentry/electron is not resolvable from here either,
+      // and the real module reads process.versions.electron at import time, which
+      // kills the whole suite during collection rather than failing a test.
+      '@sentry/electron/main': fileURLToPath(new URL('./src/stubs/sentry-electron-main.ts', import.meta.url)),
+      // A CJS package that require()s electron at module scope. Inlining it is not
+      // enough -- vite's CJS interop routes its require through Node, which never
+      // consults the alias above -- so the package itself has to be aliased.
+      'talex-mica-electron': fileURLToPath(new URL('./src/stubs/talex-mica-electron.ts', import.meta.url)),
     },
   },
   test: {
     include: ['src/**/*.test.ts'],
     environment: 'node',
+    server: {
+      deps: {
+        // ESM dependencies that import electron themselves. Left external they are
+        // loaded by Node directly, which never sees the alias above and hands them
+        // the real CommonJS electron -- so `import { BrowserWindow } from 'electron'`
+        // fails as a missing named export, blaming the source file that imported the
+        // package rather than the package. Inlining routes them through vite so the
+        // alias applies.
+        inline: ['@electron-toolkit/utils'],
+      },
+    },
   },
 })


### PR DESCRIPTION
Refs #330. Retarget of #1192 (opened against `master` by mistake).

`packages/test` on this branch: **39 failing / 10 files → 37 failing / 7 files**, with
**6 tests that previously didn't run at all**.

> The `chalk` fix that was part of #1192 is **dropped here** — `app-shell-v2` already
> declares it. Only the test-side work applies.

### Two suites were failing with *zero* failed tests

The summary counts tests, so a file that dies during collection shows as a failed *file*
with no failed *test* — invisible next to the numbers beside it.

- **`common/index.test.ts`** imported `help/tree-generator`, pruned in `63c4f5022`
  (2026-07-14); this was its only remaining caller. The dead import took down the whole
  file, including the `str-num` test that had nothing to do with it. The file-tree test
  called `genFileTree(p)` and **asserted nothing**, so the suite is removed rather than
  rewritten — no coverage to reinstate.
- **`aisdk/provider-test.test.ts`** reached the real `@sentry/electron`, which reads
  `process.versions.electron` at module scope.

Both now run: **1 and 5 tests** that previously didn't exist as far as any report was
concerned.

### Why the aliases

They make `packages/test` **independent of a ~100MB binary download**, so the suite is
hermetic and doesn't fail differently depending on whether electron's postinstall ran.

| package | treatment | why |
|---|---|---|
| `electron` | aliased to a stub | Every export throws *by name*, so a test that forgot to mock a surface is told which one. |
| `@sentry/electron/main` | aliased | No-op, not throwing: fire-and-forget telemetry no test asserts. |
| `talex-mica-electron` | aliased | Inlining isn't enough — it's CJS, and vite's interop routes its `require()` through Node, which doesn't consult the alias map. |
| `@electron-toolkit/utils` | inlined | ESM, so the alias applies once it stops being external. |

The electron stub mirrors every name `apps/core-app/src/main` imports from `'electron'`.
That list is load-bearing: a namespace has no fallback for a missing export, so an unlisted
name fails the whole importing suite at collection — the exact failure mode this PR is
about.

### `notification-service` API drift

`showUpdateDownloadCompleteNotification(version, taskId)` is now
`showUpdateReadyNotification({version, platform, onClick})` and **returns** whether it
notified. The tests asserted `.not.toThrow()`; they now assert the config gate through that
return value. **2 → 0.**

Verified **on this branch**.