### PR TITLE
fix(utils): sanitize markdown by parsing it rather than by serial replacement

### DIFF
--- a/packages/utils/__tests__/renderer/markdown-sanitizer.dom.test.ts
+++ b/packages/utils/__tests__/renderer/markdown-sanitizer.dom.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest'
+import { sanitizeMarkdownHtml } from '../../renderer/shared/markdown-sanitizer'
+
+/**
+ * The parse-and-serialize path (#900).
+ *
+ * The pragma on line 1 is load-bearing: sanitizeMarkdownHtml only parses when a DOM exists,
+ * and the repo's default vitest environment is node. Without it this file would silently
+ * exercise the regex fallback and prove nothing about the path the renderer actually takes.
+ *
+ * The defect: the regex chain ran its passes in sequence over each other's output, so
+ * deleting an attribute spliced the surrounding text into something new.
+ */
+
+/** Inputs whose sanitised form used to be executable. Verified against the pre-fix chain. */
+const SPLICES = [
+  {
+    name: 'an on-handler reassembled around a deleted style attribute',
+    input: '<img src="/nope.png" on style="y"error=alert(document.domain)>',
+    was: '<img src="/nope.png" onerror=alert(document.domain)>',
+  },
+  {
+    name: 'an iframe reassembled around a deleted handler',
+    input: '<i onerror="x"frame src="//evil.example">',
+    was: '<iframe src="//evil.example">',
+  },
+  {
+    name: 'an object element reassembled around a deleted handler',
+    input: '<obje onerror="x"ct data="//evil.example">',
+    was: '<object data="//evil.example">',
+  },
+]
+
+describe('sanitizeMarkdownHtml with a DOM', () => {
+  it('confirms it is really parsing, so the assertions below mean something', () => {
+    expect(typeof DOMParser).not.toBe('undefined')
+  })
+
+  it.each(SPLICES)('does not reassemble $name', ({ input }) => {
+    const output = sanitizeMarkdownHtml(input)
+    expect(output).not.toMatch(/\son[a-z]+\s*=/i)
+    expect(output).not.toMatch(/<(iframe|object|embed|script)\b/i)
+  })
+
+  it('still strips the cases the old chain already handled', () => {
+    expect(sanitizeMarkdownHtml('<script>alert(1)</script>')).not.toContain('alert')
+    expect(sanitizeMarkdownHtml('<img src=x onerror=alert(1)>')).not.toContain('onerror')
+    expect(sanitizeMarkdownHtml('<a href="javascript:alert(1)">x</a>')).not.toContain('javascript:')
+    expect(sanitizeMarkdownHtml('<a/href="javascript:alert(1)">x</a>')).not.toContain('javascript:')
+  })
+
+  it('drops style and the other url-bearing attributes', () => {
+    for (const attribute of ['style="x"', 'formaction="/x"', 'srcdoc="<b>"', 'ping="/x"'])
+      expect(sanitizeMarkdownHtml(`<a ${attribute}>x</a>`)).not.toContain(attribute.split('=')[0])
+  })
+
+  it('keeps ordinary markdown output intact', () => {
+    // Positive control: a sanitiser that emptied everything would satisfy every assertion
+    // above while making every README blank.
+    const output = sanitizeMarkdownHtml(
+      '<p>Hello <strong>world</strong> <a href="https://example.test">link</a></p>',
+    )
+    expect(output).toContain('<strong>world</strong>')
+    expect(output).toContain('href="https://example.test"')
+  })
+
+  it('keeps a relative image, which is how plugin READMEs reference assets', () => {
+    expect(sanitizeMarkdownHtml('<img src="./logo.png">')).toContain('src="./logo.png"')
+  })
+
+  it('removes comments, which can carry payload text', () => {
+    expect(sanitizeMarkdownHtml('<p>a<!-- <img src=x onerror=alert(1)> -->b</p>')).not.toContain('onerror')
+  })
+})

--- a/packages/utils/__tests__/renderer/markdown-sanitizer.test.ts
+++ b/packages/utils/__tests__/renderer/markdown-sanitizer.test.ts
@@ -86,3 +86,37 @@ describe('attribute separators before href/src', () => {
     )
   })
 })
