### PR TITLE
test(core-app): run the screenshot framing guarantee instead of leaving it dormant

### DIFF
--- a/apps/core-app/src/main/modules/native-capabilities/native-screenshot-macos.integration.test.ts
+++ b/apps/core-app/src/main/modules/native-capabilities/native-screenshot-macos.integration.test.ts
@@ -5,6 +5,28 @@ import { createRequire } from 'node:module'
 import { describe, expect, it } from 'vitest'
 import { NativeTransport } from './native-transport'
 
+/**
+ * A manual test, and now labelled as one (#927).
+ *
+ * TUFF_SCREENSHOT_MACOS_INTEGRATION is set in no workflow, script or mise task, so this had
+ * never run anywhere — it read as a CI guarantee while being permanently dormant. It is not
+ * enabled in CI because it needs a real display and macOS screen-recording permission, which
+ * a hosted runner does not grant; turning it on there would produce a failure that says
+ * nothing about the code.
+ *
+ * Run it on a Mac with permission granted:
+ *
+ *   TUFF_SCREENSHOT_MACOS_INTEGRATION=1 pnpm -C apps/core-app exec vitest run \
+ *     src/main/modules/native-capabilities/native-screenshot-macos.integration.test.ts
+ *
+ * Add TUFF_SCREENSHOT_MACOS_REQUIRE_AX=1 to also assert the accessibility hit-test path,
+ * which needs Accessibility permission on top.
+ *
+ * The part that does not need a display — that captured bytes travel as attachments and never
+ * enter the JSON control channel — was extracted into
+ * native-transport-image-framing.test.ts, which runs everywhere on every run. That was the
+ * guarantee worth rescuing from this file's dormancy.
+ */
 const enabled =
   process.platform === 'darwin' && process.env.TUFF_SCREENSHOT_MACOS_INTEGRATION === '1'
 const requireAx = process.env.TUFF_SCREENSHOT_MACOS_REQUIRE_AX === '1'

