### PR TITLE
fix(tuffex): make the size audit report only things worth acting on (#325)

### DIFF
--- a/apps/core-app/src/renderer/src/views/base/settings/SettingEverything.vue
+++ b/apps/core-app/src/renderer/src/views/base/settings/SettingEverything.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts" name="SettingEverything">
-import { TxButton } from '@talex-touch/tuffex'
+import { TxButton } from '@talex-touch/tuffex/button'
 import { TxInput } from '@talex-touch/tuffex/input'
 import { useAppSdk } from '@talex-touch/utils/renderer'
 import { useTuffTransport } from '@talex-touch/utils/transport'

--- a/packages/tuffex/scripts/audit-package-size.mjs
+++ b/packages/tuffex/scripts/audit-package-size.mjs
@@ -1,5 +1,5 @@
 import { readdir, readFile, stat } from 'node:fs/promises'
-import { dirname, extname, resolve } from 'node:path'
+import { dirname, extname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -14,6 +14,12 @@ const rootImportBudgets = [
     label: 'Core App renderer',
     root: coreRendererRoot,
     limit: 0,
+    // The plugin sandbox hands whole modules to untrusted plugin code, so it has to hold
+    // the namespace: resolveTalexTouchModule serves '@talex-touch/tuffex' and every
+    // '@talex-touch/tuffex/*' request from it. There is nothing to tree-shake in a
+    // registry whose keys are decided at runtime, and raising the limit to 1 instead
+    // would let the next accidental root import in unnoticed.
+    allow: ['modules/plugin/widget-registry.ts'],
   },
   {
     label: 'Nexus app',
@@ -293,14 +299,17 @@ async function auditRootImports(errors) {
     await Promise.all(
       sourceFiles.map(async (filePath) => {
         const source = await readFile(filePath, 'utf-8')
-        if (tuffexRootImportPatterns.some(pattern => pattern.test(source)))
-          rootImportFiles.push(filePath)
+        if (!tuffexRootImportPatterns.some(pattern => pattern.test(source))) return
+        const relativePath = relative(budget.root, filePath)
+        if ((budget.allow ?? []).some(allowed => relativePath === allowed)) return
+        rootImportFiles.push(filePath)
       }),
     )
 
     if (rootImportFiles.length > budget.limit) {
       errors.push(
-        `${budget.label} TuffEx root imports grew to ${rootImportFiles.length}; limit is ${budget.limit}`,
+        `${budget.label} TuffEx root imports grew to ${rootImportFiles.length}; limit is ${budget.limit}`
+        + ` (${rootImportFiles.map(filePath => relative(budget.root, filePath)).join(', ')})`,
       )
     }
 

--- a/packages/tuffex/scripts/audit-package-size.mjs
+++ b/packages/tuffex/scripts/audit-package-size.mjs
@@ -183,7 +183,11 @@ async function collectDistComponentDirs() {
     dirents
       .filter(dirent => dirent.isDirectory())
       .map(dirent => dirent.name)
-      .filter(name => !['_virtual', 'node_modules', 'packages'].includes(name)),
+      // 'utils' is shared code, not a component -- audit-package-exports.mjs excludes it
+      // from its own component enumeration for the same reason. Counting it here made
+      // every on-demand entry report "reaches unexpected component dirs: utils", which
+      // is true of all of them by design and told nobody anything.
+      .filter(name => !['_virtual', 'node_modules', 'packages', 'utils'].includes(name)),
   )
 }
 


### PR DESCRIPTION
Refs #325. `audit:size` errors: **11 → 2**.

> **Correction to my first description of this PR:** I said "31 → 30 errors". That counted
> the audit's informational size listing as errors. The real error block has **11**.

### Two different problems, both making the gate unreadable

**1. Eight of the eleven errors were the same sentence with a different prefix**

```
- base-anchor on-demand entry reaches unexpected component dirs: utils
- base-surface on-demand entry reaches unexpected component dirs: utils
- button on-demand entry reaches unexpected component dirs: utils
  … five more
```

`utils` is **shared code, not a component**. `audit-package-exports.mjs` already excludes it
from its own component enumeration for exactly that reason; this audit built its list from
`dist/es` and excluded only `_virtual`, `node_modules` and `packages`. So every on-demand
entry reported reaching a directory that all of them reach by design.

Eight errors that are true of everything tell nobody anything — and they were the bulk of
what this gate reported, which is how a gate stops being read.

**2. The root-import error named a count but not the files**

```
- Core App renderer TuffEx root imports grew to 2; limit is 0
```

The two weren't the same kind of import:

- `SettingEverything.vue` pulled `TxButton` from the package root while **114 other files in
  the same renderer** use `@talex-touch/tuffex/button`. An outlier — fixed.
- `widget-registry.ts` holds the namespace because the **plugin sandbox hands whole modules
  to untrusted plugin code**; `resolveTalexTouchModule` serves both `@talex-touch/tuffex`
  and every `@talex-touch/tuffex/*` request from it. A registry whose keys are decided at
  runtime has nothing to tree-shake.

Raising the limit to 1 would let the *next* accidental root import through unnoticed, so
budgets take an `allow` list and the limit stays **0**, with the rationale beside the entry.
The message now also **names the offending files** — it previously reported only a count, so
finding them meant grepping by hand.

### Both checks still bite

- Narrowing `base-anchor`'s `allowedComponentDirs` to `['base-anchor']` still reports
  `reaches unexpected component dirs: base-surface, card, glass-surface, spinner`.
- The root-import check still counts anything not in `allow`.

### What remains

```
- Base CSS is 29.7 KiB; limit is 16.0 KiB
- Full CSS is 465.1 KiB; limit is 330.0 KiB
```

Both over since well before this change. That's a real question about bundle size rather
than about the audit, and I haven't touched it.

Measured against a fresh `pnpm build` on this branch. Lint clean under
`packages/tuffex/eslint.config.js`, which is the config that gates this package.