### PR TITLE
fix(transport): refuse to cache a payload that cannot be keyed

### DIFF
--- a/packages/utils/__tests__/plugin-transport-cache-key.test.ts
+++ b/packages/utils/__tests__/plugin-transport-cache-key.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest'
+import { defineRawEvent } from '../transport/event/builder'
+import { createPluginTuffTransport } from '../transport/sdk/plugin-transport'
+import { TuffRendererTransport } from '../transport/sdk/renderer-transport'
+
+/**
+ * `buildCacheKey` used to fall back to `Object.prototype.toString.call(payload)` whenever
+ * JSON.stringify threw. That is `[object Object]` for every plain object, so all circular
+ * payloads for one event collapsed onto a single cache entry and the second send returned the
+ * first one's response without ever reaching the main process (#880).
+ *
+ * The issue named only the plugin transport, but renderer-transport.ts carried a byte-identical
+ * copy of the function with the same fallback, so both are covered here.
+ */
+
+let rendererChannel: { send: (eventName: string, payload?: unknown) => Promise<unknown> }
+
+vi.mock('../renderer/hooks/use-channel', () => ({
+  useChannel: () => rendererChannel,
+}))
+
+const probeEvent = defineRawEvent<Record<string, unknown>, string>('test:cache:probe')
+
+function circular(marker: string): Record<string, unknown> {
+  const node: Record<string, unknown> = { marker }
+  node.self = node
+  return node
+}
+
+function createTransport() {
+  const sendToMain = vi.fn(async (_eventName: string, payload?: any) => {
+    return `response-for-${payload?.marker ?? payload?.id ?? 'void'}`
+  })
+  return { transport: createPluginTuffTransport({ sendToMain }), sendToMain }
+}
+
+describe('TuffPluginTransport cache keying', () => {
+  it('does not serve one circular payload the response cached for another', async () => {
+    const { transport, sendToMain } = createTransport()
+
+    const first = await transport.send(probeEvent, circular('alpha'), { cache: true })
+    const second = await transport.send(probeEvent, circular('beta'), { cache: true })
+
+    // The defect: `second` came back as 'response-for-alpha' from cache.
+    expect(first).toBe('response-for-alpha')
+    expect(second).toBe('response-for-beta')
+    expect(sendToMain).toHaveBeenCalledTimes(2)
+  })
+
+  it('still caches payloads that serialize, so this is not a blanket cache disable', async () => {
+    const { transport, sendToMain } = createTransport()
+
+    const first = await transport.send(probeEvent, { marker: 'plain' }, { cache: true })
+    const second = await transport.send(probeEvent, { marker: 'plain' }, { cache: true })
+
+    expect(first).toBe('response-for-plain')
+    expect(second).toBe('response-for-plain')
+    expect(sendToMain).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps distinct serializable payloads on distinct entries', async () => {
+    const { transport, sendToMain } = createTransport()
+
+    await transport.send(probeEvent, { marker: 'one' }, { cache: true })
+    await transport.send(probeEvent, { marker: 'two' }, { cache: true })
+
+    expect(sendToMain).toHaveBeenCalledTimes(2)
+  })
+
+  it('honours an explicit cache key even when the payload cannot serialize', async () => {
+    const { transport, sendToMain } = createTransport()
+
+    const first = await transport.send(probeEvent, circular('alpha'), {
+      cache: { key: 'caller-supplied' },
+    })
+    const second = await transport.send(probeEvent, circular('beta'), {
+      cache: { key: 'caller-supplied' },
+    })
+
+    // The caller named the key, so collapsing these is the documented behaviour, not the bug.
+    expect(second).toBe(first)
+    expect(sendToMain).toHaveBeenCalledTimes(1)
+  })
+
+  it("treats an unkeyable payload as a miss under cache mode 'only'", async () => {
+    const { transport, sendToMain } = createTransport()
+
+    await expect(
+      transport.send(probeEvent, circular('alpha'), { cache: { mode: 'only' } }),
+    ).rejects.toThrow(/Cache miss/)
+    expect(sendToMain).not.toHaveBeenCalled()
+  })
+})
+
+describe('TuffRendererTransport cache keying', () => {
+  function createRenderer() {
+    const send = vi.fn(async (_eventName: string, payload?: any) => {
+      return `response-for-${payload?.marker ?? 'void'}`
+    })
+    rendererChannel = { send }
+    return { transport: new TuffRendererTransport(), send }
+  }
+
+  it('does not serve one circular payload the response cached for another', async () => {
+    const { transport, send } = createRenderer()
+
+    const first = await transport.send(probeEvent, circular('alpha'), { cache: true })
+    const second = await transport.send(probeEvent, circular('beta'), { cache: true })
+
+    expect(first).toBe('response-for-alpha')
+    expect(second).toBe('response-for-beta')
+    expect(send).toHaveBeenCalledTimes(2)
+  })
+
+  it('still caches payloads that serialize', async () => {
+    const { transport, send } = createRenderer()
+
+    await transport.send(probeEvent, { marker: 'plain' }, { cache: true })
+    await transport.send(probeEvent, { marker: 'plain' }, { cache: true })
+
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/utils/transport/sdk/plugin-transport.ts
+++ b/packages/utils/transport/sdk/plugin-transport.ts
@@ -105,7 +105,7 @@ function normalizeCacheOptions(options?: SendOptions): CacheConfig | null {
   }
 }
 
-function buildCacheKey(eventName: string, payload: unknown, overrideKey?: string): string {
+function buildCacheKey(eventName: string, payload: unknown, overrideKey?: string): string | null {
   if (overrideKey) {
     return overrideKey
   }
@@ -118,7 +118,13 @@ function buildCacheKey(eventName: string, payload: unknown, overrideKey?: string
     return `${eventName}:${JSON.stringify(payload)}`
   }
   catch {
-    return `${eventName}:${Object.prototype.toString.call(payload)}`
+    // A payload JSON.stringify refuses (circular, BigInt, a throwing toJSON) has no
+    // distinguishing key. The previous fallback was Object.prototype.toString.call(payload),
+    // a constant for every plain object -- so two sends on one event with different circular
+    // payloads shared the entry and the second returned the first's response without ever
+    // reaching the main process. Refusing to key it makes the caller skip the cache: an
+    // uncached round-trip is slower, a wrong cached answer is a bug.
+    return null
   }
 }
 
@@ -170,14 +176,18 @@ export class TuffPluginTransport implements ITuffTransport {
 
     const eventName = (event as any).toEventName() as string
     const cacheConfig = normalizeCacheOptions(options)
-    const cacheKey = cacheConfig ? buildCacheKey(eventName, payload, cacheConfig.key) : ''
+    // null when the payload cannot be serialized into a distinguishing key; such a send is
+    // uncacheable in both directions rather than sharing an entry with every other one.
+    const cacheKey = cacheConfig ? buildCacheKey(eventName, payload, cacheConfig.key) : null
     if (cacheConfig) {
-      const entry = this.cache.get(cacheKey)
-      if (entry) {
-        if (entry.expiresAt === undefined || entry.expiresAt > Date.now()) {
-          return entry.value as TRes
+      if (cacheKey !== null) {
+        const entry = this.cache.get(cacheKey)
+        if (entry) {
+          if (entry.expiresAt === undefined || entry.expiresAt > Date.now()) {
+            return entry.value as TRes
+          }
+          this.cache.delete(cacheKey)
         }
-        this.cache.delete(cacheKey)
       }
       if (cacheConfig.mode === 'only') {
         throw new Error(`[TuffTransport] Cache miss for \"${eventName}\"`)
@@ -196,7 +206,7 @@ export class TuffPluginTransport implements ITuffTransport {
 
     const shouldPassPayload = payload !== undefined
     const result = await sender(eventName, shouldPassPayload ? payload : undefined)
-    if (cacheConfig) {
+    if (cacheConfig && cacheKey !== null) {
       const expiresAt = typeof cacheConfig.ttlMs === 'number' && Number.isFinite(cacheConfig.ttlMs)
         ? Date.now() + Math.max(0, cacheConfig.ttlMs)
         : undefined

--- a/packages/utils/transport/sdk/renderer-transport.ts
+++ b/packages/utils/transport/sdk/renderer-transport.ts
@@ -65,7 +65,7 @@ function normalizeCacheOptions(options?: SendOptions): CacheConfig | null {
   }
 }
 
-function buildCacheKey(eventName: string, payload: unknown, overrideKey?: string): string {
+function buildCacheKey(eventName: string, payload: unknown, overrideKey?: string): string | null {
   if (overrideKey) {
     return overrideKey
   }
@@ -78,7 +78,10 @@ function buildCacheKey(eventName: string, payload: unknown, overrideKey?: string
     return `${eventName}:${JSON.stringify(payload)}`
   }
   catch {
-    return `${eventName}:${Object.prototype.toString.call(payload)}`
+    // Same defect as the plugin transport (#880): the old fallback was a constant for every
+    // plain object, so distinct circular payloads on one event shared a cache entry and the
+    // second send got the first's response. Unkeyable means uncached, not cached-together.
+    return null
   }
 }
 
@@ -312,9 +315,11 @@ export class TuffRendererTransport implements ITuffTransport {
 
     const eventName = event.toEventName()
     const cacheConfig = normalizeCacheOptions(options)
-    const cacheKey = cacheConfig ? buildCacheKey(eventName, payload, cacheConfig.key) : ''
+    const cacheKey = cacheConfig ? buildCacheKey(eventName, payload, cacheConfig.key) : null
     if (cacheConfig) {
-      const cached = this.readCache<TRes>(cacheKey)
+      const cached = cacheKey === null
+        ? { hit: false as const, value: undefined }
+        : this.readCache<TRes>(cacheKey)
       if (cached.hit) {
         return cached.value as TRes
       }
@@ -333,7 +338,7 @@ export class TuffRendererTransport implements ITuffTransport {
     try {
       const shouldPassPayload = payload !== undefined
       const result = await this.sendRaw<TReq, TRes>(eventName, shouldPassPayload ? payload : undefined)
-      if (cacheConfig) {
+      if (cacheConfig && cacheKey !== null) {
         this.writeCache(cacheKey, result, cacheConfig.ttlMs)
       }
       return result


### PR DESCRIPTION
Fixes the defect in #880.

## The defect

`buildCacheKey` fell back to `Object.prototype.toString.call(payload)` whenever `JSON.stringify` threw. That string is `"[object Object]"` for every plain object, so two cached sends on one event with different circular payloads shared a single cache entry — the second returned the first's response without ever reaching the main process.

## The fix

An unserializable payload has no distinguishing key, so it is now **uncacheable in both directions** rather than sharing one entry. A slower round-trip beats a wrong answer.

Preserved deliberately:

| case | behaviour |
|---|---|
| explicit `cache.key` | still caches — the caller named the key, so collapsing is documented behaviour, not the bug |
| `mode: 'only'` with unkeyable payload | miss → throws, as it already did |
| serializable payloads | unchanged; this is not a blanket cache disable |

## Scope note: the issue named one file, the defect was in two

#880 points at `plugin-transport.ts:121`. `renderer-transport.ts:68` carried a **byte-identical copy** of `buildCacheKey` with the same fallback. Fixing only the one named would have left the same defect live on the busier path, so both are fixed and both are covered. Flagging it explicitly since it widens the issue's stated scope.

## Verified by mutation, not by a green run

Reverting each source file in turn fails **exactly its own** circular-payload case and nothing else:

```
plugin-transport.ts reverted    -> 1 failed | 6 passed
renderer-transport.ts reverted  -> 1 failed | 6 passed
both fixed                      -> 7 passed
```

That the other cases hold in every state is the point: five of the seven are over-correction guards (serializable payloads still cache, distinct payloads stay distinct, explicit keys still collapse, `mode: 'only'` still throws), so a fix that simply disabled caching would fail them.

## Gates

- `packages/utils`: **134 files, 1072 passing**, 1 skipped
- `eslint --max-warnings=0` on all three changed files: exit 0
- `buildCacheKey` is module-local in both files and not exported, so there is no external type impact from the `string` → `string | null` return