### PR TITLE
ci(native-protocol): make all three legs green (#1125)

### DIFF
--- a/.github/workflows/native-protocol.yml
+++ b/.github/workflows/native-protocol.yml
@@ -50,6 +50,7 @@ jobs:
           libclang-dev
           libdbus-1-dev
           libegl-dev
+          libgbm-dev
           libpipewire-0.3-dev
           libwayland-dev
           libxcb1-dev

--- a/.github/workflows/native-protocol.yml
+++ b/.github/workflows/native-protocol.yml
@@ -135,4 +135,11 @@ jobs:
           src/main/modules/native-capabilities/native-transport-napi.integration.test.ts
 
       - name: Type-check Electron main process
+        # The type graph genuinely needs about 2.8 GB: 4,660 files, 2,793 of them
+        # dependency declarations, led by @sentry, typebox, drizzle-orm and openai.
+        # skipLibCheck is already on, so there is no configuration lever left -- the
+        # macOS runner's default heap is simply below what this check costs, and it
+        # died with FatalProcessOutOfMemory rather than reporting a type error.
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
         run: pnpm -C apps/core-app run typecheck:node

--- a/packages/tuff-native/scripts/verify-screenshot-production.js
+++ b/packages/tuff-native/scripts/verify-screenshot-production.js
@@ -30,7 +30,12 @@ try {
     ])
     if (process.platform === 'linux' && unavailableLinuxReasons.has(capability.reason)) {
       assert.equal(capability.state, 'unavailable')
-      assert.deepEqual(capability.features, [])
+      // Same unconditional append as below: even with no backend features, the
+      // capability layer still adds frozen-compose, so [] cannot occur here either.
+      // This is the branch a headless CI runner takes -- no display server, so the
+      // reason is display-server-unavailable -- which is why the Linux leg kept failing
+      // after the degraded-branch fix.
+      assert.deepEqual(capability.features, ['frozen-compose'])
     }
     else {
       assert.equal(capability.state, 'degraded')

--- a/packages/tuff-native/scripts/verify-screenshot-production.js
+++ b/packages/tuff-native/scripts/verify-screenshot-production.js
@@ -35,7 +35,13 @@ try {
     else {
       assert.equal(capability.state, 'degraded')
       assert.equal(capability.reason, 'basic-backend-only')
-      assert.deepEqual(capability.features, ['display', 'region'])
+      // ScreenshotCapability::features() appends frozen-compose to whatever the
+      // backend reports, unconditionally (native-screenshot/src/capability.rs:35-39),
+      // so this list could never be just the backend's two. The Rust contract test
+      // already expects all three (backend_contract_tests.rs:377); this assertion was
+      // the outlier, and it made the Windows leg of native-protocol.yml red on every
+      // branch. macOS never noticed because its branch does not assert features.
+      assert.deepEqual(capability.features, ['display', 'region', 'frozen-compose'])
     }
   }
 }


### PR DESCRIPTION
Fixes item 1 of #1125. **All three legs pass.**

```
Protocol (macos-latest)   pass  5m20s
Protocol (ubuntu-latest)  pass  7m21s
Protocol (windows-2022)   pass  6m31s
```

Three distinct causes, each only visible once the one before it was fixed.

### 1. Linux couldn't link — `libgbm-dev`

```
Compiling xcap v0.9.4
rust-lld: error: unable to find library -lgbm
```

`xcap` is the Linux screenshot backend and links against Mesa's **gbm**. The workflow
installs `libegl-dev`, its sibling, but not `libgbm-dev`. Exit code **101** with the linker
note buried in cargo output reads like a Rust compilation failure, which is probably why it
went unexamined.

### 2. Then Linux hit the assertion that can't be satisfied — twice

`ScreenshotCapability::features()` appends `frozen-compose` **unconditionally**
(`capability.rs:35-39`), so **both** `features` assertions in `verify-screenshot-production`
were impossible:

| branch | asserted | can occur? |
|---|---|---|
| degraded | `['display', 'region']` | no — Windows proved it |
| unavailable | `[]` | no — headless Linux proved it |

I'd argued the first from the Windows failure alone. **Linux then demonstrated the same bug
independently in the other branch** — a headless runner has no display server, so the
capability reports `unavailable` and takes the path expecting `[]`.

macOS never caught either, because its branch asserts `engine` and `state` only.

### 3. macOS died on memory, not types — measured, not guessed

`FATAL ERROR: Ineffective mark-compacts near heap limit`. Before touching a limit I checked
whether the check was doing something wrong:

```
typecheck:node passes locally, exit 0, 23s
peak resident set size            2.82 GB
files loaded                      4,660
of which dependency declarations  2,793 (60%)
heaviest                          @sentry 575, typebox 376, drizzle-orm 303, openai 279
skipLibCheck                      already true
```

`skipLibCheck` is already on, so there's no configuration lever left, and nothing in the
config is pathological — the check costs what it costs and the runner's default heap is
below it. **4 GB** gives headroom over the measured 2.82 GB without pretending the work is
smaller than it is.

### On the original report

The ubuntu failure described there was the `node-pty` postinstall — `master`-only, since
that guard doesn't exist on this branch (#1194 and #1197 closed for that reason). And
`Test Rust workspace` was never failing; the Rust tests pass on every leg.

Includes the commit from #1222, which alone doesn't make Linux green.