### PR TITLE
fix(nexus): stop serving user-uploaded images as active documents

### DIFF
--- a/apps/nexus/server/api/images/[key].get.ts
+++ b/apps/nexus/server/api/images/[key].get.ts
@@ -22,8 +22,27 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  // 设置响应头
-  event.node.res.setHeader('Content-Type', image.contentType)
+  // Content types that a browser will execute if it renders them as a top-level document.
+  // SVG is no longer accepted at upload, but anything stored before that change is still
+  // here, and this endpoint is what made it dangerous (#896).
+  const ACTIVE_DOCUMENT_TYPES = /^(?:image\/svg\+xml|text\/html|application\/xhtml\+xml|.*\bxml\b)/i
+  const isActiveDocument = ACTIVE_DOCUMENT_TYPES.test(image.contentType ?? '')
+
+  // nosniff unconditionally: without it a browser may ignore the declared type and execute
+  // what it guesses instead, which is the same failure by a different route.
+  event.node.res.setHeader('X-Content-Type-Options', 'nosniff')
+
+  if (isActiveDocument) {
+    // Served as an opaque download rather than refused, so an existing icon does not turn
+    // into a broken page — but it will no longer render inline, and such icons need
+    // re-uploading in a raster format.
+    event.node.res.setHeader('Content-Type', 'application/octet-stream')
+    event.node.res.setHeader('Content-Disposition', `attachment; filename="${key}"`)
+  }
+  else {
+    event.node.res.setHeader('Content-Type', image.contentType)
+  }
+
   event.node.res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
 
   // 返回图片数据

