### PR TITLE
fix(logger): treat an explicit per-module level as an override, not a floor

### DIFF
--- a/packages/utils/__tests__/logger-manager-module-level.test.ts
+++ b/packages/utils/__tests__/logger-manager-module-level.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { loggerManager } from '../common/logger/logger-manager'
+import { LogLevel } from '../common/logger/types'
+
+/**
+ * LogLevel is ordered DEBUG=0 .. ERROR=3, so `Math.max(globalLevel, moduleLevel)` always picked
+ * the more restrictive of the two. `setModuleConfig` applied the level directly, but the next
+ * `applyConfig()` recomputed with Math.max and discarded it — turning one module up while the
+ * global level stayed quiet was impossible, and the override vanished without a warning (#882).
+ */
+
+describe('LoggerManager per-module log level', () => {
+  beforeEach(() => {
+    loggerManager.reset()
+  })
+
+  it('lets a module be more verbose than the global level', () => {
+    loggerManager.setGlobalLevel(LogLevel.WARN)
+    const logger = loggerManager.getLogger('search-engine')
+
+    loggerManager.setModuleConfig('search-engine', true, LogLevel.DEBUG)
+
+    expect(logger.getLevel()).toBe(LogLevel.DEBUG)
+  })
+
+  it('keeps the verbose override across a later setConfig', () => {
+    loggerManager.setGlobalLevel(LogLevel.WARN)
+    const logger = loggerManager.getLogger('search-engine')
+    loggerManager.setModuleConfig('search-engine', true, LogLevel.DEBUG)
+
+    // The defect: this recomputed with Math.max(WARN, DEBUG) = WARN and silently reverted.
+    loggerManager.setConfig({ enabled: true })
+
+    expect(logger.getLevel()).toBe(LogLevel.DEBUG)
+  })
+
+  it('applies a verbose override to a logger created after the config', () => {
+    loggerManager.setGlobalLevel(LogLevel.ERROR)
+    loggerManager.setModuleConfig('file-provider', true, LogLevel.DEBUG)
+
+    const logger = loggerManager.getLogger('file-provider')
+
+    expect(logger.getLevel()).toBe(LogLevel.DEBUG)
+  })
+
+  it('still honours a module override that is more restrictive than global', () => {
+    loggerManager.setGlobalLevel(LogLevel.DEBUG)
+    const logger = loggerManager.getLogger('app-provider')
+
+    loggerManager.setModuleConfig('app-provider', true, LogLevel.ERROR)
+    loggerManager.setConfig({ enabled: true })
+
+    expect(logger.getLevel()).toBe(LogLevel.ERROR)
+  })
+
+  it('leaves MODULE_DEFAULTS bounded by the global level', () => {
+    // 'database' defaults to WARN. A quieter global must not be talked down by a default,
+    // because defaults are not stated intent the way setModuleConfig is.
+    loggerManager.setGlobalLevel(LogLevel.ERROR)
+
+    const logger = loggerManager.getLogger('database')
+
+    expect(logger.getLevel()).toBe(LogLevel.ERROR)
+  })
+})

--- a/packages/utils/common/logger/logger-manager.ts
+++ b/packages/utils/common/logger/logger-manager.ts
@@ -111,9 +111,16 @@ export class LoggerManager {
       // Determine log level
       let level = stringToLogLevel(this.config.globalLevel)
       if (moduleConfig?.level) {
-        level = Math.max(level, stringToLogLevel(moduleConfig.level))
+        // An explicit per-module level is an override, not a floor. LogLevel is ordered
+        // DEBUG=0..ERROR=3, so Math.max always picked the more restrictive of the two and made
+        // it impossible to turn one module up while the global level stayed quiet --
+        // setModuleConfig applied the level directly, then the next applyConfig() silently
+        // undid it (#882).
+        level = stringToLogLevel(moduleConfig.level)
       }
       else if (defaults?.level !== undefined) {
+        // MODULE_DEFAULTS are defaults rather than stated intent, so they stay bounded by the
+        // global level.
         level = Math.max(level, defaults.level)
       }
       if (options?.level !== undefined) {
@@ -282,9 +289,16 @@ export class LoggerManager {
       // Determine log level
       let level = stringToLogLevel(this.config.globalLevel)
       if (moduleConfig?.level) {
-        level = Math.max(level, stringToLogLevel(moduleConfig.level))
+        // An explicit per-module level is an override, not a floor. LogLevel is ordered
+        // DEBUG=0..ERROR=3, so Math.max always picked the more restrictive of the two and made
+        // it impossible to turn one module up while the global level stayed quiet --
+        // setModuleConfig applied the level directly, then the next applyConfig() silently
+        // undid it (#882).
+        level = stringToLogLevel(moduleConfig.level)
       }
       else if (defaults?.level !== undefined) {
+        // MODULE_DEFAULTS are defaults rather than stated intent, so they stay bounded by the
+        // global level.
         level = Math.max(level, defaults.level)
       }
 


### PR DESCRIPTION
Fixes the defect in #882.

> **Stacked on #1261 (#881).** Both touch `logger-manager.ts`. This branch is cut from that one, so review #1261 first — the diff here is only the level-semantics change.

## The defect

`LogLevel` is ordered `DEBUG=0 .. ERROR=3`, so `Math.max(globalLevel, moduleLevel)` always selects the **more restrictive** level. Raising verbosity for one module while the global level stays quiet was impossible.

Worse, it looked like it worked: `setModuleConfig` applies the level to the logger directly, so the developer sees debug output — until the next `setConfig()` or `loadConfig()` triggers `applyConfig()`, which recomputes with `Math.max` and silently reverts it.

## Three sites, two disagreeing semantics

| site | semantics |
|---|---|
| `setModuleConfig` | override wins — applies the level directly |
| `getLogger` | floor — `Math.max` |
| `applyConfig` | floor — `Math.max` |

`setModuleConfig` is the one expressing user intent, so the two recompute paths now match it.

**`MODULE_DEFAULTS` stay floored.** They are defaults rather than stated intent — a predefined `WARN` should not talk a deliberately quiet global back up. That asymmetry is deliberate and tested.

## Verified by mutation

Measured against the pre-fix source with #881 held constant, so the two changes are separated:

```
before this change -> 2 failed | 3 passed
after              -> 5 passed
```

The two failures are exactly the reverted-later paths. Of the three that pass in both states, one documents that the immediate `setModuleConfig` application always worked — the revert came afterwards — and two are over-correction guards:

- a *more restrictive* module override must still apply
- `MODULE_DEFAULTS` must stay bounded by global

A fix that simply dropped `Math.max` everywhere would fail the last one.

## Gates

- `packages/utils`: **135 files, 1074 passing**, 1 skipped
- `eslint --max-warnings=0` on both changed files: exit 0