### PR TITLE
fix(storage): stop ShortcutStorage handing out live internal state

### DIFF
--- a/packages/utils/__tests__/shortcut-storage.test.ts
+++ b/packages/utils/__tests__/shortcut-storage.test.ts
@@ -54,3 +54,79 @@ describe('shortcutStorage.removeShortcuts', () => {
     expect(saveConfig).not.toHaveBeenCalled()
   })
 })
+
+/**
+ * The accessors handed back the live `_config` array and live elements, so
+ * `getAllShortcuts().sort(byName)` reordered internal state with nothing written, and the next
+ * unrelated `_save()` silently persisted it (#888).
+ *
+ * The obvious fix -- "return a copy from both accessors" -- would have broken the mutators,
+ * which read through getShortcutById and assign to the object they get back. Hence the private
+ * live lookup; these tests pin both halves.
+ */
+describe('shortcutStorage encapsulation', () => {
+  function createStorage() {
+    const saveConfig = vi.fn()
+    const storage = new ShortcutStorage({
+      getConfig: () => [createShortcut('a'), createShortcut('b')],
+      saveConfig,
+    })
+    return { storage, saveConfig }
+  }
+
+  it('does not let a caller reorder internal state through getAllShortcuts', () => {
+    const { storage } = createStorage()
+
+    storage.getAllShortcuts().reverse()
+
+    expect(storage.getAllShortcuts().map(s => s.id)).toEqual(['a', 'b'])
+  })
+
+  it('does not let a caller append to internal state through getAllShortcuts', () => {
+    const { storage } = createStorage()
+
+    storage.getAllShortcuts().push(createShortcut('injected'))
+
+    expect(storage.getAllShortcuts()).toHaveLength(2)
+  })
+
+  it('does not let a caller edit a nested field through getShortcutById', () => {
+    const { storage } = createStorage()
+
+    const shortcut = storage.getShortcutById('a')!
+    shortcut.accelerator = 'Tampered'
+    shortcut.meta.enabled = false
+
+    expect(storage.getShortcutById('a')!.accelerator).toBe('CommandOrControl+Shift+K')
+    expect(storage.getShortcutById('a')!.meta.enabled).toBe(true)
+  })
+
+  it('does not retain the caller object passed to addShortcut', () => {
+    const { storage } = createStorage()
+    const incoming = createShortcut('c')
+
+    storage.addShortcut(incoming)
+    incoming.accelerator = 'Tampered'
+
+    expect(storage.getShortcutById('c')!.accelerator).toBe('CommandOrControl+Shift+K')
+  })
+
+  it('still applies updateShortcutAccelerator, which reads through the live lookup', () => {
+    const { storage, saveConfig } = createStorage()
+
+    expect(storage.updateShortcutAccelerator('a', 'CommandOrControl+J')).toBe(true)
+
+    // The trap in the issue's suggested fix: routing mutators through a copying accessor makes
+    // this silently no-op while still reporting success and still writing the file.
+    expect(storage.getShortcutById('a')!.accelerator).toBe('CommandOrControl+J')
+    expect(saveConfig).toHaveBeenCalled()
+  })
+
+  it('still applies updateShortcutEnabled, which reads through the live lookup', () => {
+    const { storage } = createStorage()
+
+    expect(storage.updateShortcutEnabled('b', false)).toBe(true)
+
+    expect(storage.getShortcutById('b')!.meta.enabled).toBe(false)
+  })
+})

--- a/packages/utils/common/storage/shortcut-storage.ts
+++ b/packages/utils/common/storage/shortcut-storage.ts
@@ -27,26 +27,48 @@ class ShortcutStorage {
     this.storage.saveConfig(StorageList.SHORTCUT_SETTING, JSON.stringify(this._config, null, 2))
   }
 
