### PR TITLE
ci(tuffex): run tuffex CI when packages/utils changes (#325)

### DIFF
--- a/.github/workflows/package-tuffex-ci.yml
+++ b/.github/workflows/package-tuffex-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "packages/tuffex/**"
+      - "packages/utils/**"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - ".github/workflows/package-tuffex-ci.yml"
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - "packages/tuffex/**"
+      - "packages/utils/**"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - ".github/workflows/package-tuffex-ci.yml"


### PR DESCRIPTION
Refs #325 — the *"path filters run the affected shard **without skipping cross-package
contract changes**"* criterion.

`packages/tuffex` declares `@talex-touch/utils` as a dependency and imports it in **eight
source files**, but `package-tuffex-ci` only triggers on `packages/tuffex/**`. A PR that
changes utils can break tuffex and this workflow won't run.

### The repo already answers this elsewhere

| package CI | lists `packages/utils/**`? |
|---|---|
| `package-tuff-cli-ci` | yes |
| `package-tuff-intelligence-ci` | yes |
| `package-tuffex-ci` | **no** — this PR |

tuffex was the only one of the three missing it. Added to both the `pull_request` and
`push` triggers so they stay in step.

### Checked, and deliberately not changed

- **The publish workflow.** It triggers on version bumps, which is a different question
  from whether a dependency change should re-run the suite.
- **The `master`/`main` push branches.** Every push-triggered workflow in the repo targets
  those, and none targets `TalexDreamSoul/app-shell-v2`. I looked at whether that's a
  #543-style broken trigger and concluded it isn't: `packages/tuffex/package.json` is at
  `0.3.9` and npm's latest is `0.3.9`, so the master-release model is working as intended.
  PRs into `app-shell-v2` do fire `pull_request`, which is where the gating happens.