### PR TITLE
fix(touch-quick-actions): publish an item instead of running the action on trigger

### DIFF
--- a/plugins/touch-quick-actions/index.js
+++ b/plugins/touch-quick-actions/index.js
@@ -260,9 +260,30 @@ const pluginLifecycle = {
   },
 
   async onFeatureTriggered(featureId, query) {
+    // A dynamic quick-action-* feature publishes an item; it does not run the action.
+    //
+    // onFeatureTriggered is re-entered on every input change — the host calls both
+    // triggerFeature and triggerInputChanged — so running the action here fired it on every
+    // keystroke. For lock-screen and mute-toggle the host requires no confirmation, so
+    // activating the feature locked the screen and each following keystroke locked it again;
+    // for shutdown and restart the destructive confirmation was re-raised each time (#817).
+    //
+    // touch-system-actions already does it this way: publish, then run from onItemAction on
+    // an explicit selection.
     const directActionId = dynamicActionId(featureId)
-    if (directActionId)
-      return await runAction(directActionId)
+    if (directActionId) {
+      const directAction = resolveActions().find(action => action.id === directActionId)
+      await publishItems([
+        buildItem({
+          id: `${featureId}-direct`,
+          featureId,
+          title: directAction?.name || directActionId,
+          subtitle: directAction?.description || '',
+          actionId: directActionId,
+        }),
+      ])
+      return true
+    }
     if (featureId !== FEATURE_ID)
       return false
 

--- a/plugins/touch-quick-actions/index.test.cjs
+++ b/plugins/touch-quick-actions/index.test.cjs
@@ -164,10 +164,48 @@ test('main-owned blocked status is preserved without local execution fallback', 
     reason: 'confirmation-denied',
   }
 
-  const result = await pluginModule.onFeatureTriggered('quick-action-shutdown', { text: '' })
+  // Routed through the item now: a dynamic feature publishes and onItemAction runs (#817).
+  // What this test is about — a blocked status from main is preserved rather than falling
+  // back to local execution — is unchanged.
+  await pluginModule.onFeatureTriggered('quick-action-shutdown', { text: '' })
+  const item = state.items.find(entry => entry.actions?.[0]?.payload?.actionId === 'shutdown')
+  assert.ok(item)
+
+  const result = await pluginModule.onItemAction(item, { actionId: 'run-action' })
 
   assert.deepEqual(state.systemCalls, ['shutdown'])
   assert.equal(result.status, 'blocked')
   assert.equal(result.reason, 'confirmation-denied')
   assert.equal(result.success, false)
+})
+
+test('a dynamic feature publishes an item instead of running the action', async () => {
+  // The defect: onFeatureTriggered is re-entered on every input change, so running here fired
+  // the action on each keystroke — locking the screen repeatedly, or re-raising the shutdown
+  // confirmation.
+  const result = await pluginModule.onFeatureTriggered('quick-action-lock-screen', { text: '' })
+
+  assert.deepEqual(state.systemCalls, [])
+  assert.equal(result, true)
+  assert.equal(state.items.length, 1)
+  assert.equal(state.items[0].actions[0].payload.actionId, 'lock-screen')
+})
+
+test('repeated triggers of a dynamic feature never execute', async () => {
+  // The shape of the bug was repetition, so repetition is what the test exercises.
+  for (const text of ['', 'l', 'lo', 'loc'])
+    await pluginModule.onFeatureTriggered('quick-action-lock-screen', { text })
+
+  assert.deepEqual(state.systemCalls, [])
+})
+
+test('the published item still runs the action when selected', async () => {
+  // Positive control: publishing instead of executing must not make the action unreachable.
+  await pluginModule.onFeatureTriggered('quick-action-lock-screen', { text: '' })
+  const item = state.items[0]
+
+  const result = await pluginModule.onItemAction(item, { actionId: 'run-action' })
+
+  assert.deepEqual(state.systemCalls, ['lock-screen'])
+  assert.equal(result.success, true)
 })


### PR DESCRIPTION
Closes #817.

## The defect

The dynamic `quick-action-*` features called `runAction` directly from `onFeatureTriggered`. That callback is **re-entered on every input change** — the host calls both `triggerFeature` and `triggerInputChanged`, and both reach it — so the mutating system action fired on every keystroke.

| action | host confirmation | effect |
|---|---|---|
| lock-screen, mute-toggle | `none` | screen locks, then locks again on each keystroke |
| shutdown, restart | `double` | destructive confirmation re-raised on each keystroke |

They now publish an item and run from `onItemAction` on an explicit selection — which is what `touch-system-actions` already does with the same capability.

## One existing test had to change

**"main-owned blocked status is preserved without local execution fallback"** asserted `systemCalls === ['shutdown']` immediately after `onFeatureTriggered`. It **encoded the defect as the expected behaviour**.

What that test exists to check is something else entirely — that a `blocked` status from main is not followed by a local fallback. It now routes through the published item and checks exactly that, unchanged in intent.

## Tests added

- a dynamic feature publishes **without executing**
- **four consecutive triggers execute nothing** — repetition was the shape of the bug, so repetition is what is exercised
- the published item **still runs the action when selected** — without this, making the action unreachable would pass everything else

All four fail against the previous `index.js`. Lint clean.