### PR TITLE
fix(core-app): move the CoreBox IPC wiring to the composition root (#524)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/core-box/core-box-import-cycle.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/core-box/core-box-import-cycle.test.ts
@@ -1,0 +1,117 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The CoreBox IPC singleton must stay off the manager's import graph (#524).
+ *
+ * manager.ts imported `ipcManager` for two lifecycle calls while ipc.ts reaches `coreBoxManager`
+ * from fifteen handler bodies, and key-transport.ts extended the loop to a third file. Every use
+ * is deferred inside a callback, so evaluation order was masked — but any refactor that read a
+ * `coreBoxManager` property at ipc.ts module scope would throw
+ * `Cannot access 'coreBoxManager' before initialization` at boot, before a window exists to show
+ * it. The wiring now lives in index.ts, which nothing in this directory imports.
+ *
+ * The detector below is general rather than a check for that one edge, so a newly introduced
+ * cycle through ipc.ts fails here too.
+ */
+
+const DIR = __dirname
+
+/**
+ * Cycles this directory still has, recorded rather than silently tolerated.
+ *
+ * All four run through window.ts, and all are genuine mutual dependencies — manager.ts uses
+ * windowManager in twelve places while window.ts reaches coreBoxManager in nine — so untangling
+ * them is a real refactor rather than a moved import, and out of scope for #524, which is about
+ * the coreBoxManager/ipcManager pair.
+ *
+ * Shrinking this list is the point. If a fix makes one disappear, this test fails and the entry
+ * comes out; a stale allowlist that quietly permits a *new* cycle is the failure mode being
+ * avoided.
+ */
+const KNOWN_REMAINING = [
+  'manager.ts -> window.ts -> manager.ts',
+  'manager.ts -> window.ts -> plugin-view-controller.ts -> manager.ts',
+  'meta-overlay.ts -> window.ts -> meta-overlay.ts',
+  'meta-overlay.ts -> window.ts -> plugin-view-controller.ts -> meta-overlay.ts'
+]
+
+function localFiles(): string[] {
+  return readdirSync(DIR).filter(
+    (name) => name.endsWith('.ts') && !name.endsWith('.test.ts') && !name.endsWith('.d.ts')
+  )
+}
+
+/** Same-directory value imports only. `import type` is erased before a module graph exists. */
+function buildGraph(): Map<string, string[]> {
+  const graph = new Map<string, string[]>()
+
+  for (const file of localFiles()) {
+    const edges: string[] = []
+    for (const line of readFileSync(path.join(DIR, file), 'utf8').split('\n')) {
+      if (!/^\s*(?:import|export)\b/.test(line)) continue
+      if (/^\s*import\s+type\b/.test(line)) continue
+      const match = line.match(/from\s+['"]\.\/([\w.-]+)['"]/)
+      if (!match) continue
+      const target = `${match[1]}.ts`
+      if (localFiles().includes(target) && !edges.includes(target)) edges.push(target)
+    }
+    graph.set(file, edges)
+  }
+
+  return graph
+}
+
+/** Every elementary cycle, each normalised to start at its alphabetically smallest member so the
+ * same loop is not reported once per entry point. */
+function findCycles(graph: Map<string, string[]>): string[] {
+  const cycles = new Set<string>()
+
+  const visit = (node: string, trail: string[]): void => {
+    for (const next of graph.get(node) ?? []) {
+      const seen = trail.indexOf(next)
+      if (seen !== -1) {
+        const loop = trail.slice(seen)
+        const pivot = loop.indexOf([...loop].sort()[0]!)
+        cycles.add([...loop.slice(pivot), ...loop.slice(0, pivot), loop[pivot]!].join(' -> '))
+        continue
+      }
+      if (trail.length > 12) continue
+      visit(next, [...trail, next])
+    }
+  }
+
+  for (const node of graph.keys()) visit(node, [node])
+  return [...cycles].sort()
+}
+
+describe('core-box import cycles', () => {
+  it('builds a graph of the directory', () => {
+    // Positive control. Both assertions below are about what the graph does *not* contain, which
+    // an empty graph would satisfy just as well.
+    const graph = buildGraph()
+
+    expect(graph.has('manager.ts')).toBe(true)
+    expect(graph.has('ipc.ts')).toBe(true)
+    expect(graph.get('ipc.ts')).toContain('key-transport.ts')
+    expect([...graph.values()].flat().length).toBeGreaterThan(20)
+  })
+
+  it('finds the cycle it is known to still have', () => {
+    // Second positive control, and the record of what #524 deliberately left alone: a detector
+    // that found nothing at all would pass the next test while checking nothing.
+    expect(findCycles(buildGraph())).toEqual(KNOWN_REMAINING)
+  })
+
+  it('has no cycle through the IPC singleton', () => {
+    const through = findCycles(buildGraph()).filter((cycle) => cycle.includes('ipc.ts'))
+
+    expect(through).toEqual([])
+  })
+
+  it('keeps manager.ts off ipc.ts entirely', () => {
+    // The specific edge #524 was filed for, pinned by name so a reviewer sees what changed.
+    expect(buildGraph().get('manager.ts')).not.toContain('ipc.ts')
+  })
+})

--- a/apps/core-app/src/main/modules/box-tool/core-box/index.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/core-box/index.test.ts
@@ -53,6 +53,10 @@ const mocks = vi.hoisted(() => {
     searchLoggerDestroy: vi.fn(() => {
       callOrder.push('search-logger-destroy')
     }),
+    ipcRegister: vi.fn(),
+    ipcUnregister: vi.fn(() => {
+      callOrder.push('ipc-unregister')
+    }),
     coreBoxManagerDestroy: vi.fn(() => {
       callOrder.push('core-box-manager-destroy')
     }),
@@ -142,9 +146,15 @@ vi.mock('../search-engine/search-logger', () => ({
   }
 }))
 
+vi.mock('./ipc', () => ({
+  ipcManager: {
+    register: mocks.ipcRegister,
+    unregister: mocks.ipcUnregister
+  }
+}))
+
 vi.mock('./manager', () => ({
   coreBoxManager: {
-    init: vi.fn(),
     destroy: mocks.coreBoxManagerDestroy,
     trigger: mocks.coreBoxManagerTrigger,
     markExpanded: mocks.markExpanded,
@@ -208,6 +218,22 @@ describe('CoreBoxModule', () => {
       expect.any(Function),
       expect.objectContaining({ enabled: true })
     )
+  })
+
+  it('registers the CoreBox IPC handlers during init', async () => {
+    // Before #524 this happened inside coreBoxManager.init(); the wiring now lives here. If it is
+    // dropped, no CoreBox IPC handler is ever registered and the launcher stops responding —
+    // with nothing throwing to say so.
+    const module = new CoreBoxModule()
+
+    expect(mocks.ipcRegister).not.toHaveBeenCalled()
+
+    await module.onInit({
+      app: {},
+      manager: { loadModule: vi.fn(async () => undefined) }
+    } as unknown as Parameters<CoreBoxModule['onInit']>[0])
+
+    expect(mocks.ipcRegister).toHaveBeenCalledTimes(1)
   })
 
   it('opens CoreBox when manager state is stale but real window is hidden', async () => {
@@ -489,6 +515,9 @@ describe('CoreBoxModule', () => {
       'dispose-lag-burst',
       'dispose-transport',
       'search-logger-destroy',
+      // Was inside coreBoxManager.destroy() before #524 moved the wiring to this module; the
+      // relative order has to survive the move.
+      'ipc-unregister',
       'core-box-manager-destroy',
       'clear-runtime'
     ])

--- a/apps/core-app/src/main/modules/box-tool/core-box/index.ts
+++ b/apps/core-app/src/main/modules/box-tool/core-box/index.ts
@@ -20,6 +20,7 @@ import { shortcutModule } from '../../global-shortcon'
 import { getMainConfig, onboardingGate } from '../../storage'
 import SearchEngineCore from '../search-engine/search-core'
 import { searchLogger } from '../search-engine/search-logger'
+import { ipcManager } from './ipc'
 import { coreBoxManager } from './manager'
 import { COREBOX_MIN_HEIGHT, windowManager } from './window'
 
@@ -75,7 +76,7 @@ export class CoreBoxModule extends BaseModule {
     this.transport = runtime.transport
     this.registerTransportHandlers()
 
-    coreBoxManager.init()
+    ipcManager.register()
 
     shortcutModule.registerMainShortcut(
       'core.box.toggle',
@@ -156,6 +157,7 @@ export class CoreBoxModule extends BaseModule {
     this.transport = null
 
     searchLogger.destroy()
+    ipcManager.unregister()
     coreBoxManager.destroy()
     windowManager.stopAppSettingSubscription()
     clearRegisteredMainRuntime('core-box')

--- a/apps/core-app/src/main/modules/box-tool/core-box/manager.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/core-box/manager.test.ts
@@ -101,13 +101,6 @@ vi.mock('../search-engine/search-logger', () => ({
   }
 }))
 
-vi.mock('./ipc', () => ({
-  ipcManager: {
-    register: vi.fn(),
-    unregister: vi.fn()
-  }
-}))
-
 vi.mock('./window', () => ({
   windowManager: {
     create: vi.fn(),

--- a/apps/core-app/src/main/modules/box-tool/core-box/manager.ts
+++ b/apps/core-app/src/main/modules/box-tool/core-box/manager.ts
@@ -15,7 +15,6 @@ import { createLogger } from '../../../utils/logger'
 import { SearchEngineCore } from '../search-engine/search-core'
 import { searchLogger } from '../search-engine/search-logger'
 import type { SearchRequestContext } from '../search-engine/search-session'
-import { ipcManager } from './ipc'
 import { windowManager } from './window'
 
 const coreBoxManagerLog = createLogger('CoreBox').child('Manager')
@@ -98,12 +97,7 @@ export class CoreBoxManager {
     return CoreBoxManager.instance
   }
 
-  public init(): void {
-    ipcManager.register()
-  }
-
   public destroy(): void {
-    ipcManager.unregister()
     windowManager.destroy()
   }
 


### PR DESCRIPTION
Closes #524.

## Cutting the other edge

The issue suggested `ipcManager.register(this)` plus dropping ipc.ts's import of the manager. That works, but it touches fifteen `coreBoxManager.` references inside a 740-line IPC file.

Mapping the graph first showed a cheaper cut. `manager.ts` had exactly **two** same-directory imports — `./ipc` and `./window` — and used `ipcManager` in exactly three places:

```
manager.ts:102  init()     -> ipcManager.register()
manager.ts:106  destroy()  -> ipcManager.unregister()
```

Both loops the issue names (`manager -> ipc -> manager` and `manager -> ipc -> key-transport -> manager`) pass through `manager -> ipc`. Removing that one edge kills both.

`CoreBoxManager.init()` existed *only* to call `ipcManager.register()`, so it is deleted, and `index.ts` — the sole caller of `init()`/`destroy()`, and the one file in this directory that nothing else imports — does the registering. Wiring at the composition root rather than inside the thing being wired.

**Worth knowing before merge:** this deletes the public `CoreBoxManager.init()`. Repo-wide it had one caller. The issue's own suggestion also changed an API (`register()`'s signature), so I took the smaller of the two, but say the word if you would rather keep the method.

## What the issue does not cover

The suggested fix would not have fully broken the cycle: `key-transport.ts:3` imports `coreBoxManager` and `ipc.ts:43` imports `key-transport`, so `manager -> ipc -> key-transport -> manager` survives dropping only ipc.ts's import. Cutting `manager -> ipc` covers both.

Four cycles remain in the directory, all through `window.ts` and all genuine mutual dependencies (manager.ts uses `windowManager` twelve times; window.ts reaches `coreBoxManager` nine times). Untangling those is a real refactor, not a moved import, and is out of scope for an issue about the coreBoxManager/ipcManager pair — so the guard records them rather than tolerating them silently. Details in the issue comment.

## Two tests that needed judgement, not repair

- **manager.test.ts** mocked `./ipc` only to keep the real module out of its graph, and never exercised `init`/`destroy`. That mock is now dead, so it is removed rather than left mocking nothing.
- **index.test.ts** had no `./ipc` mock because the `./manager` mock used to shield it; it does not any more, and the suite failed at import time on `app.getPath`. Adding the mock alone would have been enough to go green — but a dropped `ipcManager.register()` would leave CoreBox with no IPC handlers and nothing throwing to say so, so the call is asserted, and `unregister()` is threaded through the existing `callOrder` probe to pin that it still precedes `coreBoxManager.destroy()` exactly as it did inside that method.

## Guard

`core-box-import-cycle.test.ts` builds the same-directory import graph (skipping `import type`) and enumerates elementary cycles, rather than checking for the one edge — so a *new* cycle through ipc.ts fails too.

Its second test asserts the detector still finds the four known cycles. That is both the positive control (a detector finding nothing would pass the real assertion while checking nothing) and the record of what was deliberately left. My first draft guessed one cycle; running it found four, which is the reason the list is measured rather than assumed.

## Verification

- restoring `import { ipcManager } from "./ipc"` in manager.ts fails three of the four assertions; the graph-building control stays green
- 152 test files / 1215 tests pass across `box-tool`
- `pnpm typecheck:all` unchanged at 42 pre-existing errors, all from this worktree resolving `packages/utils` twice
- ESLint clean under the core-app config