### PR TITLE
fix(nexus): refuse the committed development AUTH_SECRET outside local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,12 @@ tmp/
 # ========================
 # ignore all .env.*.local
 .env*.local
+# .env itself, not just the *.local variants. apps/nexus/.env was tracked and shipped a
+# working AUTH_SECRET (#890); *.local alone never covered the plain name.
+.env
+.env.*
+!.env.example
+!.env.*.example
 .env.sentry-build-plugin
 *.local.json
 

--- a/apps/nexus/.env
+++ b/apps/nexus/.env
@@ -1,6 +1,0 @@
-AUTH_SECRET=dev-secret-change-me
-AUTH_ORIGIN=http://localhost:3200
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
-RESEND_API_KEY=
-AUTH_EMAIL_FROM=hello@tuff.app

--- a/apps/nexus/.env.example
+++ b/apps/nexus/.env.example
@@ -1,0 +1,9 @@
+# Generate one per environment, e.g. `openssl rand -base64 32`.
+# The previous value of this line was committed to the repository, so it is public and
+# is now refused outside local development (#890). Never reuse it.
+AUTH_SECRET=
+AUTH_ORIGIN=http://localhost:3200
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+RESEND_API_KEY=
+AUTH_EMAIL_FROM=hello@tuff.app

--- a/apps/nexus/server/utils/runtimeCredentialPolicy.test.ts
+++ b/apps/nexus/server/utils/runtimeCredentialPolicy.test.ts
@@ -58,3 +58,46 @@ describe('runtimeCredentialPolicy', () => {
     expect(assertRuntimeCredential(name, value, { localDevelopment: true })).toBe(value)
   })
 })
+
+/**
+ * The value that shipped in a tracked apps/nexus/.env (#890).
+ *
+ * `dev-secret-change-me` was public in the repository, 20 characters long, and matched none of
+ * the guard's rules: the placeholder patterns were anchored at the start, so `^change[-_ ]?me`
+ * never saw a value ending in it. Any deployment that picked that file up signed app JWTs with
+ * a key anyone could read, and a token minted against it authenticates as any user id.
+ */
+describe('the committed development secret', () => {
+  const name = 'AUTH_SECRET'
+
+  it('is refused outside local development', () => {
+    expect(() => assertRuntimeCredential(name, 'dev-secret-change-me', { localDevelopment: false }))
+      .toThrowError(expect.objectContaining({ code: RUNTIME_CREDENTIAL_ERROR_CODE }))
+  })
+
+  it('is still accepted in local development, so dev keeps working', () => {
+    // Positive control: refusing it everywhere would break `nuxt dev` for anyone whose .env
+    // still carries it, which is a different failure rather than a safer one.
+    expect(assertRuntimeCredential(name, 'dev-secret-change-me', { localDevelopment: true }))
+      .toBe('dev-secret-change-me')
+  })
+
+  it.each([
+    'dev-secret-change-me',
+    'api-key-change-me',
+    'something_changeme',
+    'prod-secret-change-me',
+  ])('refuses %s, where the marker is a suffix rather than a prefix', value => {
+    expect(() => assertRuntimeCredential(name, value, { localDevelopment: false }))
+      .toThrowError(expect.objectContaining({ code: RUNTIME_CREDENTIAL_ERROR_CODE }))
+  })
+
+  it.each([
+    'a-perfectly-fine-production-secret',
+    'exchange-memory-service-key-01',
+  ])('still accepts %s', value => {
+    // The suffix pattern must not swallow real secrets. `exchange-memory` contains the letters
+    // of "change me" and has to survive.
+    expect(assertRuntimeCredential(name, value, { localDevelopment: false })).toBe(value)
+  })
+})

--- a/apps/nexus/server/utils/runtimeCredentialPolicy.ts
+++ b/apps/nexus/server/utils/runtimeCredentialPolicy.ts
@@ -4,6 +4,10 @@ const MINIMUM_RUNTIME_CREDENTIAL_LENGTH = 16
 
 const LOCAL_ONLY_CREDENTIAL_VALUES = new Set([
   'tuff-dev-secret',
+  // Shipped in a tracked apps/nexus/.env, so it is public. Any deployment that picked that
+  // file up signed app JWTs with it, and a token minted against it authenticates as any user
+  // id (#890).
+  'dev-secret-change-me',
   'tuff-local-pages-preview-secret',
   'tuff-local-app-auth-jwt-secret',
   'tuff-local-intelligence-encrypt-key',
@@ -13,6 +17,10 @@ const LOCAL_ONLY_CREDENTIAL_VALUES = new Set([
 
 const DOCUMENTED_PLACEHOLDER_PATTERNS = [
   /^change[-_ ]?me(?:[-_ ].*)?$/i,
+  // Anchoring only at the start missed the far more common spelling, where the marker is a
+  // suffix: `dev-secret-change-me`, `api-key-changeme`. That is how #890 slipped through a
+  // guard written to catch exactly this kind of value.
+  /[-_ ]change[-_ ]?me$/i,
   /^your(?:[-_ ].*)?$/i,
   /^replace[-_ ]?with(?:[-_ ].*)?$/i,
   /^placeholder(?:[-_ ].*)?$/i,


### PR DESCRIPTION
Closes #890 for the part that is code. Two operational steps remain — see below.

## The defect

`apps/nexus/.env` was **tracked**, carrying `AUTH_SECRET=dev-secret-change-me`. Nuxt auto-loads `.env` from the app root, so any deployment picking that file up signed app JWTs with a key published in the repository. A token minted against it passes `verifyAppToken`, and `requireAppAuth` returns whatever `userId` it names. `nuxt.config.ts` reuses the same value as the release-download signing fallback, so those URLs were forgeable too.

## The guard was written for exactly this and missed it

| rule | why it passed |
|---|---|
| minimum length | 20 characters |
| `LOCAL_ONLY_CREDENTIAL_VALUES` | not listed |
| `DOCUMENTED_PLACEHOLDER_PATTERNS` | anchored at the start — `/^change[-_ ]?me/` never matches a value that **ends** in it |

Both closed: the literal is now local-only, and a suffix pattern catches the far more common spelling (`api-key-change-me`, `something_changeme`).

## The file

`.env` is untracked and added to `.gitignore` — the existing rule covered only `.env*.local`, never the plain name. Contents move to `.env.example` with `AUTH_SECRET` blanked.

**Local development is unaffected:** `nuxt.config` falls back to `'tuff-dev-secret'` when `isDev`, which the guard already allows. You will need to recreate `apps/nexus/.env` from the example after pulling.

`apps/core-app/.env` and `packages/tuffex/.env` stay tracked — both checked, one holds a Clerk **publishable** key (designed to ship in client bundles) and the other a component prefix. Untracking them would remove build config without fixing anything.

## Not done here, because it is not code

- **rewriting git history** to purge the value
- **rotating `AUTH_SECRET`** anywhere it was used

Until rotation, this change means the old value cannot be *used* in production — not that it is no longer *known*.

## Tests

Nine new, **five failing** against the previous guard. Two are controls: the value is still accepted in local development (refusing it everywhere would break `nuxt dev`, a different failure rather than a safer one), and `exchange-memory-service-key-01` — which contains the letters of the marker — is not swallowed by the new pattern.

*(Process note: the first push was a pure rename, because `git add` aborted on a pathspec that no longer existed and staged none of the real changes. Amended and force-pushed before opening this.)*