### PR TITLE
fix(plugin): make IFeatureCommand.value the string a manifest can actually carry

### DIFF
--- a/apps/core-app/src/main/modules/plugin/adapters/plugin-features-adapter.test.ts
+++ b/apps/core-app/src/main/modules/plugin/adapters/plugin-features-adapter.test.ts
@@ -1,11 +1,11 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import type { IProviderActivate } from '@talex-touch/utils'
-import type { IPluginFeature, ITouchPlugin } from '@talex-touch/utils/plugin'
+import type { IFeatureCommand, IPluginFeature, ITouchPlugin } from '@talex-touch/utils/plugin'
 import type { CoreBoxInputChangeRequest } from '@talex-touch/utils/transport/events/types'
 import { describe, expect, it, vi } from 'vitest'
 import { PluginStatus } from '@talex-touch/utils/plugin'
-import { PluginFeaturesAdapter } from './plugin-features-adapter'
+import { isCommandMatch, PluginFeaturesAdapter } from './plugin-features-adapter'
 import { pluginModule } from '../plugin-module'
 import { PluginViewLoader } from '../view/plugin-view-loader'
 
@@ -21,6 +21,18 @@ function createAdapter(): PluginFeaturesAdapter {
   adapter.attach(searchEngineHost)
   return adapter
 }
