### PR TITLE
fix(logger): give every config built from the defaults its own modules object

### DIFF
--- a/packages/utils/__tests__/logger-manager-defaults.test.ts
+++ b/packages/utils/__tests__/logger-manager-defaults.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { LoggerManager, loggerManager } from '../common/logger/logger-manager'
+import { LogLevel } from '../common/logger/types'
+
+/**
+ * `DEFAULT_CONFIG.modules` is one shared object and `setModuleConfig` writes into
+ * `this.config.modules`. A shallow `{ ...DEFAULT_CONFIG }` aliased it, so a module override
+ * leaked into the defaults and `reset()` restored the polluted copy — there was no way back to
+ * a clean state (#881).
+ *
+ * These assert observable behaviour (reset actually resets) rather than the shape of the copy,
+ * so they stay valid if the cloning strategy changes.
+ */
+
+describe('LoggerManager default config isolation', () => {
+  beforeEach(() => {
+    loggerManager.reset()
+  })
+
+  it('reset() clears a module override instead of restoring a polluted default', () => {
+    loggerManager.setModuleConfig('database', false, LogLevel.ERROR)
+    expect(loggerManager.getConfig().modules.database).toBeDefined()
+
+    loggerManager.reset()
+
+    expect(loggerManager.getConfig().modules).toEqual({})
+  })
+
+  // A `vi.resetModules()` + re-import case was written here and dropped: it re-evaluates
+  // DEFAULT_CONFIG along with the singleton, so it passed against the unfixed source too. The
+  // pollution is only observable within one module instance, which is what the cases here do.
+
+  it('reset() still restores the non-module defaults', () => {
+    loggerManager.disableAll()
+    loggerManager.setGlobalLevel(LogLevel.ERROR)
+
+    loggerManager.reset()
+
+    const config = loggerManager.getConfig()
+    expect(config.enabled).toBe(true)
+    expect(config.globalLevel).toBe('debug')
+  })
+
+  it('a loaded config without a modules key does not adopt the shared default object', async () => {
+    const manager = LoggerManager.getInstance()
+    // The persisted shape is partial in practice; before the fix this branch spread
+    // DEFAULT_CONFIG and left modules aliasing the shared object.
+    manager.setConfigLoader(async () => ({ enabled: true, globalLevel: 'info' }) as any)
+
+    await manager.loadConfig()
+    manager.setModuleConfig('clipboard', false, LogLevel.ERROR)
+    manager.reset()
+
+    expect(manager.getConfig().modules).toEqual({})
+  })
+
+  it('a loaded config keeps its own modules without being mutated later', async () => {
+    const manager = LoggerManager.getInstance()
+    const persisted = { enabled: true, globalLevel: 'info', modules: { tray: { enabled: false, level: 'warn' } } }
+    manager.setConfigLoader(async () => persisted as any)
+
+    await manager.loadConfig()
+    manager.setModuleConfig('terminal', false, LogLevel.ERROR)
+
+    // The caller's object must not grow entries the manager added afterwards.
+    expect(Object.keys(persisted.modules)).toEqual(['tray'])
+  })
+})

--- a/packages/utils/common/logger/logger-manager.ts
+++ b/packages/utils/common/logger/logger-manager.ts
@@ -25,6 +25,16 @@ const DEFAULT_CONFIG: LoggingConfig = {
 }
 
 /**
+ * `setModuleConfig` writes into `this.config.modules`, and a shallow `{ ...DEFAULT_CONFIG }`
+ * aliases the one shared `modules` object — so every per-module override leaked into the
+ * defaults and `reset()` restored the polluted copy, leaving no way back to a clean state
+ * (#881). Every config built from the defaults gets its own `modules` object.
+ */
+function createDefaultConfig(): LoggingConfig {
+  return { ...DEFAULT_CONFIG, modules: {} }
+}
+
+/**
  * Predefined module defaults
  */
 const MODULE_DEFAULTS: Record<string, { enabled: boolean, level: LogLevel, color: string }> = {
@@ -59,7 +69,7 @@ const MODULE_DEFAULTS: Record<string, { enabled: boolean, level: LogLevel, color
 export class LoggerManager {
   private static instance: LoggerManager | null = null
   private loggers: Map<string, ModuleLogger> = new Map()
-  private config: LoggingConfig = { ...DEFAULT_CONFIG }
+  private config: LoggingConfig = createDefaultConfig()
   private configLoader: (() => Promise<LoggingConfig | null>) | null = null
   private configSaver: ((config: LoggingConfig) => Promise<void>) | null = null
 
@@ -226,7 +236,9 @@ export class LoggerManager {
     try {
       const loaded = await this.configLoader()
       if (loaded) {
-        this.config = { ...DEFAULT_CONFIG, ...loaded }
+        // `loaded.modules` may be absent, which would alias the shared object again; and
+        // when present it belongs to the caller, so it is copied rather than adopted.
+        this.config = { ...createDefaultConfig(), ...loaded, modules: { ...loaded.modules } }
         this.applyConfig()
       }
     }
@@ -285,7 +297,7 @@ export class LoggerManager {
    * Reset to default configuration
    */
   reset(): void {
-    this.config = { ...DEFAULT_CONFIG }
+    this.config = createDefaultConfig()
     this.applyConfig()
   }
 }


### PR DESCRIPTION
Fixes the defect in #881.

## The defect

`DEFAULT_CONFIG.modules` is a single shared object and `setModuleConfig` writes into `this.config.modules`, so a shallow `{ ...DEFAULT_CONFIG }` aliases it. Every per-module override leaked into the defaults, and `reset()` re-spread the polluted copy — no way back to a clean state.

## Three spread sites, not one

The issue names the field initializer. Two more had the same aliasing:

| line | site | how it aliased |
|---|---|---|
| 62 | field initializer | outright — the case #881 describes |
| 229 | `loadConfig` | whenever the persisted config has no `modules` key, which is the common partial shape |
| 288 | `reset` | outright |

All three now go through `createDefaultConfig()`. `loadConfig` additionally **copies** `loaded.modules` instead of adopting it, so a later `setModuleConfig` does not reach back into the caller's object.

## Verified by mutation

Against the unfixed source, **3 of the 4 cases fail** — including both `loadConfig` cases the issue does not mention, which is what justified going past the named line:

```
unfixed -> 3 failed | 1 passed
fixed   -> 4 passed
```

The one that passes in both states is deliberate: *"reset() still restores the non-module defaults"* guards against a fix that clears `modules` but throws `enabled` / `globalLevel` away.

## A fifth case was written and dropped

It used `vi.resetModules()` and re-imported the module, intending to prove the override had not been burned into `DEFAULT_CONFIG`. It passed against the **unfixed** source too — resetting the module registry re-evaluates `DEFAULT_CONFIG` along with the singleton, so the pollution is unobservable that way. Shipping it would have added a test that cannot fail, so it is removed with a comment recording why.

## Adjacent, deliberately not fixed

`getConfig()` (`:203`) returns `{ ...this.config }`, whose `modules` still aliases the live internal object — a caller mutating it would mutate manager state. That is a read-side leak of the same class, but it is not what #881 reports and changing it could affect callers that rely on the current shape. Reported on the issue rather than folded in here.

## Gates

- `packages/utils`: **134 files, 1069 passing**, 1 skipped
- `eslint --max-warnings=0` on both changed files: exit 0