### PR TITLE
test(core-app): delete six vi.mock blocks that mock nothing

### DIFF
--- a/apps/core-app/src/main/channel/common.test.ts
+++ b/apps/core-app/src/main/channel/common.test.ts
@@ -432,20 +432,6 @@ vi.mock('../service/device-idle-service', () => ({
   }
 }))
 
-vi.mock('../service/storage-maintenance', () => ({
-  cleanupAnalytics: vi.fn(),
-  cleanupClipboard: vi.fn(),
-  cleanupConfig: vi.fn(),
-  cleanupDownloads: vi.fn(),
-  cleanupFileIndex: vi.fn(),
-  cleanupIntelligence: vi.fn(),
-  cleanupLogs: vi.fn(),
-  cleanupOcr: vi.fn(),
-  cleanupTemp: vi.fn(),
-  cleanupUpdates: vi.fn(),
-  cleanupUsage: vi.fn()
-}))
-
 vi.mock('../service/temp-file.service', () => ({
   tempFileService: {
     registerNamespace: tempFileRegisterNamespaceMock,

--- a/apps/core-app/src/main/modules/ai/mcp-server-admin.test.ts
+++ b/apps/core-app/src/main/modules/ai/mcp-server-admin.test.ts
@@ -8,7 +8,6 @@ import { describe, expect, it, vi } from 'vitest'
 // runtime that reconciles imported servers accepts what we wrote. Its module
 // pulls in Electron and the database, neither of which this suite needs.
 vi.mock('./ai-orchestrator-store', () => ({ aiOrchestratorStore: {} }))
-vi.mock('./ai-import-content-store', () => ({ aiImportContentStore: {} }))
 vi.mock('./intelligence-mcp-registry', () => ({ intelligenceMcpRegistry: {} }))
 
 import { mcpProfilesFromItem } from './ai-imported-config-runtime'

--- a/apps/core-app/src/main/modules/box-tool/addon/preview/preview-inventory.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/preview/preview-inventory.test.ts
@@ -79,34 +79,6 @@ vi.mock('../../../../utils/logger', () => {
   }
 })
 
-vi.mock('./abilities/currency-ability', () => ({
-  CurrencyPreviewAbility: class CurrencyPreviewAbility {
-    readonly id = 'preview.currency'
-    readonly label = 'Currency'
-    readonly priority = 40
-    readonly safety = {
-      input: {
-        maxLength: 120,
-        syntax: 'currency amount conversion, e.g. 10 USD to CNY',
-        notes: 'CoreApp realtime currency adapter test double.'
-      },
-      dependencies: ['parser', 'network', 'cache'],
-      usesDynamicExecution: false,
-      usesNetwork: true,
-      usesCache: true,
-      replacementPlan: 'CoreApp realtime adapter retained for Nexus/cache-backed rates.'
-    }
-
-    canHandle(): boolean {
-      return false
-    }
-
-    async execute(): Promise<null> {
-      return null
-    }
-  }
-}))
-
 import {
   listPreviewAbilityInventory,
   listPreviewDynamicExecutionInventory

--- a/apps/core-app/src/main/modules/ocr/ocr-service.test.ts
+++ b/apps/core-app/src/main/modules/ocr/ocr-service.test.ts
@@ -95,10 +95,6 @@ vi.mock('@sentry/electron/main', () => ({
   captureException: vi.fn()
 }))
 
-vi.mock('../../core', () => ({
-  genTouchApp: () => ({ channel: null })
-}))
-
 vi.mock('../box-tool/core-box/window', () => ({
   windowManager: {
     getAttachedPlugin: vi.fn(() => null)

--- a/apps/core-app/src/main/modules/omni-panel/index.test.ts
+++ b/apps/core-app/src/main/modules/omni-panel/index.test.ts
@@ -118,12 +118,6 @@ vi.mock('electron', () => ({
   }
 }))
 
-vi.mock('../../core', () => ({
-  genTouchApp: () => ({
-    channel: {}
-  })
-}))
-
 vi.mock('../../core/touch-window', () => ({
   TouchWindow: class TouchWindow {
     window = {

--- a/apps/core-app/src/main/modules/plugin/plugin.test.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin.test.ts
@@ -134,13 +134,6 @@ vi.mock('@sentry/electron/main', () => {
   }
 })
 
-vi.mock('../../core', () => ({
-  genTouchApp: () => ({
-    channel: {},
-    window: { window: { id: 1 } }
-  })
-}))
-
 const coreBoxManagerMock = vi.hoisted(() => ({
   exitUIMode: vi.fn(),
   getCurrentFeature: vi.fn()


### PR DESCRIPTION
Closes #711 and #528 — the latter is one of the six the former lists.

## The six

| file | mocked specifier |
|---|---|
| `plugin.test.ts` | `../../core` |
| `ocr-service.test.ts` | `../../core` |
| `omni-panel/index.test.ts` | `../../core` |
| `mcp-server-admin.test.ts` | `./ai-import-content-store` |
| `preview-inventory.test.ts` | `./abilities/currency-ability` |
| `common.test.ts` | `../service/storage-maintenance` |

60 lines that read as configured isolation and provide none.

## Confirmed behaviourally, not by grep

Each was removed and its file re-run. Every count is identical:

```
52 → 52    8 → 8    26 → 26    15 → 15    2 → 2    26 → 26
```

## With a positive control, because "removing it changed nothing" has two explanations

Either the mock was inert, **or my method cannot detect a live one**.

So I removed `plugin.test.ts`'s `electron` mock the same way: the file collapses to **"no tests"**. A real mock is detected; these six are not.

## Why deleting beats annotating

The wasted lines are not the risk. A mock naming a module the subject does not import **reads as a boundary someone considered and handled**, so the next person writing a test in that file inherits a false picture of what is isolated. A comment saying "this does nothing" preserves exactly the confusion worth removing.

All six suites pass together: **129 tests**. Lint clean.