### PR TITLE
perf(search): use rolling-row Levenshtein and bound the input length

### DIFF
--- a/packages/utils/__tests__/levenshtein-utils.test.ts
+++ b/packages/utils/__tests__/levenshtein-utils.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { LEVENSHTEIN_MAX_LENGTH, levenshteinDistance } from '../search/levenshtein-utils'
+
+/**
+ * The helper built a full (m+1)x(n+1) table, so two 20,000-character strings from a plugin
+ * allocated ~400 million slots across 20,001 nested arrays and froze the renderer before
+ * running out of memory (#887). It is now the two-row rolling form with an explicit ceiling.
+ *
+ * A rewrite of a numeric algorithm needs more than spot checks, so the main guard is a
+ * differential test against the original implementation, reproduced verbatim below.
+ */
+
+/** The pre-#887 implementation, kept here purely as the differential oracle. */
+function originalLevenshtein(s1: string, s2: string): number {
+  const m = s1.length
+  const n = s2.length
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array.from({ length: n + 1 }, () => 0))
+
+  for (let i = 0; i <= m; i++) {
+    const row = dp[i]
+    if (row)
+      row[0] = i
+  }
+  const firstRow = dp[0]
+  if (firstRow) {
+    for (let j = 0; j <= n; j++)
+      firstRow[j] = j
+  }
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = s1[i - 1] === s2[j - 1] ? 0 : 1
+      const row = dp[i]
+      const prevRow = dp[i - 1]
+      if (!row || !prevRow)
+        continue
+      row[j] = Math.min(
+        (prevRow[j] ?? 0) + 1,
+        (row[j - 1] ?? 0) + 1,
+        (prevRow[j - 1] ?? 0) + cost,
+      )
+    }
+  }
+
+  return dp[m]?.[n] ?? 0
+}
+
+/** Deterministic PRNG so a failure is reproducible rather than a one-off flake. */
+function makeRandom(seed: number) {
+  let state = seed
+  return () => {
+    state = (state * 1664525 + 1013904223) % 4294967296
+    return state / 4294967296
+  }
+}
+
+describe('levenshteinDistance', () => {
+  it('matches known distances', () => {
+    expect(levenshteinDistance('kitten', 'sitting')).toBe(3)
+    expect(levenshteinDistance('flaw', 'lawn')).toBe(2)
+    expect(levenshteinDistance('', '')).toBe(0)
+    expect(levenshteinDistance('abc', '')).toBe(3)
+    expect(levenshteinDistance('', 'abc')).toBe(3)
+    expect(levenshteinDistance('same', 'same')).toBe(0)
+  })
+
+  it('is symmetric, which the shorter/longer swap could easily break', () => {
+    expect(levenshteinDistance('a', 'abcdef')).toBe(5)
+    expect(levenshteinDistance('abcdef', 'a')).toBe(5)
+    expect(levenshteinDistance('sitting', 'kitten')).toBe(3)
+  })
+
+  it('agrees with the original implementation across randomised pairs', () => {
+    const random = makeRandom(20260808)
+    const alphabet = 'abcde'
+
+    const word = (maxLen: number) => {
+      const length = Math.floor(random() * maxLen)
+      let out = ''
+      for (let i = 0; i < length; i++)
+        out += alphabet[Math.floor(random() * alphabet.length)]
+      return out
+    }
+
+    for (let i = 0; i < 300; i++) {
+      const a = word(12)
+      const b = word(12)
+      expect(levenshteinDistance(a, b), `mismatch for ${JSON.stringify([a, b])}`)
+        .toBe(originalLevenshtein(a, b))
+    }
+  })
+
+  it('agrees with the original on lopsided lengths', () => {
+    // The swap only engages when the lengths differ, so it needs its own coverage.
+    const long = 'abcde'.repeat(20)
+    for (const short of ['', 'a', 'ace', 'edcba', 'abcde']) {
+      expect(levenshteinDistance(short, long)).toBe(originalLevenshtein(short, long))
+      expect(levenshteinDistance(long, short)).toBe(originalLevenshtein(long, short))
+    }
+  })
+
+  it('refuses input beyond the documented ceiling instead of allocating', () => {
+    const huge = 'a'.repeat(LEVENSHTEIN_MAX_LENGTH + 1)
+
+    expect(() => levenshteinDistance(huge, 'short')).toThrow(RangeError)
+    expect(() => levenshteinDistance('short', huge)).toThrow(RangeError)
+    expect(() => levenshteinDistance(huge, huge)).toThrow(/LEVENSHTEIN_MAX_LENGTH/)
+  })
+
+  it('still accepts input exactly at the ceiling', () => {
+    // Guards against an off-by-one that would reject legitimate input.
+    const atLimit = 'a'.repeat(LEVENSHTEIN_MAX_LENGTH)
+
+    expect(levenshteinDistance(atLimit, atLimit)).toBe(0)
+  })
+})

