### PR TITLE
refactor(core-app): drop the orphaned update asset ranking (#529)

### DIFF
--- a/apps/core-app/src/main/modules/update/update-asset-utils.test.ts
+++ b/apps/core-app/src/main/modules/update/update-asset-utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeUpdateAssetKey } from './update-asset-utils'
+
+/**
+ * The one survivor of #529, which had no test.
+ *
+ * Every manifest-to-asset lookup in update-system.ts goes through this key — `resolveAssetByName`,
+ * the signature lookup, and the manifest asset scan. If it stopped folding case, a manifest
+ * written as `Tuff-1.2.3.dmg` would not match an asset uploaded as `tuff-1.2.3.dmg`, and the
+ * update would report no artifact rather than fail loudly.
+ */
+
+describe('normalizeUpdateAssetKey', () => {
+  it('folds case so manifest and release spellings match', () => {
+    expect(normalizeUpdateAssetKey('Tuff-1.2.3.dmg')).toBe(
+      normalizeUpdateAssetKey('tuff-1.2.3.dmg')
+    )
+    expect(normalizeUpdateAssetKey('LATEST-RELEASE.YML')).toBe('latest-release.yml')
+  })
+
+  it('changes nothing else about the name', () => {
+    // Separators, dots and version digits are part of the identity — a key that also stripped
+    // punctuation would collide two different artifacts onto one entry.
+    expect(normalizeUpdateAssetKey('tuff-core_1.2.3-beta.2.app.zip')).toBe(
+      'tuff-core_1.2.3-beta.2.app.zip'
+    )
+    expect(normalizeUpdateAssetKey('')).toBe('')
+  })
+
+  it('keeps distinct artifacts distinct', () => {
+    expect(normalizeUpdateAssetKey('tuff-1.2.3.dmg')).not.toBe(
+      normalizeUpdateAssetKey('tuff-1.2.3.pkg')
+    )
+  })
+})

--- a/apps/core-app/src/main/modules/update/update-asset-utils.ts
+++ b/apps/core-app/src/main/modules/update/update-asset-utils.ts
@@ -1,107 +1,24 @@
-import type { UpdateArtifactComponent } from '@talex-touch/utils'
-import { UPDATE_RELEASE_MANIFEST_NAME } from '@talex-touch/utils'
+/**
+ * Asset-name normalization for update resolution.
+ *
+ * This module used to also rank candidate installers — `calculateUpdateAssetScore` and seven
+ * classification helpers. `3175ba33a` (feat(update): unify OTA lifecycle and release gates) moved
+ * asset selection to the release manifest, which names each artifact by component, and removed
+ * the only call to the scorer. The scoring table survived with no callers and no tests for three
+ * months, long enough that anyone debugging "the updater downloaded the wrong artifact" would
+ * have found it, adjusted its weights, and shipped a change that could not affect behaviour
+ * (#529). Removed rather than left as a plausible-looking implementation.
+ *
+ * Selection now happens in update-system.ts: `resolveArtifact` picks by `component`, and
+ * `resolveAssetByName` matches the manifest entry against the release asset through the key below.
+ */
 
