### PR TITLE
fix(core-app): make the static document lang match the app's default locale

### DIFF
--- a/apps/core-app/src/renderer/index.html
+++ b/apps/core-app/src/renderer/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.png" />


### PR DESCRIPTION
Addresses the one real part of #504. **The issue's main claim does not hold** — details below, since acting on it as written would have added duplicate code.

## The issue's premise is false

> *"nothing in the renderer source ever writes `document.documentElement.lang`"*

Literally true, and misleading. The attribute **is** kept in sync, via a different idiom:

```
apps/core-app/src/renderer/src/modules/lang/i18n.ts:55
  document.querySelector('html')!.setAttribute('lang', locale)
```

…inside `setI18nLanguage`, which runs both at setup and on every switch:

```
i18n.ts:35          setI18nLanguage(i18n, options.locale)   // setup
useLanguage.ts:90   setI18nLanguage(i18n, lang)             // on change
```

So a user switching to zh-CN does get `<html lang="zh-CN">`. The audit searched for one specific idiom, found nothing, and read that as the behaviour being absent.

## What is genuinely wrong

`index.html` ships `lang="en"` while the renderer defaults to `zh-CN` (`useLanguage.ts:17`). So the **first paint**, before i18n initialises, declares the wrong language. Narrow, but real for a screen-reader user — and it is the residue the issue was pointing at without knowing it.

One line: `lang="en"` → `lang="zh-CN"`.

## Why not something cleverer

Injecting the resolved locale into the HTML at build time would be the "complete" fix, but the resolved locale depends on stored settings and the system language, neither of which exist at build time. The static value can only ever be a default, so it should be the app's actual default.

## No test

The changed value is a static attribute in an HTML entry file with no renderer test harness, and the dynamic path it hands over to is already exercised by the existing `modules/lang` suite. Asserting a literal in `index.html` would restate the diff rather than test behaviour.