### PR TITLE
ci(tuffex): run the tests before publishing to npm (#325)

### DIFF
--- a/.github/workflows/package-tuffex-publish.yml
+++ b/.github/workflows/package-tuffex-publish.yml
@@ -92,6 +92,14 @@ jobs:
         if: steps.version_check.outputs.should_publish != 'true'
         run: echo "Tuffex version unchanged and already published. Skipping publish."
 
+      - name: Run tuffex tests
+        if: steps.version_check.outputs.should_publish == 'true'
+        run: pnpm -C "packages/tuffex" test
+
+      - name: Type-check package
+        if: steps.version_check.outputs.should_publish == 'true'
+        run: pnpm -C "packages/tuffex" typecheck
+
       - name: Build package
         if: steps.version_check.outputs.should_publish == 'true'
         working-directory: packages/tuffex


### PR DESCRIPTION
Refs #325 — the *"release workflows cannot publish when a suite fails"* criterion.

`package-tuffex-publish` goes **Build → Verify npm token → Publish**. It never runs the
suite, so a release could ship with the package's **1114 tests failing** and nothing would
say so.

### Following the pattern that already exists

`package-utils-publish` already does this — a `Run utils tests` step gated on
`should_publish`. This mirrors it rather than inventing something.

Typecheck is included alongside, because tuffex ships `.d.ts` and a broken public type
surface is a **publish-time** defect rather than a runtime one.

### Both gates pass today

```
vitest    145 files, 1114 tests
vue-tsc   clean
```

So this blocks nothing that would otherwise have shipped. Placed **before** Build, so a
failing suite stops the release without having spent the build first.

### Deliberately not added

The `audit:*` scripts. `audit:size` is currently over its CSS budgets — over since
**2026-06-05**, when the budget was written 16 days before the high-contrast theme layer
that broke it. Adding it here would block every tuffex release on a pre-existing condition.
That's a different decision and belongs with the budget question on #325.

### While checking the other publish workflows

| workflow | tests before publish |
|---|---|
| `package-utils-publish` | yes |
| `package-tuffex-publish` | **this PR** |
| `package-tuff-cli-publish` | no — and the package has **no test script at all** |
| `package-tuff-intelligence-publish` | no — same |

The last two aren't a workflow gap I can close by editing YAML: `packages/tuff-cli` and
`packages/tuff-intelligence` have only `build`, `dev`, `lint`, `lint:fix`, `clean`. There is
nothing to gate on. Reported on #325 rather than papered over with a step that would run
nothing.