### PR TITLE
fix(nexus): throttle the account-existence oracles

### DIFF
--- a/apps/nexus/server/api/auth/email-status.get.ts
+++ b/apps/nexus/server/api/auth/email-status.get.ts
@@ -1,11 +1,35 @@
 import { createError, getQuery } from 'h3'
+import { hashIpValue } from '../../utils/adminEmergencyStore'
+import { enforceAdminRateLimit } from '../../utils/adminRateLimitStore'
+import { resolveRequestIp } from '../../utils/ipSecurityStore'
 import { getUserByEmail } from '../../utils/authStore'
+
+/**
+ * This endpoint answers "is this address registered, and what is its status" to anyone, which
+ * is exactly an account-existence oracle: scripted over a breach list it confirms which
+ * addresses have accounts here and which are disabled or pending deletion (#921).
+ *
+ * It cannot require auth -- the sign-in flow calls it before the user is authenticated
+ * (app/composables/useSignIn.ts) to decide whether to show sign-in or sign-up. So the answer is
+ * to make enumeration expensive rather than to remove it: a person types a handful of addresses
+ * while signing in, a scripted sweep does thousands.
+ */
+const EMAIL_STATUS_RATE_LIMIT = { limit: 20, windowMs: 10 * 60_000 } as const
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event)
   const email = typeof query.email === 'string' ? query.email.trim().toLowerCase() : ''
   if (!email || !email.includes('@')) {
     throw createError({ statusCode: 400, statusMessage: 'Invalid email.' })
+  }
+
+  // Before the lookup: a throttled caller must learn nothing.
+  const ip = resolveRequestIp(event)
+  if (ip) {
+    await enforceAdminRateLimit(event, {
+      key: `auth-email-status:ip:${hashIpValue(event, ip)}`,
+      ...EMAIL_STATUS_RATE_LIMIT,
+    })
   }
 
   const user = await getUserByEmail(event, email)

--- a/apps/nexus/server/api/passkeys/options.get.ts
+++ b/apps/nexus/server/api/passkeys/options.get.ts
@@ -1,10 +1,32 @@
 import { createError, getQuery } from 'h3'
 import { useRuntimeConfig } from '#imports'
+import { hashIpValue } from '../../utils/adminEmergencyStore'
+import { enforceAdminRateLimit } from '../../utils/adminRateLimitStore'
+import { resolveRequestIp } from '../../utils/ipSecurityStore'
 import { createWebAuthnChallenge, getUserByEmail, listPasskeys } from '../../utils/authStore'
+
+/**
+ * Same account-existence oracle as /api/auth/email-status: passing an email returns 404 when no
+ * active account has it, so this is enumerable too (#921 names both). Also pre-auth by nature,
+ * so it gets the same throttle rather than a guard.
+ */
+const PASSKEY_OPTIONS_RATE_LIMIT = { limit: 20, windowMs: 10 * 60_000 } as const
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event)
   const email = typeof query.email === 'string' ? query.email.trim().toLowerCase() : ''
