### PR TITLE
fix(i18n): add the missing download destination failure message

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -2730,7 +2730,8 @@
         "defaultsRestored": "Default settings restored",
         "tempCleaned": "Temporary files cleaned up",
         "tempCleanFailed": "Failed to cleanup temporary files",
-        "tempDirSelectFailed": "Failed to select temporary directory"
+        "tempDirSelectFailed": "Failed to select temporary directory",
+        "destinationSelectFailed": "Failed to select download folder"
       }
     },
     "settingNetwork": {

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -2706,7 +2706,8 @@
         "defaultsRestored": "已恢复默认设置",
         "tempCleaned": "临时文件已清理",
         "tempCleanFailed": "清理临时文件失败",
-        "tempDirSelectFailed": "选择临时目录失败"
+        "tempDirSelectFailed": "选择临时目录失败",
+        "destinationSelectFailed": "选择下载目录失败"
       }
     },
     "settingNetwork": {


### PR DESCRIPTION
Fixes #502.

## The defect

`SettingDownload.vue:162` shows a toast keyed on `settings.settingDownload.messages.destinationSelectFailed`, absent from both locales — so a user whose folder pick failed saw the raw key string instead of an error message.

## Wording taken from its sibling, not invented

`tempDirSelectFailed` is the same operation on the temp directory, so the new key follows its phrasing exactly:

| key | en-US | zh-CN |
|---|---|---|
| `tempDirSelectFailed` *(existing)* | Failed to select temporary directory | 选择临时目录失败 |
| `destinationSelectFailed` *(new)* | Failed to select download folder | 选择下载目录失败 |

## Edited as text, not reserialised

Both locale files carry **uncommitted changes** in the working tree. Rewriting them with `json.dump` would reformat thousands of lines and collide with that work, so this is a targeted insertion next to the sibling key — 3 lines changed per file.

Their uncommitted changes are one line each and do not touch `settingDownload`, so conflict risk here is nil. Checked before editing rather than hoped for; this is why I left the larger locale gaps in #487 alone.

The result parses and the key resolves — verified after the edit, since a hand edit to JSON should not be trusted otherwise.

## Scanned the rest of the file

These reports tend to name one instance of a wider gap, so all i18n keys in `SettingDownload.vue` were checked: **32 referenced, 0 unresolved** after this change. This was genuinely the only one — the first i18n issue in this batch whose scope was complete.

**The scanner was validated before believing it.** Run against origin's locale files it reports exactly one missing key, this one:

```
against origin locales -> unresolved: 1 ['settings.settingDownload.messages.destinationSelectFailed']
positive control PASSES
```

Without that, "0 unresolved" could equally mean a regex that matches nothing.

## Gates

`eslint` on the two JSON files reports *"File ignored because no matching configuration was supplied"* — 0 errors, they are not covered by the lint config. Noting it rather than presenting exit 1 as a failure or exit 0 as a pass.