### PR TITLE
fix(storage): stop TouchStorage printing debug output on every hydrate and save

### DIFF
--- a/packages/utils/__tests__/renderer-storage-transport.test.ts
+++ b/packages/utils/__tests__/renderer-storage-transport.test.ts
@@ -191,6 +191,41 @@ describe("renderer storage transport bootstrap", () => {
     );
   });
 
+  // TouchStorage is published and instantiated by external plugins. It used to print three
+  // unconditional console.debug lines per hydrate/save, each probing `background.source` -- a
+  // field belonging to one specific app store. Consumers could neither disable nor interpret
+  // them (#883).
+  it("does not print debug noise during a normal hydrate and save", async () => {
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    try {
+      const transport = createTransportMock({
+        "quiet-save.ini": { data: {}, version: 1 },
+      });
+      transport.send.mockImplementation(
+        async (event: unknown, payload?: { key?: string }) => {
+          if (event === StorageEvents.app.save) {
+            return { success: true, version: 2 };
+          }
+          if (payload?.key) {
+            return { data: {}, version: 1 };
+          }
+          return null;
+        },
+      );
+
+      initializeRendererStorage(transport as any);
+      const storage = new TouchStorage("quiet-save.ini", { value: "initial" });
+
+      await storage.whenHydrated();
+      storage.data.value = "changed";
+      await storage.saveToRemote({ force: true });
+
+      expect(debugSpy).not.toHaveBeenCalled();
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+
   it("reloads and retries without rejecting when save detects a version conflict", async () => {
     const transport = createTransportMock();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/utils/renderer/storage/base-storage.ts
+++ b/packages/utils/renderer/storage/base-storage.ts
@@ -449,7 +449,6 @@ export class TouchStorage<T extends object> {
             : null
           const patchHasChanges = Boolean(patch && (patch.set.length > 0 || patch.unset.length > 0))
           const remoteData = (versionedResult.data ?? {}) as Partial<T>
-          console.debug(`[TouchStorage] HYDRATE("${this.#qualifiedName}") remote version=${versionedResult.version}, background.source=`, (remoteData as any)?.background?.source)
 
           this.#currentVersion = versionedResult.version
           this.#isRemoteUpdate = true
@@ -587,7 +586,6 @@ export class TouchStorage<T extends object> {
     if (!isEqual(this.#lastSyncedSnapshot, rawData)) {
       this.#localDirty = true
     }
-    console.debug(`[TouchStorage] #executeSave("${this.#qualifiedName}") SAVING, background.source=`, (rawData as any)?.background?.source)
 
     this.savingState.value = true
     try {
@@ -599,7 +597,6 @@ export class TouchStorage<T extends object> {
       })
 
       if (result.success) {
-        console.debug(`[TouchStorage] #executeSave("${this.#qualifiedName}") SUCCESS, version=${result.version}`)
         this.#currentVersion = result.version
         this.#lastSyncedSnapshot = cloneValue(toPlainStorageValue(this.data) as T) as T
         this.#localDirty = false
@@ -971,7 +968,6 @@ export class TouchStorage<T extends object> {
     if (this.#isRemoteUpdate)
       return
 
-    console.debug(`[TouchStorage] saveSync("${this.#qualifiedName}") called, background.source=`, (toRaw(this.data) as any)?.background?.source)
     void this.#executeSave({ force: true }).catch((error) => {
       this.#handleBackgroundSaveError(error)
     })


### PR DESCRIPTION
Fixes the defect in #883.

## The defect

`TouchStorage` is published and instantiated by external plugins. Three unconditional `console.debug` lines probed `(data as any)?.background?.source` — a field belonging to one specific app store — so any consumer with autosave saw `background.source= undefined` on every keystroke-driven save. Output they could neither disable nor interpret.

That the field is app-specific is confirmed by its only real users being app tests: `useWallpaper.test.ts` sets `appSetting.background.source`.

## Removing the three named lines did not fix the reported harm

The guard test written alongside them **still failed**. A fourth `console.debug` (`:600`) reported `SUCCESS, version=N` on every successful save, so the flooding continued with different text — same frequency, same undisableable channel.

Since the issue's stated harm is "flooding devtools with debug output the consumer cannot disable", stopping at the three literally-named lines would have closed the issue without fixing it. The fourth is removed too.

## The failing intermediate state is the mutation evidence

No separate revert experiment was needed here — the test was genuinely red with the `SUCCESS` line present and green once it was gone:

```
three lines removed only  -> 1 failed | 10 passed
SUCCESS line removed too  -> 11 passed
```

So the test detects a regression rather than asserting something already true. It pins the real invariant: a normal hydrate/save cycle emits **no** `console.debug`.

## Not changed — reported on the issue instead

Four `console.warn` `"SKIP:"` lines (`:558-579`) also fire on ordinary paths, during hydration and during `assignData`. They are warn level rather than debug and read as intentional diagnostics, so whether an SDK should emit them is a separate call. Flagged on #883 rather than folded in.

## Gates

- `packages/utils`: **133 files, 1066 passing**, 1 skipped
- `eslint --max-warnings=0` on both changed files: exit 0
- No test asserted the removed lines