### PR TITLE
fix(test): run the integration suite once instead of watching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Code Quality
 - `pnpm lint` - Run ESLint on all code
 - `pnpm lint:fix` - Run ESLint with auto-fix
-- `pnpm utils:test` - Run tests for utility packages
+- `pnpm utils:test` - Run the `packages/test` integration suite once and exit (despite the name, this is not `packages/utils`)
 
 ### Publishing
 - `pnpm utils:publish` - Publish @talex-touch/utils package to npm

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -10,8 +10,9 @@
   "scripts": {
     "lint": "pnpm exec eslint --cache .",
     "lint:fix": "pnpm exec eslint --cache --fix .",
-    "test": "vitest",
-    "test:coverage": "vitest --coverage",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:vitest:watch": "vitest",
     "test:watch": "nodemon"
   },
   "dependencies": {


### PR DESCRIPTION
Closes #925. **It also uncovered that the suite is red — filed separately as #1255.**

## The fix

`packages/test`'s `test` script was `vitest` with no `run`, so `pnpm utils:test` — which `CLAUDE.md` documents as the way to run these tests — started **watch mode**. Any non-interactive caller blocked until timeout instead of reporting. Every other package already uses `vitest run`.

`test:coverage` had the identical defect one line below and is fixed with it; leaving it would have fixed half the reported problem.

## On the watch script name

Watch mode is added as `test:vitest:watch`, not `test:watch` — that name is taken by a `nodemon` script running `src/index.ts`, which is unrelated to testing. **`nodemon` is not among this package's dependencies**, so that script is broken independently. I neither repurposed nor repaired it; it is noted rather than silently changed.

`CLAUDE.md` is corrected too: `utils:test` runs `packages/test`, **not** `packages/utils`.

## What running it revealed

The command now exits — with status 1 and **42 failed | 181 passed | 4 todo**.

Those failures are pre-existing and were invisible through **two** independent mechanisms:

1. locally, this script hung
2. in CI, `ci.yml:378` runs the suite under **`continue-on-error: true`**, so *Integration suite (packages/test)* reports success regardless — it has been green on every PR in this sweep

The largest cluster is real API drift: ten suites destructure `const { __test } = plugin`, and **no plugin exports `__test` any more**. `parseToolboxConfig` still exists at `plugins/touch-dev-toolbox/index.js:39`; it is simply unreachable from the tests.

**I did not fix them here, and did not remove `continue-on-error`.** Doing the latter now turns the integration job red on every PR for everyone until the 42 are repaired — a maintainer's call, not something to fold into a one-line script fix. #1255 has the full breakdown.