### PR TITLE
fix(nexus,cli): describe manifest._signature as the checksum it is, and stop using MD5

### DIFF
--- a/apps/nexus/server/utils/__tests__/tpexManifestChecksum.test.ts
+++ b/apps/nexus/server/utils/__tests__/tpexManifestChecksum.test.ts
@@ -1,0 +1,80 @@
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * What manifest._signature actually is (#893).
+ *
+ * It is an unkeyed digest of the file map. Anyone repacking the archive recomputes the
+ * per-file sha256 values and then this digest over them, so it proves the manifest is
+ * internally consistent and nothing more. Publisher authenticity comes from the keyed
+ * envelope in pluginSigning; a passing value here is not evidence of provenance.
+ *
+ * The CLI now writes SHA-256 where it wrote MD5. That is not what makes the field safe — it
+ * was never a signature — but a collision-broken digest does not belong in a field with this
+ * name, and verifiers accept both so packages built earlier keep validating.
+ */
+
+const tpexSource = readFileSync(
+  fileURLToPath(new URL('../tpex.ts', import.meta.url)),
+  'utf8',
+)
+
+const canonical = (files: Record<string, string>) => {
+  const sorted: Record<string, string> = {}
+  for (const key of Object.keys(files).sort()) sorted[key] = files[key] ?? ''
+  return JSON.stringify(sorted)
+}
+
+describe('manifest._signature checksum', () => {
+  const files = { 'a.js': 'sha256-aaa', 'b.js': 'sha256-bbb' }
+
+  it('accepts both digests, so old and new packages both validate', () => {
+    // The compatibility property. Verified by construction rather than by running the whole
+    // tpex reader, which needs a real tar buffer.
+    const json = canonical(files)
+    const sha = createHash('sha256').update(json).digest('base64')
+    const md5 = createHash('md5').update(json).digest('base64')
+
+    expect(tpexSource).toContain("createHash('sha256').update(json).digest('base64')")
+    expect(tpexSource).toContain("createHash('md5').update(json).digest('base64')")
+    expect(sha).not.toBe(md5)
+  })
+
+  it('no longer describes the field as a signature in its failure messages', () => {
+    // The actual risk in the report is a reader treating a pass as provenance. Every message
+    // the verifier can emit now says checksum.
+    const messages = tpexSource.match(/reason: '[^']*_signature[^']*'/g) ?? []
+    expect(messages.length).toBeGreaterThan(0)
+    for (const message of messages)
+      expect(message).toContain('checksum')
+  })
+
+  it('says in the source that the field carries no authenticity', () => {
+    // Load-bearing comment: the next reader needs to know before trusting a pass.
+    expect(tpexSource).toMatch(/unkeyed digest of/)
+    expect(tpexSource).toMatch(/not\s+\n?\s*\*?\s*evidence of provenance/)
+  })
+})
+
+/**
+ * The producer side, which decides what new packages carry.
+ */
+describe('cli checksum generation', () => {
+  const source = readFileSync(
+    fileURLToPath(new URL('../../../../../packages/tuff-cli-core/src/security-util.ts', import.meta.url)),
+    'utf8',
+  )
+
+  it('writes sha256 for new packages', () => {
+    expect(source).toMatch(/export function generateSignature[\s\S]*?createHash\('sha256'\)/)
+  })
+
+  it('keeps the legacy digest available rather than deleting it', () => {
+    // Verifiers still accept MD5; keeping the generator makes that pairing explicit and
+    // testable instead of an unexplained branch in the verifier.
+    expect(source).toContain('generateLegacySignature')
+    expect(source).toMatch(/generateLegacySignature[\s\S]*?createHash\('md5'\)/)
+  })
+})

--- a/apps/nexus/server/utils/tpex.ts
+++ b/apps/nexus/server/utils/tpex.ts
@@ -183,12 +183,33 @@ function buildSecurityScanFiles(files: Record<string, Buffer>) {
   })
 }
 
