### PR TITLE
fix(tuffex): stop the exports audit expecting a bundle for the test directory (#325)

### DIFF
--- a/packages/tuffex/scripts/audit-package-exports.mjs
+++ b/packages/tuffex/scripts/audit-package-exports.mjs
@@ -40,7 +40,13 @@ async function collectFiles(dir, predicate) {
 async function collectComponentSubpaths() {
   const dirents = await readdir(componentSrcRoot, { withFileTypes: true })
   return dirents
-    .filter(dirent => dirent.isDirectory() && dirent.name !== 'utils')
+    // Every directory under components/src is treated as a publishable component
+    // subpath, so anything that is not one has to be excluded here. 'utils' is shared
+    // code; '__tests__' arrived with 14274af8b and is a test directory, which the build
+    // correctly does not emit a bundle for -- leaving the audit to report
+    // dist/es/__tests__/index.js as a *missing export* rather than as something that
+    // should never have been expected.
+    .filter(dirent => dirent.isDirectory() && dirent.name !== 'utils' && !/^__.*__$/.test(dirent.name))
     .map(dirent => dirent.name)
     .sort()
 }


### PR DESCRIPTION
Refs #325. `audit:exports`: **FAIL → PASS**, against a fresh `pnpm build`.

```
[audit-package-exports] Missing exported files:
- ./dist/es/__tests__/index.d.ts
- ./dist/es/__tests__/index.js
- ./dist/lib/__tests__/index.js
- ./dist/es/__tests__/style.css
- ./dist/lib/__tests__/style.css
```

### The wording points the wrong way

I first read this as *"test files are shipping in the published package"* and was about to
report it that way. It's the opposite: **nothing is missing from the build.**

`collectComponentSubpaths()` enumerates every directory under `packages/components/src` as
a publishable component subpath and excludes only `utils`. So
`packages/components/src/__tests__` — added with `14274af8b` — is counted as a component,
the build correctly emits no bundle for a test directory, and the audit reports that
absence as a defect.

Excluded by the `__*__` shape rather than by name, so the next test or fixture directory
doesn't reproduce it. It's the only such directory among the 128 there today.

### Checked that this doesn't blunt the audit

With the filter in place, removing `dist/es/button` still produces:

```
Missing exported files:
- ./dist/es/button/index.d.ts
- ./dist/es/button/index.js
- ./dist/es/button/style.css
```

and restoring it passes again. The check still detects a genuinely missing component — it
just no longer demands one that should never exist.

### Where the tuffex gates stand on this branch

| | |
|---|---|
| `vitest` | 145 files, 1114 tests — passing |
| `typecheck` | passing |
| `audit:readme` | passing |
| `audit:exports` | **passing with this PR** |
| `audit:size` | 31 → 30 with #1234; the rest is a pre-existing `on-demand entry reaches unexpected component dirs: utils` class |
| `audit:types` | fails on a sandbox `pnpm install` needing network — environmental, untouched |