### PR TITLE
fix(renderer): bind regChannel to its receiver in useTypedChannel

### DIFF
--- a/packages/utils/__tests__/use-typed-channel-binding.test.ts
+++ b/packages/utils/__tests__/use-typed-channel-binding.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useTypedChannel } from '../renderer/hooks/use-channel'
+
+/**
+ * `send` is wrapped in a closure that calls `channel.send(...)`, so it keeps its receiver.
+ * `regChannel` was handed out by reference, so the documented usage --
+ * `const c = useTypedChannel(); c.regChannel(...)` -- called it detached. The resolved
+ * TouchChannel is a class instance whose regChannel reads `this.channelMap`, so it threw
+ * "Cannot read properties of undefined (reading 'channelMap')" (#886).
+ */
+
+/** Mirrors the real TouchChannel shape: a class that reads instance state in regChannel. */
+class FakeTouchChannel {
+  channelMap = new Map<string, Array<(data: unknown) => unknown>>()
+  sent: Array<{ eventName: string, payload: unknown }> = []
+
+  async send(eventName: string, payload?: unknown) {
+    this.sent.push({ eventName, payload })
+    return { ok: true }
+  }
+
+  regChannel(eventName: string, callback: (data: unknown) => unknown) {
+    const listeners = this.channelMap.get(eventName) ?? []
+    listeners.push(callback)
+    this.channelMap.set(eventName, listeners)
+    return () => {
+      this.channelMap.delete(eventName)
+    }
+  }
+}
+
+describe('useTypedChannel receiver binding', () => {
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).touchChannel
+  })
+
+  function setTouchChannel(channel: unknown) {
+    // resolveTouchChannel() falls back to this global when there is no injection context.
+    ;(globalThis as Record<string, unknown>).touchChannel = channel
+  }
+
+  it('keeps regChannel callable after being destructured off the wrapper', () => {
+    const channel = new FakeTouchChannel()
+    setTouchChannel(channel as any)
+
+    const typed = useTypedChannel<{ 'config-updated': (arg: unknown) => void }>()
+    const { regChannel } = typed
+
+    // The defect: TypeError: Cannot read properties of undefined (reading 'channelMap')
+    expect(() => regChannel!('config-updated' as never, vi.fn())).not.toThrow()
+    expect(channel.channelMap.has('config-updated')).toBe(true)
+  })
+
+  it('returns a working unsubscribe from the detached call', () => {
+    const channel = new FakeTouchChannel()
+    setTouchChannel(channel as any)
+
+    const { regChannel } = useTypedChannel<{ 'config-updated': (arg: unknown) => void }>()
+    const dispose = regChannel!('config-updated' as never, vi.fn())
+    dispose()
+
+    expect(channel.channelMap.has('config-updated')).toBe(false)
+  })
+
+  it('still routes send through the channel', async () => {
+    const channel = new FakeTouchChannel()
+    setTouchChannel(channel as any)
+
+    // Guards the half that already worked: send must keep going through the receiver.
+    const typed = useTypedChannel<{ 'get-config': (arg: { key: string }) => unknown }>()
+    await typed.send('get-config' as never, { key: 'theme' } as never)
+
+    expect(channel.sent).toEqual([{ eventName: 'get-config', payload: { key: 'theme' } }])
+  })
+})

--- a/packages/utils/renderer/hooks/use-channel.ts
+++ b/packages/utils/renderer/hooks/use-channel.ts
@@ -168,6 +168,11 @@ export function useTypedChannel<TChannelMap extends Record<string, any>>() {
       );
     },
 
-    regChannel: channel.regChannel,
+    // Bound, not copied. `send` above keeps its receiver because it is called through
+    // `channel.send(...)` inside a closure; `regChannel` was handed out by reference, so the
+    // documented `const c = useTypedChannel(); c.regChannel(...)` usage called it detached.
+    // The resolved TouchChannel is a class instance whose regChannel reads `this.channelMap`,
+    // so that threw "Cannot read properties of undefined (reading 'channelMap')" (#886).
+    regChannel: channel.regChannel?.bind(channel),
   };
 }


### PR DESCRIPTION
Fixes the defect in #886.

## The defect

`send` is wrapped in a closure that calls `channel.send(...)`, so it keeps its receiver. `regChannel` was handed out **by reference**, so the usage the docblock itself demonstrates —

```ts
const c = useTypedChannel<API>()
c.regChannel('config-updated', fn)
```

— called it detached.

## Verified against the real shape, not just the type

The resolved channel is a genuine class instance, so `this` matters:

```
apps/core-app/src/renderer/src/modules/channel/channel-core.ts:65   class TouchChannel implements TouchClientChannelLike
apps/core-app/src/renderer/src/modules/channel/channel-core.ts:182    const listeners = this.channelMap.get(eventName) || []
```

Detached, that reads `channelMap` off `undefined` and throws.

## Verified by mutation

```
unfixed -> 2 failed | 1 passed
fixed   -> 3 passed
```

The case that passes in **both** states is the interesting one: it asserts `send` still routes through the channel. `send` was never broken, so a test that only exercised the wrapper's `send` would have reported this bug as absent. It is kept as the guard that the fix did not disturb the half that already worked.

The two failures are the detached call itself and the unsubscribe it returns — the second matters because a `bind` that returned a fresh function each call would still leak listeners.

## Gates

- `packages/utils`: **134 files, 1068 passing**, 1 skipped
- `eslint --max-warnings=0` on both changed files: exit 0