-export interface UpdateAssetScoreInput {
-  component?: UpdateArtifactComponent
-}
-
-export function calculateUpdateAssetScore(
-  filename: string,
-  asset: UpdateAssetScoreInput,
-  platform: string
-): number {
-  let score = 0
-
-  if (asset.component === 'core') {
-    score += 200
-  }
-
-  if (filename.includes('tuff')) {
-    score += 20
-  }
-
-  if (filename.includes('latest-release')) {
-    score += 10
-  }
-
-  score += getInstallerExtensionScore(filename, platform)
-
-  return score
-}
-
-export function getInstallerExtensionScore(filename: string, platform: string): number {
-  if (platform === 'darwin') {
-    if (filename.endsWith('.app.zip')) return 180
-    if (filename.endsWith('.dmg')) return 140
-    if (filename.endsWith('.pkg')) return 130
-    if (filename.endsWith('.zip')) return 90
-    return 0
-  }
-
-  if (platform === 'win32') {
-    if (filename.endsWith('.exe')) return 140
-    if (filename.endsWith('.msi')) return 130
-    if (filename.endsWith('.zip')) return 90
-    if (filename.endsWith('.7z')) return 80
-    return 0
-  }
-
-  if (filename.endsWith('.appimage')) return 140
-  if (filename.endsWith('.deb')) return 130
-  if (filename.endsWith('.rpm')) return 120
-  if (filename.endsWith('.tar.gz') || filename.endsWith('.tgz')) return 100
-  if (filename.endsWith('.zip')) return 80
-  return 0
-}
-
-export function isUpdateManifestAsset(filename: string): boolean {
-  return normalizeUpdateAssetKey(filename) === UPDATE_RELEASE_MANIFEST_NAME
-}
-
-export function isUpdateMetadataAsset(filename: string): boolean {
-  const lower = filename.toLowerCase()
-
-  return (
-    lower.endsWith('.yml') ||
-    lower.endsWith('.yaml') ||
-    lower.endsWith('.json') ||
-    lower.endsWith('.blockmap') ||
-    lower.includes('builder-debug')
-  )
-}
-
-export function isAuxiliaryUpdateComponentAsset(filename: string): boolean {
-  return (
-    filename.includes('renderer') ||
-    filename.includes('extensions') ||
-    filename.includes('extension')
-  )
-}
-
-export function isUpdateSignatureAsset(filename: string): boolean {
-  const lower = filename.toLowerCase()
-  return lower.endsWith('.sig') || lower.endsWith('.sig.txt') || lower.endsWith('.asc')
-}
-
-export function stripUpdateSignatureSuffix(filename: string): string {
-  return filename.replace(/\.(sig|asc)(\.txt)?$/i, '')
-}
-
-export function isUpdateChecksumAsset(filename: string): boolean {
-  const lower = filename.toLowerCase()
-  return (
-    lower.endsWith('.sha256') ||
-    lower.endsWith('.sha1') ||
-    lower.endsWith('.md5') ||
-    lower.endsWith('.sha256.txt') ||
-    lower.endsWith('.sha1.txt') ||
-    lower.endsWith('.md5.txt') ||
-    lower.endsWith('.sha256sum') ||
-    lower.endsWith('.sha1sum') ||
-    lower.endsWith('.md5sum')
-  )
-}
-
+/**
+ * Case-insensitive key for matching a manifest entry to a release asset.
+ *
+ * GitHub preserves the case an asset was uploaded with while manifests are written by hand, so
+ * the two disagree often enough that every lookup in update-system.ts goes through this.
+ */
 export function normalizeUpdateAssetKey(filename: string): string {
   return filename.toLowerCase()
 }


### PR DESCRIPTION
Closes #529.

## Why these are safe to delete, established from history rather than inferred

`git log -S` found the moment they were orphaned:

```
3175ba33a  2026-07-18  feat(update): unify OTA lifecycle and release gates
-  calculateUpdateAssetScore,
-        score: target.priority * 1000 + calculateUpdateAssetScore(normalizedName, asset, platform)
```

That commit moved asset selection to the release manifest and removed the only call to the scorer **in the same change**. The scoring table and seven classification helpers stayed behind and have had no caller and no test for three months.

That mattered to check. A dead-code issue reads the same whether the code is abandoned or half-written, and deleting in-progress work is the failure mode. Here the call site was removed deliberately, which makes this deletion the tail of that commit rather than the removal of a capability.

## A correction to the issue

It infers from the missing callers that "the updater does not score candidate assets at all", which reads as a gap in the updater. Selection is manifest-driven by design — `resolveArtifact` picks by `component`, `resolveAssetByName` matches the manifest entry to the release asset by name — so no scoring step is wanted. Scoring is obsolete, not missing. The recommendation to delete is unchanged; the reason differs.

## Verification of the absence

Zero references to all eight across `apps/`, `packages/`, `plugins/`, docs and scripts. The positive control is `normalizeUpdateAssetKey` in the same sweep: it returns exactly one file (`update-system.ts`), so the search does resolve these names rather than returning nothing for everything.

`UpdateAssetScoreInput` went too — it existed only for the scorer's signature.

## The survivor now has a test

`normalizeUpdateAssetKey` had none, and every manifest-to-asset lookup in `update-system.ts` goes through it. Mutation-checked rather than assumed — three mutants, each killed by a different assertion:

| mutant | fails |
| --- | --- |
| `return filename` (identity) | folds case |
| also strips `-_.` | folds case, changes nothing else |
| also strips the extension | all three |

The third assertion survived the first two mutants, so I wrote the third mutant specifically to confirm it can fail rather than leaving it as decoration.

## Checks

- 15 test files / 105 tests pass across `modules/update`
- `pnpm typecheck:all` unchanged at 42 pre-existing errors
- ESLint clean under the core-app config