+
+/**
+ * The no-DOM fallback (#900).
+ *
+ * This file runs under the repo default environment, node, where DOMParser does not exist —
+ * so these exercise the regex path, which server-side rendering also takes. It is still a
+ * sequential chain, but it is applied until the output stops changing: a splice produces text
+ * the next round strips.
+ */
+describe('sanitizeMarkdownHtml without a DOM', () => {
+  it('confirms there is no DOM here, so these are the fallback', () => {
+    // Without this the file would quietly become a duplicate of the jsdom suite if the
+    // default environment ever changed.
+    expect(typeof globalThis.DOMParser).toBe('undefined')
+  })
+
+  it('does not leave a handler spliced back together', () => {
+    // Pre-fix this returned <img src="/nope.png" onerror=alert(document.domain)>.
+    const output = sanitizeMarkdownHtml('<img src="/nope.png" on style="y"error=alert(document.domain)>')
+    expect(output).not.toMatch(/\son[a-z]+\s*=/i)
+  })
+
+  it('does not leave a dangerous element spliced back together', () => {
+    for (const input of ['<i onerror="x"frame src="//evil.example">', '<obje onerror="x"ct data="//evil.example">'])
+      expect(sanitizeMarkdownHtml(input), input).not.toMatch(/<(iframe|object)\b/i)
+  })
+
+  it('still passes ordinary content through', () => {
+    // Positive control: iterating to a fixed point must not erode valid markup.
+    const output = sanitizeMarkdownHtml('<p>Hello <strong>world</strong> <a href="https://example.test">l</a></p>')
+    expect(output).toContain('<strong>world</strong>')
+    expect(output).toContain('href="https://example.test"')
+  })
+})

--- a/packages/utils/renderer/shared/markdown-sanitizer.ts
+++ b/packages/utils/renderer/shared/markdown-sanitizer.ts
@@ -56,9 +56,99 @@ function stripDangerousElements(html: string): string {
     .replace(new RegExp(`<\\/?(?:${DANGEROUS_ELEMENTS})\\b[^>]*>`, 'gi'), '')
 }
 
