### PR TITLE
fix(i18n): define the five account-dialog keys that only had Chinese defaults

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -661,7 +661,9 @@
       "authError": "Authentication failed. Please try again.",
       "unknownError": "Unknown authentication error. Please try again."
     },
-    "runtimeApiServer": "Runtime API server"
+    "runtimeApiServer": "Runtime API server",
+    "stepUp": "Two-step verification",
+    "syncSecurity": "Sync security"
   },
   "creditsSummary": {
     "title": "AI Credits",
@@ -741,7 +743,10 @@
     "teamRole": "Role",
     "manageTeam": "Manage Team",
     "upgradeTeam": "Upgrade to Team",
-    "personalTeam": "Personal Team"
+    "personalTeam": "Personal Team",
+    "overview": "Overview",
+    "security": "Security & sign-in",
+    "securityActions": "Sign-in and security options"
   },
   "layout": {
     "back": "Back"

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -661,7 +661,9 @@
       "authError": "认证失败，请重试。",
       "unknownError": "发生未知认证错误，请重试。"
     },
-    "runtimeApiServer": "运行时 API 服务器"
+    "runtimeApiServer": "运行时 API 服务器",
+    "stepUp": "二次验证",
+    "syncSecurity": "同步安全"
   },
   "creditsSummary": {
     "title": "AI 积分",
@@ -741,7 +743,10 @@
     "teamRole": "角色",
     "manageTeam": "管理团队",
     "upgradeTeam": "升级到 Team",
-    "personalTeam": "个人团队"
+    "personalTeam": "个人团队",
+    "overview": "概览",
+    "security": "安全与登录",
+    "securityActions": "登录与安全选项"
   },
   "layout": {
     "back": "返回"


### PR DESCRIPTION
Fixes #491.

## The defect

`TuffUserInfo.vue` calls `t(key, default)` with a **Chinese literal** as the fallback for five keys that exist in neither locale. Since the key never resolves, the Chinese default is what renders in *every* language — an English user saw 概览 and 安全与登录 in the account dialog.

## The Chinese side is not new translation

The zh values are **byte-identical** to the literals the component already rendered, verified after writing:

```
userProfile.overview: '概览' == default '概览' -> True
userProfile.security: '安全与登录' == default '安全与登录' -> True
...
```

So zh users see no change at all. Only the English side is new:

| key | en-US |
|---|---|
| `userProfile.overview` | Overview |
| `userProfile.security` | Security & sign-in |
| `userProfile.securityActions` | Sign-in and security options |
| `settingUser.stepUp` | Two-step verification |
| `settingUser.syncSecurity` | Sync security |

Two of the five live under `settingUser`, not `userProfile`, despite the issue title — both namespaces already existed, so each key sits with its siblings.

## Scope checked, not taken on trust

All **37** `t(key, default)` calls in the file were resolved against both locales:

- 32 already resolve in both
- **5** missing from both — exactly the ones reported
- 0 missing from only one locale
- 0 English-literal defaults left unresolved

So #491's count is right. Worth stating plainly, because scope accuracy has been the weak point of this batch — this is the second issue in a row whose boundary held.

## Measured against origin as a control

```
origin  : 39 keys referenced, 5 unresolved
this fix: 39 keys referenced, 0 unresolved
```

Without the before-measurement, "0 unresolved" could equally mean the scan matched nothing.

## Edited as text, not reserialised

Both locale files carry uncommitted changes in the working tree; a `json.dump` rewrite would reformat thousands of lines and collide with that work. Their pending edits are one line each and touch neither namespace, so this insertion cannot conflict — checked before editing. The result parses and every added key resolves.