### PR TITLE
test(core-app): pin which storage cleanup channels reach main (#527)

### DIFF
--- a/apps/core-app/src/renderer/src/views/storage/storage-cleanup-channels.test.ts
+++ b/apps/core-app/src/renderer/src/views/storage/storage-cleanup-channels.test.ts
@@ -1,0 +1,71 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Every channel the storage view sends must have a main-process handler (#527).
+ *
+ * Storagable.vue renders cleanup buttons that `sendRaw` to `storage:cleanup:*`. Nothing in
+ * src/main handles those names, so the buttons reach no implementation — while
+ * src/main/service/storage-maintenance.ts holds 357 lines of cleanup logic that nothing imports.
+ * Anyone debugging "cleanup did not free space" reads that file and finds the logic correct.
+ *
+ * Whether those three get wired up or the surface gets withdrawn is a product decision, so this
+ * records the gap as a list that must shrink rather than asserting either outcome. A *new*
+ * unhandled channel fails the run.
+ */
+
+const VIEW = path.resolve(process.cwd(), 'src/renderer/src/views/storage/Storagable.vue')
+const MAIN = path.resolve(process.cwd(), 'src/main')
+
+/** Channels the view sends that no main-process handler answers. Shrink, never grow. */
+const KNOWN_UNHANDLED = [
+  'storage:cleanup:downloads',
+  'storage:cleanup:file-index',
+  'storage:cleanup:updates'
+]
+
+/** A channel the same view sends through the same helper, and which *is* handled. */
+const CONTROL_CHANNEL = 'system:get-storage-usage'
+
+function channelsSentByView(): string[] {
+  const source = readFileSync(VIEW, 'utf8')
+  const found = new Set<string>()
+  for (const match of source.matchAll(/channel:\s*'([^']+)'/g)) found.add(match[1]!)
+  return [...found].sort()
+}
+
+function isHandledInMain(channel: string): boolean {
+  try {
+    execFileSync('grep', ['-rqF', channel, MAIN], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe('storage cleanup channels', () => {
+  it('finds the channels the view sends', () => {
+    // Positive control on the extraction: a regex that matched nothing would make the assertions
+    // below vacuous.
+    const channels = channelsSentByView()
+
+    expect(channels.length).toBeGreaterThan(0)
+    expect(channels).toContain('storage:cleanup:file-index')
+  })
+
+  it('can tell a handled channel from an unhandled one', () => {
+    // Positive control on the search. The view sends this one through the same helper and main
+    // answers it, so a search that could never find anything fails here rather than reporting
+    // every channel as unhandled.
+    expect(isHandledInMain(CONTROL_CHANNEL)).toBe(true)
+    expect(isHandledInMain('storage:cleanup:definitely-not-a-real-channel')).toBe(false)
+  })
+
+  it('has no unhandled channel beyond the ones already known', () => {
+    const unhandled = channelsSentByView().filter((channel) => !isHandledInMain(channel))
+
+    expect(unhandled).toEqual(KNOWN_UNHANDLED)
+  })
+})


### PR DESCRIPTION
Partial for #527 — deliberately not closing it, because the remaining half is a product decision. Details and the question are in the issue.

## What I found

The issue calls this dead code. It is worse than that: there is a **live settings surface pointing at it**.

`Storagable.vue` — mounted inside `SettingsPage` for the storage category — renders cleanup buttons that `sendRaw` to:

```
storage:cleanup:file-index
storage:cleanup:downloads
storage:cleanup:updates
```

`grep -r` across `src/main` finds no handler for any of them. Meanwhile `src/main/service/storage-maintenance.ts` implements exactly those cleanups and nothing imports it.

The absence is real, not a search artifact: the same view sends `system:get-storage-usage` through the same helper, and that one **is** answered at `channel/common.ts:262`. That channel is the positive control in the test below.

I also re-ran the issue's reference counts. Two of its eleven zeroes need a footnote — `cleanupClipboard` matches a same-named local function in `CoreBox.vue`, and `cleanupTemp` matches the download-center handler, which is a separate, genuinely wired implementation. Neither is a use of this module, so the conclusion stands.

## What this PR does, and does not, do

It ships only the half that is correct under either resolution: the gap recorded as a list that must shrink, so a *new* unhandled channel fails the run.

It does **not** wire the handlers. Doing so would turn three currently inert buttons into real deletion of a user's file index, downloads and update artifacts — not a change to make on my own initiative inside a tech-debt cleanup.

## Positive controls

Every assertion here is about absence, so two controls guard the machinery:

- the extraction must actually find channels in the view
- the handler search must find `system:get-storage-usage` and must *not* find an invented name

Without them, a broken `grep` would report all five channels as unhandled — or none — and the suite would look equally green either way.

One caveat worth stating: this lives in the renderer suite, which runs under `App suites (core-app)` — a `continue-on-error` job (#1255). It fails locally and in a full run; it will not block a PR until that changes.