### PR TITLE
test(plugins): realign dev-toolbox, batch-rename, dev-utils and text-tools (#330)

### DIFF
--- a/packages/test/src/plugins/batch-rename.test.ts
+++ b/packages/test/src/plugins/batch-rename.test.ts
@@ -1,15 +1,26 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createPluginGlobals, loadPluginModule, withoutGlobal } from './plugin-loader'
+import { createPluginGlobals, loadPluginModule, loadPluginModuleWithSourceTransform, withoutGlobal } from './plugin-loader'
 
 const batchRenameUrl = new URL('../../../../plugins/touch-batch-rename/index.js', import.meta.url)
-const renamePlugin = loadPluginModule(batchRenameUrl)
-const { __test: renameTest } = renamePlugin
+
+// e37c92c8c removed the __test export. Both helpers still exist in the plugin and are
+// simply not exported, so they are re-exported at load time into this suite's copy of
+// the module rather than adding a test-only export back to the shipped file.
+const TEST_EXPORT_NAMES = ['parseRules', 'buildRenamePlan'] as const
+
+const renameTest = loadPluginModuleWithSourceTransform<{
+  __test: Record<(typeof TEST_EXPORT_NAMES)[number], (...args: any[]) => any>
+}>(
+  batchRenameUrl,
+  source => `${source}\nmodule.exports.__test={${TEST_EXPORT_NAMES.join(',')}}`,
+  createPluginGlobals(),
+).__test
 
 class FakeBuilder {
   item: Record<string, unknown>
 
   constructor(id: string) {
-    this.item = { id }
+    this.item = { id, meta: {}, actions: [] }
   }
 
   setSource() {
@@ -31,7 +42,14 @@ class FakeBuilder {
   }
 
   setMeta(meta: Record<string, unknown>) {
-    this.item.meta = meta
+    this.item.meta = { ...(this.item.meta as Record<string, unknown>), ...meta }
+    return this
+  }
+
+  // buildItem attaches the action id here (index.js:217-218), not to meta. Without
+  // this the items came back with no actions at all, so every lookup below missed.
+  createAndAddAction(id: string, type: string, title: string, payload?: unknown) {
+    ;(this.item.actions as unknown[]).push({ id, type, title, payload })
     return this
   }
 
@@ -60,20 +78,19 @@ describe('batch rename rules', () => {
     const now = new Date(2025, 0, 2)
     const plan = renameTest.buildRenamePlan(['/tmp/foo.txt', '/tmp/bar.txt'], rules, now)
 
-    expect(plan.items[0].nextName).toBe('IMG_foo_done_20250102_001.txt')
-    expect(plan.items[1].nextName).toBe('IMG_bar_done_20250102_002.txt')
+    // The plan item field is targetName; nextName was renamed in e37c92c8c.
+
+    expect(plan.items[0].targetName).toBe('IMG_foo_done_20250102_001.txt')
+    expect(plan.items[1].targetName).toBe('IMG_bar_done_20250102_002.txt')
   })
 
   it('blocks apply action when fs.write permission is denied', async () => {
-    const request = vi.fn(async () => false)
+    const check = vi.fn(async (permissionId: string) => permissionId === 'fs.read')
     const storageSetFile = vi.fn()
     const pushedItems: Array<Record<string, any>> = []
     const pluginModule = loadPluginModule(batchRenameUrl, createPluginGlobals({
       TuffItemBuilder: FakeBuilder,
-      permission: {
-        check: async (permissionId: string) => permissionId === 'fs.read',
-        request,
-      },
+      permission: { check },
       plugin: {
         feature: {
           clearItems() {
@@ -99,10 +116,10 @@ describe('batch rename rules', () => {
       ],
     })
 
-    const applyItem = pushedItems.find(item => item.meta?.actionId === 'apply')
+    const applyItem = pushedItems.find(item => item.actions?.[0]?.id === 'apply')
     const result = await pluginModule.onItemAction(applyItem)
 
-    expect(request).toHaveBeenCalledWith('fs.write', '需要文件写入权限以执行重命名')
+    expect(check).toHaveBeenCalledWith('fs.write')
     expect(storageSetFile).not.toHaveBeenCalled()
     expect(result).toMatchObject({
       externalAction: true,
@@ -143,7 +160,7 @@ describe('batch rename rules', () => {
       ],
     })
 
-    const applyItem = pushedItems.find(item => item.meta?.actionId === 'apply')
+    const applyItem = pushedItems.find(item => item.actions?.[0]?.id === 'apply')
 
     expect(applyItem).toBeUndefined()
     expect(storageSetFile).not.toHaveBeenCalled()
@@ -155,36 +172,62 @@ describe('batch rename rules', () => {
     ]))
   })
 
+  // hasPermission (index.js:190-196) calls permission.check only. There is no
+  // permission.request path left, so the assertions that one was called with a reason
+  // string were describing a gate that e37c92c8c removed. It also collapses three
+  // distinct situations -- denied, SDK absent, check threw -- into a single false, so
+  // all three surface as 'permission-denied'. That conflation is pinned below rather
+  // than hidden, and reported on #330: a user whose permission host is missing or
+  // broken is currently told they lack a permission.
+  function undoModule(permissionOverride: unknown, storageGetFile = vi.fn()) {
+    return {
+      storageGetFile,
+      module: loadPluginModule(batchRenameUrl, createPluginGlobals({
+        permission: permissionOverride,
+        plugin: {
+          feature: {
+            clearItems() {},
+            pushItems() {},
+          },
+          storage: {
+            getFile: storageGetFile,
+            async setFile() {},
+          },
+        },
+      })),
+    }
+  }
+
+  const undoItem = {
+    meta: { defaultAction: 'batch-rename', featureId: 'batch-rename' },
+    actions: [{ id: 'undo' }],
+  }
+
   it('blocks undo action when fs.write permission is denied', async () => {
-    const request = vi.fn(async () => false)
-    const storageGetFile = vi.fn()
-    const pluginModule = loadPluginModule(batchRenameUrl, createPluginGlobals({
-      permission: {
-        check: async () => false,
-        request,
-      },
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        storage: {
-          getFile: storageGetFile,
-          async setFile() {},
-        },
-      },
-    }))
+    const check = vi.fn(async () => false)
+    const harness = undoModule({ check })
 
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'batch-rename',
-        actionId: 'undo',
-        featureId: 'batch-rename',
-      },
+    const result = await harness.module.onItemAction(undoItem)
+
+    expect(check).toHaveBeenCalledWith('fs.write')
+    expect(harness.storageGetFile).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      externalAction: true,
+      success: false,
+      status: 'blocked',
+      reason: 'permission-denied',
+      message: '缺少 fs.write 权限',
     })
+  })
 
-    expect(request).toHaveBeenCalledWith('fs.write', '需要文件写入权限以撤销重命名')
-    expect(storageGetFile).not.toHaveBeenCalled()
+  it('blocks undo action when the permission sdk is unavailable', async () => {
+    const harness = undoModule(withoutGlobal())
+
+    const result = await harness.module.onItemAction(undoItem)
+
+    expect(harness.storageGetFile).not.toHaveBeenCalled()
+    // Reported as a denial, not as a missing SDK: hasPermission returns false for both
+    // and the caller has nothing left to tell them apart with.
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
@@ -193,143 +236,47 @@ describe('batch rename rules', () => {
     })
   })
 
-  it('blocks undo action when permission sdk is unavailable', async () => {
-    const storageGetFile = vi.fn()
-    const pluginModule = loadPluginModule(batchRenameUrl, createPluginGlobals({
-      permission: withoutGlobal(),
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        storage: {
-          getFile: storageGetFile,
-          async setFile() {},
-        },
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'batch-rename',
-        actionId: 'undo',
-        featureId: 'batch-rename',
-      },
+  it('blocks undo action when the permission check throws', async () => {
+    const check = vi.fn(async () => {
+      throw new Error('permission transport failed')
     })
+    const harness = undoModule({ check })
 
-    expect(storageGetFile).not.toHaveBeenCalled()
+    const result = await harness.module.onItemAction(undoItem)
+
+    expect(check).toHaveBeenCalledWith('fs.write')
+    expect(harness.storageGetFile).not.toHaveBeenCalled()
+    // Same collapse: a transport fault is indistinguishable from a denial here.
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-sdk-unavailable',
+      reason: 'permission-denied',
     })
   })
 
-  it('blocks apply action when fs.write permission request fails', async () => {
-    const storageSetFile = vi.fn()
-    const pushedItems: Array<Record<string, any>> = []
+  it('refuses apply before a preview exists, without touching permissions', async () => {
+    const check = vi.fn(async () => true)
     const pluginModule = loadPluginModule(batchRenameUrl, createPluginGlobals({
-      TuffItemBuilder: FakeBuilder,
-      permission: {
-        check: async (permissionId: string) => permissionId === 'fs.read',
-        request: async () => {
-          throw new Error('permission transport failed')
-        },
-      },
-      plugin: {
-        feature: {
-          clearItems() {
-            pushedItems.length = 0
-          },
-          pushItems(items: Array<Record<string, any>>) {
-            pushedItems.push(...items)
-          },
-        },
-        storage: {
-          async getFile() {
-            return null
-          },
-          setFile: storageSetFile,
-        },
-      },
+      permission: { check },
     }))
 
-    await pluginModule.onFeatureTriggered('batch-rename-request-failed', {
-      text: 'prefix:NEW_',
-      inputs: [
-        { type: 'files', content: JSON.stringify(['/tmp/example.txt']) },
-      ],
+    const result = await pluginModule.onItemAction({
+      meta: { defaultAction: 'batch-rename', featureId: 'missing-preview' },
+      actions: [{ id: 'apply' }],
     })
 
-    const applyItem = pushedItems.find(item => item.meta?.actionId === 'apply')
-    const result = await pluginModule.onItemAction(applyItem)
-
-    expect(storageSetFile).not.toHaveBeenCalled()
+    // The preview check runs before the permission gate (index.js:379-383), so a user
+    // with nothing staged is not asked for fs.write first. The old test asserted
+    // undefined, which it got only because the action id was passed where nothing read
+    // it -- the handler bailed before reaching any of this.
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-request-failed',
+      reason: 'preview-missing',
+      message: '请先生成重命名预览',
     })
-  })
-
-  it('blocks undo action when fs.write permission request fails', async () => {
-    const storageGetFile = vi.fn()
-    const pluginModule = loadPluginModule(batchRenameUrl, createPluginGlobals({
-      permission: {
-        check: async () => false,
-        request: async () => {
-          throw new Error('permission transport failed')
-        },
-      },
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        storage: {
-          getFile: storageGetFile,
-          async setFile() {},
-        },
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'batch-rename',
-        actionId: 'undo',
-        featureId: 'batch-rename',
-      },
-    })
-
-    expect(storageGetFile).not.toHaveBeenCalled()
-    expect(result).toMatchObject({
-      externalAction: true,
-      success: false,
-      status: 'blocked',
-      reason: 'permission-request-failed',
-    })
-  })
-
-  it('keeps apply inert when no preview plan exists', async () => {
-    const request = vi.fn(async () => false)
-    const pluginModule = loadPluginModule(batchRenameUrl, createPluginGlobals({
-      permission: {
-        check: async () => false,
-        request,
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'batch-rename',
-        actionId: 'apply',
-        featureId: 'missing-preview',
-      },
-    })
-
-    expect(request).not.toHaveBeenCalled()
-    expect(result).toBeUndefined()
+    expect(check).not.toHaveBeenCalled()
   })
 })

--- a/packages/test/src/plugins/dev-toolbox.test.ts
+++ b/packages/test/src/plugins/dev-toolbox.test.ts
@@ -1,10 +1,23 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it, vi } from 'vitest'
-import { createPluginGlobals, loadPluginModule, withoutGlobal } from './plugin-loader'
+import { createPluginGlobals, loadPluginModule, loadPluginModuleWithSourceTransform, withoutGlobal } from './plugin-loader'
 
 const devToolboxUrl = new URL('../../../../plugins/touch-dev-toolbox/index.js', import.meta.url)
-const toolboxPlugin = loadPluginModule(devToolboxUrl)
-const { __test: toolboxTest } = toolboxPlugin
+
+// The plugin exports its lifecycle and nothing else: e37c92c8c removed the __test
+// export in the isolated-runtime migration. Both functions below still exist, they
+// are simply not exported, so they are re-exported at load time into this test's
+// copy of the module rather than adding a test-only export to the shipped file --
+// the same approach intelligence.test.ts takes.
+const TEST_EXPORT_NAMES = ['parseToolboxConfig', 'normalizeExternalUrl'] as const
+
+const toolboxTest = loadPluginModuleWithSourceTransform<{
+  __test: Record<(typeof TEST_EXPORT_NAMES)[number], (...args: any[]) => any>
+}>(
+  devToolboxUrl,
+  source => `${source}\nmodule.exports.__test={${TEST_EXPORT_NAMES.join(',')}}`,
+  createPluginGlobals(),
+).__test
 
 describe('dev toolbox config', () => {
   it('declares network permission for opening toolbox links', () => {
@@ -40,220 +53,125 @@ describe('dev toolbox config', () => {
     expect(toolboxTest.normalizeExternalUrl('not a url')).toBe('')
   })
 
-  it('blocks invalid link payloads before permission checks', async () => {
-    const openUrl = vi.fn()
-    const check = vi.fn(async () => true)
-    const request = vi.fn(async () => true)
-    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
-      openUrl,
-      permission: { check, request },
-    }))
+  // e37c92c8c moved the permission model host-side. This plugin no longer touches the
+  // permission SDK at all: onItemAction calls openUrl and reads the thrown error,
+  // where PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED means denied and anything else
+  // means the call failed (index.js:226-241). The tests below drove permission.check /
+  // permission.request, which nothing reads any more.
+  //
+  // They also passed actionId and payload inside meta. onItemAction resolves both from
+  // item.actions[0] (index.js:197-199), so action came back null, every branch was
+  // skipped, and the handler returned undefined -- which is why all eight reported
+  // "expected undefined to match object".
+  const HOST_DENIED = 'PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED'
 
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'file:///tmp/toolbox.json' },
-      },
-    })
+  function openLinkItem(url: string) {
+    return {
+      meta: { defaultAction: 'dev-toolbox' },
+      actions: [{ id: 'open-link', payload: { url } }],
+    }
+  }
+
+  it('rejects a non-HTTP link before reaching the host', async () => {
+    const openUrl = vi.fn()
+    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({ openUrl }))
+
+    const result = await pluginModule.onItemAction(openLinkItem('file:///tmp/toolbox.json'))
 
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
       reason: 'invalid-url',
+      message: '链接地址无效，仅支持 HTTP/HTTPS',
     })
-    expect(check).not.toHaveBeenCalled()
-    expect(request).not.toHaveBeenCalled()
     expect(openUrl).not.toHaveBeenCalled()
   })
 
-  it('blocks link opening when network permission is denied', async () => {
+  it('rejects a javascript: link before reaching the host', async () => {
     const openUrl = vi.fn()
-    const request = vi.fn(async () => false)
-    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
-      openUrl,
-      permission: {
-        check: async () => false,
-        request,
-      },
-    }))
+    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({ openUrl }))
 
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'https://example.com' },
-      },
+    const result = await pluginModule.onItemAction(openLinkItem('javascript:alert(1)'))
+
+    expect(result).toMatchObject({ status: 'blocked', reason: 'invalid-url' })
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+
+  it('blocks link opening when the host denies network permission', async () => {
+    const openUrl = vi.fn(async () => {
+      throw Object.assign(new Error('/private/open denied'), { code: HOST_DENIED })
     })
+    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({ openUrl }))
+
+    const result = await pluginModule.onItemAction(openLinkItem('https://example.com'))
 
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
       reason: 'permission-denied',
+      message: '缺少 network.internet 权限',
     })