+
+const featureLogWarn = vi.hoisted(() => vi.fn())
+
+vi.mock('@talex-touch/utils/common/logger', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getLogger: () => ({
+    warn: featureLogWarn,
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
 
 vi.mock('../plugin-module', () => ({
   pluginModule: {
@@ -516,5 +528,60 @@ describe('search engine coupling (#523)', () => {
     }
 
     expect(() => adapter.attach(host)).not.toThrow()
+  })
+})
+
+/**
+ * Features are declared in `manifest.json` and cross IPC, so `value` can only ever be a string.
+ * The matcher cast it to `RegExp` and called `.test`, which threw on every real declaration, and
+ * `type: 'function'` had no branch at all so it fell through to a silent `false` (#885).
+ */
+describe('plugin feature command matching', () => {
+  function command(type: IFeatureCommand['type'], value: string | string[]): IFeatureCommand {
+    return { type, value }
+  }
+
+  it('compiles a regex string pattern instead of throwing on it', () => {
+    // The defect: `(command.value as RegExp).test` -> TypeError: value.test is not a function.
+    expect(() => isCommandMatch(command('regex', '^calc '), 'calc 1+1')).not.toThrow()
+    expect(isCommandMatch(command('regex', '^calc '), 'calc 1+1')).toBe(true)
+  })
+
+  it('does not match when the regex does not apply', () => {
+    // Guards against a fix that made every regex command match unconditionally.
+    expect(isCommandMatch(command('regex', '^calc '), 'weather today')).toBe(false)
+  })
+
+  it('accepts an array of regex patterns', () => {
+    const cmd = command('regex', ['^calc ', '^convert '])
+
+    expect(isCommandMatch(cmd, 'convert 3kg')).toBe(true)
+    expect(isCommandMatch(cmd, 'translate hi')).toBe(false)
+  })
+
+  it('ignores an invalid regex pattern rather than throwing', () => {
+    featureLogWarn.mockClear()
+
+    expect(isCommandMatch(command('regex', '('), 'anything')).toBe(false)
+    expect(featureLogWarn).toHaveBeenCalledWith(expect.stringContaining('invalid regex'))
+  })
+
+  it('warns instead of failing silently for the unreachable function type', () => {
+    featureLogWarn.mockClear()
+
+    // Still false -- a matcher function genuinely cannot survive manifest JSON or IPC -- but a
+    // plugin author now gets told why the feature never matches.
+    expect(isCommandMatch(command('function', 'whatever'), 'query')).toBe(false)
+    expect(featureLogWarn).toHaveBeenCalledWith(
+      expect.stringContaining('does not survive JSON or IPC')
+    )
+  })
+
+  it('keeps match, contain and over behaving as before', () => {
+    expect(isCommandMatch(command('match', 'calc'), 'calc 1+1')).toBe(true)
+    expect(isCommandMatch(command('match', 'calc'), 'my calc')).toBe(false)
+    expect(isCommandMatch(command('contain', 'calc'), 'my calc')).toBe(true)
+    expect(isCommandMatch(command('over', ''), '')).toBe(true)
+    expect(isCommandMatch(command('match', ['a', 'b']), 'b thing')).toBe(true)
   })
 })

--- a/apps/core-app/src/main/modules/plugin/adapters/plugin-features-adapter.ts
+++ b/apps/core-app/src/main/modules/plugin/adapters/plugin-features-adapter.ts
@@ -35,7 +35,8 @@ function getErrorCode(error: unknown): string | undefined {
   return typeof code === 'string' ? code : undefined
 }
 
-function isCommandMatch(command: IFeatureCommand, queryText: string): boolean {
+/** Exported for direct branch coverage; the search path reaches it via matchesCommand. */
+export function isCommandMatch(command: IFeatureCommand, queryText: string): boolean {
   if (!command.type) {
     return true
   }
@@ -57,10 +58,43 @@ function isCommandMatch(command: IFeatureCommand, queryText: string): boolean {
       }
       return queryText.includes(command.value as string)
     case 'regex':
-      return (command.value as RegExp).test(queryText)
+      // A manifest can only carry the pattern as a string, so the old `as RegExp` cast threw
+      // `command.value.test is not a function` on every real declaration (#885). Compile here.
+      if (Array.isArray(command.value)) {
+        return command.value.some((value) => testRegexCommand(value, queryText))
+      }
+      return testRegexCommand(command.value as string, queryText)
+    case 'function':
+      // Declared in the public type but unreachable: a matcher function cannot survive
+      // manifest JSON or IPC. It used to fall through to `false`, so a plugin declaring it saw
+      // its feature silently never match with nothing to explain why.
+      pluginFeaturesLog.warn(
+        'command type "function" cannot be declared in manifest.json - a matcher function does not survive JSON or IPC. Use "regex" or "match".'
+      )
+      return false
     default:
       return false
   }
+}
+
+const regexCommandCache = new Map<string, RegExp | null>()
+
+/** Compiles once per pattern; an invalid pattern must not match rather than throw. */
+function testRegexCommand(pattern: string, queryText: string): boolean {
+  if (typeof pattern !== 'string') return false
+
+  let compiled = regexCommandCache.get(pattern)
+  if (compiled === undefined) {
+    try {
+      compiled = new RegExp(pattern)
+    } catch {
+      pluginFeaturesLog.warn(`ignoring invalid regex command pattern: ${pattern}`)
+      compiled = null
+    }
+    regexCommandCache.set(pattern, compiled)
+  }
+
+  return compiled ? compiled.test(queryText) : false
 }
 
 function normalizeClassIconValue(value: string): string {

--- a/packages/utils/plugin/index.ts
+++ b/packages/utils/plugin/index.ts
@@ -226,11 +226,24 @@ export interface ITouchPlugin extends IPluginBaseInfo {
 
 export interface IFeatureCommand {
   type: 'match' | 'contain' | 'regex' | 'function' | 'over' | 'image' | 'files' | 'directory' | 'window'
-  value: string | string[] | RegExp | FeatureCommandMatcher
+  /**
+   * Always a string pattern. Features are declared in `manifest.json` and cross IPC, so a
+   * `RegExp` or a matcher function cannot reach a consumer -- JSON degrades them to `{}` or
+   * drops them. The union used to admit both, which let the matcher cast unsoundly to `RegExp`
+   * and throw on the string a manifest actually carries (#885).
+   *
+   * For `type: 'regex'` this is the pattern source; the host compiles it.
+   */
+  value: string | string[]
   /** Optional trigger callback - not serialized over IPC */
   onTrigger?: () => void
 }
 
+/**
+ * @deprecated Never reachable. A feature command is declared in `manifest.json` and crosses
+ * IPC, so a function value cannot survive to the host. Nothing constructs one, and the
+ * `'function'` command type has no matcher branch. Kept only so existing imports still resolve.
+ */
 export type FeatureCommandMatcher = (queryText: string) => boolean
 
 export type OmniTransferTarget = 'plugin' | 'corebox' | 'system'


### PR DESCRIPTION
Fixes the two concrete failures in #885. The larger type-split it proposes is left open — see below.

## The defect

`IFeatureCommand.value` admitted `RegExp` and `FeatureCommandMatcher`, but features are declared in `manifest.json` and cross IPC, where both degrade to a plain string or `{}`. The matcher trusted the type:

| command type | before |
|---|---|
| `regex` | `(command.value as RegExp).test(...)` → **`TypeError: value.test is not a function`** on every real declaration |
| `function` | no branch at all → fell through to `default: return false`, so the feature **silently never matched** |

## The fix

- `value` narrowed to `string | string[]`
- `regex` compiles the pattern at match time, cached per pattern; an invalid pattern is ignored with a warning rather than thrown
- `function` now logs why it cannot work instead of failing silently

## Narrowing a published type is safe here

Nothing used the removed arms:

- `FeatureCommandMatcher` was referenced **only** by its own declaration and that union arm
- no manifest in `plugins/` declares `type: "regex"` or `"function"`
- nothing constructs a `RegExp` value anywhere

`typecheck:node` passes unchanged. The type stays exported and is marked `@deprecated` so existing imports still resolve — an external author passing a `RegExp` was already broken at runtime, so this surfaces an existing bug rather than creating one.

## Verified by mutation

Against the unfixed matcher, **5 of the 6 new cases fail**:

```
unfixed -> 5 failed | 16 passed
fixed   -> 21 passed
```

The sixth asserts `match` / `contain` / `over` are untouched — a careless rewrite of the switch would break it.

## Note on a lint trap hit while doing this

`no-console` is an error in core-app, and my first version used `console.warn`. Worth recording that `npx eslint … | tail` reports the **pipe's** exit code, not eslint's — it printed `exit=0` while eslint was actually exiting 1 with 2 errors. The warnings now go through the file's existing `pluginFeaturesLog`.

## Left open

The issue's suggested direction — splitting a manifest-facing type from a runtime type and compiling `regex` once at manifest load rather than at match time — is a design change beyond removing the crash. Reported on #885.