### PR TITLE
fix(core-app): make the appearance tile label row select instead of navigate

### DIFF
--- a/apps/core-app/src/renderer/src/views/base/styles/SectionItem.semantic.test.ts
+++ b/apps/core-app/src/renderer/src/views/base/styles/SectionItem.semantic.test.ts
@@ -1,18 +1,7 @@
 // @vitest-environment jsdom
 import { mount } from '@vue/test-utils'
-import { describe, expect, it, vi } from 'vitest'
-import { createThemeDetailRoute } from './section-route'
+import { describe, expect, it } from 'vitest'
 import SectionItem from './SectionItem.vue'
-
-const state = vi.hoisted(() => ({
-  push: vi.fn()
-}))
-
-vi.mock('vue-router', () => ({
-  useRouter: () => ({
-    push: state.push
-  })
-}))
 
 function mountSectionItem(disabled = false) {
   return mount(SectionItem, {
@@ -33,7 +22,7 @@ function mountSectionItem(disabled = false) {
 describe('SectionItem semantics', () => {
   it('uses a native button for card selection', async () => {
     const wrapper = mountSectionItem()
-    const action = wrapper.get('button.SectionItem-Action')
+    const action = wrapper.get('button.SectionItem-Display')
 
     expect(action.attributes('type')).toBe('button')
     expect(action.attributes('aria-pressed')).toBe('false')
@@ -43,17 +32,23 @@ describe('SectionItem semantics', () => {
     expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['filter'])
   })
 
-  it('opens the detail route from the inner button', async () => {
+  // The label row used to router.push to /styles/theme, which swapped the settings page
+  // for a blank one. Both halves of the tile select now, so this asserts selection and
+  // needs no vue-router mock.
+  it('selects from the label row rather than navigating', async () => {
     const wrapper = mountSectionItem()
+    const bar = wrapper.get('button.SectionItem-Bar')
 
-    await wrapper.get('button.SectionItem-Bar').trigger('click')
+    expect(bar.attributes('aria-pressed')).toBe('false')
 
-    expect(state.push).toHaveBeenCalledWith(createThemeDetailRoute('filter'))
+    await bar.trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['filter'])
   })
 
   it('does not allow disabled keyboard selection', async () => {
     const wrapper = mountSectionItem(true)
-    const action = wrapper.get('button.SectionItem-Action')
+    const action = wrapper.get('button.SectionItem-Display')
 
     expect(action.attributes('disabled')).toBeDefined()
     expect(wrapper.get('button.SectionItem-Bar').attributes('disabled')).toBeDefined()

--- a/apps/core-app/src/renderer/src/views/base/styles/SectionItem.vue
+++ b/apps/core-app/src/renderer/src/views/base/styles/SectionItem.vue
@@ -1,7 +1,4 @@
 <script lang="ts" name="SectionItem" setup>
-import { useRouter } from 'vue-router'
-import { createThemeDetailRoute } from './section-route'
-
 const props = defineProps<{
   title: string
   label?: string
@@ -11,18 +8,16 @@ const props = defineProps<{
 
 const value = defineModel<string>('modelValue')
 
-const router = useRouter()
-
+/**
+ * Both halves of the tile select the effect. The label row used to `router.push` to
+ * `/styles/theme` instead, which replaced the settings page with the standalone styles
+ * page and then rendered nothing, because `ThemeStyle` has no `<router-view>` for that
+ * child. A control that looks like it picks an option must pick the option.
+ */
 function handleClick() {
   if (props.disabled) return
 
   value.value = props.title
-}
-
-function goRouter() {
-  if (props.disabled) return
-
-  router.push(createThemeDetailRoute(props.title))
 }
 </script>
 
@@ -48,9 +43,10 @@ function goRouter() {
     </button>
     <button
       type="button"
-      class="SectionItem-Bar px-2 flex items-center cursor-pointer gap-2"
+      class="SectionItem-Bar SectionItem-Action px-2 flex items-center cursor-pointer gap-2"
       :disabled="disabled"
-      @click="goRouter"
+      :aria-pressed="value === title"
+      @click="handleClick"
     >
       <div w-3 h-3 rounded-full class="bg-[var(--section-active-color)]" />
       <span v-shared-element:[`theme-preference-${title}`]>


### PR DESCRIPTION
Refs #1019.

## Why

#1019's "Fixed now" section says this was already done. It is not on the merge branch — `origin/TalexDreamSoul/app-shell-v2` and `origin/master` both still contain `goRouter`, and `SectionItem.semantic.test.ts` still mocks `vue-router` and asserts `push` was called. The wrong behaviour the issue describes is live.

Clicking the label row under a window-effect tile on `/setting/appearance` calls `router.push(createThemeDetailRoute(title))` → `/styles/theme`. `ThemeStyle.vue` has no `<router-view>` for that child, so the settings page is replaced by the standalone styles page and the detail renders nothing.

## What

- Both halves of the tile select the effect; the label row carries `aria-pressed` like the preview above it
- `useRouter` / `createThemeDetailRoute` dropped from the component
- The semantic test pinned the navigation, so it pinned the bug — rewritten to assert selection, `vue-router` mock removed
- Test selectors made explicit (`.SectionItem-Display` vs `.SectionItem-Bar`) now that both buttons carry `SectionItem-Action`

## Out of scope, deliberately

`section-route.ts`, `ThemePreference.vue`, `theme-preference-state.ts` and the `/styles/theme` registration stay. After this change nothing points into that cluster — which is exactly the state #1019 asks a product decision about (finish it vs delete it). Deleting is a product call, so the issue stays open for it.

## Verification

Run from inside `apps/core-app`:

- `npx vitest run src/renderer/src/views/base/styles/` — 6 files, 17 tests passing
- `npx eslint <both changed files> --max-warnings=0` — exit 0
- `npm run typecheck:web` — exit 0