-    expect(request).toHaveBeenCalledWith('network.internet', '需要 network.internet 权限以默认浏览器打开开发工具箱链接')
-    expect(openUrl).not.toHaveBeenCalled()
   })
 
-  it('blocks link opening when permission sdk is unavailable', async () => {
-    const openUrl = vi.fn()
-    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
-      openUrl,
-      permission: withoutGlobal(),
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'https://example.com' },
-      },
+  it('separates a failed host open from a denied one', async () => {
+    const openUrl = vi.fn(async () => {
+      throw new Error('open transport failed')
     })
+    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({ openUrl }))
 
+    const result = await pluginModule.onItemAction(openLinkItem('https://example.com'))
+
+    // A transport failure reported as a permission denial sends the user to a
+    // permission screen that has nothing to fix.
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-sdk-unavailable',
+      reason: 'open-url-failed',
+      message: '打开外部链接失败',
     })
-    expect(openUrl).not.toHaveBeenCalled()
   })
 
-  it('blocks link opening when network permission request fails', async () => {
-    const openUrl = vi.fn()
-    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
-      openUrl,
-      permission: {
-        check: async () => false,
-        request: async () => {
-          throw new Error('permission transport failed')
-        },
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'https://example.com' },
-      },
-    })
-
-    expect(result).toMatchObject({
-      externalAction: true,
-      success: false,
-      status: 'blocked',
-      reason: 'permission-request-failed',
-    })
-    expect(openUrl).not.toHaveBeenCalled()
-  })
-
-  it('blocks link opening when network permission check fails without requesting', async () => {
-    const openUrl = vi.fn()
-    const request = vi.fn(async () => true)
-    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
-      openUrl,
-      permission: {
-        check: async () => {
-          throw new Error('permission check failed')
-        },
-        request,
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'https://example.com' },
-      },
-    })
-
-    expect(result).toMatchObject({
-      externalAction: true,
-      success: false,
-      status: 'blocked',
-      reason: 'permission-request-failed',
-    })
-    expect(request).not.toHaveBeenCalled()
-    expect(openUrl).not.toHaveBeenCalled()
-  })
-
-  it('blocks link opening when the openUrl capability is unavailable', async () => {
+  it('blocks link opening when the host exposes no openUrl capability', async () => {
     const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
       openUrl: withoutGlobal(),
-      permission: {
-        check: async () => true,
-        request: async () => true,
-      },
     }))
 
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'https://example.com' },
-      },
-    })
+    const result = await pluginModule.onItemAction(openLinkItem('https://example.com'))
 
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
       reason: 'open-url-unavailable',
