### PR TITLE
fix(core-app): require the declared network permissions on the request handlers

### DIFF
--- a/apps/core-app/src/main/modules/network/network-module.ts
+++ b/apps/core-app/src/main/modules/network/network-module.ts
@@ -11,6 +11,9 @@ import type { TalexEvents } from '../../core/eventbus/touch-event'
 import { resolveMainRuntime } from '../../core/runtime-accessor'
 import { BaseModule } from '../abstract-base-module'
 import { getNetworkService } from './network-service'
+import type { HandlerContext } from '@talex-touch/utils/transport/main'
+import { withPermission } from '../permission/channel-guard'
+import { classifyNetworkTarget } from '../../utils/network-target-policy'
 
 const NETWORK_STATUS_POLL_INTERVAL_MS = 5000
 
@@ -61,14 +64,63 @@ export class NetworkModule extends BaseModule {
       publishStatus(net.isOnline(), reason)
     }
 
+    // These three issue requests from the main process, outside any plugin view's session, so
+    // they bypass the confinement installPluginViewNavigationPolicy puts on a plugin's own
+    // network. They ran with no permission check at all, even though the registry declares
+    // network.local and network.internet for exactly this capability (#906).
+    //
+    // The required permission depends on the destination: reaching localhost admin panels,
+    // 169.254.169.254 or the LAN is network.local, the rest is network.internet. withPermission
+    // takes a fixed id, so the target is classified first and dispatched to the matching
+    // wrapper. Non-plugin callers pass through either way — channel-guard returns early
+    // without a plugin id — which is intended here, since the bypass this closes is a plugin
+    // escaping its own view policy.
+    const guarded = <TPayload, TResult>(
+      handler: (payload: TPayload, context: HandlerContext) => Promise<TResult>,
+      readTarget: (payload: TPayload) => unknown
+    ) => {
+      const forLocal = withPermission<TPayload, TResult>(
+        { permissionId: 'network.local', errorMessage: 'Permission network.local required' },
+        handler
+      )
+      const forInternet = withPermission<TPayload, TResult>(
+        { permissionId: 'network.internet', errorMessage: 'Permission network.internet required' },
+        handler
+      )
+
+      return async (payload: TPayload, context: HandlerContext): Promise<TResult> => {
+        const target = classifyNetworkTarget(readTarget(payload))
+        // A local file source is not a network request; the local-file allowlist governs it.
+        if (target === 'non-http') {
+          return await handler(payload, context)
+        }
+        const wrapped = target === 'local' ? forLocal : forInternet
+        return (await wrapped(payload, context)) as TResult
+      }
+    }
+
     this.disposers.push(
-      transport.on(NetworkEvents.api.request, async (request) => await service.request(request)),
-      transport.on(NetworkEvents.api.readText, async (payload) => {
-        return await service.readText(payload.source, payload.options)
-      }),
-      transport.on(NetworkEvents.api.readBinary, async (payload) => {
-        return await service.readBinary(payload.source, payload.options)
-      }),
+      transport.on(
+        NetworkEvents.api.request,
+        guarded(
+          async (request) => await service.request(request),
+          (request) => (request as { url?: unknown } | undefined)?.url
+        )
+      ),
+      transport.on(
+        NetworkEvents.api.readText,
+        guarded(
+          async (payload) => await service.readText(payload.source, payload.options),
+          (payload) => payload?.source
+        )
+      ),
+      transport.on(
+        NetworkEvents.api.readBinary,
+        guarded(
+          async (payload) => await service.readBinary(payload.source, payload.options),
+          (payload) => payload?.source
+        )
+      ),
       transport.on(NetworkEvents.api.toTfileUrl, (payload) => service.toTfileUrl(payload.source)),
       transport.on(NetworkEvents.api.getConfig, () => service.getConfig()),
       transport.on(NetworkEvents.api.updateConfig, (payload) =>

--- a/apps/core-app/src/main/utils/network-target-policy.test.ts
+++ b/apps/core-app/src/main/utils/network-target-policy.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { classifyNetworkTarget } from './network-target-policy'
+
+/**
+ * Which permission a network request needs (#906).
+ *
+ * The request/readText/readBinary transport handlers forwarded whatever they were given with
+ * no permission check, even though the registry declares network.local and network.internet
+ * for exactly this. A plugin could therefore sidestep the confinement
+ * installPluginViewNavigationPolicy puts on its own view — the request is issued by the main
+ * process, outside that session, from the user's LAN position.
+ */
+describe('classifyNetworkTarget', () => {
+  it('treats ordinary public hosts as internet', () => {
+    // Positive control: a classifier that answered 'local' for everything would make every
+    // assertion below pass while demanding the wrong permission for normal use.
+    for (const url of ['https://example.test/api', 'http://example.test', 'https://1.1.1.1/'])
+      expect(classifyNetworkTarget(url), url).toBe('internet')
+  })
+
+  it('treats loopback as local', () => {
+    for (const url of ['http://127.0.0.1:8080/admin', 'http://localhost:3000', 'http://[::1]/'])
+      expect(classifyNetworkTarget(url), url).toBe('local')
+  })
+
+  it('treats the cloud metadata address as local', () => {
+    expect(classifyNetworkTarget('http://169.254.169.254/latest/meta-data/')).toBe('local')
+  })
+
+  it('treats private IPv4 ranges as local', () => {
+    for (const host of ['10.0.0.5', '172.16.0.1', '172.31.255.254', '192.168.1.1'])
+      expect(classifyNetworkTarget(`http://${host}/`), host).toBe('local')
+  })
+
+  it('does not over-claim addresses adjacent to private ranges', () => {
+    // 172.15 and 172.32 sit outside the private block. Misclassifying them would demand
+    // network.local for ordinary internet hosts.
+    for (const host of ['172.15.0.1', '172.32.0.1', '11.0.0.1', '193.168.1.1'])
+      expect(classifyNetworkTarget(`https://${host}/`), host).toBe('internet')
+  })
+
+  it('treats IPv6 unique-local and link-local as local', () => {
+    for (const url of ['http://[fd00::1]/', 'http://[fe80::1]/'])
+      expect(classifyNetworkTarget(url), url).toBe('local')
+  })
+
+  it('treats mDNS and internal suffixes as local', () => {
+    for (const host of ['printer.local', 'metadata.google.internal', 'app.localhost'])
+      expect(classifyNetworkTarget(`http://${host}/`), host).toBe('local')
+  })
+
+  it('reports a non-http source separately, since it is not a network request', () => {
+    // readText and readBinary also accept file paths, which the local-file allowlist governs.
+    for (const source of ['/tmp/file.txt', 'C:\\Users\\me\\a.txt', 'tfile:///x/y.png'])
+      expect(classifyNetworkTarget(source), source).toBe('non-http')
+  })
+
+  it('falls back to local for input it cannot parse', () => {
+    // The more restrictive answer: a malformed target must not fall through to the weaker
+    // permission.
+    for (const source of ['http://', '', '   ', undefined, null, 42])
+      expect(classifyNetworkTarget(source), String(source)).toBe('local')
+  })
+})
+
+/**
+ * That the module wires it to all three handlers.
+ *
+ * network-module builds a transport and a service in onInit, so the call sites are asserted at
+ * source level. Guarding a subset would leave a working bypass, which is the whole finding.
+ */
+describe('network module wiring', () => {
+  const source = readFileSync(
+    fileURLToPath(new URL('../modules/network/network-module.ts', import.meta.url)),
+    'utf8',
+  )
+
+  it('guards request, readText and readBinary', () => {
+    const guarded = source.match(/guarded\(/g) ?? []
+    // Three call sites plus the helper's own definition is not counted — `guarded(` appears
+    // only at use sites, since the helper is declared as `const guarded = <...>(`.
+    expect(guarded).toHaveLength(3)
+  })
+
+  it('requires both network permissions, chosen by destination', () => {
+    expect(source).toContain("permissionId: 'network.local'")
+    expect(source).toContain("permissionId: 'network.internet'")
+    expect(source).toContain('classifyNetworkTarget(')
+  })
+
+  it('does not leave any of the three handlers calling the service directly', () => {
+    // The shape they had before: `transport.on(NetworkEvents.api.request, async (request) =>
+    // await service.request(request))`.
+    expect(source).not.toMatch(/NetworkEvents\.api\.request,\s*async \(request\) =>/)
+    expect(source).not.toMatch(/NetworkEvents\.api\.readText,\s*async \(payload\) => \{\s*return await service/)
+    expect(source).not.toMatch(/NetworkEvents\.api\.readBinary,\s*async \(payload\) => \{\s*return await service/)
+  })
+})

--- a/apps/core-app/src/main/utils/network-target-policy.test.ts
+++ b/apps/core-app/src/main/utils/network-target-policy.test.ts
@@ -74,7 +74,7 @@ describe('classifyNetworkTarget', () => {
 describe('network module wiring', () => {
   const source = readFileSync(
     fileURLToPath(new URL('../modules/network/network-module.ts', import.meta.url)),
-    'utf8',
+    'utf8'
   )
 
   it('guards request, readText and readBinary', () => {
@@ -94,7 +94,11 @@ describe('network module wiring', () => {
     // The shape they had before: `transport.on(NetworkEvents.api.request, async (request) =>
     // await service.request(request))`.
     expect(source).not.toMatch(/NetworkEvents\.api\.request,\s*async \(request\) =>/)
-    expect(source).not.toMatch(/NetworkEvents\.api\.readText,\s*async \(payload\) => \{\s*return await service/)
-    expect(source).not.toMatch(/NetworkEvents\.api\.readBinary,\s*async \(payload\) => \{\s*return await service/)
+    expect(source).not.toMatch(
+      /NetworkEvents\.api\.readText,\s*async \(payload\) => \{\s*return await service/
+    )
+    expect(source).not.toMatch(
+      /NetworkEvents\.api\.readBinary,\s*async \(payload\) => \{\s*return await service/
+    )
   })
 })

--- a/apps/core-app/src/main/utils/network-target-policy.ts
+++ b/apps/core-app/src/main/utils/network-target-policy.ts
@@ -1,0 +1,61 @@
+export type NetworkTargetClass = 'local' | 'internet' | 'non-http'
+
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]', '0.0.0.0'])
+
+/**
+ * Whether a hostname names a machine on the caller's own network rather than the internet.
+ *
+ * 169.254.169.254 is the cloud instance-metadata address, and loopback covers the
+ * admin panels a desktop app is uniquely well placed to reach — both are the point of
+ * separating `network.local` from `network.internet` in the permission registry.
+ */
+function isLocalHostname(hostname: string): boolean {
+  const host = hostname.replace(/^\[|\]$/g, '').toLowerCase()
+  if (LOOPBACK_HOSTS.has(host) || host === '::') return true
+  if (host.endsWith('.local') || host.endsWith('.internal') || host.endsWith('.localhost'))
+    return true
+
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host)
+  if (ipv4) {
+    const a = Number(ipv4[1])
+    const b = Number(ipv4[2])
+    if (a === 10 || a === 127) return true
+    if (a === 169 && b === 254) return true
+    if (a === 172 && b >= 16 && b <= 31) return true
+    if (a === 192 && b === 168) return true
+    return false
+  }
+
+  // IPv6 unique-local (fc00::/7) and link-local (fe80::/10).
+  return /^f[cd][0-9a-f]{2}:/.test(host) || /^fe[89ab][0-9a-f]:/.test(host)
+}
+
+/**
+ * Classifies where a network request is headed, so the right permission can be required.
+ *
+ * The three network transport handlers forwarded whatever they were given with no permission
+ * check at all, even though the registry declares network.local and network.internet for
+ * exactly this. That let a plugin sidestep the confinement
+ * installPluginViewNavigationPolicy puts on its own view: the request is issued by the main
+ * process, outside the view's session, with the user's LAN position (#906).
+ *
+ * 'non-http' covers sources that are not network requests at all — readText and readBinary
+ * accept local file paths, which are policed separately by the local-file allowlist.
+ *
+ * Anything unparseable is treated as 'local', the more restrictive answer, so a malformed
+ * target cannot fall through to the weaker permission.
+ */
+export function classifyNetworkTarget(source: unknown): NetworkTargetClass {
+  const raw = typeof source === 'string' ? source.trim() : ''
+  if (!raw) return 'local'
+
+  if (!/^https?:\/\//i.test(raw)) {
+    return 'non-http'
+  }
+
+  try {
+    return isLocalHostname(new URL(raw).hostname) ? 'local' : 'internet'
+  } catch {
+    return 'local'
+  }
+}


### PR DESCRIPTION
Closes #906.

## The defect

`request`, `readText` and `readBinary` forwarded whatever they were given to the HTTP service with **no permission check**, although the registry declares `network.local` and `network.internet` for exactly this capability.

`installPluginViewNavigationPolicy` confines a plugin view's own network to its plugin root via `session.webRequest.onBeforeRequest`. These handlers walked around it: the request is issued by the **main process**, outside that session, from the user's LAN position, and the body is returned to the plugin. localhost admin panels, `169.254.169.254` and internal hosts were all reachable.

## The rule

`withPermission` takes a fixed id, so the destination is classified first and dispatched to whichever wrapper matches:

| destination | permission |
|---|---|
| loopback, private IPv4/IPv6, link-local, `.local`/`.internal` | `network.local` |
| everything else | `network.internet` |
| a local file path (readText/readBinary) | neither — the local-file allowlist governs it |

Unparseable input classifies as **local**, the more restrictive answer, so a malformed target cannot fall through to the weaker permission.

## One thing that is intended, not overlooked

Non-plugin callers still pass through, because `channel-guard` returns early when there is no plugin id. That is the right scope here — the bypass this closes is a *plugin* escaping the policy on its own view. Gating the renderer needs a different mechanism, and pretending otherwise would overstate the containment.

## Tests

Twelve. Nine on the classifier: loopback, metadata address, private IPv4, IPv6 unique-local and link-local, `.local`/`.internal`/`.localhost`, non-http sources, unparseable input.

Two are controls in the other direction — public hosts classify as `internet`, and addresses merely *adjacent* to private ranges (`172.15.x`, `172.32.x`, `11.x`, `193.168.x`) are **not** claimed as local. Over-claiming would demand `network.local` for ordinary browsing, which is its own failure.

Three are source-level wiring guards (the module builds a transport and a service in `onInit`), asserting all **three** handlers are wrapped, both permissions appear, and none of the old direct-to-service shapes remain. All three fail against the previous handlers.

The existing network suites pass unchanged. Lint clean; `typecheck:node` reports zero errors in the changed files.