### PR TITLE
fix(core-app): name the provider deactivate control and make it focusable

### DIFF
--- a/apps/core-app/src/renderer/src/views/box/ActivatedProviders.a11y.test.ts
+++ b/apps/core-app/src/renderer/src/views/box/ActivatedProviders.a11y.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import ActivatedProviders from './ActivatedProviders.vue'
+
+/**
+ * The deactivate affordance on each provider pill was a div whose only content is a UnoCSS icon
+ * class -- no text to announce, no role, no tabindex, no key handler (#510).
+ */
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => (key === 'common.remove' ? 'Remove' : key) })
+}))
+
+vi.mock('@talex-touch/tuffex/icon', () => ({
+  TxIcon: { template: '<i />' }
+}))
+
+vi.mock('~/components/render/icon-color-mode', () => ({
+  normalizeCoreBoxIcon: () => null,
+  shouldRenderCoreBoxIconColorful: () => false
+}))
+
+function mountProviders(closable = true) {
+  return mount(ActivatedProviders, {
+    props: {
+      providers: [
+        {
+          id: 'p1',
+          name: 'Clipboard',
+          meta: { feature: { render: { basic: { title: 'History' } } } }
+        },
+        { id: 'p2', name: 'Files', meta: { feature: { render: { basic: { title: 'Search' } } } } }
+      ] as never,
+      closable
+    }
+  })
+}
+
+describe('ActivatedProviders deactivate control', () => {
+  it('is a real button rather than a div', () => {
+    const controls = mountProviders().findAll('.Activated-Provider-Deactivate')
+
+    expect(controls.length).toBeGreaterThan(0)
+    for (const control of controls) expect(control.element.tagName).toBe('BUTTON')
+  })
+
+  it('names each control with its own provider, not a shared label', () => {
+    // Several pills are on screen at once, so a bare "Remove" would announce them identically.
+    const labels = mountProviders()
+      .findAll('.Activated-Provider-Deactivate')
+      .map((control) => control.attributes('aria-label'))
+
+    expect(labels).toEqual(['Remove Clipboard', 'Remove Files'])
+    expect(new Set(labels).size).toBe(labels.length)
+  })
+
+  it('still emits deactivate-provider on activation', async () => {
+    const wrapper = mountProviders()
+
+    await wrapper.get('.Activated-Provider-Deactivate').trigger('click')
+
+    expect(wrapper.emitted('deactivate-provider')).toHaveLength(1)
+  })
+
+  it('renders no control at all when not closable', () => {
+    // Guards against the button leaking in when the pill is meant to be fixed.
+    expect(mountProviders(false).findAll('.Activated-Provider-Deactivate')).toHaveLength(0)
+  })
+})

--- a/apps/core-app/src/renderer/src/views/box/ActivatedProviders.vue
+++ b/apps/core-app/src/renderer/src/views/box/ActivatedProviders.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { IProviderActivate, ITuffIcon } from '@talex-touch/utils'
 import { TxIcon as TuffIcon } from '@talex-touch/tuffex/icon'
+import { useI18n } from 'vue-i18n'
 import type { IUseSearch } from '~/modules/box/adapter/types'
 import {
   normalizeCoreBoxIcon,
@@ -32,6 +33,17 @@ function getUniqueKey(provider: IProviderActivate): string {
 
 function hasVice(provider: IProviderActivate): boolean {
   return Boolean(provider.meta?.feature || props.closable)
+}
+
+const { t } = useI18n()
+
+/**
+ * The pill's close control is icon-only, so its name has to carry the provider too -- several
+ * pills can be on screen and "Remove" alone would announce all of them identically (#510).
+ */
+function getDeactivateLabel(provider: IProviderActivate): string {
+  const name = provider.name || provider.meta?.pluginName || provider.id
+  return `${t('common.remove')} ${name}`
 }
 
 function getProviderIconInput(provider: IProviderActivate): ProviderIconInput {
@@ -77,10 +89,18 @@ function getProviderIconStyle(provider: IProviderActivate): Record<string, strin
       </div>
       <div v-if="hasVice(provider)" class="Activated-Provider-PillVice">
         <span v-if="provider.meta?.feature">{{ provider.meta.feature.render?.basic?.title }}</span>
-        <div
+        <!--
+          A real button: the only content is a UnoCSS icon class, so there is no text node to
+          announce and nothing made it focusable (#510). Deactivating is an action, so button
+          is the honest role and it brings Enter/Space without hand-written handlers.
+        -->
+        <button
           v-if="props.closable"
+          type="button"
+          class="Activated-Provider-Deactivate"
           cursor-pointer
           i-carbon-close
+          :aria-label="getDeactivateLabel(provider)"
           @click="emit('deactivate-provider', getUniqueKey(provider))"
         />
       </div>
@@ -89,6 +109,23 @@ function getProviderIconStyle(provider: IProviderActivate): Record<string, strin
 </template>
 
 <style lang="scss" scoped>
+.Activated-Provider-Deactivate {
+  // Was a div, so it carried no native chrome. Reset it back so promoting the element to a
+  // button is an accessibility change only, not a visual one.
+  appearance: none;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+
+  // A focusable control that shows no focus is an invisible tab stop.
+  &:focus-visible {
+    outline: 2px solid var(--tx-color-primary);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+}
+
 .ActivatedProvidersContainer {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Fixes #510.

## The defect

The close affordance on each active CoreBox provider pill was a `div` whose only content is a UnoCSS icon class — no text to announce, no role, no tabindex, no key handler.

## The name has to say *which* pill

This is the part the issue does not call out. Several provider pills can be on screen at once, so labelling each close button `"Remove"` would announce them **identically** — a screen-reader user would hear four indistinguishable controls and have no way to pick the right one.

The label composes the existing `common.remove` key with the provider name already shown in the pill:

```
Remove Clipboard   /   移除 Clipboard
Remove Files       /   移除 Files
```

A test asserts the labels are distinct, not merely present.

## No new locale keys

`common.remove` already exists in both locales (`"Remove"` / `"移除"`). The two language files currently carry uncommitted changes, so avoiding new keys keeps this PR out of their way — same approach as #506.

## Same discipline as the other a11y fixes

Native chrome reset so promoting div → button is an accessibility change only, and a `:focus-visible` ring because a focusable control that shows no focus is an invisible tab stop.

## Verified by mutation

```
unfixed component -> 3 failed | 1 passed
this change       -> 4 passed
```

The one passing in both states is deliberate: no control renders when `closable` is false. It guards the button leaking into pills meant to be fixed.

## Gates

- `npm run typecheck:web`: exit 0
- `eslint --max-warnings=0`: exit 0
- New suite: 4 passing