### PR TITLE
ref(core-app): drop the superseded update-asset ranking helpers

### DIFF
--- a/apps/core-app/src/main/modules/update/update-asset-utils.ts
+++ b/apps/core-app/src/main/modules/update/update-asset-utils.ts
@@ -1,107 +1,13 @@
-import type { UpdateArtifactComponent } from '@talex-touch/utils'
-import { UPDATE_RELEASE_MANIFEST_NAME } from '@talex-touch/utils'
-
-export interface UpdateAssetScoreInput {
-  component?: UpdateArtifactComponent
-}
-
-export function calculateUpdateAssetScore(
-  filename: string,
-  asset: UpdateAssetScoreInput,
-  platform: string
-): number {
-  let score = 0
-
-  if (asset.component === 'core') {
-    score += 200
-  }
-
-  if (filename.includes('tuff')) {
-    score += 20
-  }
-
-  if (filename.includes('latest-release')) {
-    score += 10
-  }
-
-  score += getInstallerExtensionScore(filename, platform)
-
-  return score
-}
-
-export function getInstallerExtensionScore(filename: string, platform: string): number {
-  if (platform === 'darwin') {
-    if (filename.endsWith('.app.zip')) return 180
-    if (filename.endsWith('.dmg')) return 140
-    if (filename.endsWith('.pkg')) return 130
-    if (filename.endsWith('.zip')) return 90
-    return 0
-  }
-
-  if (platform === 'win32') {
-    if (filename.endsWith('.exe')) return 140
-    if (filename.endsWith('.msi')) return 130
-    if (filename.endsWith('.zip')) return 90
-    if (filename.endsWith('.7z')) return 80
-    return 0
-  }
-
-  if (filename.endsWith('.appimage')) return 140
-  if (filename.endsWith('.deb')) return 130
-  if (filename.endsWith('.rpm')) return 120
-  if (filename.endsWith('.tar.gz') || filename.endsWith('.tgz')) return 100
-  if (filename.endsWith('.zip')) return 80
-  return 0
-}
-
-export function isUpdateManifestAsset(filename: string): boolean {
-  return normalizeUpdateAssetKey(filename) === UPDATE_RELEASE_MANIFEST_NAME
-}
-
-export function isUpdateMetadataAsset(filename: string): boolean {
-  const lower = filename.toLowerCase()
-
-  return (
-    lower.endsWith('.yml') ||
-    lower.endsWith('.yaml') ||
-    lower.endsWith('.json') ||
-    lower.endsWith('.blockmap') ||
-    lower.includes('builder-debug')
-  )
-}
-
-export function isAuxiliaryUpdateComponentAsset(filename: string): boolean {
-  return (
-    filename.includes('renderer') ||
-    filename.includes('extensions') ||
-    filename.includes('extension')
-  )
-}
-
-export function isUpdateSignatureAsset(filename: string): boolean {
-  const lower = filename.toLowerCase()
-  return lower.endsWith('.sig') || lower.endsWith('.sig.txt') || lower.endsWith('.asc')
-}
-
-export function stripUpdateSignatureSuffix(filename: string): string {
-  return filename.replace(/\.(sig|asc)(\.txt)?$/i, '')
-}
-
-export function isUpdateChecksumAsset(filename: string): boolean {
-  const lower = filename.toLowerCase()
-  return (
-    lower.endsWith('.sha256') ||
-    lower.endsWith('.sha1') ||
-    lower.endsWith('.md5') ||
-    lower.endsWith('.sha256.txt') ||
-    lower.endsWith('.sha1.txt') ||
-    lower.endsWith('.md5.txt') ||
-    lower.endsWith('.sha256sum') ||
-    lower.endsWith('.sha1sum') ||
-    lower.endsWith('.md5sum')
-  )
-}
-
+/**
+ * Release assets are resolved by exact name against the release manifest
+ * (`update-system.ts` `resolveAssetByName` / `fetchReleaseManifest`), which returns null when no
+ * manifest is present rather than falling back to guesswork.
+ *
+ * This module previously also carried filename-heuristic ranking -- calculateUpdateAssetScore,
+ * getInstallerExtensionScore and six asset-classification predicates. That was the older,
+ * manifest-less approach; nothing has called any of it since the manifest became mandatory, so
+ * it was removed rather than left to read as live installer-selection policy (#529).
+ */
 export function normalizeUpdateAssetKey(filename: string): string {
   return filename.toLowerCase()
 }


### PR DESCRIPTION
Fixes #529. 107 lines down to 13.

## The finding holds

Nine exports, one caller. `normalizeUpdateAssetKey` is used by `update-system.ts`; the other eight — `calculateUpdateAssetScore`, `getInstallerExtensionScore` and six asset-classification predicates — had no callers and no tests.

Each was searched across `apps`, `packages`, `plugins` and `scripts`, with `normalizeUpdateAssetKey` as the positive control (1 file). `UpdateAssetScoreInput` was exported but referenced nowhere.

## The framing needed checking before deleting

The issue calls `calculateUpdateAssetScore` *"the app's sole implementation of update-installer ranking"* — which reads as though deleting it removes behaviour users depend on. It does not, and confirming that was the point of this pass.

Installers are resolved **by exact name against the release manifest**:

```
update-system.ts  resolveAssetByName        -> normalizeUpdateAssetKey equality
update-system.ts  manifest.artifacts.find   -> component match
update-system.ts  fetchReleaseManifest      -> returns null when no manifest asset exists
```

That last line matters: there is **no heuristic fallback**. A release without a manifest yields nothing rather than a best-guess installer.

So the scoring was the older manifest-less approach, fully superseded — not ranking that should be happening and silently is not. There is no code path that reaches it.

## Why deleting beats leaving it

Left in place, 94 lines of filename heuristics read as live installer-selection policy while having no bearing on which installer users actually receive. The next person tracing an update bug would reasonably start there and lose time.

The surviving function carries a comment recording what was removed and why, so that conclusion does not have to be re-derived.

## Gates

- `npm run typecheck:node`: exit 0
- update suites: **14 files, 102 tests passing**
- `eslint --max-warnings=0`: exit 0