### PR TITLE
fix(core-app,plugins): never fetch a plugin Prelude over the network in a packaged build

### DIFF
--- a/apps/core-app/src/main/modules/plugin/dev-prelude-guard.test.ts
+++ b/apps/core-app/src/main/modules/plugin/dev-prelude-guard.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Where a plugin's Prelude may come from (#809, #810, #811).
+ *
+ * loadPreludeScript took the remote branch whenever `dev.enable && dev.source && dev.address`,
+ * with no reference to whether the app was packaged. Three shipped manifests carried exactly
+ * that, so an installed app issued GET http://127.0.0.1:<port>/index.js and executed the
+ * response as the plugin's Prelude. Usually nothing listens and the plugin fails to load;
+ * if anything does, it owns the plugin.
+ *
+ * Two separate fixes, and both are needed: the manifests are corrected so today's builds are
+ * right, and the guard makes the next manifest with the same mistake harmless.
+ */
+
+const PLUGINS_WITH_DEV_BLOCKS = ['clipboard-history', 'touch-intelligence', 'touch-translation']
+
+describe('shipped plugin manifests', () => {
+  it.each(PLUGINS_WITH_DEV_BLOCKS)('%s does not ship with dev mode enabled', (name) => {
+    const manifest = JSON.parse(
+      readFileSync(
+        fileURLToPath(new URL(`../../../../../../plugins/${name}/manifest.json`, import.meta.url)),
+        'utf8'
+      )
+    )
+    expect(manifest.dev?.enable).not.toBe(true)
+  })
+
+  it('finds no other plugin shipping an enabled dev block', () => {
+    // The three above were the whole set when this was written. A new one appearing should
+    // fail here rather than ship — which is the only way this stays true.
+    const pluginsDir = fileURLToPath(new URL('../../../../../../plugins/', import.meta.url))
+    const { readdirSync, existsSync } = require('node:fs') as typeof import('node:fs')
+
+    const enabled = readdirSync(pluginsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => `${pluginsDir}${entry.name}/manifest.json`)
+      .filter(existsSync)
+      .filter((file) => {
+        const manifest = JSON.parse(readFileSync(file, 'utf8'))
+        return manifest.dev?.enable === true
+      })
+
+    expect(enabled).toEqual([])
+  })
+})
+
+describe('remote prelude guard', () => {
+  const source = readFileSync(fileURLToPath(new URL('./plugin.ts', import.meta.url)), 'utf8')
+
+  it('takes the remote branch only when the app is not packaged', () => {
+    expect(source).toContain(
+      'if (!app.isPackaged && this.dev.enable && this.dev.source && this.dev.address)'
+    )
+  })
+
+  it('no longer has an unguarded remote branch', () => {
+    // The exact shape it had. Asserting its absence is what catches a revert.
+    expect(source).not.toContain('if (this.dev.enable && this.dev.source && this.dev.address) {')
+  })
+
+  it('says why it refused rather than failing silently', () => {
+    // A packaged build with a dev manifest now loads the bundled Prelude. Without a log the
+    // difference between "dev source ignored" and "dev source used" is invisible.
+    expect(source).toContain('Ignoring dev.source in a packaged build')
+  })
+})

--- a/apps/core-app/src/main/modules/plugin/plugin.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin.ts
@@ -1989,7 +1989,21 @@ export class TouchPlugin implements ITouchPlugin {
 
   private async loadPreludeScript(): Promise<string> {
     const shouldBundlePrelude = this.dev.enable
-    if (this.dev.enable && this.dev.source && this.dev.address) {
+    // A packaged build never fetches its Prelude over the network, whatever the manifest says.
+    //
+    // Three shipped manifests carried dev.enable/source with a localhost address, so an
+    // installed app issued GET http://127.0.0.1:<port>/index.js and executed whatever came
+    // back as the plugin's Prelude — normally nothing is listening and the plugin simply
+    // fails to load, but any unrelated local process on that port owns the plugin (#809,
+    // #810, #811). The manifests are fixed too; this is the guard that makes the next one
+    // harmless, since nothing else on this path consulted isPackaged.
+    if (app.isPackaged && this.dev.enable && this.dev.source && this.dev.address) {
+      this.logger.warn(
+        'Ignoring dev.source in a packaged build; loading the bundled Prelude instead.',
+        { meta: { address: this.dev.address } }
+      )
+    }
+    if (!app.isPackaged && this.dev.enable && this.dev.source && this.dev.address) {
       const remoteIndexUrl = new URL('index.js', this.dev.address).toString()
       this.logger.info(`[Dev] Fetching remote script from ${remoteIndexUrl}`)
       const response = await getNetworkService().request<string>({

--- a/plugins/clipboard-history/manifest.json
+++ b/plugins/clipboard-history/manifest.json
@@ -11,7 +11,7 @@
   },
   "description": "一款全平台剪贴板历史记录插件，从 Tuff 核心提取剪贴板历史。",
   "dev": {
-    "enable": true,
+    "enable": false,
     "address": "http://127.0.0.1:3488",
     "source": true,
     "autoStart": true

--- a/plugins/touch-intelligence/manifest.json
+++ b/plugins/touch-intelligence/manifest.json
@@ -12,7 +12,7 @@
   "description": "CoreBox 智能问答、内置 AI 命令与本地自定义命令注册表",
   "main": "index.js",
   "dev": {
-    "enable": true,
+    "enable": false,
     "source": true,
     "address": "http://127.0.0.1:5174/"
   },

--- a/plugins/touch-translation/manifest.json
+++ b/plugins/touch-translation/manifest.json
@@ -12,7 +12,7 @@
   "description": "一款全平台资源聚合翻译平台，支持多种翻译服务",
   "main": "index.js",
   "dev": {
-    "enable": true,
+    "enable": false,
     "address": "http://localhost:3733/",
     "source": true
   },


### PR DESCRIPTION
Closes #809, #810 and #811 — one PR, because the systemic half of the fix is a single guard and splitting it across three would be worse.

## The defect

`loadPreludeScript` took the remote branch whenever `dev.enable && dev.source && dev.address`, **with no reference to whether the app was packaged**. Three shipped manifests carried exactly that:

| plugin | address |
|---|---|
| clipboard-history | `http://127.0.0.1:3488` (+ `autoStart`) |
| touch-intelligence | `http://127.0.0.1:5174/` |
| touch-translation | `http://localhost:3733/` |

So an installed app issued `GET http://127.0.0.1:<port>/index.js` and executed the response as the plugin's Prelude. Usually nothing listens and the plugin silently fails to load; **if any unrelated local process does, it owns the plugin.**

## Both halves

The manifests now ship `dev.enable: false` — that fixes today's builds.

The guard on `app.isPackaged` makes the *next* manifest with the same mistake harmless. Nothing else on this path consulted `isPackaged`, so there was no second line of defence — which is why a manifest edit alone would leave the same trap armed for whoever adds the fourth plugin.

A packaged build meeting a dev manifest now **logs why** it ignored `dev.source`. Without that, "dev source ignored" and "dev source used" look identical in a log.

## The three were the whole set

I enumerated every `manifest.json` under `plugins/` rather than trusting the three issues to be the complete list. They were. **A test re-runs that enumeration**, so a fourth appearing fails here rather than shipping.

## Tests

Seven, **five failing** against the previous state: each manifest, the enumeration, the guarded branch, the absence of the old unguarded shape, and the log.

The 1190 tests under `src/main/modules/plugin` pass unchanged. Lint clean.