-export function sanitizeMarkdownHtml(html: string): string {
-  if (!html) return ''
+const DANGEROUS_ELEMENT_SET = new Set(DANGEROUS_ELEMENTS.split('|'))
+const URL_ATTRIBUTES = new Set(['href', 'src'])
+const BANNED_ATTRIBUTES = new Set([
+  'style',
+  'formaction',
+  'xlink:href',
+  'action',
+  'srcdoc',
+  'background',
+  'ping',
+])
 
+/**
+ * Parses the HTML, filters it as a tree, and serialises the result.
+ *
+ * The regex chain below applies its passes in sequence over each other's output, so deleting
+ * an attribute can splice the surrounding text into something new. Executing it proves the
+ * point: `<img src="/nope.png" on style="y"error=alert(1)>` came out as
+ * `<img src="/nope.png" onerror=alert(1)>`, and `<i onerror="x"frame src="//evil">` became a
+ * real iframe (#900). No amount of pass ordering fixes that shape — the passes are the
+ * problem.
+ *
+ * A tree has no such seams: an attribute is removed from a node, not from a string, so
+ * nothing can be spliced together by its removal. The policy applied here is the same one the
+ * regexes expressed, so this is a change of mechanism rather than of what counts as safe.
+ *
+ * Returns null when there is no DOM to parse with, which is the caller's signal to fall back.
+ */
+function sanitizeByParsing(html: string): string | null {
+  if (typeof DOMParser === 'undefined')
+    return null
+
+  let doc: Document
+  try {
+    doc = new DOMParser().parseFromString(`<body>${html}</body>`, 'text/html')
+  }
+  catch {
+    return null
+  }
+  if (!doc?.body)
+    return null
+
+  // Comments can hide payload content and are not needed in rendered markdown.
+  const walker = doc.createTreeWalker(doc.body, 128 /* NodeFilter.SHOW_COMMENT */)
+  const comments: ChildNode[] = []
+  while (walker.nextNode()) comments.push(walker.currentNode as ChildNode)
+  for (const comment of comments) comment.remove()
+
+  for (const element of Array.from(doc.body.querySelectorAll('*'))) {
+    if (DANGEROUS_ELEMENT_SET.has(element.tagName.toLowerCase())) {
+      element.remove()
+      continue
+    }
+
+    for (const attribute of Array.from(element.attributes)) {
+      const name = attribute.name.toLowerCase()
+
+      if (name.startsWith('on') || BANNED_ATTRIBUTES.has(name)) {
+        element.removeAttribute(attribute.name)
+        continue
+      }
+
+      if (URL_ATTRIBUTES.has(name) && !isAllowedUrl(attribute.value)) {
+        element.removeAttribute(attribute.name)
+      }
+    }
+  }
+
+  return doc.body.innerHTML
+}
+
+/**
+ * The fallback for contexts with no DOM — server-side rendering, and unit tests that have not
+ * asked for one.
+ *
+ * Still the sequential regex chain, so still subject in principle to the splice class in
+ * #900, but applied repeatedly until the output stops changing. A splice produces text that
+ * the next round strips, so the fixed point is reached with the handler gone. The iteration
+ * cap is a guard against a pathological input, not an expected path: two rounds settle
+ * everything observed.
+ */
+function sanitizeByStrippingUntilStable(html: string): string {
+  let current = html
+  for (let round = 0; round < 8; round += 1) {
+    const next = stripOnce(current)
+    if (next === current)
+      return current
+    current = next
+  }
+  return current
+}
+
+function stripOnce(html: string): string {
   return stripDangerousElements(html)
     // Event-handler attributes. Allow `/` as a separator too, since
     // `<img/onerror=...>` is valid HTML that the previous `\s+on` pattern missed.
@@ -81,6 +171,16 @@ export function sanitizeMarkdownHtml(html: string): string {
       if (!isAllowedUrl(value)) return ''
       return ` ${name.toLowerCase()}="${sanitizeAttributeValue(value.trim())}"`
     })
+}
+
+export function sanitizeMarkdownHtml(html: string): string {
+  if (!html) return ''
+
+  const parsed = sanitizeByParsing(html)
+  if (parsed !== null)
+    return parsed
+
+  return sanitizeByStrippingUntilStable(html)
 }
 
 export function renderMarkdownToSafeHtml(markdown: string): string {


### PR DESCRIPTION
Closes #900.

## The defect, reproduced

The passes run in sequence over each other's output, so deleting an attribute splices the surrounding text into something new. All three reported cases confirmed by executing the chain:

```
<img src="/nope.png" on style="y"error=alert(1)>  ->  <img src="/nope.png" onerror=alert(1)>
<i onerror="x"frame src="//evil.example">         ->  <iframe src="//evil.example">
<obje onerror="x"ct data="//evil.example">        ->  <object data="//evil.example">
```

That output reaches `v-html` in the Nexus store *and* the Electron renderer, and `readme_markdown` is attacker-controlled by anyone holding `plugin:publish`.

## The fix

Where a DOM exists, the HTML is parsed, filtered as a tree, and serialised. **A tree has no seams** — an attribute is removed from a node, not from a string, so nothing can be spliced together by its removal.

The policy is the one the regexes already expressed: same dangerous elements, same banned attributes, same `isAllowedUrl` on `href`/`src`. This changes the *mechanism*, not what counts as safe.

## Why not DOMPurify

The issue offered DOMPurify **or** a parse-and-serialize allowlist. I took the second.

`dompurify` is already in the lockfile via `packages/tuffex`, but adding it to `packages/utils` changes the lockfile's importers — and this worktree shares `node_modules` with the main checkout, so regenerating it here would write into that tree. `DOMParser` needs no dependency and exists wherever this code runs.

## The fallback, stated honestly

Server-side rendering has no DOM, so the regex chain remains for that path — now applied **until the output stops changing**, since a splice produces text the next round strips.

That is a mitigation of the class, not a proof against it. The comment in the code says so; I would rather the next reader know the fallback is the weaker path than assume both are equivalent.

## Tests

Thirteen new, across both paths.

The jsdom file asserts `DOMParser` **is** defined; the node file asserts it **is not**. Without those, either file would silently degrade into a copy of the other — the same trap as #580.

**Five fail against the previous version.** Positive controls on both sides: ordinary markdown, relative image sources (`./logo.png`, how plugin READMEs reference assets) and links all survive.

## Regression check

`apps/core-app/src/renderer` — identical before and after (1 pre-existing failure, 728 passing). The `PreviewSDK` latency benchmark fails only under full-suite load and passes in isolation both ways; unrelated to this change.