### PR TITLE
feat(search): report push features that no declared provider covers (#1203)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-provider-registry.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-provider-registry.ts
@@ -60,6 +60,7 @@ type DestroyableSearchProvider = ISearchProvider<ProviderContext> & {
 
 const SEARCH_PROVIDER_ISSUE_CODES: Record<SearchProviderRegistryIssue['code'], true> = {
   SEARCH_PROVIDER_DERIVED_FROM_PUSH_FEATURE: true,
+  SEARCH_PROVIDER_PARTIAL_PUSH_FEATURE_COVERAGE: true,
   SEARCH_PROVIDER_INVALID: true,
   SEARCH_PROVIDER_POLICY_BLOCKED: true,
   SEARCH_PROVIDER_PERMISSION_MISSING: true,

--- a/apps/core-app/src/main/modules/plugin/plugin-loaders.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-loaders.ts
@@ -542,6 +542,20 @@ abstract class BasePluginLoader {
       return
     }
 
+    if (issue.code === 'SEARCH_PROVIDER_PARTIAL_PUSH_FEATURE_COVERAGE') {
+      this.touchPlugin.issues.push({
+        type: 'warning',
+        message: issue.message,
+        source: 'manifest.json',
+        code: issue.code,
+        suggestion:
+          'Declare a searchProvider carrying each push feature\'s featureId, or drop push from the features that should not reach root results.',
+        meta: { featureIds: issue.featureIds ?? [] },
+        timestamp: Date.now()
+      })
+      return
+    }
+
     if (issue.code === 'SEARCH_PROVIDER_PERMISSION_MISSING') {
       this.touchPlugin.issues.push({
         type: 'error',

--- a/apps/core-app/src/main/modules/plugin/plugin-loaders.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-loaders.ts
@@ -549,7 +549,7 @@ abstract class BasePluginLoader {
         source: 'manifest.json',
         code: issue.code,
         suggestion:
-          'Declare a searchProvider carrying each push feature\'s featureId, or drop push from the features that should not reach root results.',
+          "Declare a searchProvider carrying each push feature's featureId, or drop push from the features that should not reach root results.",
         meta: { featureIds: issue.featureIds ?? [] },
         timestamp: Date.now()
       })

--- a/packages/utils/__tests__/search/indexing-source.test.ts
+++ b/packages/utils/__tests__/search/indexing-source.test.ts
@@ -1168,6 +1168,9 @@ describe("search provider sdk contracts", () => {
       hasPushFeatures: true,
       hasExplicitProviders: false,
       needsExplicitProviderMigration: true,
+      // Nothing declared, so there is no per-feature mapping to be partial about --
+      // needsExplicitProviderMigration already covers this manifest.
+      uncoveredPushFeatureIds: [],
     });
 
     expect(
@@ -1186,6 +1189,38 @@ describe("search provider sdk contracts", () => {
       explicitProviderCount: 1,
       hasExplicitProviders: true,
       needsExplicitProviderMigration: false,
+      // The declared provider carries no featureId, so the mapping is implicit and
+      // nothing can be concluded about coverage. Reporting the push feature as
+      // uncovered here would fire on every hand-written single-provider manifest.
+      uncoveredPushFeatureIds: [],
+    });
+  });
+
+  it("names push features left without a provider once the manifest maps any by id", () => {
+    // needsExplicitProviderMigration only fires when there are *no* declared providers,
+    // so a manifest that declares one and forgets the rest reported nothing at all.
+    expect(
+      getSearchProviderManifestCoverage(
+        [
+          { id: "ask", name: "Ask", push: true },
+          { id: "rewrite", name: "Rewrite", push: true },
+          { id: "summarize", name: "Summarize", push: true },
+        ],
+        [
+          {
+            id: "plugin.ask",
+            featureId: "ask",
+            mode: "push",
+            permissionScopes: ["root-results"],
+            defaultState: "ask",
+          },
+        ],
+      ),
+    ).toMatchObject({
+      pushFeatureCount: 3,
+      explicitProviderCount: 1,
+      needsExplicitProviderMigration: false,
+      uncoveredPushFeatureIds: ["rewrite", "summarize"],
     });
   });
 

--- a/packages/utils/search/indexing-source.ts
+++ b/packages/utils/search/indexing-source.ts
@@ -353,10 +353,13 @@ export interface SearchProviderManifestCoverage {
   hasPushFeatures: boolean;
   hasExplicitProviders: boolean;
   needsExplicitProviderMigration: boolean;
+  /** Push features with no declared provider carrying their featureId. */
+  uncoveredPushFeatureIds: string[];
 }
 
 export type SearchProviderManifestResolutionIssueCode =
   | "SEARCH_PROVIDER_DERIVED_FROM_PUSH_FEATURE"
+  | "SEARCH_PROVIDER_PARTIAL_PUSH_FEATURE_COVERAGE"
   | "SEARCH_PROVIDER_INVALID"
   | "SEARCH_PROVIDER_POLICY_BLOCKED"
   | "SEARCH_PROVIDER_PERMISSION_MISSING";
@@ -504,6 +507,12 @@ export function getSearchProviderManifestCoverage(
     .filter((feature) => feature?.push === true)
     .map((feature) => feature.id || feature.name || "<unknown>");
 
+  const coveredFeatureIds = new Set(
+    (Array.isArray(manifestProviders) ? manifestProviders : [])
+      .map((provider) => (provider as { featureId?: string })?.featureId)
+      .filter((featureId): featureId is string => typeof featureId === "string"),
+  );
+
   return {
     pushFeatureIds,
     pushFeatureCount: pushFeatureIds.length,
@@ -516,6 +525,19 @@ export function getSearchProviderManifestCoverage(
     needsExplicitProviderMigration:
       pushFeatureIds.length > 0 &&
       (!Array.isArray(manifestProviders) || manifestProviders.length === 0),
+    // Push features with no provider of their own. needsExplicitProviderMigration only
+    // fires when there are *no* declared providers, so one declaration used to silence
+    // the check for every other push feature in the manifest. Matched by featureId
+    // rather than by count: the counts can coincide while the ids do not.
+    //
+    // Only meaningful once some provider names a feature. A manifest whose providers
+    // carry no featureId at all is using an implicit mapping -- touch-browser-bookmarks
+    // pairs one unnamed provider with one push feature -- and there is nothing to
+    // conclude from that, so it reports nothing rather than everything.
+    uncoveredPushFeatureIds:
+      coveredFeatureIds.size === 0
+        ? []
+        : pushFeatureIds.filter((featureId) => !coveredFeatureIds.has(featureId)),
   };
 }
 
@@ -597,6 +619,19 @@ export function resolveSearchProviderManifestDescriptors(
   const providers = coverage.hasExplicitProviders
     ? explicitProviders
     : deriveSearchProvidersFromPushFeatures(features, input.defaults);
+
+  if (
+    coverage.hasExplicitProviders &&
+    coverage.uncoveredPushFeatureIds.length > 0
+  ) {
+    issues.push({
+      type: "warning",
+      code: "SEARCH_PROVIDER_PARTIAL_PUSH_FEATURE_COVERAGE",
+      message:
+        'Manifest declares "searchProviders" but some push features have no provider of their own; they reach root results without a declared admission policy.',
+      featureIds: coverage.uncoveredPushFeatureIds,
+    });
+  }
 
   if (derivedFromPushFeatures) {
     issues.push({


### PR DESCRIPTION
Refs #1203. Makes the gap visible; **does not** decide what to do about it.

`touch-intelligence` declares **5 push features and 1 `searchProvider`**, and the resolver
reports **zero issues**. `needsExplicitProviderMigration` is the only check on this path and
it requires `manifestProviders.length === 0` — so declaring a single provider silences it
for every other push feature. The coverage object already carried `pushFeatureCount` and
`explicitProviderCount`; nothing compared them.

### The new code

`SEARCH_PROVIDER_PARTIAL_PUSH_FEATURE_COVERAGE`, raised when providers are declared but some
push feature has none of its own. Matched **by `featureId`, not by count** — counts can
coincide while the ids don't.

### One false positive found and excluded

My first version reported `touch-browser-bookmarks` too. Its manifest pairs **one unnamed
provider with one push feature** — an implicit mapping, and nothing to conclude from. Firing
there would hit every hand-written single-provider manifest.

So the check only engages once *some* provider names a feature. If none carries a
`featureId`, it reports nothing rather than everything.

### Against the real manifests

```
touch-intelligence       intelligence-rewrite, intelligence-summarize,
                         intelligence-explain, intelligence-command-registry
touch-browser-bookmarks  (nothing)
```

Exactly the four from the issue.

### What this deliberately leaves open

Those four either need providers with an admission policy, or shouldn't be declaring
`push: true`. That's a manifest decision and a security one — I've made it visible rather
than guessing which way it goes. The point of #1203 was that nothing reported it at all.

### Verification

- `packages/utils`: **132 files, 1057 tests passing**.
- Extended the coverage contract test with the partial case, and pinned the implicit-mapping
  case so the false positive can't come back.
- Lint clean under `packages/utils/eslint.config.js`.