+      message: '当前运行时不支持打开外部链接',
     })
   })
 
-  it('returns an explicit blocked result when openUrl fails', async () => {
-    const openUrl = vi.fn(async () => {
-      throw new Error('host open failed')
-    })
-    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
-      openUrl,
-      permission: {
-        check: async () => true,
-        request: async () => true,
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'https://example.com' },
-      },
-    })
-
-    expect(result).toMatchObject({
-      externalAction: true,
-      success: false,
-      status: 'blocked',
-      reason: 'open-url-failed',
-    })
-    expect(openUrl).toHaveBeenCalledWith('https://example.com/')
-  })
-
-  it('opens link after network permission is granted', async () => {
+  it('opens a normalized link when the host allows it', async () => {
     const openUrl = vi.fn(async () => undefined)
-    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({
-      openUrl,
-      permission: {
-        check: async () => true,
-        request: async () => true,
-      },
-    }))
+    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({ openUrl }))
 
-    const result = await pluginModule.onItemAction({
-      meta: {
-        defaultAction: 'dev-toolbox',
-        actionId: 'open-link',
-        payload: { url: 'https://example.com' },
-      },
-    })
+    const result = await pluginModule.onItemAction(openLinkItem('http://example.com'))
 
     expect(result).toMatchObject({ externalAction: true, status: 'started' })
-    expect(openUrl).toHaveBeenCalledWith('https://example.com/')
+    // normalizeExternalUrl runs before the host call, so the host receives the parsed
+    // form rather than the raw payload.
+    expect(openUrl).toHaveBeenCalledWith('http://example.com/')
+  })
+
+  it('ignores items whose default action is not the toolbox', async () => {
+    const openUrl = vi.fn()
+    const pluginModule = loadPluginModule(devToolboxUrl, createPluginGlobals({ openUrl }))
+
+    const result = await pluginModule.onItemAction({
+      meta: { defaultAction: 'something-else' },
+      actions: [{ id: 'open-link', payload: { url: 'https://example.com' } }],
+    })
+
+    expect(result).toBeUndefined()
+    expect(openUrl).not.toHaveBeenCalled()
   })
 })

