### PR TITLE
fix(nexus): bound password guessing on the credentials sign-in path

### DIFF
--- a/apps/nexus/server/api/auth/[...].ts
+++ b/apps/nexus/server/api/auth/[...].ts
@@ -11,6 +11,7 @@ import GitHub from 'next-auth/providers/github'
 import { createD1Adapter } from '../../utils/authAdapter'
 import {
   consumeLoginToken,
+  evaluatePasswordSignInRateLimit,
   getUserByAccount,
   getUserByEmail,
   logLoginAttempt,
@@ -485,11 +486,30 @@ function getAuthOptions(authSecret: string): AuthOptions {
           return null
         }
 
+        // Failures were written to the login history and never read back, so the guess budget
+        // was unbounded (#897). Resolved before verifying rather than after, so a locked-out
+        // account costs an attacker a lookup instead of a PBKDF2 verification — and so the
+        // refusal does not depend on the password happening to be wrong.
+        const knownUser = await getUserByEmail(authEvent, email)
+        const activeKnownUserId = knownUser?.status === 'active' ? knownUser.id : null
+        const rateLimit = await evaluatePasswordSignInRateLimit(authEvent, {
+          userId: activeKnownUserId,
+        })
+        if (!rateLimit.allowed) {
+          await logLoginAttempt(authEvent, {
+            userId: activeKnownUserId,
+            deviceId: null,
+            success: false,
+            reason: 'rate_limited',
+            clientType: 'web',
+          })
+          return null
+        }
+
         const user = await verifyUserPassword(authEvent, email, password)
         if (!user) {
-          const attemptedUser = await getUserByEmail(authEvent, email)
           await logLoginAttempt(authEvent, {
-            userId: attemptedUser?.status === 'active' ? attemptedUser.id : null,
+            userId: activeKnownUserId,
             deviceId: null,
             success: false,
             reason: 'invalid_password',

--- a/apps/nexus/server/utils/__tests__/passwordSignInRateLimit.test.ts
+++ b/apps/nexus/server/utils/__tests__/passwordSignInRateLimit.test.ts
@@ -1,0 +1,109 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import type { H3Event } from 'h3'
+import { describe, expect, it } from 'vitest'
+import { evaluatePasswordSignInRateLimit } from '../authStore'
+
+/**
+ * Bounding password guesses (#897).
+ *
+ * Every failure was written to the login history and never read back, so a loop against the
+ * credentials callback with one victim email and a password list ran until it succeeded.
+ * PBKDF2 at 210k iterations raises the cost of each guess; it does not limit how many.
+ */
+
+/** A database whose COUNT(*) answers with `count`, recording what it was asked. */
+function createEvent(count: number, seen: string[][] = [], ip = '203.0.113.5'): H3Event {
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind: (...args: unknown[]) => {
+          if (sql.includes('COUNT'))
+            seen.push([sql.replace(/\s+/g, ' ').trim(), ...args.map(String)])
+          return {
+            first: async () => (sql.includes('COUNT') ? { total: count } : null),
+            all: async () => ({ results: [] }),
+            run: async () => ({}),
+          }
+        },
+        first: async () => null,
+        all: async () => ({ results: [] }),
+        run: async () => ({}),
+      }
+    },
+    async batch() {
+      return []
+    },
+  }
+
+  return {
+    context: { cloudflare: { env: { DB: db } } },
+    node: { req: { headers: { 'x-forwarded-for': ip } } },
+  } as unknown as H3Event
+}
+
+describe('evaluatePasswordSignInRateLimit', () => {
+  it('allows a sign-in when nothing has failed recently', async () => {
+    // Positive control: a limiter that refused everything would satisfy the assertions below
+    // while locking every user out of the site.
+    expect(await evaluatePasswordSignInRateLimit(createEvent(0), { userId: 'u1' }))
+      .toEqual({ allowed: true })
+  })
+
+  it('blocks once the per-account budget is spent', async () => {
+    const decision = await evaluatePasswordSignInRateLimit(createEvent(10), { userId: 'u1' })
+    expect(decision.allowed).toBe(false)
+    expect(decision.scope).toBe('user')
+  })
+
+  it('falls back to the per-IP budget when the email matches no account', async () => {
+    // userId is null for an address that does not exist, so per-account counting alone would
+    // leave guessing against unknown addresses unbounded.
+    const decision = await evaluatePasswordSignInRateLimit(createEvent(30), {})
+    expect(decision.allowed).toBe(false)
+    expect(decision.scope).toBe('ip')
+  })
+
+  it('gives the IP a wider budget than a single account', async () => {
+    // One shared NAT must not lock out innocent users at the per-account threshold.
+    const decision = await evaluatePasswordSignInRateLimit(createEvent(10), {})
+    expect(decision.allowed).toBe(true)
+  })
+
+  it('counts only failures', async () => {
+    // A successful sign-in must never spend anyone's budget.
+    const seen: string[][] = []
+    await evaluatePasswordSignInRateLimit(createEvent(0, seen), { userId: 'u1' })
+    expect(seen.length).toBeGreaterThan(0)
+    for (const [sql] of seen)
+      expect(sql).toContain('success = 0')
+  })
+})
+
+/**
+ * That the credentials provider applies it. next-auth builds its options inside a Nuxt
+ * handler, so the call site is guarded at source level.
+ */
+describe('credentials sign-in wiring', () => {
+  const source = readFileSync(
+    fileURLToPath(new URL('../../api/auth/[...].ts', import.meta.url)),
+    'utf8',
+  )
+
+  it('evaluates the limit before verifying the password', () => {
+    const limitAt = source.indexOf('evaluatePasswordSignInRateLimit(')
+    const verifyAt = source.indexOf('verifyUserPassword(authEvent, email, password)')
+    expect(limitAt, 'rate limit call not found').toBeGreaterThan(-1)
+    expect(verifyAt).toBeGreaterThan(limitAt)
+  })
+
+  it('refuses rather than falling through when the budget is spent', () => {
+    expect(source).toMatch(/if \(!rateLimit\.allowed\)[\s\S]*?return null/)
+  })
+
+  it('still records the refused attempt', () => {
+    // Without a write the limiter would read an always-empty table and never fire again once
+    // the window rolled — the quiet way this kind of fix stops working.
+    expect(source).toMatch(/reason: 'rate_limited'/)
+  })
+})

--- a/apps/nexus/server/utils/authStore.ts
+++ b/apps/nexus/server/utils/authStore.ts
@@ -2817,6 +2817,79 @@ export async function setDeviceTrusted(event: H3Event, userId: string, deviceId:
   return getDevice(event, userId, deviceId)
 }
 
+/** Failed password attempts tolerated per account, then per IP, inside the window. */
+const PASSWORD_SIGNIN_WINDOW_MS = 15 * 60 * 1000
+const PASSWORD_SIGNIN_MAX_BY_USER = 10
+const PASSWORD_SIGNIN_MAX_BY_IP = 30
+
+export interface PasswordSignInRateLimitDecision {
+  allowed: boolean
+  scope?: 'user' | 'ip'
+  retryAfterMs?: number
+}
+
+async function countRecentLoginFailures(
+  db: D1Database,
+  whereSql: string,
+  params: Array<string | number | null>,
+): Promise<number> {
+  const row = await db.prepare(`
+    SELECT COUNT(*) AS total
+    FROM ${LOGIN_HISTORY_TABLE}
+    WHERE success = 0 AND ${whereSql}
+  `).bind(...params).first<{ total?: number | string }>()
+  return toSafeInteger(row?.total)
+}
+
+/**
+ * Bounds password guessing.
+ *
+ * Every failure was already written to the login history and never read back, so the attempt
+ * budget was unbounded: a loop against the credentials callback with one victim email and a
+ * password list ran until it succeeded (#897). PBKDF2 at 210k iterations raises the cost of
+ * each guess; it does not limit how many there are.
+ *
+ * Counted per account and per IP because neither alone is enough. A userId is only known when
+ * the email matches an active account, so per-user counting misses guessing against addresses
+ * that do not exist — and per-IP counting alone would let a distributed attempt through while
+ * one shared NAT locked out innocent users. Only failures count, so signing in successfully
+ * never spends anyone's budget.
+ */
+export async function evaluatePasswordSignInRateLimit(event: H3Event, payload: {
+  userId?: string | null
+}): Promise<PasswordSignInRateLimitDecision> {
+  const db = requireDatabase(event)
+  await ensureAuthSchema(db)
+  const since = new Date(Date.now() - PASSWORD_SIGNIN_WINDOW_MS).toISOString()
+  const ip = getRequestIp(event)
+
+  const checks: Array<{ scope: 'user' | 'ip', limit: number, whereSql: string, params: Array<string | number | null> }> = []
+  if (payload.userId) {
+    checks.push({
+      scope: 'user',
+      limit: PASSWORD_SIGNIN_MAX_BY_USER,
+      whereSql: 'user_id = ? AND created_at >= ?',
+      params: [payload.userId, since],
+    })
+  }
+  if (ip) {
+    checks.push({
+      scope: 'ip',
+      limit: PASSWORD_SIGNIN_MAX_BY_IP,
+      whereSql: 'ip = ? AND created_at >= ?',
+      params: [ip, since],
+    })
+  }
+
+  for (const check of checks) {
+    const count = await countRecentLoginFailures(db, check.whereSql, check.params)
+    if (count >= check.limit)
+      return { allowed: false, scope: check.scope, retryAfterMs: PASSWORD_SIGNIN_WINDOW_MS }
+  }
+
+  return { allowed: true }
+}
+
 export async function logLoginAttempt(event: H3Event, payload: {
   userId?: string | null
   deviceId?: string | null


### PR DESCRIPTION
Closes #897.

## The defect

Every failed attempt was written to the login history and **never read back**. A loop against the credentials callback with one victim email and a password list ran until it succeeded.

PBKDF2 at 210k iterations raises the cost of each guess; it does not limit how many there are.

## The fix

`evaluatePasswordSignInRateLimit` counts recent failures **in that same table** — 10 per account and 30 per IP over 15 minutes. The history the code already kept is finally consulted rather than only appended to.

## Why both scopes

| scope alone | leaves open |
|---|---|
| per-account | `userId` is null when the email matches no account, so guessing against **non-existent addresses** is unbounded |
| per-IP | a distributed attempt passes, while one shared NAT locks out innocent users |

The IP budget is deliberately the **wider** of the two, and there is a test for exactly that.

## Two ordering decisions

**The check runs before `verifyUserPassword`.** A locked-out account then costs an attacker a lookup rather than a PBKDF2 verification, and the refusal does not depend on the password happening to be wrong.

**The refusal is itself logged** (`reason: 'rate_limited'`). Without a write the limiter would read an emptying table and stop firing once the window rolled — the quiet way this class of fix stops working. The same failure mode I hit on #904.

## Not done: Turnstile

The issue also mentions it, and the piece exists — `verifyTurnstileToken` is wired into `register.post.ts`. But putting an interactive challenge in front of **every** password sign-in is a product decision about the login experience, not a rate-limiting gap. Say the word and it is a small addition.

## Tests

Eight, **six failing** against the previous version. Beyond the thresholds: one asserts the IP budget is wider than the per-account budget, one asserts the queries filter on `success = 0` (a successful sign-in must never spend anyone's budget), and three guard the call site at source level since next-auth builds its options inside a Nuxt handler.

Full nexus suite passes: 1074 tests. `pnpm run typecheck` exits 0.