### PR TITLE
refactor(core-app): move the runtime rollout inventory out of production

### DIFF
--- a/apps/core-app/src/main/modules/plugin/host/official-plugin-prelude-simple.test.ts
+++ b/apps/core-app/src/main/modules/plugin/host/official-plugin-prelude-simple.test.ts
@@ -766,6 +766,16 @@ describe('official simple Prelude isolation regression', () => {
       { text: '' },
       { id: 'quick-action-lock-screen' }
     ]).promise
+    // A dynamic quick-action-* feature publishes an item; the action runs from onItemAction on
+    // an explicit selection (#817). onFeatureTriggered is re-entered on every input change, so
+    // executing there fired lock-screen on each keystroke. What this test is about — the second
+    // generation works while the first is closed — is unchanged.
+    expect(second.state.systemActions).toEqual([])
+    const secondLockItem = actionItem(second.state.items, 'run-action')
+    await expect(
+      second.runtime.callLifecycle('onItemAction', [secondLockItem, { actionId: 'run-action' }])
+        .promise
+    ).resolves.toMatchObject({ status: 'started', success: true })
     expect(second.state.systemActions).toEqual(['lock-screen'])
     await expect(first.runtime.callLifecycle('onItemAction', [lockItem]).promise).rejects.toEqual(
       new PluginHostChildError('PLUGIN_HOST_CHILD_CLOSED')

--- a/apps/core-app/src/main/modules/plugin/plugin-runtime-rollout.test.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-runtime-rollout.test.ts
@@ -1,13 +1,42 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
-import {
-  PLUGIN_RUNTIME_COMPATIBLE_OFFICIAL_PRELUDES,
-  shouldInstallPluginRuntimeServiceByDefault
-} from './plugin-runtime-rollout'
+import { shouldInstallPluginRuntimeServiceByDefault } from './plugin-runtime-rollout'
 
 const workspaceRoot = path.resolve(__dirname, '../../../../../..')
 const pluginsRoot = path.join(workspaceRoot, 'plugins')
+
+/**
+ * The preludes this suite scans for privileged APIs.
+ *
+ * It used to be exported from plugin-runtime-rollout.ts and read as a production gate, which
+ * nothing consulted (#536). It is a test inventory, so it lives with the test; adding a name
+ * here opts a prelude into being scanned, not into the runtime.
+ */
+const COMPATIBLE_OFFICIAL_PRELUDES = Object.freeze([
+  'clipboard-history',
+  'touch-batch-rename',
+  'touch-browser-bookmarks',
+  'touch-browser-data',
+  'touch-browser-open',
+  'touch-code-snippets',
+  'touch-dev-toolbox',
+  'touch-dev-utils',
+  'touch-dictation',
+  'touch-emoji-symbols',
+  'touch-intelligence',
+  'touch-quick-actions',
+  'touch-quickops',
+  'touch-snipaste',
+  'touch-snippets',
+  'touch-system-actions',
+  'touch-text-snippets',
+  'touch-text-tools',
+  'touch-translation',
+  'touch-window-manager',
+  'touch-window-presets',
+  'touch-workspace-scripts'
+] as const)
 
 const EXPECTED_UNMIGRATED = Object.freeze({})
 
@@ -39,34 +68,15 @@ function officialManifestNames(): string[] {
 describe('plugin runtime production rollout gate', () => {
   it('enables the production default only after all 22 manifested activations are compatible', () => {
     const official = officialManifestNames()
-    const compatible = new Set<string>(PLUGIN_RUNTIME_COMPATIBLE_OFFICIAL_PRELUDES)
+    const compatible = new Set<string>(COMPATIBLE_OFFICIAL_PRELUDES)
     const unmigrated = official.filter((name) => !compatible.has(name))
 
     expect(official).toHaveLength(22)
-    expect(PLUGIN_RUNTIME_COMPATIBLE_OFFICIAL_PRELUDES).toEqual([
-      'clipboard-history',
-      'touch-batch-rename',
-      'touch-browser-bookmarks',
-      'touch-browser-data',
-      'touch-browser-open',
-      'touch-code-snippets',
-      'touch-dev-toolbox',
-      'touch-dev-utils',
-      'touch-dictation',
-      'touch-emoji-symbols',
-      'touch-intelligence',
-      'touch-quick-actions',
-      'touch-quickops',
-      'touch-snipaste',
-      'touch-snippets',
-      'touch-system-actions',
-      'touch-text-snippets',
-      'touch-text-tools',
-      'touch-translation',
-      'touch-window-manager',
-      'touch-window-presets',
-      'touch-workspace-scripts'
-    ])
+    // The inventory used to be compared against a hardcoded copy of itself here, which was
+    // already a tautology when both lived in production. Now that the list is this file's own
+    // constant, the meaningful direction is the other one: every plugin on disk must be in it,
+    // which `unmigrated` asserts below, and nothing may be in it that is not on disk.
+    expect([...COMPATIBLE_OFFICIAL_PRELUDES].sort()).toEqual([...official].sort())
     expect(unmigrated).toEqual(Object.keys(EXPECTED_UNMIGRATED).sort())
     expect(unmigrated).toHaveLength(0)
     expect(shouldInstallPluginRuntimeServiceByDefault()).toBe(true)
@@ -129,7 +139,7 @@ describe('plugin runtime production rollout gate', () => {
       /\bnode:(?:fs(?:\/promises)?|child_process|sqlite|worker_threads)\b/,
       /\belectron\b/
     ]
-    for (const name of PLUGIN_RUNTIME_COMPATIBLE_OFFICIAL_PRELUDES) {
+    for (const name of COMPATIBLE_OFFICIAL_PRELUDES) {
       const sourcePath =
         name === 'clipboard-history'
           ? path.join(pluginsRoot, name, 'index', 'main.ts')

--- a/apps/core-app/src/main/modules/plugin/plugin-runtime-rollout.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-runtime-rollout.ts
@@ -1,28 +1,19 @@
-export const PLUGIN_RUNTIME_COMPATIBLE_OFFICIAL_PRELUDES = Object.freeze([
-  'clipboard-history',
-  'touch-batch-rename',
-  'touch-browser-bookmarks',
-  'touch-browser-data',
-  'touch-browser-open',
-  'touch-code-snippets',
-  'touch-dev-toolbox',
-  'touch-dev-utils',
-  'touch-dictation',
-  'touch-emoji-symbols',
-  'touch-intelligence',
-  'touch-quick-actions',
-  'touch-quickops',
-  'touch-snipaste',
-  'touch-snippets',
-  'touch-system-actions',
-  'touch-text-snippets',
-  'touch-text-tools',
-  'touch-translation',
-  'touch-window-manager',
-  'touch-window-presets',
-  'touch-workspace-scripts'
-] as const)
-
+/**
+ * The isolated plugin runtime is installed unconditionally.
+ *
+ * This module used to export a frozen 22-name "runtime compatible" allowlist that nothing in
+ * production read — the runtime was installed for every plugin regardless. Anyone adding a
+ * plugin hit the rollout test's length assertion, added their name to the allowlist to make it
+ * pass, and reasonably concluded they had opted the plugin in; in fact the runtime had been
+ * active for it all along (#536).
+ *
+ * The inventory now lives in plugin-runtime-rollout.test.ts, which is the only thing that ever
+ * used it — it scans those preludes for privileged APIs. Adding a name there reads as what it
+ * is: updating a test's inventory, not flipping a runtime switch.
+ *
+ * If a real gate is wanted, it belongs here and must be consulted below — that is a behaviour
+ * change (plugins off the list would lose the runtime) rather than the cleanup this was.
+ */
 const PLUGIN_RUNTIME_DEFAULT_ENABLED = true
 
 export function shouldInstallPluginRuntimeServiceByDefault(): boolean {


### PR DESCRIPTION
Closes #536. **Also repairs a regression I introduced in #817** — see the second half.

## #536: the allowlist gates nothing

`plugin-runtime-rollout.ts` exported a frozen 22-name "runtime compatible" allowlist that **nothing in production read**. `shouldInstallPluginRuntimeServiceByDefault` returns a hardcoded `true`.

The cost is not the dead constant. Anyone adding a plugin hits the rollout test's length assertion, adds their name to the allowlist to make it pass, and reasonably concludes they have **opted the plugin into the new runtime** — while it had been active for it all along.

**Of the two options offered, I took the second.** Making the gate consult the list is a *behaviour change*: plugins off it would lose the runtime they have today. That is a product decision. So the list moves into the test that was already its only consumer, and the module states why there is no gate and what adding one would mean.

The test already held a hardcoded copy of the list and asserted the two were equal — a tautology even when both lived in production. That is replaced by the direction that carries information: **the inventory and the plugins on disk must be the same set**. Adding a phantom name fails 2 of 6; the old assertion would not have noticed.

Behaviour is unchanged: the runtime is installed unconditionally, exactly as before.

## The regression, and how it got through

`official-plugin-prelude-simple.test.ts` asserted that triggering a dynamic `quick-action-*` feature **executes** `lock-screen` — the behaviour #817 removed. My change turned it red and I merged anyway.

**Two failures on my part:**

1. I updated the encoded-defect assertions in `plugins/touch-quick-actions` and concluded I had found them all. This one lives in `apps/core-app`, testing the same plugin through the runtime host.
2. **CI reported green.** `App suites (core-app)` runs under `continue-on-error` — the exact mechanism I had *just* written up on #1255 as hiding other people's failures. It hid mine on #1249 while I was documenting it.

Fixed the same way as the plugin's own suite: trigger publishes, `onItemAction` executes. The generation-isolation subject is untouched, and a new assertion that `systemActions` is empty right after the trigger pins the new behaviour rather than merely tolerating it.

`src/main/modules/plugin`: **1191 tests, all passing.**