### PR TITLE
test(core-app): stop widget-registry losing 20 tests to a tight hook timeout (#323)

### DIFF
--- a/apps/core-app/src/renderer/src/modules/plugin/widget-registry.test.ts
+++ b/apps/core-app/src/renderer/src/modules/plugin/widget-registry.test.ts
@@ -103,7 +103,13 @@ describe('widget-registry runtime hosts', () => {
       handleWidgetFailed,
       handleWidgetRegister
     } = await import('./widget-registry'))
-  }, 10000)
+    // 30s, not 10s. This import pulls a large graph and takes ~4.5s on its own, but the
+    // hook runs while the rest of the 636-file suite is being transformed concurrently,
+    // and under that contention it exceeded 10s. A timed-out beforeAll fails the whole
+    // file with *zero* failed tests, so these 20 disappeared from the run rather than
+    // reporting anything -- the failure mode is silence, which is why the headroom is
+    // worth more than the tightness here.
+  }, 30000)
 
   beforeEach(() => {
     transportState.handlers.clear()


### PR DESCRIPTION
Refs #323. Found while re-baselining this issue against `app-shell-v2`.

The suite's `beforeAll` dynamically imports `./widget-registry` with a **10 second**
budget. On its own the whole file takes about **4.5s**, so the budget looks generous — but
the hook runs while the rest of the **636-file** suite is being transformed concurrently,
and under that contention it went over.

### The failure mode is silence

A timed-out `beforeAll` fails the file with **zero failed tests**. The 20 tests were
reported as **skipped**, not failed, so nothing in the summary said they had stopped
running.

That's the same shape as the two suites recovered in #1224 — and the third time on this
issue that the real work has been making an invisible failure visible.

```
test files   5 failed → 4 failed
passing      5272 → 5292
skipped      28 → 8
```

### Why raise it rather than restructure

The dynamic import exists so the module is loaded *after* the mocks are in place, which is
worth keeping. For a hook whose failure is invisible, headroom is worth more than
tightness — 30s costs nothing on a run that takes 4.5s.

### Where CoreApp stands on this branch

The remaining **4** failures are unrelated to test hygiene:

| | |
|---|---|
| `runtime-modules` | node-pty not installed in this worktree — environmental |
| `native-screenshot-transport-napi` | drives a real screen capture, needs macOS Screen Recording permission — environmental |
| `runtime-modules.contract` | the **openai v4/v6 closure conflict** — this issue's blocker, and it should stay red |
| `quick-ops-flow-ai-adapter-audit` | fixed in #1227 |

So with #1227 and this, CoreApp on `app-shell-v2` is down to two environmental failures and
the one real blocker.