### PR TITLE
fix(i18n): define the eight prompt-selector keys missing from both locales

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -4694,6 +4694,14 @@
     "providerName": "Provider Name",
     "providerNamePlaceholder": "Enter provider name",
     "customCompatible": "Custom (OpenAI Compatible)",
+    "managePrompts": "Manage prompts",
+    "selectPrompt": "Select a prompt",
+    "builtinPrompts": "Built-in prompts",
+    "builtin": "Built-in",
+    "customPrompts": "Custom prompts",
+    "custom": "Custom",
+    "createNewPrompt": "Create new prompt",
+    "promptSelectedHint": "This prompt will be used for the current capability.",
     "compatible": "Compatible",
     "search": {
       "placeholder": "Search providers..."

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -4646,6 +4646,14 @@
     "providerName": "提供商名称",
     "providerNamePlaceholder": "输入提供商名称",
     "customCompatible": "自定义（OpenAI 兼容）",
+    "managePrompts": "管理提示词",
+    "selectPrompt": "选择提示词",
+    "builtinPrompts": "内置提示词",
+    "builtin": "内置",
+    "customPrompts": "自定义提示词",
+    "custom": "自定义",
+    "createNewPrompt": "新建提示词",
+    "promptSelectedHint": "当前能力将使用该提示词。",
     "compatible": "兼容",
     "search": {
       "placeholder": "搜索提供商..."


### PR DESCRIPTION
Fixes #487.

## The defect

`IntelligencePromptSelector.vue` labels every group header, empty state and action with `intelligence.*` keys present in neither locale, so the dropdown rendered raw key strings.

One of them is an `aria-label` (`:109`), so the manage button was **unnamed for a screen reader** — an a11y consequence the issue does not mention.

## Correcting my earlier comment on this issue

I previously wrote that the file references **ten** bare keys against the issue's eight. It references **eleven**, of which exactly **eight** are unresolved — I had compared a *reference* count against a *missing* count. `intelligence.instructions` and `intelligence.instructionsPlaceholder` both resolve fine.

The issue's figure of eight was correct.

## Inserted by line number, not by anchor text

`"compatible": "Compatible"` occurs **twice** in `en-US.json`, at two different nesting depths. A text replace would have been a coin flip about which object received the keys.

So insertion is by line number, with the target line asserted to be the intended one before writing, and every key read back through the parsed JSON afterwards.

## Measured against origin as a control

```
origin  : 11 referenced, 8 unresolved
this fix: 11 referenced, 0 unresolved
```

Locale parity is **unchanged** at 12 en-only leaves — all eight keys went into both files. Those 12 are the dead keys tracked in #503, not a regression from this change.

## Why this could be done now when I declined earlier

I left this alone in an earlier pass because both locale files carry uncommitted changes. Having since checked what those changes actually are — a single `home.toolInterrupted` key in each — they touch neither `intelligence` nor the insertion point, so there is nothing to collide with.

The larger locale work in #503 stays untouched, because that one is a *deletion* of ~116 dead keys and genuinely needs a decision first.