### PR TITLE
fix(core-app): refuse plugin callers on window lifecycle and path handlers

### DIFF
--- a/apps/core-app/src/main/channel/common.ts
+++ b/apps/core-app/src/main/channel/common.ts
@@ -1221,6 +1221,27 @@ export class CommonChannelModule extends BaseModule {
     this.registerPresetTransportHandlers(transport, registerSafeHandler)
   }
 
+  /**
+   * Refuses a handler call that arrived from a plugin.
+   *
+   * Every transport handler is registered on the plugin channel as well as the main one, and
+   * inspecting context.plugin is voluntary per handler — so these were reachable from a
+   * plugin view. window.close ends the application, hide and minimize deny service to the
+   * user, and getCwd/getPath/getPackage hand over the filesystem layout that makes a path
+   * traversal or a shell sink easy to aim (#807).
+   *
+   * This is the per-handler form of the audience mechanism proposed in #688. That change
+   * would make host-only the default for every handler; until then, the handlers that can
+   * end the app or disclose its layout should not depend on it.
+   */
+  private assertHostOnly(context: HandlerContext | undefined, eventName: string): void {
+    if (!context?.plugin) return
+    log.warn('Blocked a host-only handler invoked from a plugin', {
+      meta: { eventName, plugin: context.plugin.name }
+    })
+    throw new Error('HOST_ONLY_HANDLER')
+  }
+
   private resolvePluginTempNamespace(context?: HandlerContext): string {
     const pluginName = context?.plugin?.name
     if (!pluginName) throw new Error('PLUGIN_CONTEXT_REQUIRED')
@@ -1435,9 +1456,18 @@ export class CommonChannelModule extends BaseModule {
         const query = normalizeCapabilityQuery(payload)
         return await listPlatformCapabilities(query)
       }),
-      transport.on(AppEvents.window.close, () => closeApp(touchApp)),
-      transport.on(AppEvents.window.hide, () => touchApp.window.window.hide()),
-      transport.on(AppEvents.window.minimize, () => touchApp.window.minimize()),
+      transport.on(AppEvents.window.close, (_payload, context) => {
+        this.assertHostOnly(context, 'window.close')
+        return closeApp(touchApp)
+      }),
+      transport.on(AppEvents.window.hide, (_payload, context) => {
+        this.assertHostOnly(context, 'window.hide')
+        touchApp.window.window.hide()
+      }),
+      transport.on(AppEvents.window.minimize, (_payload, context) => {
+        this.assertHostOnly(context, 'window.minimize')
+        touchApp.window.minimize()
+      }),
       transport.on(AppEvents.window.maximize, () => touchApp.window.maximize()),
       transport.on(AppEvents.window.unmaximize, () => touchApp.window.unmaximize()),
       transport.on(AppEvents.window.toggleMaximize, () => touchApp.window.toggleMaximize()),
@@ -1459,9 +1489,15 @@ export class CommonChannelModule extends BaseModule {
           payload && typeof payload === 'object' ? (payload as OpenDevToolsOptions) : undefined
         touchApp.window.openDevTools(options)
       }),
-      transport.on(AppEvents.system.getCwd, () => process.cwd()),
+      transport.on(AppEvents.system.getCwd, (_payload, context) => {
+        this.assertHostOnly(context, 'system.getCwd')
+        return process.cwd()
+      }),
       transport.on(AppEvents.system.getOS, () => getOSInformation()),
-      transport.on(AppEvents.system.getPackage, () => packageJson),
+      transport.on(AppEvents.system.getPackage, (_payload, context) => {
+        this.assertHostOnly(context, 'system.getPackage')
+        return packageJson
+      }),
       transport.on<void, AutoStartGetResponse>(AppEvents.system.autoStartGet, () =>
         this.getAutoStartStatus()
       ),
@@ -1476,7 +1512,8 @@ export class CommonChannelModule extends BaseModule {
         AppEvents.system.traySettingsUpdate,
         (payload) => this.updateTraySettings(payload, touchApp)
       ),