--- a/apps/core-app/src/main/modules/native-capabilities/native-transport-image-framing.test.ts
+++ b/apps/core-app/src/main/modules/native-capabilities/native-transport-image-framing.test.ts
@@ -1,0 +1,102 @@
+import { Buffer } from 'node:buffer'
+import { describe, expect, it, vi } from 'vitest'
+import { NativeTransport } from './native-transport'
+import { capability, FakeNativeCarrier, successResponse } from './native-transport.test-helpers'
+
+/**
+ * Image bytes must travel as attachments, never inside the JSON control channel (#927).
+ *
+ * That guarantee was stated only by native-screenshot-macos.integration.test.ts, which runs
+ * behind TUFF_SCREENSHOT_MACOS_INTEGRATION=1 — set in no workflow, script or mise task. So
+ * the assertion existed and had never executed: a change to NativeTransport that serialised
+ * captured screen bytes into the JSON payload would have shipped unnoticed.
+ *
+ * It does not need a real screen. The property is about how the transport frames a response,
+ * so it is exercised here against a fake carrier and runs on every machine, every run.
+ * The macOS file keeps the parts that genuinely need a display.
+ */
+
+/** Recognisable bytes: a PNG signature followed by a marker that must not appear in JSON. */
+const IMAGE_BYTES = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.from('SCREEN-PIXELS-DO-NOT-SERIALISE')
+])
+
+function createTransport() {
+  const carrier = new FakeNativeCarrier('fixture', [capability('screenshot.capture')])
+  carrier.invokeImpl = async (control) =>
+    successResponse(
+      control,
+      {
+        // Metadata only — what a caller needs to interpret the attachment.
+        mimeType: 'image/png',
+        width: 1280,
+        height: 800,
+        imageParts: [{ attachmentId: 'output-0', offset: 0, byteLength: IMAGE_BYTES.byteLength }]
+      },
+      [IMAGE_BYTES]
+    )
+
+  const logger = { info: vi.fn(), warn: vi.fn() }
+  return { transport: new NativeTransport({ carriers: [carrier], logger }), logger, carrier }
+}
+
+describe('screenshot response framing', () => {
+  it('delivers the image bytes as an attachment', async () => {
+    // Positive control: a transport that dropped attachments would satisfy every "not in the
+    // JSON" assertion below while losing the image.
+    const { transport } = createTransport()
+    await transport.initialize()
+
+    const result = await transport.invoke('screenshot.capture', 'capture', {})
+
+    expect(result.attachments[0]?.equals(IMAGE_BYTES)).toBe(true)
+    await transport.dispose()
+  })
+
+  it('keeps the image bytes out of the JSON value', async () => {
+    // The guarantee the dormant test was carrying.
+    const { transport } = createTransport()
+    await transport.initialize()
+
+    const result = await transport.invoke('screenshot.capture', 'capture', {})
+
+    const serialised = JSON.stringify(result.value)
+    expect(serialised).not.toContain('SCREEN-PIXELS-DO-NOT-SERIALISE')
+    expect(serialised).not.toContain(IMAGE_BYTES.toString('base64'))
+    expect(result.value).toMatchObject({ mimeType: 'image/png', width: 1280, height: 800 })
+    await transport.dispose()
+  })
+
+  it('keeps the image bytes out of the logs', async () => {
+    // A payload logged verbatim is the same leak by another route, and the sibling test in
+    // native-transport.test.ts shows payload logging is a live concern here.
+    const { transport, logger } = createTransport()
+    await transport.initialize()
+    await transport.invoke('screenshot.capture', 'capture', {})
+
+    const logged = JSON.stringify([logger.info.mock.calls, logger.warn.mock.calls])
+    expect(logged).not.toContain('SCREEN-PIXELS-DO-NOT-SERIALISE')
+    await transport.dispose()
+  })
+
+  it('describes the attachment by reference rather than by content', async () => {
+    // imageParts is how a caller finds the bytes; it must carry ids and offsets, not data.
+    const { transport } = createTransport()
+    await transport.initialize()
+
+    const result = await transport.invoke<
+      Record<string, never>,
+      {
+        imageParts: Array<{ attachmentId: string; offset: number; byteLength: number }>
+      }
+    >('screenshot.capture', 'capture', {})
+
+    expect(result.value.imageParts[0]).toEqual({
+      attachmentId: 'output-0',
+      offset: 0,
+      byteLength: IMAGE_BYTES.byteLength
+    })
+    await transport.dispose()
+  })
+})


### PR DESCRIPTION
Closes #927.

## The problem with both offered options

`TUFF_SCREENSHOT_MACOS_INTEGRATION` is set in no workflow, script or mise task, so the file's stated guarantee — *"runs the complete protocol flow without exposing image JSON"* — had never executed anywhere.

- **Enable it in CI**: a hosted macOS runner grants no screen-recording permission, so it would fail and say nothing about the code — on a workflow that is already red per #1125.
- **Delete it**: discards a real privacy property.

## The property does not need a display

Whether captured bytes travel as **attachments** or get serialised into the **JSON control channel** is a question about how the transport frames a response.

It is now asserted against the `FakeNativeCarrier` that `native-transport.test.ts` already uses, and **runs everywhere on every run**. A change that put screen bytes in the payload now fails a test rather than passing unobserved.

## Four tests

- the attachment still arrives — **positive control**; a transport that dropped attachments would satisfy every "not in the JSON" assertion while losing the image
- the bytes are absent from `JSON.stringify(result.value)`, raw and base64
- the bytes are absent from the logs — the same leak by another route, and the sibling test shows payload logging is a live concern in this transport
- `imageParts` describes the attachment by id and offset rather than by content

## The macOS file stays, and now says what it is

Why it is not in CI, the exact command to run it, and what `TUFF_SCREENSHOT_MACOS_REQUIRE_AX` adds.

**Dormant is acceptable when it is labelled. Dormant while reading as a CI guarantee is not.**

`native-capabilities` suite: 57 passed, 3 skipped. Lint clean.