### PR TITLE
fix(nexus): rate limit the anonymous install-counter decrement

### DIFF
--- a/apps/nexus/server/api/store/uninstall.post.ts
+++ b/apps/nexus/server/api/store/uninstall.post.ts
@@ -1,11 +1,52 @@
 import { readBody } from 'h3'
+import { hashIpValue } from '../../utils/adminEmergencyStore'
+import { enforceAdminRateLimit } from '../../utils/adminRateLimitStore'
+import { resolveRequestIp } from '../../utils/ipSecurityStore'
 import { decrementPluginInstalls, getPluginBySlug } from '../../utils/pluginsStore'
+
+/**
+ * Rate limits for the anonymous install-counter decrement.
+ *
+ * The endpoint has no auth guard and no proof the caller ever installed the plugin, so an
+ * anonymous loop of POST {"slug":"competitor-plugin"} could drive any plugin's publicly
+ * displayed install count to 0 within seconds (#922).
+ *
+ * Authentication is deliberately NOT added here. The shipped client
+ * (core-app store-api.service.ts reportPluginUninstall) posts only `{ slug }` with no
+ * credentials and ignores the response, so requiring a session would silently stop every
+ * genuine uninstall from being counted. Closing that properly means changing the client and
+ * recording uninstalls per identity, which needs its own task; until then these limits blunt
+ * the described attack without breaking the real caller.
+ *
+ * A real user uninstalls a handful of plugins in a sitting, never hundreds, so these ceilings
+ * sit far above legitimate traffic.
+ */
+const UNINSTALL_RATE_LIMIT = {
+  /** Total decrements one address may report. */
+  perIp: { limit: 30, windowMs: 10 * 60_000 },
+  /** Decrements one address may report against a single plugin -- the targeted-attack shape. */
+  perIpPlugin: { limit: 5, windowMs: 10 * 60_000 },
+} as const
 
 export default defineEventHandler(async (event) => {
   const body = await readBody<{ slug?: string }>(event)
 
   if (!body?.slug)
     return { success: false, message: 'Plugin slug is required.' }
+
+  const ip = resolveRequestIp(event)
+  if (ip) {
+    const ipHash = hashIpValue(event, ip)
+
+    await enforceAdminRateLimit(event, {
+      key: `store-uninstall:ip:${ipHash}`,
+      ...UNINSTALL_RATE_LIMIT.perIp,
+    })
+    await enforceAdminRateLimit(event, {
+      key: `store-uninstall:ip-plugin:${ipHash}:${body.slug}`,
+      ...UNINSTALL_RATE_LIMIT.perIpPlugin,
+    })
+  }
 
   const plugin = await getPluginBySlug(event, body.slug, { forStore: true })
 

--- a/apps/nexus/test/api/store/uninstall-rate-limit.api.test.ts
+++ b/apps/nexus/test/api/store/uninstall-rate-limit.api.test.ts
@@ -1,0 +1,113 @@
+import type { H3Event } from 'h3'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import handler from '../../../server/api/store/uninstall.post'
+
+/**
+ * /api/store/uninstall has no auth guard and no proof the caller ever installed the plugin, so
+ * an anonymous loop of POST {"slug":"competitor-plugin"} could drive any plugin's public install
+ * count to 0 within seconds (#922).
+ *
+ * Auth is deliberately not the fix: the shipped core-app client posts only `{ slug }` with no
+ * credentials and ignores the response, so requiring a session would silently stop every genuine
+ * uninstall from counting. These tests pin the rate limit AND the fact that an ordinary
+ * unauthenticated call still works.
+ */
+
+const h3Mocks = vi.hoisted(() => ({
+  readBody: vi.fn(),
+}))
+
+const rateLimitMocks = vi.hoisted(() => ({
+  enforceAdminRateLimit: vi.fn(),
+}))
+
+const ipMocks = vi.hoisted(() => ({
+  resolveRequestIp: vi.fn(),
+  hashIpValue: vi.fn((_event: unknown, ip: string) => `hashed:${ip}`),
+}))
+
+const pluginsStoreMocks = vi.hoisted(() => ({
+  getPluginBySlug: vi.fn(),
+  decrementPluginInstalls: vi.fn(),
+}))
+
+vi.hoisted(() => {
+  // Nuxt auto-import; the handler module calls it at load time.
+  Object.defineProperty(globalThis, 'defineEventHandler', {
+    configurable: true,
+    value: <T>(fn: T) => fn,
+  })
+})
+
+vi.mock('h3', () => h3Mocks)
+vi.mock('../../../server/utils/adminRateLimitStore', () => rateLimitMocks)
+vi.mock('../../../server/utils/adminEmergencyStore', () => ({ hashIpValue: ipMocks.hashIpValue }))
+vi.mock('../../../server/utils/ipSecurityStore', () => ({ resolveRequestIp: ipMocks.resolveRequestIp }))
+vi.mock('../../../server/utils/pluginsStore', () => pluginsStoreMocks)
+
+const event = {} as H3Event
+
+function invoke() {
+  return (handler as unknown as (event: H3Event) => Promise<unknown>)(event)
+}
+
+describe('store uninstall rate limiting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    h3Mocks.readBody.mockResolvedValue({ slug: 'victim-plugin' })
+    ipMocks.resolveRequestIp.mockReturnValue('203.0.113.9')
+    ipMocks.hashIpValue.mockImplementation((_e: unknown, ip: string) => `hashed:${ip}`)
+    rateLimitMocks.enforceAdminRateLimit.mockResolvedValue(undefined)
+    pluginsStoreMocks.getPluginBySlug.mockResolvedValue({ id: 'plugin-1' })
+    pluginsStoreMocks.decrementPluginInstalls.mockResolvedValue(0)
+  })
+
+  it('rate limits per address and per address+plugin before touching the counter', async () => {
+    await invoke()
+
+    const keys = rateLimitMocks.enforceAdminRateLimit.mock.calls.map(call => call[1].key)
+    expect(keys).toEqual([
+      'store-uninstall:ip:hashed:203.0.113.9',
+      'store-uninstall:ip-plugin:hashed:203.0.113.9:victim-plugin',
+    ])
+  })
+
+  it('does not decrement when the rate limit rejects', async () => {
+    rateLimitMocks.enforceAdminRateLimit.mockRejectedValueOnce(
+      Object.assign(new Error('Rate limited'), { statusCode: 429 }),
+    )
+
+    await expect(invoke()).rejects.toThrow('Rate limited')
+
+    // The whole point: a throttled attacker must not still get their decrement through.
+    expect(pluginsStoreMocks.decrementPluginInstalls).not.toHaveBeenCalled()
+  })
+
+  it('still decrements for an ordinary unauthenticated call', async () => {
+    // The shipped client sends no credentials, so this path must keep working.
+    const result = await invoke()
+
+    expect(pluginsStoreMocks.decrementPluginInstalls).toHaveBeenCalledWith(event, 'plugin-1')
+    expect(result).toEqual({ success: true, slug: 'victim-plugin' })
+  })
+
+  it('rejects a missing slug before doing any work', async () => {
+    h3Mocks.readBody.mockResolvedValue({})
+
+    const result = await invoke()
+
+    expect(result).toEqual({ success: false, message: 'Plugin slug is required.' })
+    expect(rateLimitMocks.enforceAdminRateLimit).not.toHaveBeenCalled()
+    expect(pluginsStoreMocks.decrementPluginInstalls).not.toHaveBeenCalled()
+  })
+
+  it('still works when the address cannot be resolved', async () => {
+    // Rate limiting keys on the address; an unknown address must not break the endpoint.
+    ipMocks.resolveRequestIp.mockReturnValue(undefined)
+
+    await invoke()
+
+    expect(rateLimitMocks.enforceAdminRateLimit).not.toHaveBeenCalled()
+    expect(pluginsStoreMocks.decrementPluginInstalls).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Addresses the attack in #922 — but **not** with the issue's first suggestion. See below.

## The defect

`/api/store/uninstall` has no auth guard, no rate limit and no proof the caller ever installed the plugin. An anonymous loop of `POST {"slug":"competitor-plugin"}` drives any plugin's publicly displayed install count to 0 within seconds.

## ⚠️ Requiring auth would silently break the real client

The issue suggests *"Require an authenticated session or app token"*. The shipped client sends none:

```ts
// apps/core-app/src/main/service/store-api.service.ts:161
await performStoreHttpRequest({
  url,                                   // /api/store/uninstall
  method: 'POST',
  headers: { 'Content-Type': 'application/json' },
  data: { slug },                        // <- no credentials
  timeout: 10_000
})
```

…and it is **fire-and-forget** — the result is only logged at debug level. So adding `requireAuth` would 401 every genuine uninstall, the counter would stop decrementing entirely, and nothing would surface the breakage.

## What this does instead

Two limits through the existing `enforceAdminRateLimit`, keyed on a hashed IP:

| key | limit | purpose |
|---|---|---|
| `store-uninstall:ip:<hash>` | 30 / 10 min | overall volume from one address |
| `store-uninstall:ip-plugin:<hash>:<slug>` | 5 / 10 min | the targeted shape — hammering one competitor's slug |

A real user uninstalls a handful of plugins in a sitting, so both sit far above legitimate traffic.

## Verified by mutation

```
unprotected handler -> 2 failed | 3 passed
this change         -> 5 passed
```

The two failures are the limiter keys and — the one that matters — **a throttled caller still getting their decrement through**.

The three that pass in both states are deliberate guards against a fix that breaks the client: an ordinary unauthenticated call must still decrement, a missing slug must short-circuit before any work, and an unresolvable address must not break the endpoint.

## Still open

Auth plus a per-identity uninstall ledger (so a decrement can only undo that identity's own install) is the real fix, and it needs a client change shipped first. Reported on #922 rather than half-done here.

## Gates

- `apps/nexus` store suite: **4 files, 18 passing**
- nexus typecheck: exit 0
- `eslint --max-warnings=0`: exit 0