### PR TITLE
fix(core-app): give the add-plugin control a name and keyboard access

### DIFF
--- a/apps/core-app/src/renderer/src/components/plugin/layout/PluginList.a11y.test.ts
+++ b/apps/core-app/src/renderer/src/components/plugin/layout/PluginList.a11y.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import PluginList from './PluginList.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key })
+}))
+
+/**
+ * The add-plugin affordance was a self-closing div whose only visual is CSS, so it had no text
+ * node to announce, no role, no tabindex and no key handler -- invisible to a screen reader and
+ * unreachable by keyboard (#506).
+ */
+
+function mountList() {
+  return mount(PluginList, {
+    props: { plugins: [] },
+    global: {
+      stubs: {
+        TxScroll: { template: '<div><slot /></div>' },
+        PluginListModule: true
+      }
+    }
+  })
+}
+
+describe('PluginList add-plugin control', () => {
+  it('is a real button with an accessible name', () => {
+    const control = mountList().get('#newPluginBtn')
+
+    expect(control.element.tagName).toBe('BUTTON')
+    expect(control.attributes('type')).toBe('button')
+    // The plus is drawn in CSS, so the name can only come from aria-label.
+    expect(control.attributes('aria-label')).toBeTruthy()
+  })
+
+  it('emits add-plugin when activated', async () => {
+    const wrapper = mountList()
+
+    await wrapper.get('#newPluginBtn').trigger('click')
+
+    expect(wrapper.emitted('add-plugin')).toHaveLength(1)
+  })
+
+  it('needs no explicit tabindex because a button is focusable by default', () => {
+    // Guards a "fix" that adds aria-label but leaves a div: it would pass the name assertion
+    // above while still being unreachable.
+    const control = mountList().get('#newPluginBtn')
+
+    expect(control.element.tagName).toBe('BUTTON')
+    expect(control.attributes('disabled')).toBeUndefined()
+  })
+})

--- a/apps/core-app/src/renderer/src/components/plugin/layout/PluginList.vue
+++ b/apps/core-app/src/renderer/src/components/plugin/layout/PluginList.vue
@@ -86,12 +86,41 @@ watch(
     </PluginListModule>
 
     <div class="PluginList-Add transition-cubic fake-background">
-      <div id="newPluginBtn" class="new-plus" @click="() => emits('add-plugin')" />
+      <!--
+        A real button, not a div: the plus is drawn entirely in CSS, so there is no text node
+        for a screen reader to announce and nothing made it focusable (#506). The accessible
+        name comes from aria-label because adding visible text would change the control from a
+        round icon into a labelled one.
+      -->
+      <button
+        id="newPluginBtn"
+        type="button"
+        class="new-plus"
+        :aria-label="t('plugin.add')"
+        @click="() => emits('add-plugin')"
+      />
     </div>
   </TxScroll>
 </template>
 
 <style lang="scss" scoped>
+.new-plus {
+  // The control was a div, so it inherited no native chrome. Reset it back to that so promoting
+  // it to a button is an accessibility change only, not a visual one.
+  appearance: none;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--tx-color-primary);
+    outline-offset: 2px;
+    border-radius: 50%;
+  }
+}
+
 .PluginList-Add {
   &:before {
     filter: invert(0.25);


### PR DESCRIPTION
Fixes #506.

## The defect

The add-plugin affordance was `<div id="newPluginBtn" class="new-plus" @click="…" />` — the plus is drawn entirely in CSS, so there was **no text node to announce**, no role, no tabindex and no key handler.

## Promoted to a real button

Unlike the sidebar items in #505, this is an **action**, not navigation — so `<button type="button">` is the honest role, and it brings focusability plus Enter/Space handling for free rather than by hand.

The accessible name uses `aria-label` with the **existing** `plugin.add` key, already present in both locales (`"Add Plugin"` / `"添加插件"`). No new keys, so the two locale files — which currently carry uncommitted changes — are untouched.

## Two things the issue does not ask for, both necessary

- **Native chrome reset** (`appearance`, `padding`, `border`, `background`). Without it, promoting a div to a button changes the visual. This has to be an accessibility change only.
- **`:focus-visible` ring.** A focusable control that shows no focus is an invisible tab stop — the same trap as in #505. Satisfying the issue's literal text without this would leave the control technically reachable and practically unusable.

## A note on the issue's evidence

It cites the plus coming from `.PluginList-Add:before`. That selector exists but only sets `filter` and `transition` — it declares no `content`, and `.new-plus` had no styling anywhere in the renderer. The glyph's actual source is not what the issue describes. That does not change the finding (there is still no text node either way), but anyone reading the issue as a guide to the markup should know.

## Verified by mutation

```
unfixed component -> 2 failed | 1 passed
this change       -> 3 passed
```

The one passing in both states is deliberate: clicking still emits `add-plugin`. The whole point is that behaviour is unchanged.

## Gates

- `npm run typecheck:web`: exit 0
- `eslint --max-warnings=0`: exit 0
- New suite: 3 passing