### PR TITLE
build: fail publish validation when an entry points at an unbuilt output

### DIFF
--- a/packages/tuff-cli/package.json
+++ b/packages/tuff-cli/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "build": "tsup",
+    "prepublishOnly": "pnpm run build",
     "dev": "tsup --watch",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",

--- a/packages/tuff-core/package.json
+++ b/packages/tuff-core/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --splitting --clean --target node24 --platform node",
+    "prepublishOnly": "pnpm run build",
     "dev": "tsup src/index.ts --format esm --dts --splitting --clean --target node24 --platform node --watch",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",

--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -45,6 +45,7 @@
     }
   },
   "scripts": {
+    "prepublishOnly": "pnpm run build",
     "build": "node ./node_modules/gulp/bin/gulp.js -f packages/script/build/index.ts",
     "build:vite": "vite build",
     "dev": "vite build --watch",

--- a/scripts/validate-publish-manifests.mjs
+++ b/scripts/validate-publish-manifests.mjs
@@ -161,17 +161,59 @@ function assertPublishConfig(packages) {
   return issues
 }
 
+/**
+ * A manifest can point `main` / `module` / `types` at a build output that nothing guarantees to
+ * exist. @talex-touch/tuff-core shipped exactly that shape -- `dist/index.js` with no dist, no
+ * prepublishOnly and an `export {}` entry -- and this validator passed it, so `npm publish`
+ * would have produced a package that fails to resolve for every consumer (#889).
+ *
+ * The rule: if an entry field points into a directory that is not present in the working tree,
+ * the package must have a `prepublishOnly` script, so publishing cannot skip the build.
+ */
+function findUnbuiltEntryIssues({ manifest, manifestPath, packageInfo }) {
+  const entryFields = ['main', 'module', 'types', 'typings']
+  const packageDir = path.join(repoRoot, packageInfo.path)
+  const missing = []
+
+  for (const field of entryFields) {
+    const value = manifest[field]
+    if (typeof value !== 'string' || value.length === 0)
+      continue
+    if (!fs.existsSync(path.join(packageDir, value)))
+      missing.push(`${field} -> ${value}`)
+  }
+
+  if (missing.length === 0)
+    return []
+  if (typeof manifest.scripts?.prepublishOnly === 'string')
+    return []
+
+  return [{
+    package: packageInfo.name,
+    manifestPath: toPosixPath(path.relative(repoRoot, manifestPath)),
+    phase: 'source',
+    field: 'scripts.prepublishOnly',
+    spec: missing.join(', '),
+    reason:
+      'entry points at a build output that is absent from the tree and no prepublishOnly '
+      + 'script guarantees it is built, so publishing would ship a package that cannot resolve',
+  }]
+}
+
 function getSourceIssues(packages) {
   return packages.flatMap((packageInfo) => {
     const manifestPath = path.join(repoRoot, packageInfo.path, 'package.json')
     const manifest = readJson(manifestPath)
-    return findForbiddenSpecIssues({
-      manifest,
-      manifestPath,
-      packageInfo,
-      forbiddenProtocols: sourceForbiddenProtocols,
-      phase: 'source',
-    })
+    return [
+      ...findForbiddenSpecIssues({
+        manifest,
+        manifestPath,
+        packageInfo,
+        forbiddenProtocols: sourceForbiddenProtocols,
+        phase: 'source',
+      }),
+      ...findUnbuiltEntryIssues({ manifest, manifestPath, packageInfo }),
+    ]
   })
 }
 


### PR DESCRIPTION
Addresses the harm in #889. The package's *fate* stays open — see the last section.

## The defect

`@talex-touch/tuff-core` declares `main`/`module`/`types` under `dist/`, has no `dist`, no `prepublishOnly`, and an `export {}` entry. `npm publish` would ship a package that fails to resolve for every consumer.

## The durable problem is the gate, not the package

The repo already has a publish gate — and it **passed this package**:

```
$ node scripts/validate-publish-manifests.mjs
[publish-manifest] Validation passed (source): …, @talex-touch/tuff-core, …
```

Its source phase only checked dependency protocols; nothing verified that an entry could exist. So the fix goes there: an entry field pointing at a path absent from the tree now requires a `prepublishOnly` script, so publishing cannot skip the build.

## Adding the check immediately found a second package #889 does not mention

```
- package: @talex-touch/tuff-core   field: scripts.prepublishOnly
- package: @talex-touch/tuff-cli    field: scripts.prepublishOnly
```

`tuff-cli` has the identical shape — `dist/index.js`, a build script, no `prepublishOnly`. Both now declare it.

## Verified, not assumed

- **The build behind the promise actually runs.** `tsup` on `tuff-core` exits 0 and produces `dist/index.js` + `index.d.ts`. A `prepublishOnly` pointing at a broken build would just move the failure. The `dist` was removed again afterwards — it is gitignored build output, not part of this change.
- **The check fires.** Removing `prepublishOnly` from `tuff-core` again fails validation with exit 1, naming the package and the missing field. A gate that cannot fail is what created this situation in the first place.

## Deliberately not decided

`tuff-core`'s entry is still `export {}` and **nothing in the monorepo depends on it**. Whether to implement the "low-level build and publish primitives" or retire the package is a product call, and #889 offers both. This change only makes an accidental publish impossible, which is the concrete harm the issue describes. The issue stays open for the fate question.