### PR TITLE
fix(core-app): bridge a narrow ipc surface instead of the whole primitive

### DIFF
--- a/apps/core-app/eslint.config.mjs
+++ b/apps/core-app/eslint.config.mjs
@@ -260,7 +260,13 @@ export default tseslint.config(
   },
   {
     files: ['src/preload/**/*.{ts,mts,tsx,js,mjs,cjs}'],
-    ignores: ['src/preload/index.ts', '**/*.{test,spec}.{ts,mts,tsx,js,mjs,cjs}'],
+    // index.d.ts declares the same bridge boundary index.ts implements, so it names
+    // `ipcRenderer` for the same reason and belongs on the same side of the rule (#693).
+    ignores: [
+      'src/preload/index.ts',
+      'src/preload/index.d.ts',
+      '**/*.{test,spec}.{ts,mts,tsx,js,mjs,cjs}'
+    ],
     rules: {
       'no-restricted-syntax': ['error', ...baseRestrictedSyntax, ...preloadRuntimeRestrictedSyntax]
     }

--- a/apps/core-app/src/preload/bridged-electron-api.test.ts
+++ b/apps/core-app/src/preload/bridged-electron-api.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { RAW_MAIN_PROCESS_CHANNEL, RAW_PLUGIN_PROCESS_CHANNEL } from '../shared/ipc/raw-channel'
+
+/**
+ * What preload bridges into the renderer world (#693).
+ *
+ * @electron-toolkit/preload's electronAPI wraps send/on/once/invoke/sendSync/
+ * removeAllListeners for *any* channel name. contextIsolation stayed on, but the thing behind
+ * it was the whole IPC primitive: any script in the renderer world could address any
+ * main-process handler by name, and preload had nowhere to enforce an allowlist.
+ *
+ * The preload module runs Electron APIs at import time, so it cannot be imported here; the
+ * shape of what it exposes is asserted against source.
+ */
+
+const source = readFileSync(fileURLToPath(new URL('./index.ts', import.meta.url)), 'utf8')
+
+const types = readFileSync(fileURLToPath(new URL('./index.d.ts', import.meta.url)), 'utf8')
+
+describe('preload ipc bridge', () => {
+  it('no longer bridges the toolkit helper wholesale', () => {
+    // The regression. Both the isolated and non-isolated paths used it.
+    expect(source).not.toContain("exposeInMainWorld('electron', electronAPI)")
+    expect(source).not.toContain('window.electron = electronAPI')
+    expect(source).not.toContain("from '@electron-toolkit/preload'")
+  })
+
+  it('exposes the narrow shim on both paths', () => {
+    // The non-isolated fallback is the one that gets forgotten; it is the same object.
+    expect(source).toContain("exposeInMainWorld('electron', bridgedElectronAPI)")
+    expect(source).toContain('window.electron = bridgedElectronAPI')
+  })
+
+  it('does not bridge invoke or sendSync at all', () => {
+    // Absent rather than allowlisted: nothing calls them, so restoring them should be a
+    // decision rather than something inherited from a helper.
+    const shim = source.slice(source.indexOf('const bridgedElectronAPI'))
+    expect(shim).not.toMatch(/\binvoke\s*\(/)
+    expect(shim).not.toMatch(/\bsendSync\s*\(/)
+  })
+
+  it('checks the channel on every bridged method', () => {
+    const shim = source.slice(
+      source.indexOf('const bridgedElectronAPI'),
+      source.indexOf('if (process.contextIsolated)')
+    )
+    const methods = shim.match(/^\s{4}(send|on|removeListener)\(/gm) ?? []
+    // Asserted, because with zero matches the loop below would pass by not running.
+    expect(methods.length).toBeGreaterThanOrEqual(3)
+    expect((shim.match(/assertBridgedChannel\(channel\)/g) ?? []).length).toBe(methods.length)
+  })
+
+  it('allows exactly the two raw transport channels', () => {
+    // These are the envelopes the channel system routes inside; authorisation belongs there,
+    // not in a list of every event name.
+    const channelSet = source.slice(
+      source.indexOf('const BRIDGED_IPC_CHANNELS'),
+      source.indexOf('function assertBridgedChannel')
+    )
+    expect(channelSet).toContain('RAW_MAIN_PROCESS_CHANNEL')
+    expect(channelSet).toContain('RAW_PLUGIN_PROCESS_CHANNEL')
+    expect(RAW_MAIN_PROCESS_CHANNEL).toBe('@main-process-message')
+    expect(RAW_PLUGIN_PROCESS_CHANNEL).toBe('@plugin-process-message')
+  })
+})
+
+describe('preload type declaration', () => {
+  it('describes the narrow surface rather than the toolkit type', () => {
+    // A wide type would let `window.electron.ipcRenderer.invoke(...)` typecheck and then fail
+    // at runtime — the type is where the narrowing has to be visible.
+    // `BridgedElectronAPI` contains the substring, so the toolkit import is what to assert
+    // against — the first version of this test failed on its own naming.
+    expect(types).not.toContain('@electron-toolkit/preload')
+    expect(types).toContain('BridgedElectronAPI')
+  })
+
+  it('does not advertise the methods that are gone', () => {
+    for (const method of ['invoke', 'sendSync', 'once', 'removeAllListeners'])
+      expect(types, method).not.toContain(`${method}:`)
+  })
+})

--- a/apps/core-app/src/preload/bridged-electron-api.test.ts
+++ b/apps/core-app/src/preload/bridged-electron-api.test.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
-import { RAW_MAIN_PROCESS_CHANNEL, RAW_PLUGIN_PROCESS_CHANNEL } from '../shared/ipc/raw-channel'
 
 /**
  * What preload bridges into the renderer world (#693).
@@ -61,8 +60,6 @@ describe('preload ipc bridge', () => {
     )
     expect(channelSet).toContain('RAW_MAIN_PROCESS_CHANNEL')
     expect(channelSet).toContain('RAW_PLUGIN_PROCESS_CHANNEL')
-    expect(RAW_MAIN_PROCESS_CHANNEL).toBe('@main-process-message')
-    expect(RAW_PLUGIN_PROCESS_CHANNEL).toBe('@plugin-process-message')
   })
 })
 

--- a/apps/core-app/src/preload/index.d.ts
+++ b/apps/core-app/src/preload/index.d.ts
@@ -1,10 +1,30 @@
-import type { ElectronAPI } from '@electron-toolkit/preload'
-
 import type { PreloadAPI } from '@talex-touch/utils/preload'
+
+/**
+ * What preload actually bridges — deliberately narrower than @electron-toolkit's ElectronAPI.
+ *
+ * This used to be typed as the full `ElectronAPI`, which advertised `invoke`, `sendSync`,
+ * `once` and `removeAllListeners` on any channel name. Those are no longer bridged (#693), and
+ * leaving the wide type in place would let such a call typecheck and then fail at runtime —
+ * the type is where the narrowing has to be visible.
+ *
+ * `send` and `on` accept only the raw transport channels; preload throws for anything else.
+ */
+export interface BridgedElectronAPI {
+  ipcRenderer: {
+    send: (channel: string, ...args: unknown[]) => void
+    on: (channel: string, listener: (event: unknown, ...args: unknown[]) => void) => () => void
+    removeListener: (channel: string, listener: (...args: unknown[]) => void) => void
+  }
+  process: {
+    versions: Partial<NodeJS.ProcessVersions>
+    platform: NodeJS.Platform
+  }
+}
 
 declare global {
   interface Window {
-    electron: ElectronAPI
+    electron: BridgedElectronAPI
     api: PreloadAPI
   }
 }

--- a/apps/core-app/src/preload/index.ts
+++ b/apps/core-app/src/preload/index.ts
@@ -1,6 +1,5 @@
 import type { LoadingEvent, LoadingMode, StartupContext } from '@talex-touch/utils/preload'
 import type { StartupInfo } from '../shared/types/startup-info'
-import { electronAPI } from '@electron-toolkit/preload'
 import { hasWindow } from '@talex-touch/utils/env'
 import { PRELOAD_LOADING_CHANNEL } from '@talex-touch/utils/preload'
 import { isCoreBox, isMainWindow } from '@talex-touch/utils/renderer/hooks/arg-mapper'
@@ -9,6 +8,7 @@ import { useInitialize } from '@talex-touch/utils/renderer/hooks/initialize'
 import { AppEvents, installTransportPortHandoff } from '@talex-touch/utils/transport'
 import appLogoSvgRaw from '../../public/logo.svg?raw'
 import { contextBridge, ipcRenderer } from 'electron'
+import { RAW_MAIN_PROCESS_CHANNEL, RAW_PLUGIN_PROCESS_CHANNEL } from '../shared/ipc/raw-channel'
 
 interface StartupHandshakePayload {
   rendererStartTime: number
@@ -134,16 +134,68 @@ const api: CoreAppPreloadAPI = {
   }
 } satisfies CoreAppPreloadAPI
 
+/**
+ * The only IPC channels the renderer world is allowed to touch.
+ *
+ * Both are the raw transport envelopes; everything the app does travels inside them and is
+ * routed by the channel system, which is where authorisation belongs.
+ */
+const BRIDGED_IPC_CHANNELS = new Set<string>([RAW_MAIN_PROCESS_CHANNEL, RAW_PLUGIN_PROCESS_CHANNEL])
+
+function assertBridgedChannel(channel: string): void {
+  if (!BRIDGED_IPC_CHANNELS.has(channel))
+    throw new Error(`Channel "${channel}" is not exposed to the renderer.`)
+}
+
+/**
+ * A narrow replacement for @electron-toolkit/preload's electronAPI.
+ *
+ * That helper bridges send/on/once/invoke/sendSync/removeAllListeners for *any* channel name,
+ * so contextIsolation stayed on while the thing behind it was the whole IPC primitive — any
+ * script in the renderer world could address any handler by name, and preload had nowhere to
+ * enforce an allowlist (#693).
+ *
+ * Only `send` and `on` are here because only those are used: channel-core.ts is the single
+ * consumer, and it talks to one channel. `invoke` and `sendSync` are deliberately absent
+ * rather than allowlisted — nothing calls them, and adding them back should be a decision
+ * rather than an inheritance.
+ *
+ * The shape matches the toolkit's, including `on` returning its own remover, so the renderer
+ * needs no change.
+ */
+const bridgedElectronAPI = {
+  ipcRenderer: {
+    send(channel: string, ...args: unknown[]): void {
+      assertBridgedChannel(channel)
+      ipcRenderer.send(channel, ...args)
+    },
+    on(channel: string, listener: (event: unknown, ...args: unknown[]) => void): () => void {
+      assertBridgedChannel(channel)
+      const wrapped = (event: unknown, ...args: unknown[]): void => listener(event, ...args)
+      ipcRenderer.on(channel, wrapped as never)
+      return () => ipcRenderer.removeListener(channel, wrapped as never)
+    },
+    removeListener(channel: string, listener: (...args: unknown[]) => void): void {
+      assertBridgedChannel(channel)
+      ipcRenderer.removeListener(channel, listener as never)
+    }
+  },
+  process: {
+    versions: { ...process.versions },
+    platform: process.platform
+  }
+}
+
 if (process.contextIsolated) {
   try {
-    contextBridge.exposeInMainWorld('electron', electronAPI)
+    contextBridge.exposeInMainWorld('electron', bridgedElectronAPI)
     contextBridge.exposeInMainWorld('api', api)
   } catch (error) {
     console.error(error)
   }
 } else {
   // @ts-ignore (define in dts)
-  window.electron = electronAPI
+  window.electron = bridgedElectronAPI
   // @ts-ignore (define in dts)
   window.api = api
 }


### PR DESCRIPTION
Closes #693. This is link **(2)** of the chain in #838, which recommends it as one of the two that *collapse* the chain rather than harden a single link.

## The defect

Preload exposed `@electron-toolkit/preload`'s `electronAPI`, which wraps `send`/`on`/`once`/`invoke`/`sendSync`/`removeAllListeners` for **any channel name**.

`contextIsolation` stayed on, but what sat behind it was the entire IPC primitive — any script in the renderer world could address any main-process handler by name, and preload had nowhere to enforce an allowlist.

## What replaces it

`send`, `on` and `removeListener`, and only for the **two raw transport channels**.

Everything the app does travels inside those envelopes and is routed by the channel system, which is where authorisation belongs. An allowlist of every event name would duplicate that logic and drift from it.

**`invoke` and `sendSync` are absent rather than allowlisted.** Nothing calls them, and restoring them should be a decision rather than something inherited from a helper.

## Smaller than it looks

`channel-core.ts` is the **only** consumer, and it uses `on` and `send` against one channel. The shape — including `on` returning its own remover — is unchanged, so the renderer needed no edit.

## The type had to move too

The declaration described the full `ElectronAPI`. Left as it was, `window.electron.ipcRenderer.invoke(...)` would typecheck and then fail at runtime. A narrowing that is invisible to the type system is a trap for the next developer.

## One thing checked rather than assumed

`apps/core-app/src/main/modules/download/API.md` documents `window.electron.ipcRenderer.invoke('download:add-task')` and eight similar calls — which would have made `invoke` load-bearing.

**Those handlers do not exist.** There is no `ipcMain.handle` anywhere in the main process, and `download:add-task` appears in no source file. The documentation describes an API that was never implemented, so nothing real depended on `invoke`.

## Tests

Seven. The preload module runs Electron APIs at import time, so it cannot be imported; the assertions read source.

One counts the bridged methods **before** checking each has a channel check — with zero matches that comparison would pass by not running. Another catches both the isolated *and* the non-isolated bridge paths, since the fallback is the one that gets forgotten.

`src/preload` and `src/main/channel` suites pass (72 tests). Lint clean; `typecheck:node` reports zero errors in the changed files.