-      transport.on(AppEvents.system.getPath, (payload) => {
+      transport.on(AppEvents.system.getPath, (payload, context) => {
+        this.assertHostOnly(context, 'system.getPath')
         const name = typeof payload?.name === 'string' ? payload.name : ''
         if (!name) {
           return null

--- a/apps/core-app/src/main/channel/host-only-handlers.test.ts
+++ b/apps/core-app/src/main/channel/host-only-handlers.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Handlers a plugin must not be able to call (#807).
+ *
+ * Every transport handler is registered on the plugin channel as well as the main one, and
+ * inspecting context.plugin is voluntary per handler. window.close ends the application;
+ * hide and minimize deny service to the user; getCwd/getPath/getPackage hand over the
+ * filesystem layout that makes a path traversal or a shell sink easy to aim.
+ *
+ * A separate file from common.test.ts on purpose: that one mocks node:fs with a readFileSync
+ * returning '', so these assertions would have read an empty string there — and a
+ * `not.toContain` written the same way would have passed while verifying nothing.
+ */
+
+const source = readFileSync(fileURLToPath(new URL('./common.ts', import.meta.url)), 'utf8')
+
+function guardBody(): string {
+  const start = source.indexOf('private assertHostOnly(')
+  expect(start, 'assertHostOnly not found — this guard is reading the wrong file').toBeGreaterThan(
+    -1
+  )
+  const end = source.indexOf('private resolvePluginTempNamespace(')
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('host-only transport handlers', () => {
+  const HOST_ONLY_EVENTS = [
+    'window.close',
+    'window.hide',
+    'window.minimize',
+    'system.getCwd',
+    'system.getPackage',
+    'system.getPath'
+  ]
+
+  it('is reading the real source', () => {
+    // Positive control for the file read itself, which is what silently failed the first
+    // time this suite was written.
+    expect(source.length).toBeGreaterThan(1000)
+    expect(source).toContain('registerTransportHandlers')
+  })
+
+  it.each(HOST_ONLY_EVENTS)('%s refuses a plugin caller', (eventName) => {
+    expect(source).toContain(`this.assertHostOnly(context, '${eventName}')`)
+  })
+
+  it('refuses rather than returning a value', () => {
+    expect(guardBody()).toContain('throw new Error')
+    expect(guardBody()).toContain('if (!context?.plugin) return')
+  })
+
+  it('logs which handler and which plugin', () => {
+    // A refusal whose reason a plugin author cannot see reads as a broken host.
+    expect(guardBody()).toContain('eventName')
+    expect(guardBody()).toContain('context.plugin.name')
+  })
+})


### PR DESCRIPTION
Closes #807.

## The defect

Every transport handler is registered on the plugin channel as well as the main one, and inspecting `context.plugin` is voluntary per handler. So a plugin view could:

| handler | effect |
|---|---|
| `window.close` | **ends the application** |
| `window.hide`, `window.minimize` | denies service to the user |
| `system.getCwd`, `getPath`, `getPackage` | hands over the filesystem layout that makes a path traversal or a shell sink easy to aim |

`assertHostOnly` throws when a call carries plugin context, and the six handlers use it. The log names both the handler and the plugin — **a refusal whose reason the plugin author cannot see reads as a broken host rather than a policy.**

## Why not wait for #688

The issue suggests marking these host-only "under the audience mechanism proposed for the double-channel registration issue". I did not wait.

That change makes host-only the default across **379 registrations** and needs a staged rollout (measured and written up on #688). These six can end the app or disclose its layout *today*. When #688 lands these become redundant rather than wrong.

## Deliberately narrow

`window.maximize` / `unmaximize` are left alone — annoying from a plugin, but not denial of service or disclosure. `system.getOS` already returns no more than a user agent string.

## A test-placement detail that is not cosmetic

The tests live in their own file rather than `common.test.ts`, because **that file mocks `node:fs` with a `readFileSync` returning ``**. My first version of these assertions lived there and read an empty string — they failed loudly, but written as `not.toContain` they would have **passed while verifying nothing**.

The new file carries a positive control on the read itself.

## Tests

Nine, **six failing** against the previous handlers. The three channel suites (36 tests) pass. Lint clean.