--- a/packages/utils/search/levenshtein-utils.ts
+++ b/packages/utils/search/levenshtein-utils.ts
@@ -1,45 +1,71 @@
 /**
+ * Longest input `levenshteinDistance` will process, per argument.
+ *
+ * The helper is exported from `@talex-touch/utils/search`, so a plugin can hand it arbitrary
+ * text -- clipboard contents, a whole document. The previous full (m+1)x(n+1) table meant two
+ * 20,000-character strings allocated ~400 million slots across 20,001 nested arrays, freezing
+ * the renderer before running out of memory (#887). The rolling form below removes most of that
+ * cost, but the work is still O(m*n) in time, so an explicit ceiling stays.
+ *
+ * 4096 is far above any realistic query, title or path this is used for.
+ */
+export const LEVENSHTEIN_MAX_LENGTH = 4096
+
+/**
  * Computes the Levenshtein distance between two strings.
- * This is a standard dynamic programming implementation.
+ *
+ * Uses the two-row rolling form, iterating the shorter string in the inner dimension, so memory
+ * is O(min(m, n)) rather than O(m * n).
  *
  * @param s1 The first string.
  * @param s2 The second string.
  * @returns The Levenshtein distance.
+ * @throws RangeError when either argument exceeds {@link LEVENSHTEIN_MAX_LENGTH}. Refusing is
+ * deliberate: silently returning an approximation would make a wrong number indistinguishable
+ * from a real distance.
  */
 export function levenshteinDistance(s1: string, s2: string): number {
-  const m = s1.length
-  const n = s2.length
-
-  // Create a 2D array (m+1)x(n+1) to store distances
-  const dp: number[][] = Array.from({ length: m + 1 }, () => Array.from({ length: n + 1 }, () => 0))
-
-  // Initialize the DP table
-  for (let i = 0; i <= m; i++) {
-    const row = dp[i]
-    if (row)
-      row[0] = i
-  }
-  const firstRow = dp[0]
-  if (firstRow) {
-    for (let j = 0; j <= n; j++)
-      firstRow[j] = j
+  if (s1.length > LEVENSHTEIN_MAX_LENGTH || s2.length > LEVENSHTEIN_MAX_LENGTH) {
+    throw new RangeError(
+      `[levenshteinDistance] input exceeds LEVENSHTEIN_MAX_LENGTH (${LEVENSHTEIN_MAX_LENGTH}): `
+      + `got ${s1.length} and ${s2.length}. Truncate or pre-filter before comparing.`,
+    )
   }
 
-  // Fill the DP table
-  for (let i = 1; i <= m; i++) {
-    for (let j = 1; j <= n; j++) {
-      const cost = s1[i - 1] === s2[j - 1] ? 0 : 1
-      const row = dp[i]
-      const prevRow = dp[i - 1]
-      if (!row || !prevRow)
-        continue
-      row[j] = Math.min(
-        (prevRow[j] ?? 0) + 1, // Deletion
-        (row[j - 1] ?? 0) + 1, // Insertion
-        (prevRow[j - 1] ?? 0) + cost, // Substitution
+  if (s1 === s2)
+    return 0
+  if (s1.length === 0)
+    return s2.length
+  if (s2.length === 0)
+    return s1.length
+
+  // Keep the shorter string on the inner axis so the rows stay as small as possible.
+  const [shorter, longer] = s1.length <= s2.length ? [s1, s2] : [s2, s1]
+  const width = shorter.length
+
+  let previous = new Array<number>(width + 1)
+  let current = new Array<number>(width + 1)
+
+  for (let j = 0; j <= width; j++)
+    previous[j] = j
+
+  for (let i = 1; i <= longer.length; i++) {
+    current[0] = i
+    const longerChar = longer[i - 1]
+
+    for (let j = 1; j <= width; j++) {
+      const cost = longerChar === shorter[j - 1] ? 0 : 1
+      current[j] = Math.min(
+        (previous[j] ?? 0) + 1, // Deletion
+        (current[j - 1] ?? 0) + 1, // Insertion
+        (previous[j - 1] ?? 0) + cost, // Substitution
       )
     }
+
+    const swap = previous
+    previous = current
+    current = swap
   }
 
-  return dp[m]?.[n] ?? 0
+  return previous[width] ?? 0
 }


### PR DESCRIPTION
Fixes the defect in #887.

## The defect

`levenshteinDistance` is exported from `@talex-touch/utils/search` and has **no internal callers** — it is purely published surface, so a plugin can hand it arbitrary text. The full `(m+1)x(n+1)` table meant two 20,000-character strings allocated ~400 million slots across 20,001 nested arrays.

## The fix

Two-row rolling form, iterating the **shorter** string on the inner axis, so memory is `O(min(m, n))`. Time is still `O(m*n)`, so `LEVENSHTEIN_MAX_LENGTH` (4096) is exported and exceeding it throws `RangeError`.

Refusing rather than approximating is deliberate and consistent with the rest of this sweep: a silently wrong distance is indistinguishable from a real one.

## Measured, not asserted

Two 4000-character strings:

| | heap delta | time |
|---|---|---|
| old | **121.5 MB** | 430 ms |
| new | no measurable retained allocation (negative delta — GC ran) | **55 ms** |

## A numeric rewrite needs more than spot checks

The main guard is a **differential test**: the pre-fix implementation is reproduced verbatim in the test file as an oracle, and compared against the new one across

- 300 seeded random pairs (deterministic PRNG, so a failure is reproducible rather than a flake)
- lopsided-length cases, which are the only ones that exercise the shorter/longer swap

Plus symmetry checks, since the swap is exactly what could break `d(a,b) == d(b,a)`.

## What the mutation run shows, and why it is weaker here

Against the unfixed source **only the ceiling case fails**. That is expected rather than reassuring: the differential oracle *is* the old implementation, so it necessarily agrees with itself. The differential test's job is to catch a regression in *this* rewrite, not to fail against the original. The ceiling test is what pins the genuinely new behaviour, and an at-the-limit case guards the off-by-one that would reject legitimate input.

## Gates

- `packages/utils`: **134 files, 1071 passing**, 1 skipped
- `eslint --max-warnings=0` on both changed files: exit 0