--- a/apps/nexus/server/utils/imageStorage.test.ts
+++ b/apps/nexus/server/utils/imageStorage.test.ts
@@ -25,9 +25,13 @@ describe('imageStorage', () => {
 
     const result = await uploadImageFromBuffer(
       h3Event,
-      Buffer.from('<svg />'),
-      'private customer icon.svg',
-      'image/svg+xml',
+      // A raster fixture: svg is no longer an accepted icon format (#896). This test is
+      // about upload lifecycle analytics, not about which formats are allowed.
+      // Seven bytes, matching the size assertions below. The contents do not need to be a
+      // real PNG — this test is about upload lifecycle analytics.
+      Buffer.from('fakepng'),
+      'private customer icon.png',
+      'image/png',
       {
         actorId: 'publisher@example.com',
         resourceType: 'plugin-icon',
@@ -52,17 +56,17 @@ describe('imageStorage', () => {
 
     expect(result.storageChannel).toBe('memory')
     expect(JSON.stringify(rows)).not.toContain('publisher@example.com')
-    expect(JSON.stringify(rows)).not.toContain('private customer icon.svg')
+    expect(JSON.stringify(rows)).not.toContain('private customer icon.png')
     expect(rows.every(row => row.resourceId === resourceId)).toBe(true)
     expect(rows).toEqual(expect.arrayContaining([
       expect.objectContaining({
         action: 'resource.started',
         resourceId,
-        channel: 'image/svg+xml',
+        channel: 'image/png',
         unit: 'file',
         quantity: 1,
         metadata: expect.objectContaining({
-          extension: 'svg',
+          extension: 'png',
           pluginId: marker,
           size: 7,
           source: 'plugin-version-publish',
@@ -72,11 +76,11 @@ describe('imageStorage', () => {
       expect.objectContaining({
         action: 'resource.completed',
         resourceId,
-        channel: 'image/svg+xml',
+        channel: 'image/png',
         unit: 'byte',
         quantity: 7,
         metadata: expect.objectContaining({
-          extension: 'svg',
+          extension: 'png',
           pluginId: marker,
           storageChannel: 'memory',
           storageProvider: 'memory',

--- a/apps/nexus/server/utils/imageStorage.ts
+++ b/apps/nexus/server/utils/imageStorage.ts
@@ -44,13 +44,16 @@ const ATTACHMENT_TYPES = [
   'text/markdown',
 ]
 
+// No 'svg'. An SVG is an active document: it can carry <script>, and /api/images/[key]
+// echoes the stored content type, so one uploaded through the non-admin plugin:publish scope
+// ran same-origin against any visitor who opened it (#896). Raster formats have no such
+// execution surface.
 const IMAGE_ALLOWED_EXTENSIONS = [
   'jpg',
   'jpeg',
   'png',
   'gif',
   'webp',
-  'svg',
   'ico',
   'bmp',
   'avif',
@@ -81,7 +84,6 @@ const MIME_EXTENSION_MAP: Record<string, string> = {
   'image/png': 'png',
   'image/gif': 'gif',
   'image/webp': 'webp',
-  'image/svg+xml': 'svg',
   'application/pdf': 'pdf',
   'application/zip': 'zip',
   'application/x-zip-compressed': 'zip',
@@ -397,7 +399,8 @@ export async function uploadImageFromBuffer(
 
   try {
     // Get extension from filename
-    const ext = fileName.split('.').pop()?.toLowerCase() ?? 'svg'
+    // Empty rather than a guessed default, so a name with no extension reports what it is.
+    const ext = fileName.includes('.') ? (fileName.split('.').pop()?.toLowerCase() ?? '') : ''
 
     // Validate extension
     if (!IMAGE_ALLOWED_EXTENSIONS.includes(ext)) {

--- a/apps/nexus/test/api/imageActiveDocument.test.ts
+++ b/apps/nexus/test/api/imageActiveDocument.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { beforeEach, describe, expect, it, vi } from 'vitest'

--- a/apps/nexus/test/api/imageActiveDocument.test.ts
+++ b/apps/nexus/test/api/imageActiveDocument.test.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * SVG served from the app origin (#896).
+ *
+ * `plugin:publish` is not admin-only, so any registered user could upload a plugin icon.
+ * The default allow-list accepted `svg`, and /api/images/[key] echoed the stored content type
+ * with no `nosniff` and no disposition — so opening the URL as a top-level document ran the
+ * publisher's script same-origin against the visitor's dashboard session.
+ */
+
+// vi.hoisted: the vi.mock factory below is hoisted above ordinary top-level declarations.
+const { getImage } = vi.hoisted(() => ({ getImage: vi.fn() }))
+
+vi.mock('../../server/utils/imageStorage', async () => {
+  const actual = await vi.importActual<typeof import('../../server/utils/imageStorage')>(
+    '../../server/utils/imageStorage',
+  )
+  return { ...actual, getImage }
+})
+
+vi.stubGlobal('defineEventHandler', (fn: unknown) => fn)
+
+type Handler = (event: unknown) => Promise<unknown>
+
+function createEvent(key: string) {
+  const headers: Record<string, string> = {}
+  return {
+    headers,
+    event: {
+      context: { params: { key } },
+      node: { res: { setHeader: (name: string, value: string) => { headers[name] = String(value) } } },
+    },
+  }
+}
+
+async function load(): Promise<Handler> {
+  const mod = await import('../../server/api/images/[key].get')
+  return mod.default as unknown as Handler
+}
+
+describe('image responses', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('never serves an svg as an active document', async () => {
+    // The regression. Content-Type used to be echoed verbatim.
+    getImage.mockResolvedValue({ data: Buffer.from('<svg/>'), contentType: 'image/svg+xml' })
+    const { event, headers } = createEvent('abc123')
+    await (await load())(event)
+
+    expect(headers['Content-Type']).toBe('application/octet-stream')
+    expect(headers['Content-Disposition']).toMatch(/^attachment;/)
+  })
+
+  it.each(['text/html', 'application/xhtml+xml', 'application/xml'])(
+    'neutralises %s too',
+    async (contentType) => {
+      // Anything a browser will render as a document, not just svg — the stored type is
+      // whatever the uploader's client claimed.
+      getImage.mockResolvedValue({ data: Buffer.from('x'), contentType })
+      const { event, headers } = createEvent('abc123')
+      await (await load())(event)
+
+      expect(headers['Content-Type']).toBe('application/octet-stream')
+    },
+  )
+
+  it('sets nosniff on every response', async () => {
+    // Without it a browser may execute what it guesses rather than what is declared, which
+    // is the same failure by another route.
+    getImage.mockResolvedValue({ data: Buffer.from('x'), contentType: 'image/png' })
+    const { event, headers } = createEvent('abc123')
+    await (await load())(event)
+
+    expect(headers['X-Content-Type-Options']).toBe('nosniff')
+  })
+
+  it('still serves a raster image inline', async () => {
+    // Positive control: forcing attachment on everything would satisfy the assertions above
+    // while breaking every plugin icon on the site.
+    getImage.mockResolvedValue({ data: Buffer.from('x'), contentType: 'image/png' })
+    const { event, headers } = createEvent('abc123')
+    await (await load())(event)
+
+    expect(headers['Content-Type']).toBe('image/png')
+    expect(headers['Content-Disposition']).toBeUndefined()
+  })
+})
+
+describe('image upload allow-list', () => {
+  // IMAGE_ALLOWED_EXTENSIONS and the mime map are module-private, so the list is read from
+  // source. Uploading through the real path needs a database and a storage binding.
+  const source = readFileSync(
+    fileURLToPath(new URL('../../server/utils/imageStorage.ts', import.meta.url)),
+    'utf8',
+  )
+
+  function extensionList(): string {
+    const start = source.indexOf('const IMAGE_ALLOWED_EXTENSIONS = [')
+    expect(start, 'extension list not found — this guard is reading the wrong file').toBeGreaterThan(-1)
+    const end = source.indexOf(']', start)
+    return source.slice(start, end)
+  }
+
+  it('no longer offers svg as an accepted extension', () => {
+    expect(extensionList()).not.toContain("'svg'")
+  })
+
+  it('still offers the raster formats, so icons keep working', () => {
+    // Positive control: an empty list would satisfy the assertion above and reject every
+    // upload.
+    for (const extension of ["'png'", "'jpg'", "'webp'", "'gif'"])
+      expect(extensionList(), extension).toContain(extension)
+  })
+
+  it('no longer maps a content type to svg', () => {
+    expect(source).not.toContain("'image/svg+xml':")
+  })
+})


### PR DESCRIPTION
Closes #896.

## The chain

`plugin:publish` is **not** admin-only, the default image allow-list accepted `svg`, and `/api/images/[key]` echoed the stored content type with no `nosniff` and no disposition. Opening that URL as a top-level document rendered the publisher's SVG **on the Nexus origin** and ran its script against the visitor's dashboard session.

## Three changes — the second is the one that matters for existing data

**1. `svg` removed** from the extension list and the mime map, so it cannot be uploaded again.

On its own that leaves **every SVG uploaded before this change still live**, which is why it is not the whole fix.

**2. The endpoint neutralises active document types on read** — `svg`, `html`, `xhtml`, `xml` are served as `application/octet-stream` with `Content-Disposition: attachment`.

That defuses stored payloads without deleting data. **Consequence worth stating:** an existing SVG icon stops rendering inline and needs re-uploading in a raster format. Raster types are untouched and still inline.

**3. `X-Content-Type-Options: nosniff` on every response**, not just the rewritten ones — without it a browser may execute what it *guesses* rather than what is declared, which is the same failure by another route. The report notes the header appears nowhere in the repository; this is its first use.

Also removed a `?? 'svg'` default when reading an upload's extension. With svg disallowed it failed closed anyway, but it reported `Invalid image extension: svg` for a filename that had **no** extension.

## Tests

Nine, **seven failing** against the previous version.

Two are positive controls, and they are the ones that would catch an over-broad fix: a raster image is still served **inline with no disposition**, and the extension list still offers `png`/`jpg`/`webp`/`gif` — an empty list would satisfy every negative assertion while rejecting all uploads.

459 tests across `server/utils/__tests__` and `test/api` pass. `pnpm run typecheck` exits 0.

*(The allow-list assertions read the source: `IMAGE_ALLOWED_EXTENSIONS` and the mime map are module-private, and exercising the real upload path needs a database and a storage binding.)*