-function generateSignature(filesObject: Record<string, string>): string {
+function canonicalFileMapJson(filesObject: Record<string, string>): string {
   const sortedKeys = Object.keys(filesObject).sort()
   const sortedObject: Record<string, string> = {}
   for (const key of sortedKeys)
     sortedObject[key] = filesObject[key] ?? ''
-  return createHash('md5').update(JSON.stringify(sortedObject)).digest('base64')
+  return JSON.stringify(sortedObject)
+}
+
+/**
+ * The checksum values manifest._signature may legitimately hold.
+ *
+ * The field name is misleading and this is the honest description of it: an unkeyed digest of
+ * the file map, which anyone repacking the archive recomputes along with the per-file hashes
+ * it covers. It proves the manifest is internally consistent and nothing more. Publisher
+ * authenticity comes from the keyed envelope in pluginSigning, and a passing value here is not
+ * evidence of provenance (#893).
+ *
+ * SHA-256 is what the CLI now writes; MD5 is accepted so packages built before that change
+ * keep validating. Neither makes the field a signature — MD5 is dropped from new packages
+ * because a collision-broken digest has no business in a field with this name.
+ */
+function fileMapChecksums(filesObject: Record<string, string>): string[] {
+  const json = canonicalFileMapJson(filesObject)
+  return [
+    createHash('sha256').update(json).digest('base64'),
+    createHash('md5').update(json).digest('base64'),
+  ]
 }
 
 function normalizeManifestFileKey(key: string): string {
@@ -223,7 +244,7 @@ function verifyManifestIntegrity(
   if (!expectedFiles || typeof expectedFiles !== 'object' || Array.isArray(expectedFiles))
     return { valid: false, reason: 'manifest._files is missing or invalid.' }
   if (typeof expectedSignature !== 'string' || !expectedSignature.trim())
-    return { valid: false, reason: 'manifest._signature is missing or invalid.' }
+    return { valid: false, reason: 'manifest._signature checksum is missing or invalid.' }
 
   const actualFiles: Record<string, string> = {}
   for (const [name, fileBuffer] of Object.entries(files)) {
@@ -251,12 +272,16 @@ function verifyManifestIntegrity(
       return { valid: false, reason: `manifest._files hash mismatch for ${key}.` }
   }
 
-  const signatureCandidates = new Set([
-    generateSignature(expectedRecord as Record<string, string>),
-    generateSignature(normalizedExpectedFiles),
+  const checksumCandidates = new Set([
+    ...fileMapChecksums(expectedRecord as Record<string, string>),
+    ...fileMapChecksums(normalizedExpectedFiles),
   ])
-  if (!signatureCandidates.has(expectedSignature.trim()))
-    return { valid: false, reason: 'manifest._signature does not match manifest._files.' }
+  if (!checksumCandidates.has(expectedSignature.trim())) {
+    return {
+      valid: false,
+      reason: 'manifest._signature checksum does not match manifest._files.',
+    }
+  }
 
   return { valid: true }
 }

--- a/packages/tuff-cli-core/src/security-util.ts
+++ b/packages/tuff-cli-core/src/security-util.ts
@@ -25,13 +25,32 @@ export function generateFilesSha256(filePaths: string[], baseDir: string): Recor
  * @param filesObject - The object containing file paths and their hashes.
  * @returns The Base64 encoded signature.
  */
-export function generateSignature(filesObject: Record<string, string>): string {
+function canonicalFileMapJson(filesObject: Record<string, string>): string {
   const sortedKeys = Object.keys(filesObject).sort()
   const sortedObject: Record<string, string> = {}
   for (const key of sortedKeys) {
     sortedObject[key] = filesObject[key]
   }
-  const jsonString = JSON.stringify(sortedObject)
-  const md5Hash = crypto.createHash('md5').update(jsonString).digest('base64')
-  return md5Hash
+  return JSON.stringify(sortedObject)
+}
+
+/**
+ * A checksum over the file map, written to manifest._signature.
+ *
+ * Despite the field name this carries no authenticity: it is unkeyed, so anyone repacking the
+ * archive recomputes it along with the per-file hashes it covers. Publisher authenticity comes
+ * from the separate keyed envelope in pluginSigning, and nothing should read a passing value
+ * here as provenance (#893).
+ *
+ * SHA-256 rather than the previous MD5. The change is not what makes the field safe — it was
+ * never a signature — but a collision-broken digest has no place in a field with this name,
+ * and verifiers accept both so existing packages keep validating.
+ */
+export function generateSignature(filesObject: Record<string, string>): string {
+  return crypto.createHash('sha256').update(canonicalFileMapJson(filesObject)).digest('base64')
+}
+
+/** The pre-2026-08 digest, still accepted by verifiers for packages built before the change. */
+export function generateLegacySignature(filesObject: Record<string, string>): string {
+  return crypto.createHash('md5').update(canonicalFileMapJson(filesObject)).digest('base64')
 }


### PR DESCRIPTION
Closes #893.

## What the field actually is

`verifyManifestIntegrity` **requires** `manifest._signature` and feeds its result into `policyPassed` — but the value is an **unkeyed digest of the file map**. Anyone repacking the archive recomputes the per-file sha256 values and then this digest over them. It proves the manifest is internally consistent and nothing more.

The name claims otherwise, and that is the risk the report identifies: a reader or a code path treating a pass as provenance is relying on a control that does not exist.

## The part that addresses the finding

The verifier's messages and internal names now say **checksum**, and the source states plainly that authenticity comes from the keyed envelope in `pluginSigning`.

The digest change below does **not** make the field a signature. It never was one.

## The digest

The CLI writes SHA-256 where it wrote MD5; the verifier accepts **both**, so packages built before this keep validating.

Worth being precise about why: MD5 is collision-broken and has no business in a field with this name — but it was **not exploitable here**. The map it covers is already verified file-by-file against the extracted contents, so a collision buys an attacker nothing. This is hygiene, not the fix.

## The rename I did not do

The issue also asks to rename the manifest field. It is **required** by the verifier, so renaming breaks every existing package and every producer at once — that is a format migration needing dual-read support and a version marker, not a fix.

The misleading name is neutralised where it does harm: in what the code *says* about it.

## Admission, checked rather than assumed

`integrity.valid` gates `policyPassed` alongside `packagePolicy.ok`, and the keyed publisher signature is verified separately in `pluginSigning`. **Nothing admits a package on the strength of this field alone** — the third part of the suggested direction already held.

## Tests

Five, **all failing** against the previous version. One asserts that every failure message mentioning the field also says *checksum*, so the naming cannot quietly regress.

Suites pass unchanged: 197 in nexus server utils, 49 in `tuff-cli-core`. `pnpm run typecheck` exits 0.