### PR TITLE
fix(utils): order canonical signing JSON by codepoint, not ICU collation

### DIFF
--- a/packages/utils/__tests__/plugin-signing-canonical.test.ts
+++ b/packages/utils/__tests__/plugin-signing-canonical.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { serializePluginFileMap, serializePluginSigningValue } from '../plugin/signing'
+
+/**
+ * The canonical byte string that plugin signatures cover (#894).
+ *
+ * Key order was decided by `localeCompare(left, right, 'en')`. That string is signed by the
+ * publisher CLI and verified independently by Nexus on Cloudflare Workers and by the Electron
+ * main process, so an ICU difference between those runtimes could make the same object
+ * serialize differently on signer and verifier.
+ *
+ * The sharper problem is collation-ignorable code points: ICU reports distinct strings as
+ * equal, `Array.prototype.sort` then leaves them in input order, and for a file map that order
+ * comes from tar entries the publisher chooses.
+ */
+describe('canonical key ordering', () => {
+  it('is stable regardless of the order keys arrive in', () => {
+    const forward = serializePluginSigningValue({ a: 1, B: 2, c: 3 })
+    const reverse = serializePluginSigningValue({ c: 3, B: 2, a: 1 })
+    expect(forward).toBe(reverse)
+  })
+
+  it('orders by codepoint, so uppercase precedes lowercase', () => {
+    // The observable difference from localeCompare('en'), which puts 'a' before 'B'.
+    expect(serializePluginSigningValue({ a: 1, B: 2 })).toBe('{"B":2,"a":1}')
+  })
+
+  it('separates keys that ICU collation reports as equal', () => {
+    // Confirmed against this runtime: 'a­b'.localeCompare('ab', 'en') === 0. With a
+    // comparator returning 0 the sort is input-order dependent, which is the defect.
+    const soft = 'a­b'
+    expect(soft.localeCompare('ab', 'en')).toBe(0)
+
+    const forward = serializePluginSigningValue({ [soft]: 1, ab: 2 })
+    const reverse = serializePluginSigningValue({ ab: 2, [soft]: 1 })
+    expect(forward).toBe(reverse)
+  })
+
+  it('gives a file map the same hash input whatever order the archive listed it in', () => {
+    // serializePluginFileMap feeds fileMapSha256, which sits inside the signed payload. This
+    // is the property the whole canonicalisation exists to provide.
+    const entries: Array<[string, string]> = [
+      ['README.md', 'a'],
+      ['src/index.js', 'b'],
+      ['LICENSE', 'c'],
+      ['src/Index.js', 'd'],
+      ['a‍b.txt', 'e'],
+      ['ab.txt', 'f'],
+    ]
+
+    const forward = serializePluginFileMap(Object.fromEntries(entries))
+    const reverse = serializePluginFileMap(Object.fromEntries([...entries].reverse()))
+    expect(forward).toBe(reverse)
+  })
+
+  it('still serializes ordinary payloads', () => {
+    // Positive control: an ordering fix that broke serialization would satisfy the equality
+    // assertions above by returning the same wrong thing twice.
+    expect(serializePluginSigningValue({ contract: 'x', version: '1.0.0', nested: { b: 1, a: 2 } }))
+      .toBe('{"contract":"x","nested":{"a":2,"b":1},"version":"1.0.0"}')
+  })
+
+  it('keeps array order, which is data rather than key order', () => {
+    expect(serializePluginSigningValue({ list: ['c', 'a', 'b'] })).toBe('{"list":["c","a","b"]}')
+  })
+
+  it('still drops undefined and rejects non-finite numbers', () => {
+    expect(serializePluginSigningValue({ a: undefined, b: 1 })).toBe('{"b":1}')
+    expect(() => serializePluginSigningValue({ a: Number.NaN })).toThrow(TypeError)
+  })
+})

--- a/packages/utils/plugin/signing.ts
+++ b/packages/utils/plugin/signing.ts
@@ -177,7 +177,21 @@ function canonicalize(value: unknown): unknown {
     return value.map(item => canonicalize(item))
   if (isRecord(value)) {
     const normalized: Record<string, unknown> = {}
-    for (const key of Object.keys(value).sort((left, right) => left.localeCompare(right, 'en'))) {
+    // Codepoint order, not localeCompare. This string is the exact bytes three runtimes sign
+    // and verify — the publisher CLI, Nexus on Cloudflare Workers, and the Electron main
+    // process — and localeCompare is ICU-dependent, so small-icu and full-icu builds could
+    // disagree about the canonical form of the same object (#894).
+    //
+    // The sharper problem is that ICU collation returns 0 for distinct strings differing only
+    // by ignorable code points: `'a\u00ADb'.localeCompare('ab', 'en')` is 0. A comparator
+    // returning 0 leaves those keys in input order, and for serializePluginFileMap that order
+    // comes from tar entry ordering the publisher controls — so fileMapSha256 was not a
+    // function of the file map alone.
+    //
+    // Object.keys already yields unique keys, so there are no duplicates left to reject;
+    // a codepoint comparator never returns 0 for distinct strings, which is what makes the
+    // ordering total.
+    for (const key of Object.keys(value).sort((left, right) => (left < right ? -1 : left > right ? 1 : 0))) {
       const child = value[key]
       if (child === undefined)
         continue


### PR DESCRIPTION
Closes #894.

> ⚠️ **This changes the canonical form, so existing plugin signatures will need re-signing.** Details below — please read before merging.

## The defect

`canonicalize` sorted keys with `localeCompare(left, right, 'en')`. That string is the exact bytes **three runtimes** sign and verify:

| runtime | role |
|---|---|
| publisher CLI (`plugin-signer.ts:150`) | signs |
| Nexus on Cloudflare Workers (`pluginSigning.ts:438`) | verifies |
| Electron main (`signature-verifier.ts:242`) | verifies |

All three import `serializePluginSigningPayload` from this one file, so one comparator decides all of them — and ICU collation data differs between small-icu, full-icu and the Workers runtime.

**The sharper half**, verified on this runtime:

```
'a­b'.localeCompare('ab', 'en')  ===  0
```

A comparator returning `0` leaves those keys in **input order**, and for `serializePluginFileMap` that order comes from tar entries the publisher chooses. So `fileMapSha256` was not a function of the file map alone.

## On "reject duplicate keys"

`Object.keys` already yields unique keys, so there is nothing to reject. What was missing is a **total ordering** — a codepoint comparator never returns 0 for distinct strings, which is precisely what fixes the collision case.

## The breaking part

Codepoint order puts `B` before `a`; `localeCompare('en')` puts `a` before `B`. Any file map with mixed-case names — `README.md` beside `src/index.js` is the normal case — canonicalizes differently now, its `fileMapSha256` changes, and that hash sits **inside the signed payload**.

**Plugins signed before this change will fail verification and need re-signing.**

If that is unacceptable, the alternative is gating the comparator on the payload's existing `policyVersion` so old signatures verify under the old rule. I did not build it: it doubles the canonicalization surface, and choosing between *re-sign* and *keep two canonical forms alive* is a call for whoever owns the signing rollout.

## Tests

Seven, **three failing** against the previous comparator: the codepoint ordering itself, the soft-hyphen collision, and a file map whose serialization must not depend on archive order.

Two are controls — arrays keep their order (that is data, not key order), and an ordinary payload still serializes correctly, since an ordering fix that broke serialization would satisfy the equality assertions by returning the same wrong thing twice.

Consumer suites pass unchanged: **1183** in core-app plugin, **191** in nexus server utils, and the 14 existing signing tests in utils.