-  getAllShortcuts(): Shortcut[] {
-    return this._config
-  }
-
-  getShortcutById(id: string): Shortcut | undefined {
+  /**
+   * The live element, for internal mutators only.
+   *
+   * The public accessors below hand out clones, but `updateShortcutAccelerator` and
+   * `updateShortcutEnabled` work by assigning to the returned object and then calling
+   * `_save()`. Routing them through the public accessor would have them mutate a throwaway
+   * copy and persist the unchanged config -- the shortcut editor would appear to accept a
+   * change that never took effect.
+   */
+  private _findShortcut(id: string): Shortcut | undefined {
     return this._config.find(s => s.id === id)
   }
 
+  /**
+   * A deep copy. Callers used to receive the live array, so `getAllShortcuts().sort(byName)`
+   * reordered internal state with nothing written, and the reorder was then persisted by the
+   * next unrelated `_save()` -- a transient UI sort silently became the saved order (#888).
+   */
+  getAllShortcuts(): Shortcut[] {
+    return this._config.map(shortcut => structuredClone(shortcut))
+  }
+
+  /** A deep copy, for the same reason as {@link getAllShortcuts}. */
+  getShortcutById(id: string): Shortcut | undefined {
+    const shortcut = this._findShortcut(id)
+    return shortcut ? structuredClone(shortcut) : undefined
+  }
+
   addShortcut(shortcut: Shortcut): boolean {
-    if (this.getShortcutById(shortcut.id)) {
+    if (this._findShortcut(shortcut.id)) {
       console.warn(`Shortcut with ID ${shortcut.id} already exists.`)
       return false
     }
-    this._config.push(shortcut)
+    // Stored by value, not by reference: keeping the caller's object would leave them holding
+    // a handle to internal state, which is the same defect as the accessors had, just inbound.
+    this._config.push(structuredClone(shortcut))
     this._save()
     return true
   }
 
   updateShortcutAccelerator(id: string, newAccelerator: string): boolean {
-    const shortcut = this.getShortcutById(id)
+    const shortcut = this._findShortcut(id)
     if (!shortcut) {
       return false
     }
@@ -57,7 +79,7 @@ class ShortcutStorage {
   }
 
   updateShortcutEnabled(id: string, enabled: boolean): boolean {
-    const shortcut = this.getShortcutById(id)
+    const shortcut = this._findShortcut(id)
     if (!shortcut) {
       return false
     }


### PR DESCRIPTION
Fixes the defect in #888 — but **not** by the route the issue suggests. See the middle section.

## The defect

`getAllShortcuts` returned the live `_config` array and `getShortcutById` a live element, so `getAllShortcuts().sort(byName)` reordered internal state with nothing written, and the next unrelated `_save()` silently persisted it. A transient UI sort became the saved shortcut order.

## ⚠️ The issue's suggested fix would have introduced a worse bug

> *"Return a defensive copy (`[...this._config]`, deep-cloning entries) from **both accessors**."*

`updateShortcutAccelerator` and `updateShortcutEnabled` read through `getShortcutById` and **assign to the object they get back**, then call `_save()`:

```ts
const shortcut = this.getShortcutById(id)
shortcut.accelerator = newAccelerator     // <- mutates a clone under the suggested fix
this._save()                              // <- writes the unchanged config
return true                               // <- reports success
```

Against a copying accessor both mutators silently no-op while still returning `true` and still writing the file — the shortcut editor would appear to accept changes that never take effect. That is worse than the leak being fixed, and it would not show up as a crash.

So the mutators go through a private `_findShortcut` that still returns the live element; only the **public** accessors clone.

## Both failure modes are demonstrated, not argued

The same suite run against each variant:

| variant | result |
|---|---|
| origin, unfixed | **4 failed** \| 4 passed — the four leaks |
| the issue's literal suggestion | **3 failed** \| 5 passed — incl. `updateShortcutAccelerator`, `updateShortcutEnabled` |
| this change | **8 passed** |

## Also closed: the inbound leak the issue does not mention

`addShortcut` pushed the caller's object straight into `_config`, so `addShortcut(obj); obj.accelerator = 'x'` mutated saved state — the same defect as the accessors had, just travelling the other way. It now clones on the way in, and a test pins it.

## Gates

- `packages/utils`: **133 files, 1071 passing**, 1 skipped
- `eslint --max-warnings=0` on both changed files: exit 0