### PR TITLE
docs(nexus): point the component table at paths that still exist

### DIFF
--- a/apps/nexus/content/docs/dev/tools/tuffex.en.mdc
+++ b/apps/nexus/content/docs/dev/tools/tuffex.en.mdc
@@ -86,19 +86,19 @@ code: |
 | Component | Description | Source |
 |-----------|-------------|--------|
 | `TuffButton` | Interactive button with tactile feedback | `button/` |
-| `TuffFlatButton` | Flat button with hover effects and loading | `base/button/FlatButton` |
-| `TuffSwitch` | Toggle switch with smooth animations | `base/switch/TSwitch` |
-| `TuffInput` | Input with clearable and textarea support | `base/input/FlatInput` |
-| `TuffCheckbox` | Checkbox with SVG tick animation | `base/checkbox/TCheckbox` |
-| `TuffSelect` | Dropdown select with floating positioning | `base/select/TSelect` |
-| `TuffSelectItem` | Select option item | `base/select/TSelectItem` |
-| `TuffProgress` | Progress bar with indeterminate mode | `base/ProgressBar` |
+| `TuffFlatButton` | Flat button with hover effects and loading | `flat-button/` |
+| `TuffSwitch` | Toggle switch with smooth animations | `switch/` |
+| `TuffInput` | Input with clearable and textarea support | `flat-input/` |
+| `TuffCheckbox` | Checkbox with SVG tick animation | `checkbox/` |
+| `TuffSelect` | Dropdown select with floating positioning | `select/` |
+| `TuffSelectItem` | Select option item | `select/` |
+| `TuffProgress` | Progress bar with indeterminate mode | `progress/` |
 
 **Planned**
 
 | Component | Description | Source |
 |-----------|-------------|--------|
-| `TuffModal` | Modal dialog with entrance animations | `base/dialog/` |
+| `TuffModal` | Modal dialog with entrance animations | `modal/` |
 | `TxScroll` | Custom scrollbar with native feel | `@talex-touch/tuffex` |
 | `TuffTabs` | Tab navigation with indicator animations | `tabs/` |
 | `TuffMenu` | Menu component | `menu/` |

--- a/apps/nexus/content/docs/dev/tools/tuffex.zh.mdc
+++ b/apps/nexus/content/docs/dev/tools/tuffex.zh.mdc
@@ -86,19 +86,19 @@ code: |
 | 组件 | 描述 | 来源 |
 |------|------|------|
 | `TuffButton` | 带触感反馈的交互按钮 | `button/` |
-| `TuffFlatButton` | 扁平按钮，支持 loading 状态 | `base/button/FlatButton` |
-| `TuffSwitch` | 流畅动画的开关组件 | `base/switch/TSwitch` |
-| `TuffInput` | 输入框，支持 clearable 和 textarea | `base/input/FlatInput` |
-| `TuffCheckbox` | 复选框，SVG 动画勾选效果 | `base/checkbox/TCheckbox` |
-| `TuffSelect` | 下拉选择器，浮动定位 | `base/select/TSelect` |
-| `TuffSelectItem` | 选择器选项 | `base/select/TSelectItem` |
-| `TuffProgress` | 进度条，支持 indeterminate | `base/ProgressBar` |
+| `TuffFlatButton` | 扁平按钮，支持 loading 状态 | `flat-button/` |
+| `TuffSwitch` | 流畅动画的开关组件 | `switch/` |
+| `TuffInput` | 输入框，支持 clearable 和 textarea | `flat-input/` |
+| `TuffCheckbox` | 复选框，SVG 动画勾选效果 | `checkbox/` |
+| `TuffSelect` | 下拉选择器，浮动定位 | `select/` |
+| `TuffSelectItem` | 选择器选项 | `select/` |
+| `TuffProgress` | 进度条，支持 indeterminate | `progress/` |
 
 **计划中**
 
 | 组件 | 描述 | 来源 |
 |------|------|------|
-| `TuffModal` | 带入场动画的模态对话框 | `base/dialog/` |
+| `TuffModal` | 带入场动画的模态对话框 | `modal/` |
 | `TxScroll` | 原生体验的自定义滚动条 | `@talex-touch/tuffex` |
 | `TuffTabs` | 带指示器动画的标签页 | `tabs/` |
 | `TuffMenu` | 菜单组件 | `menu/` |


### PR DESCRIPTION
Fixes most of #1284, with one row deliberately left open.

## The defect

The plugin-developer component table listed `Source` paths under core-app's `components/base/`, where these primitives used to live. They moved into tuffex, so the paths lead nowhere — and nothing in the doc signals that, so an author following it hits a missing module unable to tell whether they mistyped, whether it moved, or whether it is gone.

## Verified before writing, not after

Every replacement path was checked to resolve **before** being put in the doc, so this does not swap one set of dead links for another:

| was | now |
|---|---|
| `base/switch/TSwitch` | `switch/` |
| `base/checkbox/TCheckbox` | `checkbox/` |
| `base/select/TSelect` | `select/` |
| `base/select/TSelectItem` | `select/` |
| `base/ProgressBar` | `progress/` |
| `base/button/FlatButton` | `flat-button/` |
| `base/input/FlatInput` | `flat-input/` |
| `base/dialog/` | `modal/` |

This matches the convention the `TuffButton` row already used (`button/`). Both the English and Chinese files carry the same table; both are updated.

## Correcting my own report

#1284 said **six** of eight `base/*` paths were gone. **Five** were. `base/dialog/` still exists — I had tested a directory using a file-existence check.

That is the same class of false positive the audit issues keep producing, and I produced it while writing up an audit issue. The row still needed repointing, because the `TuffModal` it documents lives in tuffex `modal/` now, but the count was wrong and the issue says so.

## One row left alone

`TuffMenu` → `menu/`, which does not exist either — this one is **pre-existing**, not something I introduced, and it surfaced only because I verified every path afterwards.

tuffex has `context-menu/` and `dropdown-menu/`, and no `TuffMenu` symbol exists anywhere in source to disambiguate. Picking one would be a guess about which component the row means, so it stays on the issue.

## On the missing guard

#1284 suggests a check that fails when a documented component path does not resolve. I have not added one: it needs a decision about which docs are in scope and what a "path" means across `.mdc` files, and a half-scoped checker would give false confidence. Worth its own task — without it this recurs on the next retirement, which is exactly how it got here.

## Gates

`eslint` on these two `.mdc` files exits 1 **both before and after** this change — `.mdc` linting is already failing on this base, so there is no delta. Verified against the unmodified files rather than assumed.