+
+  // Only the email-carrying form is an oracle; an anonymous discovery call reveals nothing.
+  if (email) {
+    const ip = resolveRequestIp(event)
+    if (ip) {
+      await enforceAdminRateLimit(event, {
+        key: `passkey-options:ip:${hashIpValue(event, ip)}`,
+        ...PASSKEY_OPTIONS_RATE_LIMIT,
+      })
+    }
+  }
+
   const user = email ? await getUserByEmail(event, email) : null
   if (email && (!user || user.status !== 'active')) {
     throw createError({ statusCode: 404, statusMessage: 'User not found.' })

--- a/apps/nexus/test/api/auth/email-status-rate-limit.api.test.ts
+++ b/apps/nexus/test/api/auth/email-status-rate-limit.api.test.ts
@@ -1,0 +1,101 @@
+import type { H3Event } from 'h3'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import handler from '../../../server/api/auth/email-status.get'
+
+/**
+ * /api/auth/email-status returns whether an arbitrary address is registered and its status, with
+ * no auth, no Turnstile and no throttle -- an account-existence oracle scriptable over a breach
+ * list (#921).
+ *
+ * Auth is not available as a fix: the sign-in flow calls this before the user is authenticated
+ * to decide whether to show sign-in or sign-up. These tests pin the throttle AND the fact that
+ * an ordinary anonymous lookup still answers.
+ */
+
+const h3Mocks = vi.hoisted(() => ({
+  createError: vi.fn((input: { statusCode: number, statusMessage: string }) =>
+    Object.assign(new Error(input.statusMessage), input)),
+  getQuery: vi.fn(),
+}))
+
+const rateLimitMocks = vi.hoisted(() => ({ enforceAdminRateLimit: vi.fn() }))
+const ipMocks = vi.hoisted(() => ({
+  resolveRequestIp: vi.fn(),
+  hashIpValue: vi.fn((_event: unknown, ip: string) => `hashed:${ip}`),
+}))
+const authStoreMocks = vi.hoisted(() => ({ getUserByEmail: vi.fn() }))
+
+vi.hoisted(() => {
+  Object.defineProperty(globalThis, 'defineEventHandler', {
+    configurable: true,
+    value: <T>(fn: T) => fn,
+  })
+})
+
+vi.mock('h3', () => h3Mocks)
+vi.mock('../../../server/utils/adminRateLimitStore', () => rateLimitMocks)
+vi.mock('../../../server/utils/adminEmergencyStore', () => ({ hashIpValue: ipMocks.hashIpValue }))
+vi.mock('../../../server/utils/ipSecurityStore', () => ({ resolveRequestIp: ipMocks.resolveRequestIp }))
+vi.mock('../../../server/utils/authStore', () => authStoreMocks)
+
+const event = {} as H3Event
+
+function invoke() {
+  return (handler as unknown as (event: H3Event) => Promise<unknown>)(event)
+}
+
+describe('email-status enumeration throttle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    h3Mocks.getQuery.mockReturnValue({ email: 'Victim@Example.COM' })
+    h3Mocks.createError.mockImplementation((input: { statusCode: number, statusMessage: string }) =>
+      Object.assign(new Error(input.statusMessage), input))
+    ipMocks.resolveRequestIp.mockReturnValue('203.0.113.9')
+    ipMocks.hashIpValue.mockImplementation((_e: unknown, ip: string) => `hashed:${ip}`)
+    rateLimitMocks.enforceAdminRateLimit.mockResolvedValue(undefined)
+    authStoreMocks.getUserByEmail.mockResolvedValue({ id: 'u1', status: 'active' })
+  })
+
+  it('throttles per address', async () => {
+    await invoke()
+
+    expect(rateLimitMocks.enforceAdminRateLimit).toHaveBeenCalledWith(event, expect.objectContaining({
+      key: 'auth-email-status:ip:hashed:203.0.113.9',
+    }))
+  })
+
+  it('does not reveal whether the account exists once throttled', async () => {
+    rateLimitMocks.enforceAdminRateLimit.mockRejectedValueOnce(
+      Object.assign(new Error('Rate limited'), { statusCode: 429 }),
+    )
+
+    await expect(invoke()).rejects.toThrow('Rate limited')
+
+    // The whole point: a throttled caller must not still get the oracle's answer.
+    expect(authStoreMocks.getUserByEmail).not.toHaveBeenCalled()
+  })
+
+  it('still answers an ordinary anonymous lookup', async () => {
+    // The sign-in flow depends on this working without credentials.
+    const result = await invoke()
+
+    expect(authStoreMocks.getUserByEmail).toHaveBeenCalledWith(event, 'victim@example.com')
+    expect(result).toEqual({ exists: true, status: 'active' })
+  })
+
+  it('rejects a malformed address before consuming quota', async () => {
+    h3Mocks.getQuery.mockReturnValue({ email: 'not-an-email' })
+
+    await expect(invoke()).rejects.toThrow('Invalid email.')
+    expect(rateLimitMocks.enforceAdminRateLimit).not.toHaveBeenCalled()
+  })
+
+  it('still answers when the address cannot be resolved', async () => {
+    ipMocks.resolveRequestIp.mockReturnValue(undefined)
+
+    const result = await invoke()
+
+    expect(rateLimitMocks.enforceAdminRateLimit).not.toHaveBeenCalled()
+    expect(result).toEqual({ exists: true, status: 'active' })
+  })
+})


### PR DESCRIPTION
Addresses #921.

## The defect

`/api/auth/email-status` returns whether an arbitrary address is registered **and its status**, with no auth, no Turnstile and no rate limit. Scripted over a breach list it confirms which addresses have accounts here and which are `disabled` / pending deletion.

## Why auth is not the fix

The sign-in flow calls it **before the user is authenticated**:

```
apps/nexus/app/composables/useSignIn.ts:1236
  const result = await requestJson<{ exists: boolean, status: string }>('/api/auth/email-status', …)
```

It decides whether to show sign-in or sign-up. Guarding or removing it breaks sign-in. So the goal is to make enumeration expensive, not impossible: a person types a handful of addresses while signing in, a scripted sweep does thousands. 20 per 10 minutes per address sits well above the first and well below the second.

## Both oracles, not just the one in the title

The issue notes the same leak at `api/passkeys/options.get.ts` — passing an email there returns 404 when no active account has it. Verified: it had no rate limiting either. Both are throttled now.

Only the **email-carrying** form of the passkey endpoint is throttled; an anonymous discovery call reveals nothing and should not consume quota.

## The limiter runs before the lookup

In both handlers, so a throttled caller learns nothing rather than being told after the answer was already computed.

## Verified by mutation

```
unprotected handler -> 2 failed | 3 passed
this change         -> 5 passed
```

The two failures are the throttle itself and — the one that matters — **a throttled caller still receiving the oracle's answer**.

The three that pass in both states guard against a fix that breaks sign-in: an ordinary anonymous lookup must still answer, a malformed address must not consume quota, and an unresolvable address must not break the endpoint.

## Gates

- `apps/nexus` auth + store suites: **8 files, 27 passing**
- `nuxt typecheck`: exit 0
- `eslint --max-warnings=0` on all three changed files: exit 0