### PR TITLE
test(core-app): make the plugin channel key lifecycle testable, and test it

### DIFF
--- a/apps/core-app/src/main/core/channel-core.ts
+++ b/apps/core-app/src/main/core/channel-core.ts
@@ -3,6 +3,7 @@ import type { WebContentsView } from 'electron'
 import type { TalexTouch } from '../types'
 import { Buffer } from 'node:buffer'
 import { randomBytes } from 'node:crypto'
+import { PluginChannelKeyRegistry } from './plugin-channel-key-registry'
 import { performance } from 'node:perf_hooks'
 import { structuredStrictStringify } from '@talex-touch/utils'
 import { getLogger } from '@talex-touch/utils/common/logger'
@@ -135,9 +136,11 @@ class TouchChannel {
 
   pendingMap: Map<string, (data: RawStandardChannelData) => void> = new Map()
 
-  keyToNameMap: Map<string, string> = new Map()
-  nameToKeyMap: Map<string, string> = new Map()
-  keyToIdentityMap: Map<string, PluginActivationIdentity> = new Map()
+  /**
+   * Extracted so the key lifecycle can be tested without standing up Electron (#929).
+   * TouchChannel keeps the public methods below as thin delegates.
+   */
+  private readonly keyRegistry = new PluginChannelKeyRegistry()
 
   app: TalexTouch.TouchApp
 
@@ -160,64 +163,27 @@ class TouchChannel {
     name: string,
     activation?: Pick<PluginActivationIdentity, 'pluginInstanceId' | 'activationGeneration'>
   ): string {
-    const existingKey = this.nameToKeyMap.get(name)
-    if (existingKey) {
-      const existingIdentity = this.keyToIdentityMap.get(existingKey)
-      const sameActivation =
-        existingIdentity &&
-        (!activation ||
-          (existingIdentity.pluginInstanceId === activation.pluginInstanceId &&
-            existingIdentity.activationGeneration === activation.activationGeneration))
-      if (sameActivation) {
-        return existingKey
-      }
-      this.keyToNameMap.delete(existingKey)
-      this.keyToIdentityMap.delete(existingKey)
-      this.nameToKeyMap.delete(name)
-    }
-
-    const key = randomBytes(16).toString('hex')
-    const identity: PluginActivationIdentity = {
-      name,
-      pluginInstanceId: activation?.pluginInstanceId ?? `legacy:${name}`,
-      activationGeneration: activation?.activationGeneration ?? 1,
-      key
-    }
-    this.keyToNameMap.set(key, name)
-    this.nameToKeyMap.set(name, key)
-    this.keyToIdentityMap.set(key, identity)
-
-    return key
+    return this.keyRegistry.requestKey(name, activation)
   }
 
   revokeKey(key: string): boolean {
-    const name = this.keyToNameMap.get(key)
-    if (!name) {
-      return false
-    }
-
-    this.keyToNameMap.delete(key)
-    this.nameToKeyMap.delete(name)
-    this.keyToIdentityMap.delete(key)
-
-    return true
+    return this.keyRegistry.revokeKey(key)
   }
 
   resolveKey(key: string): string | undefined {
-    return this.keyToNameMap.get(key)
+    return this.keyRegistry.resolveKey(key)
   }
 
   isValidKey(key: string): boolean {
-    return this.keyToIdentityMap.has(key)
+    return this.keyRegistry.isValidKey(key)
   }
 
   resolveIdentity(key: string): PluginActivationIdentity | undefined {
-    return this.keyToIdentityMap.get(key)
+    return this.keyRegistry.resolveIdentity(key)
   }
 
   resolveCurrentIdentity(name: string): PluginActivationIdentity | undefined {
-    const key = this.nameToKeyMap.get(name)
-    return key ? this.keyToIdentityMap.get(key) : undefined
+    return this.keyRegistry.resolveCurrentIdentity(name)
   }
 
   resolveSenderIdentity(sender: Electron.WebContents): PluginActivationIdentity | undefined {
@@ -790,7 +756,7 @@ class TouchChannel {
       return Promise.resolve()
     }
 
-    const key = this.nameToKeyMap.get(pluginName)
+    const key = this.keyRegistry.keyForName(pluginName)
 
     const payload = { ...toRecord(arg), plugin: pluginName }
 
@@ -889,7 +855,7 @@ class TouchChannel {
     const uiView = WindowManager.getInstance().getUIView()
     if (!uiView) return
 
-    const key = this.nameToKeyMap.get(pluginName)
+    const key = this.keyRegistry.keyForName(pluginName)
     const webContents = getWebContents(uiView)
     if (!webContents || webContents.isDestroyed()) return
 

--- a/apps/core-app/src/main/core/plugin-channel-key-registry.test.ts
+++ b/apps/core-app/src/main/core/plugin-channel-key-registry.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { PluginChannelKeyRegistry } from './plugin-channel-key-registry'
+
+/**
+ * The per-plugin channel key lifecycle (#929).
+ *
+ * Every test that touched requestKey/revokeKey/isValidKey/resolveIdentity replaced them with
+ * vi.fn(), so the rotation logic itself had never run. The failure that matters: if the
+ * activation comparison stops distinguishing generations, requestKey hands back the previous
+ * generation's key after a plugin reload, the stale key stays valid, and a disabled activation
+ * keeps sending on a channel it should have lost.
+ */
+const activation = (pluginInstanceId: string, activationGeneration: number) => ({
+  pluginInstanceId,
+  activationGeneration
+})
+
+describe('key issuance', () => {
+  let registry: PluginChannelKeyRegistry
+
+  beforeEach(() => {
+    registry = new PluginChannelKeyRegistry()
+  })
+
+  it('issues a key that resolves back to the plugin', () => {
+    // Positive control: a registry issuing nothing usable would satisfy every rotation
+    // assertion below while breaking every plugin channel.
+    const key = registry.requestKey('demo', activation('instance-1', 1))
+
+    expect(key).toMatch(/^[0-9a-f]{32}$/)
+    expect(registry.isValidKey(key)).toBe(true)
+    expect(registry.resolveKey(key)).toBe('demo')
+    expect(registry.resolveIdentity(key)).toMatchObject({
+      name: 'demo',
+      pluginInstanceId: 'instance-1',
+      activationGeneration: 1
+    })
+  })
+
+  it('returns the same key for the same activation', () => {
+    const first = registry.requestKey('demo', activation('instance-1', 1))
+    expect(registry.requestKey('demo', activation('instance-1', 1))).toBe(first)
+  })
+
+  it('rotates when the activation generation advances', () => {
+    // A plugin reload. The old key must stop working.
+    const first = registry.requestKey('demo', activation('instance-1', 1))
+    const second = registry.requestKey('demo', activation('instance-1', 2))
+
+    expect(second).not.toBe(first)
+    expect(registry.isValidKey(first)).toBe(false)
+    expect(registry.resolveIdentity(first)).toBeUndefined()
+    expect(registry.resolveKey(first)).toBeUndefined()
+  })
+
+  it('rotates when the plugin instance changes', () => {
+    // Same generation number, different instance — reinstalled rather than reloaded.
+    const first = registry.requestKey('demo', activation('instance-1', 1))
+    const second = registry.requestKey('demo', activation('instance-2', 1))
+
+    expect(second).not.toBe(first)
+    expect(registry.isValidKey(first)).toBe(false)
+  })
+
+  it('leaves no stale entry in any map after rotation', () => {
+    // A key dropped from one map but left in another is the injection this prevents.
+    const first = registry.requestKey('demo', activation('instance-1', 1))
+    const second = registry.requestKey('demo', activation('instance-1', 2))
+
+    expect(registry.resolveKey(first)).toBeUndefined()
+    expect(registry.resolveIdentity(first)).toBeUndefined()
+    expect(registry.isValidKey(first)).toBe(false)
+    expect(registry.keyForName('demo')).toBe(second)
+    expect(registry.resolveCurrentIdentity('demo')).toMatchObject({ activationGeneration: 2 })
+  })
+
+  it('keeps different plugins on different keys', () => {
+    const first = registry.requestKey('alpha', activation('instance-a', 1))
+    const second = registry.requestKey('beta', activation('instance-b', 1))
+
+    expect(second).not.toBe(first)
+    expect(registry.resolveKey(first)).toBe('alpha')
+    expect(registry.resolveKey(second)).toBe('beta')
+  })
+
+  it('treats a caller with no activation as matching whatever is current', () => {
+    // The legacy requestKey(name) path must not rotate a live key out from under its owner.
+    const first = registry.requestKey('demo', activation('instance-1', 1))
+    expect(registry.requestKey('demo')).toBe(first)
+  })
+
+  it('defaults an activation-less first request rather than failing', () => {
+    const key = registry.requestKey('legacy-plugin')
+    expect(registry.resolveIdentity(key)).toMatchObject({
+      pluginInstanceId: 'legacy:legacy-plugin',
+      activationGeneration: 1
+    })
+  })
+})
+
+describe('key revocation', () => {
+  let registry: PluginChannelKeyRegistry
+
+  beforeEach(() => {
+    registry = new PluginChannelKeyRegistry()
+  })
+
+  it('invalidates the key and every lookup through it', () => {
+    const key = registry.requestKey('demo', activation('instance-1', 1))
+
+    expect(registry.revokeKey(key)).toBe(true)
+    expect(registry.isValidKey(key)).toBe(false)
+    expect(registry.resolveKey(key)).toBeUndefined()
+    expect(registry.resolveIdentity(key)).toBeUndefined()
+    expect(registry.resolveCurrentIdentity('demo')).toBeUndefined()
+    expect(registry.keyForName('demo')).toBeUndefined()
+  })
+
+  it('reports whether anything was revoked', () => {
+    const key = registry.requestKey('demo', activation('instance-1', 1))
+
+    expect(registry.revokeKey(key)).toBe(true)
+    expect(registry.revokeKey(key)).toBe(false)
+    expect(registry.revokeKey('0'.repeat(32))).toBe(false)
+  })
+
+  it('lets the plugin obtain a fresh key afterwards', () => {
+    // Revocation must not lock a plugin out permanently.
+    const key = registry.requestKey('demo', activation('instance-1', 1))
+    registry.revokeKey(key)
+    const reissued = registry.requestKey('demo', activation('instance-1', 2))
+
+    expect(reissued).not.toBe(key)
+    expect(registry.isValidKey(reissued)).toBe(true)
+  })
+
+  it('does not disturb another plugin', () => {
+    const alpha = registry.requestKey('alpha', activation('instance-a', 1))
+    const beta = registry.requestKey('beta', activation('instance-b', 1))
+
+    registry.revokeKey(alpha)
+
+    expect(registry.isValidKey(beta)).toBe(true)
+    expect(registry.resolveKey(beta)).toBe('beta')
+  })
+})

--- a/apps/core-app/src/main/core/plugin-channel-key-registry.ts
+++ b/apps/core-app/src/main/core/plugin-channel-key-registry.ts
@@ -1,0 +1,99 @@
+import type { PluginActivationIdentity } from '@talex-touch/utils/transport'
+import { randomBytes } from 'node:crypto'
+
+/**
+ * Per-plugin channel keys and the activation they belong to.
+ *
+ * This is the isolation CLAUDE.md describes as "plugin channels use encrypted keys instead of
+ * direct names". It lived inside TouchChannel, where it could not be tested: constructing that
+ * class pulls in Electron, Sentry, the perf monitor and most of the main process, so every
+ * test that touched these methods replaced them with vi.fn() and the rotation logic itself had
+ * never run (#929).
+ *
+ * It is pure state with no Electron dependency, so it belongs in its own unit — which is also
+ * the shape a security boundary should have.
+ */
+export class PluginChannelKeyRegistry {
+  private readonly keyToName = new Map<string, string>()
+  private readonly nameToKey = new Map<string, string>()
+  private readonly keyToIdentity = new Map<string, PluginActivationIdentity>()
+
+  /**
+   * Returns the plugin's current key, minting a new one when the activation has changed.
+   *
+   * The rotation is the point: after a reload, the previous activation must not keep a working
+   * key. A caller that supplies no activation matches whatever is current, which keeps the
+   * legacy `requestKey(name)` path from rotating a live key out from under its owner.
+   */
+  requestKey(
+    name: string,
+    activation?: Pick<PluginActivationIdentity, 'pluginInstanceId' | 'activationGeneration'>
+  ): string {
+    const existingKey = this.nameToKey.get(name)
+    if (existingKey) {
+      const existingIdentity = this.keyToIdentity.get(existingKey)
+      const sameActivation =
+        existingIdentity &&
+        (!activation ||
+          (existingIdentity.pluginInstanceId === activation.pluginInstanceId &&
+            existingIdentity.activationGeneration === activation.activationGeneration))
+      if (sameActivation) {
+        return existingKey
+      }
+      // All three maps move together. A key dropped from one but left in another is exactly
+      // the stale-key injection this rotation exists to prevent.
+      this.keyToName.delete(existingKey)
+      this.keyToIdentity.delete(existingKey)
+      this.nameToKey.delete(name)
+    }
+
+    const key = randomBytes(16).toString('hex')
+    const identity: PluginActivationIdentity = {
+      name,
+      pluginInstanceId: activation?.pluginInstanceId ?? `legacy:${name}`,
+      activationGeneration: activation?.activationGeneration ?? 1,
+      key
+    }
+    this.keyToName.set(key, name)
+    this.nameToKey.set(name, key)
+    this.keyToIdentity.set(key, identity)
+
+    return key
+  }
+
+  /** Returns whether a key existed to revoke, so a caller can tell a real key from a made-up one. */
+  revokeKey(key: string): boolean {
+    const name = this.keyToName.get(key)
+    if (!name) {
+      return false
+    }
+
+    this.keyToName.delete(key)
+    this.nameToKey.delete(name)
+    this.keyToIdentity.delete(key)
+
+    return true
+  }
+
+  resolveKey(key: string): string | undefined {
+    return this.keyToName.get(key)
+  }
+
+  isValidKey(key: string): boolean {
+    return this.keyToIdentity.has(key)
+  }
+
+  resolveIdentity(key: string): PluginActivationIdentity | undefined {
+    return this.keyToIdentity.get(key)
+  }
+
+  resolveCurrentIdentity(name: string): PluginActivationIdentity | undefined {
+    const key = this.nameToKey.get(name)
+    return key ? this.keyToIdentity.get(key) : undefined
+  }
+
+  /** The key currently issued to a plugin, if any. */
+  keyForName(name: string): string | undefined {
+    return this.nameToKey.get(name)
+  }
+}


### PR DESCRIPTION
Closes #929.

## What was untested

`requestKey` / `revokeKey` / `isValidKey` / `resolveIdentity` implement the per-plugin channel isolation, and **every test that touched them replaced them with `vi.fn()`**. The rotation logic had never run.

## Adding tests needed a change of shape, not a bigger mock

The methods live on `TouchChannel`, whose constructor reaches Electron, Sentry, the perf monitor and most of the main process. I worked through a long chain of stubs — `MessageChannelMain`, `talex-mica-electron`, `@sentry/electron/main`, a dozen `app` members, the prebuilt loggers — and each fix revealed the next missing export, ending at a CJS/ESM conflict that is an artifact of this worktree's symlinked `node_modules` rather than of the code.

Whatever that exercise was, it was not a test of key rotation.

The lifecycle is **pure state with no Electron dependency**, so it moved to `PluginChannelKeyRegistry` and `TouchChannel` delegates. Same logic, same comparison, same three maps kept in step — only the file changed. The two direct reads of `nameToKeyMap` elsewhere in `channel-core` became `keyForName`.

## Twelve tests, no mocking at all

That is the argument for the extraction: the suite has no `vi.mock` in it.

**Mutation-tested rather than asserted:** replacing the generation comparison with `true` fails **2 of the 12**.

Coverage includes what rotation must *not* break — a caller with no activation matches whatever is current, so the legacy `requestKey(name)` path cannot rotate a live key out from under its owner — plus a positive control that an issued key resolves back to its plugin, since a registry issuing nothing usable would satisfy every rotation assertion.

## Verification

`src/main/channel` + `src/main/core`: **168 passed, 1 failed**. That failure is the packaged-runtime-closure contract which `ci.yml`'s own comment names as one of core-app's two known-failing files. `typecheck:node` reports zero errors in the changed files.