### PR TITLE
fix(core-app): give the plugin features adapter its engine instead of importing it (#523)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/addon/context-actions/context-actions-provider.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/context-actions/context-actions-provider.test.ts
@@ -57,6 +57,8 @@ vi.mock('../../../plugin/plugin-module', () => ({
 
 vi.mock('../../../plugin/adapters/plugin-features-adapter', () => ({
   default: {
+    // search-core calls this as it registers the provider (#523).
+    attach: vi.fn(),
     onSearch: mocks.pluginSearch
   }
 }))

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
@@ -116,6 +116,8 @@ vi.mock('../../database', () => ({
 }))
 vi.mock('../../plugin/adapters/plugin-features-adapter', () => ({
   default: {
+    // search-core calls this as it registers the provider (#523).
+    attach: vi.fn(),
     id: 'plugin-features',
     onSearch: vi.fn(),
     supportedInputTypes: ['text'],

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.gather-ordering.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.gather-ordering.test.ts
@@ -108,6 +108,8 @@ vi.mock('../../database', () => ({
 
 vi.mock('../../plugin/adapters/plugin-features-adapter', () => ({
   default: {
+    // search-core calls this as it registers the provider (#523).
+    attach: vi.fn(),
     id: 'plugin-features',
     type: 'plugin',
     supportedInputTypes: [TuffInputType.Text],

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.regression-baseline.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.regression-baseline.test.ts
@@ -59,6 +59,8 @@ vi.mock('../../database', () => ({
 
 vi.mock('../../plugin/adapters/plugin-features-adapter', () => ({
   default: {
+    // search-core calls this as it registers the provider (#523).
+    attach: vi.fn(),
     id: 'plugin-features',
     type: 'plugin',
     supportedInputTypes: [TuffInputType.Text, TuffInputType.Image, TuffInputType.Files],

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.trace.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.trace.test.ts
@@ -152,6 +152,8 @@ vi.mock('../../database', () => ({
 
 vi.mock('../../plugin/adapters/plugin-features-adapter', () => ({
   default: {
+    // search-core calls this as it registers the provider (#523).
+    attach: vi.fn(),
     id: 'plugin-features',
     type: 'plugin',
     supportedInputTypes: [TuffInputType.Text],

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
@@ -329,6 +329,7 @@ export class SearchEngineCore
     }
     this.registerProvider(fileProvider)
 
+    PluginFeaturesAdapter.attach(this)
     this.registerProvider(PluginFeaturesAdapter)
     this.registerProvider(previewProvider)
   }

--- a/apps/core-app/src/main/modules/plugin/adapters/plugin-features-adapter.test.ts
+++ b/apps/core-app/src/main/modules/plugin/adapters/plugin-features-adapter.test.ts
@@ -1,20 +1,26 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
 import type { IProviderActivate } from '@talex-touch/utils'
 import type { IPluginFeature, ITouchPlugin } from '@talex-touch/utils/plugin'
 import type { CoreBoxInputChangeRequest } from '@talex-touch/utils/transport/events/types'
 import { describe, expect, it, vi } from 'vitest'
 import { PluginStatus } from '@talex-touch/utils/plugin'
 import { PluginFeaturesAdapter } from './plugin-features-adapter'
-import searchEngineCore from '../../box-tool/search-engine/search-core'
 import { pluginModule } from '../plugin-module'
 import { PluginViewLoader } from '../view/plugin-view-loader'
 
-vi.mock('../../box-tool/search-engine/search-core', () => ({
-  default: {
-    getActivationState: vi.fn(() => null),
-    activateProviders: vi.fn(),
-    deactivateProvider: vi.fn()
-  }
-}))
+const searchEngineHost = {
+  getActivationState: vi.fn<() => IProviderActivate[] | null>(() => null),
+  activateProviders: vi.fn(),
+  deactivateProvider: vi.fn()
+}
+
+/** Every adapter under test is attached, mirroring what search-core does at registration. */
+function createAdapter(): PluginFeaturesAdapter {
+  const adapter = new PluginFeaturesAdapter()
+  adapter.attach(searchEngineHost)
+  return adapter
+}
 
 vi.mock('../plugin-module', () => ({
   pluginModule: {
@@ -64,7 +70,7 @@ function createFeature(): IPluginFeature {
 
 describe('plugin-features-adapter', () => {
   it('preserves feature match source metadata for cross-provider sorting', () => {
-    const adapter = new PluginFeaturesAdapter()
+    const adapter = createAdapter()
     const item = adapter.createTuffItem(
       createPlugin(),
       createFeature(),
@@ -77,7 +83,7 @@ describe('plugin-features-adapter', () => {
   })
 
   it('preserves matched alias metadata for visible token highlighting', () => {
-    const adapter = new PluginFeaturesAdapter()
+    const adapter = createAdapter()
     const item = adapter.createTuffItem(createPlugin(), createFeature(), [], 'token', {
       text: 'Clipboard',
       matchRanges: [{ start: 0, end: 'Clipboard'.length }]
@@ -90,7 +96,7 @@ describe('plugin-features-adapter', () => {
   })
 
   it('includes feature id in generated search tokens for alias/id matching', () => {
-    const adapter = new PluginFeaturesAdapter()
+    const adapter = createAdapter()
     const feature = {
       ...createFeature(),
       id: 'clipboard-history',
@@ -107,7 +113,7 @@ describe('plugin-features-adapter', () => {
   })
 
   it('generates typed pinyin evidence for compound Chinese feature names', () => {
-    const adapter = new PluginFeaturesAdapter()
+    const adapter = createAdapter()
     const feature = {
       ...createFeature(),
       id: 'wechat-message',
@@ -134,14 +140,14 @@ describe('plugin-features-adapter', () => {
   })
 
   it('does not force footer hints hidden for plugin feature items by default', () => {
-    const adapter = new PluginFeaturesAdapter()
+    const adapter = createAdapter()
     const item = adapter.createTuffItem(createPlugin(), createFeature())
 
     expect(item.meta?.footerHints).toBeUndefined()
   })
 
   it('preserves explicit color and colorful feature icons for CoreBox rendering', () => {
-    const adapter = new PluginFeaturesAdapter()
+    const adapter = createAdapter()
     const item = adapter.createTuffItem(createPlugin(), {
       ...createFeature(),
       icon: { type: 'file', value: 'assets/logo.svg', color: '#22c55e', colorful: true }
@@ -156,7 +162,7 @@ describe('plugin-features-adapter', () => {
   })
 
   it('keeps class feature icons in the themed icon branch', () => {
-    const adapter = new PluginFeaturesAdapter()
+    const adapter = createAdapter()
     const item = adapter.createTuffItem(createPlugin(), {
       ...createFeature(),
       icon: { type: 'class', value: 'i-ri-clipboard-line' }
@@ -169,7 +175,7 @@ describe('plugin-features-adapter', () => {
   })
 
   it('normalizes legacy remixicon values to UnoCSS icon classes', () => {
-    const adapter = new PluginFeaturesAdapter()
+    const adapter = createAdapter()
     const dashItem = adapter.createTuffItem(createPlugin(), {
       ...createFeature(),
       icon: { type: 'remixicon' as never, value: 'ri-clipboard-line' }
@@ -190,7 +196,7 @@ describe('plugin-features-adapter', () => {
   })
 
   it('honors explicit plugin feature footer hint declarations', () => {
-    const adapter = new PluginFeaturesAdapter()
+    const adapter = createAdapter()
     const item = adapter.createTuffItem(createPlugin(), {
       ...createFeature(),
       footerHints: {
@@ -216,7 +222,7 @@ describe('plugin-features-adapter', () => {
   })
 
   it('does not repopulate feature items for active push features with empty query', async () => {
-    const adapter = new PluginFeaturesAdapter()
+    const adapter = createAdapter()
     const pushFeature = { ...createFeature(), push: true }
     const plugin = {
       ...createPlugin(),
@@ -225,7 +231,7 @@ describe('plugin-features-adapter', () => {
       getFeatures: vi.fn(() => [pushFeature])
     } as unknown as ITouchPlugin
     ;(pluginModule.pluginManager!.plugins as Map<string, ITouchPlugin>).set('test-plugin', plugin)
-    vi.mocked(searchEngineCore.getActivationState).mockReturnValue([
+    searchEngineHost.getActivationState.mockReturnValue([
       {
         id: 'plugin-features',
         meta: {
@@ -241,11 +247,11 @@ describe('plugin-features-adapter', () => {
     expect(result.activate).toHaveLength(1)
     expect(plugin.getFeatures).not.toHaveBeenCalled()
     ;(pluginModule.pluginManager!.plugins as Map<string, ITouchPlugin>).clear()
-    vi.mocked(searchEngineCore.getActivationState).mockReturnValue(null)
+    searchEngineHost.getActivationState.mockReturnValue(null)
   })
 
   it('forwards empty input to active push features', async () => {
-    const adapter = new PluginFeaturesAdapter()
+    const adapter = createAdapter()
     const pushFeature = { ...createFeature(), push: true }
     const triggerFeature = vi.fn(async () => true)
     const triggerInputChanged = vi.fn()
@@ -257,7 +263,7 @@ describe('plugin-features-adapter', () => {
       triggerInputChanged
     } as unknown as ITouchPlugin
     ;(pluginModule.pluginManager!.plugins as Map<string, ITouchPlugin>).set('test-plugin', plugin)
-    vi.mocked(searchEngineCore.getActivationState).mockReturnValue([
+    searchEngineHost.getActivationState.mockReturnValue([
       {
         id: 'plugin-features',
         meta: {
@@ -278,11 +284,11 @@ describe('plugin-features-adapter', () => {
     expect(triggerFeature).toHaveBeenCalledWith(pushFeature, query)
     expect(triggerInputChanged).toHaveBeenCalledWith(pushFeature, query)
     ;(pluginModule.pluginManager!.plugins as Map<string, ITouchPlugin>).clear()
-    vi.mocked(searchEngineCore.getActivationState).mockReturnValue(null)
+    searchEngineHost.getActivationState.mockReturnValue(null)
   })
 
   it('routes pushed item actionId when defaultAction is omitted', async () => {
-    const adapter = new PluginFeaturesAdapter()
+    const adapter = createAdapter()
     const activation = { id: 'plugin-features', meta: { pluginName: 'test-plugin' } }
     const onItemAction = vi.fn(async () => ({
       externalAction: true,
@@ -329,7 +335,7 @@ describe('plugin-features-adapter', () => {
   })
 
   it('honors explicit hidden input for webcontent features with accepted inputs', async () => {
-    const adapter = new PluginFeaturesAdapter()
+    const adapter = createAdapter()
     const feature = {
       ...createFeature(),
       acceptedInputTypes: ['text'],
@@ -368,14 +374,14 @@ describe('plugin-features-adapter', () => {
 
     expect(activation?.showInput).toBe(false)
     expect(activation?.forceMax).toBe(true)
-    expect(searchEngineCore.activateProviders).toHaveBeenCalledWith([
+    expect(searchEngineHost.activateProviders).toHaveBeenCalledWith([
       expect.objectContaining({ showInput: false, forceMax: true })
     ])
     ;(pluginModule.pluginManager!.plugins as Map<string, ITouchPlugin>).clear()
   })
 
   it('keeps push widget feature activations at normal height by default', async () => {
-    const adapter = new PluginFeaturesAdapter()
+    const adapter = createAdapter()
     const feature = {
       ...createFeature(),
       push: true,
@@ -412,14 +418,14 @@ describe('plugin-features-adapter', () => {
     } as never)
 
     expect(activation?.forceMax).toBe(false)
-    expect(searchEngineCore.activateProviders).toHaveBeenCalledWith([
+    expect(searchEngineHost.activateProviders).toHaveBeenCalledWith([
       expect.objectContaining({ forceMax: false, hideResults: false, showInput: true })
     ])
     ;(pluginModule.pluginManager!.plugins as Map<string, ITouchPlugin>).clear()
   })
 
   it('propagates forceMax for push widget feature activations', async () => {
-    const adapter = new PluginFeaturesAdapter()
+    const adapter = createAdapter()
     const feature = {
       ...createFeature(),
       push: true,
@@ -457,9 +463,58 @@ describe('plugin-features-adapter', () => {
     } as never)
 
     expect(activation?.forceMax).toBe(true)
-    expect(searchEngineCore.activateProviders).toHaveBeenCalledWith([
+    expect(searchEngineHost.activateProviders).toHaveBeenCalledWith([
       expect.objectContaining({ forceMax: true, hideResults: false, showInput: true })
     ])
     ;(pluginModule.pluginManager!.plugins as Map<string, ITouchPlugin>).clear()
+  })
+})
+
+describe('search engine coupling (#523)', () => {
+  const SOURCE = readFileSync(path.join(__dirname, 'plugin-features-adapter.ts'), 'utf8')
+
+  it('does not import the search engine', () => {
+    // Positive control: the read must have produced the real file, or the absence check below
+    // would pass over an empty string.
+    expect(SOURCE).toContain('export class PluginFeaturesAdapter')
+    expect(SOURCE.length).toBeGreaterThan(1000)
+
+    // search-core imports this module to register it, so importing back closes the cycle that
+    // makes whichever module evaluates second see a half-built binding.
+    const imports = SOURCE.split('\n').filter(
+      (line) => /^\s*import\b/.test(line) && !/^\s*import\s+type\b/.test(line)
+    )
+
+    // Second control, on the filter rather than the read: it has to actually extract value
+    // imports, or the assertion below is checking an empty list.
+    expect(imports.some((line) => line.includes('@talex-touch/utils'))).toBe(true)
+
+    expect(imports.filter((line) => line.includes('search-engine/search-core'))).toEqual([])
+  })
+
+  it('refuses to run before the engine attaches', async () => {
+    // The point of throwing rather than no-oping. Under the old cycle a half-initialized import
+    // would have registered undefined and plugin features would have quietly stopped appearing
+    // in CoreBox with nothing logged; this makes that state impossible to reach silently.
+    const detached = new PluginFeaturesAdapter()
+
+    await expect(
+      detached.handleActiveFeatureInput({
+        query: { text: '' }
+      } as unknown as CoreBoxInputChangeRequest)
+    ).rejects.toThrow(/attach\(\) must run/)
+  })
+
+  it('is satisfied by the shape search-core passes it', () => {
+    // Guards the structural interface from drifting into something the real engine does not
+    // implement. attach() is typed, so this is really a compile-time check made visible.
+    const adapter = new PluginFeaturesAdapter()
+    const host = {
+      getActivationState: () => null,
+      activateProviders: () => {},
+      deactivateProvider: () => {}
+    }
+
+    expect(() => adapter.attach(host)).not.toThrow()
   })
 })

--- a/apps/core-app/src/main/modules/plugin/adapters/plugin-features-adapter.ts
+++ b/apps/core-app/src/main/modules/plugin/adapters/plugin-features-adapter.ts
@@ -21,7 +21,6 @@ import { PluginStatus } from '@talex-touch/utils/plugin'
 import { matchFeature } from '@talex-touch/utils/search'
 import { CoreBoxEvents } from '@talex-touch/utils/transport/events'
 import { getRegisteredMainRuntime } from '../../../core/runtime-accessor'
-import searchEngineCore from '../../box-tool/search-engine/search-core'
 import { resolveClipboardInputs } from '../../box-tool/search-engine/utils/resolve-clipboard-inputs'
 
 import { pluginModule } from '../plugin-module'
@@ -104,6 +103,19 @@ function resolveFeatureFooterHints(feature: IPluginFeature): TuffFooterHints | u
   return feature.footerHints
 }
 
+/**
+ * The slice of the search engine this adapter drives.
+ *
+ * Declared structurally rather than imported, so the adapter stays off search-core's import graph
+ * (#523). search-core's `attach(this)` call is what type-checks that the real engine still
+ * satisfies this shape, so the two cannot drift apart silently.
+ */
+export interface SearchEngineActivationHost {
+  getActivationState: () => IProviderActivate[] | null
+  activateProviders: (activations: IProviderActivate[] | null) => void
+  deactivateProvider: (uniqueKey: string) => void
+}
+
 export class PluginFeaturesAdapter implements ISearchProvider<ProviderContext> {
   public readonly id = 'plugin-features'
   public readonly type: TuffSourceType = 'plugin'
@@ -117,9 +129,27 @@ export class PluginFeaturesAdapter implements ISearchProvider<ProviderContext> {
 
   public readonly priority = 'fast' as const
 
+  private host: SearchEngineActivationHost | null = null
+
+  /** Called by the search engine as it registers this provider. */
+  public attach(host: SearchEngineActivationHost): void {
+    this.host = host
+  }
+
+  /**
+   * Throws rather than no-oping: registering activations against a missing engine would leave
+   * plugin features absent from CoreBox results with nothing in the logs to explain it, which is
+   * the failure mode #523 describes.
+   */
+  private get engine(): SearchEngineActivationHost {
+    if (!this.host)
+      throw new Error('[PluginFeaturesAdapter] attach() must run before the adapter is used')
+    return this.host
+  }
+
   public async handleActiveFeatureInput(payload: CoreBoxInputChangeRequest): Promise<boolean> {
     const query = payload.query
-    const activationState = searchEngineCore.getActivationState()
+    const activationState = this.engine.getActivationState()
 
     const activeFeatureActivation = activationState?.find((a) => a.id === this.id)
     if (!activeFeatureActivation?.meta?.pluginName) {
@@ -298,13 +328,13 @@ export class PluginFeaturesAdapter implements ISearchProvider<ProviderContext> {
         showInput: shouldShowInput,
         forceMax: feature.interaction?.forceMax === true
       }
-      searchEngineCore.activateProviders([activation])
+      this.engine.activateProviders([activation])
 
       try {
         await PluginViewLoader.loadPluginView(plugin as TouchPlugin, feature, query)
       } catch (error) {
         pluginFeaturesLog.error('[PluginFeaturesAdapter] webcontent feature execute failed:', error)
-        searchEngineCore.deactivateProvider(`${this.id}:${pluginName}`)
+        this.engine.deactivateProvider(`${this.id}:${pluginName}`)
         return null
       }
 
@@ -314,7 +344,7 @@ export class PluginFeaturesAdapter implements ISearchProvider<ProviderContext> {
         )
       ) {
         // Deactivate if view loading failed
-        searchEngineCore.deactivateProvider(`${this.id}:${pluginName}`)
+        this.engine.deactivateProvider(`${this.id}:${pluginName}`)
         return null
       }
 
@@ -356,7 +386,7 @@ export class PluginFeaturesAdapter implements ISearchProvider<ProviderContext> {
         showInput: shouldShowInput, // show input if feature accepts input types or has allowInput
         forceMax: feature.interaction?.forceMax === true
       }
-      searchEngineCore.activateProviders([activation])
+      this.engine.activateProviders([activation])
 
       logExecuteBreadcrumb('push-trigger-start')
       let shouldActivate: boolean | void
@@ -368,13 +398,13 @@ export class PluginFeaturesAdapter implements ISearchProvider<ProviderContext> {
           durationMs: Date.now() - executeStart,
           errorCode: getErrorCode(error)
         })
-        searchEngineCore.deactivateProvider(`${this.id}:${pluginName}`)
+        this.engine.deactivateProvider(`${this.id}:${pluginName}`)
         return null
       }
 
       if (typeof shouldActivate === 'boolean' && shouldActivate === false) {
         // Deactivate if feature explicitly returns false
-        searchEngineCore.deactivateProvider(`${this.id}:${pluginName}`)
+        this.engine.deactivateProvider(`${this.id}:${pluginName}`)
         return null
       }
 
@@ -506,7 +536,7 @@ export class PluginFeaturesAdapter implements ISearchProvider<ProviderContext> {
   }
 
   public async onSearch(query: TuffQuery, signal: AbortSignal): Promise<TuffSearchResult> {
-    const activationState = searchEngineCore.getActivationState()
+    const activationState = this.engine.getActivationState()
 
     if (activationState) {
       const activeFeatureActivation = activationState.find((a) => a.id === this.id)


### PR DESCRIPTION
Closes #523.

## The fix

`search-core.ts` and `plugin-features-adapter.ts` imported each other's default export, and both build their singleton at module evaluation. It survives today only because the one reference is deferred to `registerDefaults()` — moving it into the constructor would register `undefined` as a search provider, and plugin features would stop appearing in CoreBox with nothing logged.

I took the direction the issue suggested, though the reverse cut was cheaper. search-core references the adapter **once** (`registerDefaults`, line 332) against the adapter's **eight** references to the engine, so cutting `search-core -> adapter` would have been one edit instead of eight — but it would have pulled `registerProvider(PluginFeaturesAdapter)` out of `registerDefaults()` and split the provider list across two files. Keeping all six providers registered in one place is worth the extra edits.

The adapter declares the slice it needs as a structural interface rather than importing the engine to type it:

```ts
export interface SearchEngineActivationHost {
  getActivationState: () => IProviderActivate[] | null
  activateProviders: (activations: IProviderActivate[] | null) => void
  deactivateProvider: (uniqueKey: string) => void
}
```

`search-core` calls `PluginFeaturesAdapter.attach(this)` before registering, and that call is what type-checks that the real engine still satisfies the shape — so the interface cannot drift from the engine without a compile error, which is the usual objection to hand-declared structural types.

**The unattached accessor throws rather than no-ops.** A silent fallback would reproduce precisely the failure this issue describes: activations going nowhere, features missing, nothing in the logs.

## Test changes that are judgement, not repair

- The adapter's own suite mocked the `search-core` module. That mock intercepts nothing now, so it is replaced by an explicit host attached to every adapter the suite builds — 16 construction sites via a helper.
- Four search-core suites and the context-actions suite pass a hand-built `default` object as the adapter. They gained `attach: vi.fn()`. I did **not** make `attach` optional in search-core (`attach?.(this)`) to avoid touching them — that would have let a real adapter missing `attach` reach registration and fail later, quietly.

## Verification, including one check that did not work

Reverting the adapter and re-running the suite is **not** good evidence here: the old adapter imports search-core, which pulls electron in at module scope, so the file fails to load and every test reports as not-run. That is a failure, but of a coarser kind than the guard is claiming.

So the scan logic was run directly against the HEAD source instead:

```
control (extracts value imports): true
offenders on HEAD source: ["import searchEngineCore from '../../box-tool/search-engine/search-core'"]
```

It finds the import it is looking for, and its control confirms the filter extracts real import lines rather than returning an empty list.

Also:

- 68 test files / 593 tests pass across `plugin/adapters` and `search-engine`
- full core-app suite sits at the two documented pre-existing failures (openai runtime closure, `touch-quickops` contract). A third file, `intelligence-invoke-actor-boundary`, timed out at 5s under full-suite concurrency; it passes alone and contains no reference to anything changed here, so I am reporting it as a flake rather than claiming a clean run
- `pnpm typecheck:all` unchanged at 42 pre-existing errors
- ESLint clean under the core-app config