### PR TITLE
fix(core-app): make the code keypad operable by keyboard

### DIFF
--- a/apps/core-app/src/renderer/src/components/base/input/FlatCodeInput.a11y.test.ts
+++ b/apps/core-app/src/renderer/src/components/base/input/FlatCodeInput.a11y.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import FlatCodeInput from './FlatCodeInput.vue'
+
+/**
+ * The keypad rendered each digit as a click-only span -- no role, no tabindex, no key handler --
+ * and conveyed selection through a CSS class alone, so a keyboard or screen-reader user could
+ * neither operate it nor tell what was selected (#509).
+ */
+
+describe('FlatCodeInput keypad accessibility', () => {
+  it('renders nine focusable buttons rather than spans', () => {
+    const items = mount(FlatCodeInput).findAll('.FlatCodeInput-Item')
+
+    expect(items).toHaveLength(9)
+    for (const item of items) expect(item.element.tagName).toBe('BUTTON')
+  })
+
+  it('exposes selection through aria-pressed, not only a class', async () => {
+    const wrapper = mount(FlatCodeInput)
+    const third = wrapper.findAll('.FlatCodeInput-Item')[2]!
+
+    expect(third.attributes('aria-pressed')).toBe('false')
+
+    await third.trigger('click')
+
+    expect(third.attributes('aria-pressed')).toBe('true')
+  })
+
+  it('reflects deselection back into aria-pressed', async () => {
+    // Each digit toggles, so the state has to travel both ways or the announcement goes stale.
+    const wrapper = mount(FlatCodeInput)
+    const first = wrapper.findAll('.FlatCodeInput-Item')[0]!
+
+    await first.trigger('click')
+    await first.trigger('click')
+
+    expect(first.attributes('aria-pressed')).toBe('false')
+  })
+
+  it('still emits the joined code once six digits are entered', async () => {
+    const wrapper = mount(FlatCodeInput)
+    const items = wrapper.findAll('.FlatCodeInput-Item')
+
+    for (const index of [0, 1, 2, 3, 4, 5]) await items[index]!.trigger('click')
+
+    expect(wrapper.emitted('input')?.[0]).toEqual(['123456'])
+  })
+
+  it('does not claim to be disabled, because the handler ignores that class', () => {
+    // The `disabled` class is visual only -- inputCode never checks it, so mapping it to
+    // aria-disabled would announce behaviour the component does not have.
+    const wrapper = mount(FlatCodeInput)
+    const items = wrapper.findAll('.FlatCodeInput-Item')
+
+    for (const item of items) expect(item.attributes('aria-disabled')).toBeUndefined()
+  })
+})

--- a/apps/core-app/src/renderer/src/components/base/input/FlatCodeInput.vue
+++ b/apps/core-app/src/renderer/src/components/base/input/FlatCodeInput.vue
@@ -25,13 +25,25 @@ watch(codes, (val) => {
 
 <template>
   <div class="FlatCodeInput-Container">
-    <span
+    <!--
+      Buttons, not spans: each digit toggles in and out of the code, so it is an action and
+      needs to be focusable and Enter/Space-operable. aria-pressed carries the selected state
+      that was previously conveyed by the `active` class alone (#509).
+
+      The `disabled` class is deliberately NOT mapped to aria-disabled: inputCode ignores it and
+      the digit still toggles, so announcing "disabled" would describe behaviour the component
+      does not have.
+    -->
+    <button
       v-for="i in 9"
+      :key="i"
+      type="button"
       :class="{
         active: codes.includes(i),
         disabled: codes.length > 0 && codes[codes.length - 1] !== i
       }"
       class="FlatCodeInput-Item"
+      :aria-pressed="codes.includes(i)"
       @click="inputCode(i)"
       v-text="i"
     />
@@ -41,6 +53,19 @@ watch(codes, (val) => {
 <style lang="scss" scoped>
 .FlatCodeInput-Container {
   .FlatCodeInput-Item {
+    // Was a span, so it carried no native chrome. Reset it back so promoting these to buttons
+    // is an accessibility change only, not a visual one.
+    appearance: none;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+
+    &:focus-visible {
+      outline: 2px solid var(--tx-color-primary);
+      outline-offset: 2px;
+    }
+
     &.active {
       opacity: 0.5;
 


### PR DESCRIPTION
Fixes #509.

## The defect

Each of the nine digits was a click-only `span` — no role, no tabindex, no key handler — and selection was conveyed by a CSS class alone.

## Buttons with `aria-pressed`, not menu items

Each digit **toggles** in and out of the code (`inputCode` splices it back out if already present) rather than being a one-shot. A pressed-state button is the shape that matches, and it brings Enter/Space without hand-written handlers.

Native chrome is reset and a `:focus-visible` ring added, so this is an accessibility change only — same discipline as #505 and #506.

## What I deliberately did **not** do

The `disabled` class is **not** mapped to `aria-disabled`.

```ts
// inputCode never consults it — the digit toggles regardless
:class="{ disabled: codes.length > 0 && codes[codes.length - 1] !== i }"
```

So the class is visual only. Mapping it would announce a restriction the component does not enforce — a screen-reader user would be told a digit is unavailable and then find it works. Better to expose nothing than something false.

## A pre-existing mismatch worth recording

That class marks every digit except the last-entered one as "disabled", yet all of them remain enterable. Either the visual is wrong or the handler is — but deciding **which** changes what a user can type, so it is a product call, not a cleanup. Reported on the issue; not changed here.

## Verified by mutation

```
unfixed component -> 3 failed | 2 passed
this change       -> 5 passed
```

The two passing in both states are deliberate guards: the six-digit `input` emit must still fire (behaviour unchanged), and `aria-disabled` must stay absent — a "fix" that mapped the class would fail that one.

## Gates

- `npm run typecheck:web`: exit 0
- `eslint --max-warnings=0`: exit 0
- New suite: 5 passing