### PR TITLE
fix(core-app): make sidebar navigation items reachable by keyboard

### DIFF
--- a/apps/core-app/src/renderer/src/components/menu/TouchMenuItem.a11y.test.ts
+++ b/apps/core-app/src/renderer/src/components/menu/TouchMenuItem.a11y.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import TouchMenuItem from './TouchMenuItem.vue'
+
+/**
+ * TouchMenuItem is the sidebar's primary navigation item and routes on click, but its root was a
+ * bare div with no role, no tabindex and no key handler -- reachable only by mouse (#505).
+ */
+
+const push = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push, afterEach: () => () => {} }),
+  useRoute: () => ({ path: '/elsewhere', matched: [] })
+}))
+
+function mountItem(props: Record<string, unknown> = {}) {
+  return mount(TouchMenuItem, {
+    props: { name: 'Home', route: '/home', ...props },
+    global: {
+      directives: { wave: {} },
+      provide: { changePointer: () => {} }
+    }
+  })
+}
+
+describe('TouchMenuItem keyboard reachability', () => {
+  it('is focusable and announces itself as a link', () => {
+    const root = mountItem().get('.TouchMenuItem-Container')
+
+    expect(root.attributes('role')).toBe('link')
+    expect(root.attributes('tabindex')).toBe('0')
+  })
+
+  it('routes on Enter and on Space, not only on click', async () => {
+    const wrapper = mountItem()
+    const root = wrapper.get('.TouchMenuItem-Container')
+
+    await root.trigger('keydown.enter')
+    expect(push).toHaveBeenCalledWith('/home')
+
+    push.mockClear()
+    await root.trigger('keydown.space')
+    expect(push).toHaveBeenCalledWith('/home')
+  })
+
+  it('marks the active item as the current page', () => {
+    // `active` is computed via the doActive prop against the current route, not passed directly.
+    const root = mountItem({ doActive: () => true }).get('.TouchMenuItem-Container')
+
+    expect(root.attributes('aria-current')).toBe('page')
+  })
+
+  it('leaves aria-current off an inactive item', () => {
+    // Otherwise every item would claim to be the current page, which is worse than none doing so.
+    const root = mountItem({ doActive: () => false }).get('.TouchMenuItem-Container')
+
+    expect(root.attributes('aria-current')).toBeUndefined()
+  })
+
+  it('takes a disabled item out of the tab order and says so', async () => {
+    push.mockClear()
+    const wrapper = mountItem({ disabled: true })
+    const root = wrapper.get('.TouchMenuItem-Container')
+
+    expect(root.attributes('tabindex')).toBe('-1')
+    expect(root.attributes('aria-disabled')).toBe('true')
+
+    // Disabled must hold for the keyboard path too, not just for click.
+    await root.trigger('keydown.enter')
+    expect(push).not.toHaveBeenCalled()
+  })
+})

--- a/apps/core-app/src/renderer/src/components/menu/TouchMenuItem.a11y.test.ts
+++ b/apps/core-app/src/renderer/src/components/menu/TouchMenuItem.a11y.test.ts
@@ -17,7 +17,7 @@ vi.mock('vue-router', () => ({
 
 function mountItem(props: Record<string, unknown> = {}) {
   return mount(TouchMenuItem, {
-    props: { name: 'Home', route: '/home', ...props },
+    props: { icon: 'i-ri-home-line', name: 'Home', route: '/home', ...props },
     global: {
       directives: { wave: {} },
       provide: { changePointer: () => {} }

--- a/apps/core-app/src/renderer/src/components/menu/TouchMenuItem.vue
+++ b/apps/core-app/src/renderer/src/components/menu/TouchMenuItem.vue
@@ -67,7 +67,7 @@ onUnmounted(() => {
   }
 })
 
-function handleClick($event: MouseEvent) {
+function handleClick($event: MouseEvent | KeyboardEvent) {
   if (props.disabled) return
 
   if (props.route) router.push(props.route)

--- a/apps/core-app/src/renderer/src/components/menu/TouchMenuItem.vue
+++ b/apps/core-app/src/renderer/src/components/menu/TouchMenuItem.vue
@@ -80,15 +80,28 @@ function handleClick($event: MouseEvent) {
 </script>
 
 <template>
+  <!--
+    Kept as a div rather than promoted to <button>: this routes, so `link` announces what it
+    actually does where a button would promise an action. Keeping the element means role,
+    tabindex and key handling all have to be supplied by hand -- a bare div was reachable only
+    by mouse (#505). Space is handled alongside Enter because the element is not a native
+    control, so nothing supplies either for free.
+  -->
   <div
     ref="dom"
     v-wave
+    role="link"
     :data-route="props.route"
+    :tabindex="disabled ? -1 : 0"
+    :aria-current="active ? 'page' : undefined"
+    :aria-disabled="disabled ? 'true' : undefined"
     class="TouchMenuItem-Container fake-background"
     flex
     items-center
     :class="{ active, disabled }"
     @click="handleClick"
+    @keydown.enter.prevent="handleClick"
+    @keydown.space.prevent="handleClick"
   >
     <slot>
       <span :class="icon" class="TouchMenu-Tab-Icon" />
@@ -99,6 +112,13 @@ function handleClick($event: MouseEvent) {
 
 <style lang="scss" scoped>
 .TouchMenuItem-Container {
+  // Without this the item takes focus but shows nothing, which is worse than being unreachable:
+  // a keyboard user would be moving through invisible stops.
+  &:focus-visible {
+    outline: 2px solid var(--tx-color-primary);
+    outline-offset: -2px;
+  }
+
   &:hover {
     --fake-inner-opacity: 0.5;
     --fake-color: var(--tx-fill-color-dark);


### PR DESCRIPTION
Fixes #505.

## The defect

`TouchMenuItem` is the primary sidebar navigation item and routes on click, but its root was a bare `div` — no role, no tabindex, no key handler. A keyboard-only user could not reach or activate any top-level destination.

## Why it stays a div

`role="link"` rather than a promoted `<button>`: it **routes**, so link announces what it actually does where a button would promise an action. The cost is that role, tabindex and key handling all have to be supplied by hand — and `Space` is handled alongside `Enter`, because a non-native control gets neither for free.

## Beyond the reported scope, deliberately

| addition | why |
|---|---|
| `aria-current="page"` on the active item | otherwise a screen-reader user can reach every destination but cannot tell which one they are on |
| `aria-disabled` + `tabindex="-1"` when disabled | `handleClick` already bailed on `disabled`; without these the item was still a focus stop that silently did nothing |
| `:focus-visible` outline | **the important one** — without it the item takes focus and shows nothing, which is worse than being unreachable: the user is moving through invisible stops |

Making it focusable without a visible focus ring would have satisfied the issue's literal text while leaving it unusable, so the outline is not optional here.

## Verified by mutation

```
unfixed component -> 4 failed | 1 passed
this change       -> 5 passed
```

The one that passes in both states is deliberate: *aria-current absent on an inactive item*. It guards a fix that marks **every** item as the current page, which would be worse than marking none.

## Gates

- `npm run typecheck:web`: exit 0
- `eslint --max-warnings=0`: exit 0
- New suite: 5 passing