--- a/packages/test/src/plugins/dev-utils.test.ts
+++ b/packages/test/src/plugins/dev-utils.test.ts
@@ -1,11 +1,33 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createPluginGlobals, loadPluginModule, withoutGlobal } from './plugin-loader'
+import { createPluginGlobals, loadPluginModule, loadPluginModuleWithSourceTransform, withoutGlobal } from './plugin-loader'
 
-const devUtilsPlugin = loadPluginModule(
-  new URL('../../../../plugins/touch-dev-utils/index.js', import.meta.url),
+const devUtilsUrl = new URL('../../../../plugins/touch-dev-utils/index.js', import.meta.url)
+
+// e37c92c8c removed the __test export in the isolated-runtime migration. All ten
+// helpers below still exist in the plugin, they are simply not exported, so they are
+// re-exported at load time into this suite's copy of the module rather than adding a
+// test-only export back to the shipped file -- the approach intelligence.test.ts
+// already uses.
+const TEST_EXPORT_NAMES = [
+  'buildQueryString',
+  'escapeStringLiteral',
+  'formatTimestampDetails',
+  'parseJwt',
+  'parseQueryString',
+  'toCamelCase',
+  'toKebabCase',
+  'toPascalCase',
+  'toSnakeCase',
+  'unescapeStringLiteral',
+] as const
+
+const devUtilsTest = loadPluginModuleWithSourceTransform<{
+  __test: Record<(typeof TEST_EXPORT_NAMES)[number], (...args: any[]) => any>
+}>(
+  devUtilsUrl,
+  source => `${source}\nmodule.exports.__test={${TEST_EXPORT_NAMES.join(',')}}`,
   createPluginGlobals(),
-)
-const { __test: devUtilsTest } = devUtilsPlugin
+).__test
 
 class FakeBuilder {
   item: Record<string, any>
@@ -95,7 +117,7 @@ describe('touch-dev-utils helpers', () => {
   it('builds copy actions as plugin actions', async () => {
     const pushed: Array<Array<Record<string, any>>> = []
     const pluginModule = loadPluginModule(
-      new URL('../../../../plugins/touch-dev-utils/index.js', import.meta.url),
+      devUtilsUrl,
       createPluginGlobals({
         TuffItemBuilder: FakeBuilder,
         plugin: {
@@ -125,63 +147,96 @@ describe('touch-dev-utils helpers', () => {
     expect(camelItem?.actions[0].payload).toEqual({ text: expect.any(String) })
   })
 
-  it('blocks copy action when clipboard.write permission is denied', async () => {
-    const writeText = vi.fn()
-    const request = vi.fn(async () => false)
+  // e37c92c8c moved the permission model host-side: this plugin no longer calls the
+  // permission SDK, it calls clipboard.writeText and reads the thrown error, where
+  // PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED means denied and anything else means the
+  // write failed (index.js:561-570). The two tests here drove permission.request,
+  // which nothing reads any more.
+  const HOST_DENIED = 'PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED'
+
+  function copyItem(text: string) {
+    return {
+      meta: { defaultAction: 'copy' },
+      actions: [{ type: 'copy', payload: text }],
+    }
+  }
+
+  it('blocks copy action when the host denies clipboard.write', async () => {
+    const writeText = vi.fn(async () => {
+      throw Object.assign(new Error('/private/clipboard denied'), { code: HOST_DENIED })
+    })
     const pluginModule = loadPluginModule(
-      new URL('../../../../plugins/touch-dev-utils/index.js', import.meta.url),
-      createPluginGlobals({
-        clipboard: { writeText },
-        permission: {
-          check: async () => false,
-          request,
-        },
-      }),
+      devUtilsUrl,
+      createPluginGlobals({ clipboard: { writeText } }),
     )
 
-    const result = await pluginModule.onItemAction({
-      meta: { defaultAction: 'copy' },
-      actions: [{ type: 'copy', payload: 'helloWorld' }],
-    })
+    const result = await pluginModule.onItemAction(copyItem('helloWorld'))
 
-    expect(request).toHaveBeenCalledWith('clipboard.write', '需要剪贴板写入权限以复制开发工具结果')
-    expect(writeText).not.toHaveBeenCalled()
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
       reason: 'permission-denied',
+      message: '缺少 clipboard.write 权限',
     })
   })
 
-  it('blocks copy action when permission sdk is unavailable', async () => {
-    const writeText = vi.fn()
+  it('separates a failed clipboard write from a denied one', async () => {
+    const writeText = vi.fn(async () => {
+      throw new Error('clipboard transport failed')
+    })
     const pluginModule = loadPluginModule(
-      new URL('../../../../plugins/touch-dev-utils/index.js', import.meta.url),
-      createPluginGlobals({
-        clipboard: { writeText },
-        permission: withoutGlobal(),
-      }),
+      devUtilsUrl,
+      createPluginGlobals({ clipboard: { writeText } }),
     )
 
-    const result = await pluginModule.onItemAction({
-      meta: { defaultAction: 'copy' },
-      actions: [{ type: 'copy', payload: 'helloWorld' }],
-    })
+    const result = await pluginModule.onItemAction(copyItem('helloWorld'))
 
-    expect(writeText).not.toHaveBeenCalled()
+    // Reporting a transport failure as a denial sends the user to a permission screen
+    // that has nothing to fix.
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: 'clipboard-write-failed',
+      message: '复制失败',
     })
+  })
+
+  it('blocks copy action when the host exposes no clipboard', async () => {
+    const pluginModule = loadPluginModule(
+      devUtilsUrl,
+      createPluginGlobals({ clipboard: withoutGlobal() }),
+    )
+
+    const result = await pluginModule.onItemAction(copyItem('helloWorld'))
+
+    expect(result).toMatchObject({
+      externalAction: true,
+      success: false,
+      status: 'blocked',
+      reason: 'clipboard-unavailable',
+      message: '当前环境不支持写入剪贴板',
+    })
+  })
+
+  it('copies the payload when the host allows it', async () => {
+    const writeText = vi.fn(async () => undefined)
+    const pluginModule = loadPluginModule(
+      devUtilsUrl,
+      createPluginGlobals({ clipboard: { writeText } }),
+    )
+
+    const result = await pluginModule.onItemAction(copyItem('helloWorld'))
+
+    expect(result).toMatchObject({ externalAction: true, status: 'started' })
+    expect(writeText).toHaveBeenCalledWith('helloWorld')
   })
 
   it('copies action payload after clipboard.write permission is granted', async () => {
     const writeText = vi.fn()
     const pluginModule = loadPluginModule(
-      new URL('../../../../plugins/touch-dev-utils/index.js', import.meta.url),
+      devUtilsUrl,
       createPluginGlobals({
         clipboard: { writeText },
         permission: {

--- a/packages/test/src/plugins/text-tools.test.ts
+++ b/packages/test/src/plugins/text-tools.test.ts
@@ -1,7 +1,41 @@
-import { describe, expect, it, vi } from 'vitest'
+import { createHash } from 'node:crypto'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { createPluginGlobals, loadPluginModule, withoutGlobal } from './plugin-loader'
 
 const textToolsUrl = new URL('../../../../plugins/touch-text-tools/index.js', import.meta.url)
+
+// The plugin's MD5 / SHA-1 items call globalThis.crypto.digest(algorithm, bytes) --
+// a host capability, not Web Crypto (whose digest lives on crypto.subtle and has no
+// MD5 anyway). Node's global crypto has no such method, so digestHex threw
+// CRYPTO_DIGEST_UNAVAILABLE. The hash items are not individually guarded, so the throw
+// escaped onFeatureTriggered and every test in this file received the generic
+// '加载失败' item rather than any real output -- four different assertions, one cause.
+//
+// It is installed here rather than through createPluginGlobals because the loader
+// restores overridden globals as soon as the module finishes compiling. Globals the
+// plugin destructures at module scope survive that; globalThis.crypto is read inside
+// digestHex at call time, long after the restore, so it has to be present for the
+// duration of the test. Backed by node:crypto so the hashes are genuine.
+const realCrypto = Object.getOwnPropertyDescriptor(globalThis, 'crypto')
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, 'crypto', {
+    configurable: true,
+    writable: true,
+    value: {
+      async digest(algorithm: string, data: Uint8Array) {
+        const hash = createHash(algorithm.toLowerCase().replace('-', ''))
+        hash.update(data)
+        return new Uint8Array(hash.digest()).buffer
+      },
+    },
+  })
+})
+
+afterAll(() => {
+  if (realCrypto)
+    Object.defineProperty(globalThis, 'crypto', realCrypto)
+})
 
 class FakeBuilder {
   item: Record<string, any>
@@ -73,22 +107,27 @@ describe('touch-text-tools actions', () => {
     })
   })
 
-  it('blocks copy action when clipboard.write permission is denied', async () => {
-    const hide = vi.fn()
-    const writeText = vi.fn()
-    const request = vi.fn(async () => false)
-    const pluginModule = loadPluginModule(textToolsUrl, createPluginGlobals({
-      clipboard: { writeText },
-      permission: {
-        check: async () => false,
-        request,
-      },
+  // e37c92c8c moved the permission model host-side: this plugin no longer calls the
+  // permission SDK, it calls clipboard.writeText and reads the thrown error, where
+  // PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED means denied and anything else means the
+  // write failed (index.js:324-333). These drove permission.request, which nothing
+  // reads any more.
+  const HOST_DENIED = 'PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED'
+
+  function copyItem(text: string) {
+    return {
+      meta: { defaultAction: 'copy' },
+      actions: [{ id: 'copy', type: 'plugin', payload: { text } }],
+    }
+  }
+
+  function moduleWithClipboard(clipboard: unknown) {
+    return loadPluginModule(textToolsUrl, createPluginGlobals({
+      TuffItemBuilder: FakeBuilder,
+      clipboard,
       plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        box: { hide },
+        feature: { clearItems() {}, pushItems() {} },
+        box: { hide() {} },
         storage: {
           async getFile() {
             return null
@@ -97,90 +136,60 @@ describe('touch-text-tools actions', () => {
         },
       },
     }))
+  }
 
-    const result = await pluginModule.onItemAction({
-      meta: { defaultAction: 'copy' },
-      actions: [{ type: 'copy', payload: 'HELLO' }],
+  it('blocks copy action when the host denies clipboard.write', async () => {
+    const writeText = vi.fn(async () => {
+      throw Object.assign(new Error('/private/clipboard denied'), { code: HOST_DENIED })
     })
 
-    expect(request).toHaveBeenCalledWith('clipboard.write', '需要剪贴板写入权限以复制文本工具结果')
-    expect(writeText).not.toHaveBeenCalled()
-    expect(hide).not.toHaveBeenCalled()
+    const result = await moduleWithClipboard({ writeText }).onItemAction(copyItem('HELLO'))
+
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
       reason: 'permission-denied',
+      message: '缺少 clipboard.write 权限',
     })
   })
 
-  it('blocks copy action when permission sdk is unavailable', async () => {
-    const hide = vi.fn()
-    const writeText = vi.fn()
-    const pluginModule = loadPluginModule(textToolsUrl, createPluginGlobals({
-      clipboard: { writeText },
-      permission: withoutGlobal(),
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        box: { hide },
-        storage: {
-          async getFile() {
-            return null
-          },
-          async setFile() {},
-        },
-      },
-    }))
-
-    const result = await pluginModule.onItemAction({
-      meta: { defaultAction: 'copy' },
-      actions: [{ type: 'copy', payload: 'HELLO' }],
+  it('separates a failed clipboard write from a denied one', async () => {
+    const writeText = vi.fn(async () => {
+      throw new Error('clipboard transport failed')
     })
 
-    expect(writeText).not.toHaveBeenCalled()
-    expect(hide).not.toHaveBeenCalled()
+    const result = await moduleWithClipboard({ writeText }).onItemAction(copyItem('HELLO'))
+
+    // Reporting a transport failure as a denial sends the user to a permission screen
+    // that has nothing to fix.
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: 'clipboard-write-failed',
+      message: '复制失败',
     })
   })
 
-  it('copies action payload after clipboard.write permission is granted', async () => {
-    const hide = vi.fn()
-    const writeText = vi.fn()
-    const pluginModule = loadPluginModule(textToolsUrl, createPluginGlobals({
-      clipboard: { writeText },
-      permission: {
-        check: async () => true,
-        request: vi.fn(),
-      },
-      plugin: {
-        feature: {
-          clearItems() {},
-          pushItems() {},
-        },
-        box: { hide },
-        storage: {
-          async getFile() {
-            return null
-          },
-          async setFile() {},
-        },
-      },
-    }))
+  it('blocks copy action when the host exposes no clipboard', async () => {
+    const result = await moduleWithClipboard(withoutGlobal()).onItemAction(copyItem('HELLO'))
 
-    const result = await pluginModule.onItemAction({
-      meta: { defaultAction: 'copy' },
-      actions: [{ type: 'copy', payload: { text: 'HELLO' } }],
+    expect(result).toMatchObject({
+      externalAction: true,
+      success: false,
+      status: 'blocked',
+      reason: 'clipboard-unavailable',
+      message: '当前环境不支持写入剪贴板',
     })
+  })
 
-    expect(writeText).toHaveBeenCalledWith('HELLO')
-    expect(hide).toHaveBeenCalledTimes(1)
+  it('copies the payload text when the host allows it', async () => {
+    const writeText = vi.fn(async () => undefined)
+
+    const result = await moduleWithClipboard({ writeText }).onItemAction(copyItem('HELLO'))
+
     expect(result).toMatchObject({ externalAction: true, status: 'started' })
+    expect(writeText).toHaveBeenCalledWith('HELLO')
   })
 })


### PR DESCRIPTION
Refs #330. Retarget of #1199 + #1202 (both opened against `master` by mistake), combined
since they're the same class of change.

**29 failures → 0.** All four suites pass on this branch: **35/35**.

| suite | before |
|---|---|
| `dev-toolbox` | 11 failing |
| `batch-rename` | 7 failing |
| `dev-utils` | 7 failing |
| `text-tools` | 4 failing |

### `__test` is gone — deliberately

`e37c92c8c` removed it, and the plugins' own suites assert its absence. The internals are
re-exported **at load time into the test's copy of the module** — the pattern
`intelligence.test.ts` already uses — rather than adding a test-only export back to a
shipped plugin.

### The action shape moved

`onItemAction` resolves the action id and payload from `item.actions[0]`, not `item.meta`.
The tests passed them in `meta`, so the handler fell through every branch and returned
`undefined` — which is why unrelated behaviours all reported the same symptom.

### The permission model moved host-side

`ensurePermission` and the `permission.request` calls were deleted. Plugins now call the
capability and read the thrown error: `PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED` means
denied, anything else means the call failed. `batch-rename` keeps `permission.check` only.

### `text-tools`: four failures, one cause

The MD5/SHA-1 items call `globalThis.crypto.digest` — a **host capability**, not Web Crypto
(whose `digest` lives on `crypto.subtle` and has no MD5). Nothing provided it, so
`digestHex` threw and, because the hash items aren't individually guarded, the throw escaped
`onFeatureTriggered` and every test got the plugin's generic `加载失败` item.

**Worth knowing:** `createPluginGlobals` can't supply that. The loader restores overridden
globals as soon as the module finishes *compiling*; globals destructured at module scope
survive, but `globalThis.crypto` is read inside `digestHex` at call time. It has to go in
`beforeAll`.

### Two behaviours now pinned

- **A transport failure is not a permission denial.** Three plugins distinguish them and
  nothing was checking it — conflating them sends a user to a permission screen with nothing
  to fix.
- **`hasPermission` collapses three cases into one.** Denied, SDK-absent and check-threw all
  become `false`, so all three surface as `permission-denied`. Pinned as current behaviour
  and flagged — a user whose permission host is missing is currently told they *lack a
  permission*. Your call whether that's worth separating.

### One test was passing for the wrong reason

`keeps apply inert when no preview plan exists` asserted `undefined` — which it got only
because the action id was passed where nothing reads it, so the handler bailed before
reaching any logic. Against the real shape the plugin returns `preview-missing` **without
touching permissions**. Rewritten to assert that.