### PR TITLE
fix(core-app): take the permission gate off its own barrel (#525)

### DIFF
--- a/apps/core-app/src/main/modules/permission/channel-guard.test.ts
+++ b/apps/core-app/src/main/modules/permission/channel-guard.test.ts
@@ -7,7 +7,7 @@ const mocks = vi.hoisted(() => ({
   getPluginByName: vi.fn()
 }))
 
-vi.mock('./index', () => ({
+vi.mock('./permission-module-ref', () => ({
   getPermissionModule: mocks.getPermissionModule
 }))
 

--- a/apps/core-app/src/main/modules/permission/channel-guard.ts
+++ b/apps/core-app/src/main/modules/permission/channel-guard.ts
@@ -5,7 +5,7 @@ import type { TuffEvent } from '@talex-touch/utils/transport'
 import type { HandlerContext, ITuffTransportMain } from '@talex-touch/utils/transport/main'
 import { isAuthoritativePluginContext } from '@talex-touch/utils/transport/security/plugin-identity'
 import { CAPABILITY_AUTH_MIN_VERSION } from '@talex-touch/utils/plugin'
-import { getPermissionModule } from './index'
+import { getPermissionModule } from './permission-module-ref'
 
 export interface ProtectedChannelOptions {
   permissionId: string

--- a/apps/core-app/src/main/modules/permission/index.ts
+++ b/apps/core-app/src/main/modules/permission/index.ts
@@ -20,6 +20,7 @@ import {
 import { createLogger } from '../../utils/logger'
 import { BaseModule } from '../abstract-base-module'
 import { teardownPluginStorage } from '../plugin/runtime/plugin-storage-lifecycle'
+import { setPermissionModule } from './permission-module-ref'
 import { PermissionGuard } from './permission-guard'
 import { PermissionStore } from './permission-store'
 
@@ -31,6 +32,7 @@ const resolveKeyManager = (channel: unknown): unknown =>
 export { createProtectedRegister, registerProtectedChannels, withPermission } from './channel-guard'
 export type { ProtectedChannelDefinition, ProtectedChannelOptions } from './channel-guard'
 export { PermissionGuard } from './permission-guard'
+export { getPermissionModule, setPermissionModule } from './permission-module-ref'
 export type { ApiPermissionMapping, PermissionCheckResult } from './permission-guard'
 
 /**
@@ -406,15 +408,4 @@ export class PermissionModule extends BaseModule {
     await this.store.shutdown()
     permLog.info('Permission module destroyed')
   }
-}
-
-// Export singleton getter
-let permissionModule: PermissionModule | null = null
-
-export function getPermissionModule(): PermissionModule | null {
-  return permissionModule
-}
-
-export function setPermissionModule(module: PermissionModule): void {
-  permissionModule = module
 }

--- a/apps/core-app/src/main/modules/permission/permission-barrel-cycle.test.ts
+++ b/apps/core-app/src/main/modules/permission/permission-barrel-cycle.test.ts
@@ -1,0 +1,95 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Nothing in this directory may reach its own barrel at runtime (#525).
+ *
+ * index.ts re-exports channel-guard's public API, so a value import of './index' from inside the
+ * directory closes a cycle through the code that gates IPC channels. It works today only because
+ * `getPermissionModule` was a hoisted function declaration; the moment index.ts gains module-scope
+ * initialization that runs before it, the guard resolves an uninitialized binding and the failure
+ * shows up as a permission check that silently never runs.
+ *
+ * `import type` is exempt: it is erased before the module graph exists.
+ *
+ * A source scan rather than an import-order test, because the hazard is the edge itself — an
+ * import-order test would only catch the orderings someone thought to write.
+ */
+
+const DIR = __dirname
+const SELF_BARREL = /from\s+['"]\.(?:\/index)?['"]/
+
+interface ImportStatement {
+  file: string
+  line: number
+  text: string
+}
+
+function collectImports(): { statements: ImportStatement[]; files: string[] } {
+  const files = readdirSync(DIR).filter(
+    (name) => name.endsWith('.ts') && !name.endsWith('.test.ts') && !name.endsWith('.d.ts')
+  )
+
+  const statements: ImportStatement[] = []
+  for (const file of files) {
+    const lines = readFileSync(path.join(DIR, file), 'utf8').split('\n')
+    lines.forEach((text, index) => {
+      if (/^\s*(?:import|export)\b/.test(text) && /\bfrom\s+['"]/.test(text))
+        statements.push({ file, line: index + 1, text: text.trim() })
+    })
+  }
+
+  return { statements, files }
+}
+
+describe('permission barrel cycle', () => {
+  it('reads the directory it claims to check', () => {
+    // Positive control. Every assertion below is "nothing matched", which a scan reading zero
+    // files or zero lines would also satisfy.
+    const { statements, files } = collectImports()
+
+    // Kept independent of whether the fix is in place: this test must stay green on a tree where
+    // the cycle has been reintroduced, so that a failure here means the scan broke and a failure
+    // below means the cycle came back.
+    expect(files).toContain('index.ts')
+    expect(files).toContain('channel-guard.ts')
+    expect(statements.length).toBeGreaterThan(10)
+    expect(statements.some((statement) => statement.file === 'channel-guard.ts')).toBe(true)
+  })
+
+  it('has no value import of the barrel from inside the directory', () => {
+    const { statements } = collectImports()
+
+    const offenders = statements.filter(
+      (statement) => SELF_BARREL.test(statement.text) && !/^import\s+type\b/.test(statement.text)
+    )
+
+    expect(
+      offenders.map((offender) => `${offender.file}:${offender.line} ${offender.text}`)
+    ).toEqual([])
+  })
+
+  it('detects a barrel import when one is present', () => {
+    // Proves the regex above actually matches the shape it is meant to catch — the form this
+    // issue was filed for, plus the bare-directory spelling that resolves to the same file.
+    expect(SELF_BARREL.test("import { getPermissionModule } from './index'")).toBe(true)
+    expect(SELF_BARREL.test("import { getPermissionModule } from '.'")).toBe(true)
+    expect(SELF_BARREL.test("export { PermissionGuard } from './permission-guard'")).toBe(false)
+    expect(SELF_BARREL.test("import { setPermissionModule } from './permission-module-ref'")).toBe(
+      false
+    )
+  })
+
+  it('keeps the barrel re-exporting the singleton accessors', () => {
+    // Fourteen files outside this directory import getPermissionModule from the barrel. Moving the
+    // definition must stay invisible to them.
+    const barrel = readFileSync(path.join(DIR, 'index.ts'), 'utf8')
+    expect(barrel).toMatch(
+      /export\s*\{[^}]*getPermissionModule[^}]*\}\s*from\s+['"]\.\/permission-module-ref['"]/
+    )
+    expect(barrel).toMatch(
+      /export\s*\{[^}]*setPermissionModule[^}]*\}\s*from\s+['"]\.\/permission-module-ref['"]/
+    )
+  })
+})

--- a/apps/core-app/src/main/modules/permission/permission-module-ref.ts
+++ b/apps/core-app/src/main/modules/permission/permission-module-ref.ts
@@ -1,0 +1,21 @@
+/**
+ * Singleton holder for the permission module.
+ *
+ * Split out of index.ts so channel-guard.ts — the code that gates IPC channels — can reach the
+ * getter without importing the barrel that re-exports channel-guard itself (#525). The barrel
+ * still re-exports both functions, so callers outside this directory are unaffected.
+ *
+ * The `PermissionModule` import below is type-only and erased at compile time, so nothing here
+ * puts index.ts back on the runtime graph.
+ */
+import type { PermissionModule } from './index'
+
+let permissionModule: PermissionModule | null = null
+
+export function getPermissionModule(): PermissionModule | null {
+  return permissionModule
+}
+
+export function setPermissionModule(module: PermissionModule): void {
+  permissionModule = module
+}

--- a/apps/core-app/src/main/modules/plugin/plugin-localization-channels.test.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-localization-channels.test.ts
@@ -24,7 +24,7 @@ const mocks = vi.hoisted(() => ({
   getPluginByName: vi.fn()
 }))
 
-vi.mock('../permission/index', () => ({
+vi.mock('../permission/permission-module-ref', () => ({
   getPermissionModule: mocks.getPermissionModule
 }))
 


### PR DESCRIPTION
Closes #525.

## The cycle

`channel-guard.ts` imported `getPermissionModule` from `./index`, and `index.ts:31` re-exports `createProtectedRegister` / `registerProtectedChannels` / `withPermission` from `./channel-guard`. The code that gates IPC channels depended on the barrel that depends on it.

It works today, and it is worth being precise about why: `getPermissionModule` is a hoisted function declaration, so it is reachable even while `index.ts` is mid-evaluation. The hazard is latent — `let permissionModule` sits in TDZ, so the moment index.ts gains module-scope initialization that calls into the guard before that line evaluates, the lookup throws or returns nothing and the failure shows up as a permission check that never ran.

## Why the suggested fix did not apply

The issue proposed importing from the module that defines the getter. There isn t one — `index.ts:414` defines it itself. So the singleton holder moves out to `permission-module-ref.ts`, and the barrel re-exports both accessors. The fourteen files outside this directory that import `getPermissionModule` from the barrel are untouched.

The new file s `import type { PermissionModule } from "./index"` is type-only and erased before a module graph exists, so it does not put the edge back.

## A test that would have gone quietly dead

`plugin-localization-channels.test.ts` mocked `../permission/index` — not for its own use, but to control what `channel-guard` saw. Its subject imports only `createProtectedRegister` and never touches the barrel. Moving the singleton would have left that mock intercepting nothing: `getPermissionModule()` would return the real `null`, and the four `denies ... without invoking its host service` cases would have passed while exercising no gate at all. The mock is retargeted at the new holder, preserving its intent rather than its vehicle.

I swept the other six production files that import `channel-guard` for the same pattern — none of their tests mock the permission barrel. The sweep has a positive control: its pattern matches both `vi.mock("../permission/index")` and `vi.mock("../permission")` and correctly does not match the new path, so an empty result means empty rather than broken.

## Guard

`permission-barrel-cycle.test.ts` scans the directory for value imports of its own barrel, exempting `import type`. A source scan rather than an import-order test, because the hazard is the edge itself — an import-order test only catches the orderings someone thought to write.

Its positive control is deliberately independent of the fix: on a tree where the cycle is reintroduced, the control test stays green and exactly one substantive assertion fails. My first version conflated the two and both went red, which would have made a real regression indistinguishable from a broken scan.

## Verification

- reintroducing `import { getPermissionModule } from "./index"` in channel-guard fails the guard, control still green
- 17 test files / 212 tests pass across every file touching the permission barrel
- `pnpm typecheck:all` at 42 errors, unchanged, all from this worktree resolving `packages/utils` twice through symlinked `node_modules`
- ESLint clean under the core-app config