### PR TITLE
fix(utils): reject a plugin channel message that carries no uniqueKey

### DIFF
--- a/packages/utils/__tests__/plugin-prelude-unique-key.test.ts
+++ b/packages/utils/__tests__/plugin-prelude-unique-key.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getPluginChannelPreludeCode } from '../transport/prelude'
+
+/**
+ * The plugin channel's isolation boundary (#875).
+ *
+ * The prelude validated `header.uniqueKey` against the injected key, but a message carrying no
+ * `uniqueKey` at all only logged a warning and was then dispatched normally. Anything able to
+ * emit on the shared `@plugin-process-message` channel could therefore reach this plugin's
+ * handlers by simply omitting the key — the check was bypassed by not participating in it.
+ *
+ * The prelude is a generated source string, so these evaluate it with a fake electron and
+ * drive the real handler rather than asserting on the text. jsdom because the generated code
+ * assigns to `window`.
+ */
+
+const UNIQUE_KEY = 'plugin-unique-key-abc'
+
+interface Harness {
+  /** The listener the prelude registered for @plugin-process-message. */
+  deliver: (message: unknown) => void
+  /** Messages that reached a registered plugin handler. */
+  received: unknown[]
+}
+
+function loadPrelude(): Harness {
+  const received: unknown[] = []
+  let listener: ((event: unknown, arg: unknown) => void) | null = null
+
+  const fakeElectron = {
+    ipcRenderer: {
+      on(channel: string, handler: (event: unknown, arg: unknown) => void) {
+        if (channel === '@plugin-process-message')
+          listener = handler
+      },
+      send() {},
+      removeListener() {},
+    },
+  }
+
+  const code = getPluginChannelPreludeCode({ uniqueKey: UNIQUE_KEY })
+  // eslint-disable-next-line no-new-func
+  new Function('require', 'window', `${code}`)(
+    (name: string) => (name === 'electron' ? fakeElectron : {}),
+    window,
+  )
+
+  const channel = (window as unknown as { $channel: { regChannel: (name: string, cb: (data: unknown) => void) => void } }).$channel
+  channel.regChannel('demo-event', (data) => {
+    received.push(data)
+  })
+
+  if (!listener)
+    throw new Error('prelude did not register a @plugin-process-message listener')
+
+  return {
+    deliver: (message: unknown) => (listener as (event: unknown, arg: unknown) => void)({}, message),
+    received,
+  }
+}
+
+function message(header: Record<string, unknown>) {
+  return {
+    name: 'demo-event',
+    code: 200,
+    data: { hello: 'world' },
+    sync: undefined,
+    header: { status: 'request', type: 'plugin', ...header },
+  }
+}
+
+describe('plugin prelude uniqueKey enforcement', () => {
+  let harness: Harness
+
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    harness = loadPrelude()
+  })
+
+  it('delivers a message carrying the right key', () => {
+    // Positive control: an enforcement that dropped everything would satisfy the rejections
+    // below while making the plugin channel useless.
+    harness.deliver(message({ uniqueKey: UNIQUE_KEY }))
+    expect(harness.received).toHaveLength(1)
+  })
+
+  it('drops a message with no uniqueKey at all', () => {
+    // The regression: this used to warn and then dispatch.
+    harness.deliver(message({}))
+    expect(harness.received).toHaveLength(0)
+  })
+
+  it.each([undefined, null, '', 0, false])('drops a falsy uniqueKey (%s)', (value) => {
+    harness.deliver(message({ uniqueKey: value }))
+    expect(harness.received).toHaveLength(0)
+  })
+
+  it('still drops a mismatched key', () => {
+    harness.deliver(message({ uniqueKey: 'someone-elses-key' }))
+    expect(harness.received).toHaveLength(0)
+  })
+
+  it('reports a missing key as an error rather than a warning', () => {
+    // It is a rejection now, so it belongs at the same level as a mismatch — a warning reads
+    // as "this happened and we continued", which is exactly what used to happen.
+    harness.deliver(message({}))
+    expect(console.error).toHaveBeenCalled()
+  })
+})

--- a/packages/utils/transport/prelude.ts
+++ b/packages/utils/transport/prelude.ts
@@ -35,10 +35,18 @@ export function getPluginChannelPreludeCode(
       if (arg) {
         const { name, header, code, plugin, data, sync } = arg;
         if (header) {
+          // A missing key is a rejection, not a warning.
+          //
+          // This used to warn and then dispatch the message anyway, so the key check that is
+          // the plugin channel's isolation boundary was bypassed by simply not supplying a
+          // key — anything able to emit on the shared @plugin-process-message channel reached
+          // this plugin's handlers (#875).
           const { uniqueKey: thisUniqueKey } = header;
           if (!thisUniqueKey) {
-            console.warn('[Plugin] uniqueKey missing in header:', arg);
-          } else if (thisUniqueKey !== uniqueKey) {
+            console.error('[Plugin] uniqueKey missing in header:', arg);
+            return null;
+          }
+          if (thisUniqueKey !== uniqueKey) {
             console.error('[Plugin] uniqueKey mismatch:', thisUniqueKey, uniqueKey);
             return null;
           }


### PR DESCRIPTION
Closes #875.

## The defect

```js
if (!thisUniqueKey) {
  console.warn('[Plugin] uniqueKey missing in header:', arg)   // ← and then continues
} else if (thisUniqueKey !== uniqueKey) {
  return null
}
```

Only a **mismatched** key was rejected. A message with no key at all warned and was dispatched — so the check that is the plugin channel's isolation boundary was bypassed **by not participating in it**. Anything able to emit on the shared `@plugin-process-message` channel reached this plugin's handlers by omitting the field.

Missing is now treated exactly like a mismatch, and logged at `error` rather than `warn` — a warning reads as *"this happened and we continued"*, which is precisely what used to happen.

## On how it is tested

The prelude is a **generated source string**, so the tests evaluate it with a fake `electron` and drive the listener it registers.

That distinction matters here: the defect was in control flow, and a source-level assertion would have been satisfied by any code that merely *mentioned* the field.

## Tests

Nine, **seven failing** against the previous version.

They cover every falsy shape a key can arrive as, not just an absent property — `undefined`, `null`, ``, `0` and `false` all took the warn-and-continue path, and a fix checking only `in header` would miss them.

One is a positive control that a correctly keyed message still arrives, since dropping everything would satisfy all the rest.

The sibling `plugin-channel-send-sync-hard-cut` suite passes unchanged. Lint clean.