### PR TITLE
fix(build): resolve nested dependencies instead of stopping at the scope directory (#323)

### DIFF
--- a/apps/core-app/scripts/build-target/runtime-modules.js
+++ b/apps/core-app/scripts/build-target/runtime-modules.js
@@ -258,11 +258,43 @@ function getAppRuntimeRootModules(options = {}) {
   }))
 }
 
-function tryResolvePackageRoot(candidatePath) {
-  if (fs.existsSync(path.join(candidatePath, 'package.json'))) {
+function findContainingNodeModules(startDir) {
+  let current = startDir
+  while (current && path.basename(current) !== 'node_modules') {
+    const parent = path.dirname(current)
+    if (parent === current) {
+      return null
+    }
+    current = parent
+  }
+  return path.basename(current) === 'node_modules' ? current : null
+}
+
+function tryResolvePackageRoot(candidatePath, expectedName) {
+  const manifestPath = path.join(candidatePath, 'package.json')
+  if (!fs.existsSync(manifestPath)) {
+    return null
+  }
+  if (!expectedName) {
     return candidatePath
   }
-  return null
+  // A candidate directory having a package.json is not enough: the sibling-lookup
+  // candidate below joins the requested name onto the parent's *scope* directory, so
+  // @langchain/openai asking for "openai" lands back on @langchain/openai itself, which
+  // has a package.json and was accepted. The walker then believed it had found openai,
+  // never descended into the real one, and its dependencies were silently absent from
+  // the packaged closure.
+  try {
+    const name = JSON.parse(fs.readFileSync(manifestPath, 'utf8')).name
+    // Tolerate a manifest with no name rather than rejecting it; only a positive
+    // mismatch is evidence that this is the wrong package.
+    if (name && name !== expectedName) {
+      return null
+    }
+  } catch {
+    return null
+  }
+  return candidatePath
 }
 
 function getRealPath(candidatePath) {
@@ -321,7 +353,15 @@ function resolveRuntimeModuleRoot(moduleName, runtimePaths, sourceDir, options =
     }
     if (realSourceDir !== sourceDir) {
       directCandidates.push(path.join(realSourceDir, 'node_modules', moduleName))
-      directCandidates.push(path.join(path.dirname(realSourceDir), moduleName))
+      // Siblings live in the node_modules directory that contains this package, which is
+      // one level up for "foo" and two for "@scope/foo". Walking to the nearest
+      // node_modules handles both; going up a fixed single level put scoped packages in
+      // their own scope directory, so @langchain/openai looking for "openai" resolved to
+      // itself and its real dependency was never reached.
+      const containingNodeModules = findContainingNodeModules(realSourceDir)
+      if (containingNodeModules) {
+        directCandidates.push(path.join(containingNodeModules, moduleName))
+      }
     }
   }
   directCandidates.push(path.join(runtimePaths.workspaceNodeModules, moduleName))
@@ -333,7 +373,7 @@ function resolveRuntimeModuleRoot(moduleName, runtimePaths, sourceDir, options =
   }
 
   for (const candidate of directCandidates) {
-    const resolved = tryResolvePackageRoot(candidate)
+    const resolved = tryResolvePackageRoot(candidate, moduleName)
     if (resolved) {
       return resolved
     }

--- a/apps/core-app/src/main/core/runtime-modules.contract.test.ts
+++ b/apps/core-app/src/main/core/runtime-modules.contract.test.ts
@@ -169,6 +169,13 @@ describe('runtime module manifest contract', () => {
     const names = collectRuntimeModuleClosure(getPlatformRuntimeRootModules('mac', 'arm64'), {
       dedupeBy: 'name',
       dependencyTypes: ['dependencies', 'optionalDependencies', 'peerDependencies'],
+      // An optional peer is by definition not required by the package declaring it, and
+      // following them lets a wildcard claim a name it does not own: langsmith declares
+      // `openai: '*'` as an optional peer, which resolved to the hoisted v6 and stopped
+      // @langchain/openai's own openai@^4.87.3 from ever being walked. The packaged
+      // closure (collectAppRuntimeModuleClosure) does not follow peers at all, so this
+      // now models what is actually shipped.
+      includeOptionalPeerDependencies: false,
       includeTargetNodeModules: false,
       logger: { warn: () => undefined },
       maxDepth: 20,


### PR DESCRIPTION
Fixes the last real item on #323 — the one described there as the openai v4/v6 blocker.

It isn't a version conflict. **Two bugs in the closure resolver**, one hiding the other.

### 1. The sibling lookup went up one level, not to the containing `node_modules`

For an unscoped package those are the same directory. For `@scope/name` they aren't.
Resolving `openai` from `@langchain/openai` produced:

```
.../node_modules/@langchain  +  openai  =  .../node_modules/@langchain/openai
```

— the package that asked. It has a `package.json`, so it was accepted.

### 2. `tryResolvePackageRoot` never checked the name

It only checked that `package.json` **exists**. That's what let the wrong directory
through. It now compares names, tolerating a manifest without one — only a *positive*
mismatch is evidence.

### What the build actually ships, before and after

```
before   621 modules   openai@6.26.0                       formdata-node absent
after    627 modules   openai@6.26.0 and openai@4.104.0    formdata-node present
```

Both versions is **correct** here: core-app declares `openai: ^6.26.0` directly, and
`@langchain/openai` carries its own `openai: ^4.87.3` nested. Before this,
`@langchain/openai` would have loaded **v6 at runtime — a major it wasn't built against** —
because that's all that was packaged. That's the real defect; the failing assertion was
just the symptom.

### The contract test was also asking for something the build never does

It followed `peerDependencies` *including optional ones*, and `langsmith` declares
`openai: '*'` as an **optional peer**, which resolved to the hoisted v6 and stopped
langchain's own dependency being walked.

`collectAppRuntimeModuleClosure` — what the build uses — doesn't follow peers at all. The
test now passes `includeOptionalPeerDependencies: false` so it models what ships. An
optional peer is by definition not required by the package declaring it.

### Two premises from the issue that turned out wrong

- **`@langchain/openai@0.4.9` does not *peer* `openai`.** It's a regular dependency
  (`^4.87.3`); its only peer is `@langchain/core`. Installation was never in conflict —
  both versions are in the lockfile.
- **`dedupeBy: 'path'` was never going to help.** I ran both modes: identical, 271 modules
  each. The *visit* is keyed on name before dedupe applies.

### Verification

- `runtime-modules.contract` + `runtime-modules`: **16/16 passing** (was 1 failing).
- Full core-app suite: `runtime-modules.contract` no longer appears in the failures. What
  remains is `widget-registry` (#1228), `quick-ops` (#1227), the screenshot integration test
  needing macOS Screen Recording permission, and three timing-sensitive tests that fail
  under load on this machine — none related to this change.
- Lint clean under `apps/core-app/eslint.config.mjs`.