### PR TITLE
ref(nexus): share the runtime-server migration policy between main and renderer

### DIFF
--- a/apps/core-app/src/main/modules/nexus/runtime-base.ts
+++ b/apps/core-app/src/main/modules/nexus/runtime-base.ts
@@ -1,29 +1,24 @@
 import type { AppSetting } from '@talex-touch/utils/common/storage/entity/app-settings'
 import { StorageList } from '@talex-touch/utils'
 import {
+  applyTuffNexusRuntimeServerMigration,
   NEXUS_BASE_URL,
   type TuffNexusRuntimeServer,
+  type TuffNexusRuntimeServerSettings,
   resolveTuffNexusBaseUrl
 } from '@talex-touch/utils/env'
 import { getMainConfig, saveMainConfig } from '../storage'
 
-type LegacyDevSettings = AppSetting['dev'] & {
-  authServer?: TuffNexusRuntimeServer
-  runtimeServer?: TuffNexusRuntimeServer
-}
-
-function normalizeRuntimeServer(value: unknown): TuffNexusRuntimeServer {
-  return value === 'local' ? 'local' : 'production'
-}
-
+/**
+ * Only the storage plumbing lives here. The migration policy itself is shared with the renderer
+ * copy of this module via @talex-touch/utils/env -- the two had drifted while claiming to decide
+ * the same thing (#522).
+ */
 export function ensureRuntimeServerSettings(appSettings: AppSetting): TuffNexusRuntimeServer {
-  const dev = (appSettings.dev ?? {}) as LegacyDevSettings
-  const current = dev.runtimeServer
-  const next = current ?? dev.authServer ?? 'production'
-  dev.runtimeServer = normalizeRuntimeServer(next)
-  delete dev.authServer
+  const dev = (appSettings.dev ?? {}) as AppSetting['dev'] & TuffNexusRuntimeServerSettings
+  const runtimeServer = applyTuffNexusRuntimeServerMigration(dev)
   appSettings.dev = dev
-  return dev.runtimeServer
+  return runtimeServer
 }
 
 export function getRuntimeServerMode(): TuffNexusRuntimeServer {

--- a/apps/core-app/src/renderer/src/modules/nexus/runtime-base.ts
+++ b/apps/core-app/src/renderer/src/modules/nexus/runtime-base.ts
@@ -1,20 +1,18 @@
 import type { AppSetting } from '@talex-touch/utils/common/storage/entity/app-settings'
 import {
+  applyTuffNexusRuntimeServerMigration,
   NEXUS_BASE_URL,
   type TuffNexusRuntimeServer,
+  type TuffNexusRuntimeServerSettings,
   resolveTuffNexusBaseUrl
 } from '@talex-touch/utils/env'
 import { appSetting } from '~/modules/storage/app-storage'
 
-type LegacyDevSettings = AppSetting['dev'] & {
-  authServer?: TuffNexusRuntimeServer
-  runtimeServer?: TuffNexusRuntimeServer
-}
-
-function normalizeRuntimeServer(value: unknown): TuffNexusRuntimeServer {
-  return value === 'local' ? 'local' : 'production'
-}
-
+/**
+ * Only the storage plumbing lives here -- the renderer mutates the reactive settings store, and
+ * seeds `dev` when it is absent, which the main-process copy has no need to do. The migration
+ * policy itself is shared via @talex-touch/utils/env (#522).
+ */
 export function ensureRuntimeServerSettings(): TuffNexusRuntimeServer {
   if (!appSetting.dev) {
     appSetting.dev = {
@@ -24,13 +22,10 @@ export function ensureRuntimeServerSettings(): TuffNexusRuntimeServer {
     }
   }
 
-  const dev = appSetting.dev as LegacyDevSettings
-  const current = dev.runtimeServer
-  const next = current ?? dev.authServer ?? 'production'
-  dev.runtimeServer = normalizeRuntimeServer(next)
-  delete dev.authServer
+  const dev = appSetting.dev as AppSetting['dev'] & TuffNexusRuntimeServerSettings
+  const runtimeServer = applyTuffNexusRuntimeServerMigration(dev)
   appSetting.dev = dev
-  return dev.runtimeServer
+  return runtimeServer
 }
 
 export function getRuntimeServerMode(): TuffNexusRuntimeServer {

--- a/packages/utils/__tests__/nexus-runtime-server-policy.test.ts
+++ b/packages/utils/__tests__/nexus-runtime-server-policy.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyTuffNexusRuntimeServerMigration,
+  normalizeTuffNexusRuntimeServer,
+} from '../env'
+
+/**
+ * This policy was implemented twice -- once for the main process, once for the renderer -- and
+ * the two had already drifted (#522). Now that both call one function, the behaviour needs
+ * asserting once rather than being inferred from two call sites.
+ */
+
+describe('normalizeTuffNexusRuntimeServer', () => {
+  it('treats only the exact string "local" as local', () => {
+    expect(normalizeTuffNexusRuntimeServer('local')).toBe('local')
+  })
+
+  it.each([['production'], ['LOCAL'], ['Local'], [''], ['staging']])(
+    'coerces %o to production',
+    (value) => {
+      expect(normalizeTuffNexusRuntimeServer(value)).toBe('production')
+    },
+  )
+
+  it('coerces non-strings to production rather than trusting them', () => {
+    // The failure mode this guards is a corrupted settings file silently selecting a
+    // non-production backend.
+    for (const value of [undefined, null, 0, 1, true, {}, []])
+      expect(normalizeTuffNexusRuntimeServer(value)).toBe('production')
+  })
+})
+
+describe('applyTuffNexusRuntimeServerMigration', () => {
+  it('adopts the retired authServer when runtimeServer is absent', () => {
+    const dev = { authServer: 'local' as const }
+
+    expect(applyTuffNexusRuntimeServerMigration(dev)).toBe('local')
+    expect(dev.runtimeServer).toBe('local')
+    expect('authServer' in dev).toBe(false)
+  })
+
+  it('prefers runtimeServer over authServer when both exist', () => {
+    const dev = { runtimeServer: 'production' as const, authServer: 'local' as const }
+
+    expect(applyTuffNexusRuntimeServerMigration(dev)).toBe('production')
+    expect('authServer' in dev).toBe(false)
+  })
+
+  it('defaults to production when neither is set', () => {
+    const dev: Record<string, unknown> = {}
+
+    expect(applyTuffNexusRuntimeServerMigration(dev)).toBe('production')
+    expect(dev.runtimeServer).toBe('production')
+  })
+
+  it('drops authServer even when it is the value being adopted', () => {
+    // Leaving it behind would let a later read resurrect the retired field.
+    const dev = { authServer: 'local' as const }
+
+    applyTuffNexusRuntimeServerMigration(dev)
+
+    expect(Object.keys(dev)).toEqual(['runtimeServer'])
+  })
+
+  it('leaves unrelated dev settings untouched', () => {
+    const dev = { authServer: 'local' as const, developerMode: true, autoCloseDev: false }
+
+    applyTuffNexusRuntimeServerMigration(dev)
+
+    expect(dev.developerMode).toBe(true)
+    expect(dev.autoCloseDev).toBe(false)
+  })
+})

--- a/packages/utils/env/index.ts
+++ b/packages/utils/env/index.ts
@@ -164,6 +164,38 @@ export interface TuffNexusBaseUrlOptions {
   env?: EnvLike
 }
 
+/**
+ * The `dev` settings slice this policy migrates. `authServer` is the retired name for what is
+ * now `runtimeServer`; both may be present on settings written by older builds.
+ */
+export interface TuffNexusRuntimeServerSettings {
+  authServer?: TuffNexusRuntimeServer
+  runtimeServer?: TuffNexusRuntimeServer
+  [key: string]: unknown
+}
+
+/** Anything that is not the string `local` is production -- unknown values must not disable TLS. */
+export function normalizeTuffNexusRuntimeServer(value: unknown): TuffNexusRuntimeServer {
+  return value === 'local' ? 'local' : 'production'
+}
+
+/**
+ * Migrates a `dev` settings object in place and returns the resolved runtime server.
+ *
+ * The main and renderer processes each read and persist these settings differently, but the
+ * policy itself -- prefer runtimeServer, fall back to the retired authServer, default to
+ * production, then drop authServer -- was duplicated in both and had already drifted (#522).
+ * Only the storage plumbing belongs to each process; this does not.
+ */
+export function applyTuffNexusRuntimeServerMigration(
+  dev: TuffNexusRuntimeServerSettings
+): TuffNexusRuntimeServer {
+  const next = dev.runtimeServer ?? dev.authServer ?? 'production'
+  dev.runtimeServer = normalizeTuffNexusRuntimeServer(next)
+  delete dev.authServer
+  return dev.runtimeServer
+}
+
 export function resolveTuffNexusBaseUrl(options: TuffNexusBaseUrlOptions = {}): string {
   const explicit = readEnvValue(options.env, TUFF_NEXUS_BASE_URL_ENV)?.trim()
   if (explicit)


### PR DESCRIPTION
Fixes #522.

## The defect

The policy deciding which Nexus backend the app talks to — *prefer `runtimeServer`, fall back to the retired `authServer`, default to production, then drop `authServer`* — was implemented twice, once per process. The copies had already drifted: the renderer also exported `setRuntimeServerMode`.

**The drift is the part that matters.** Two implementations of "which backend do we trust" can disagree about what a corrupted settings value means, and the main and renderer processes would then talk to different servers with nothing reporting it.

## Split by what actually differs

| | where it lives now | why |
|---|---|---|
| migration policy, `normalize` | `@talex-touch/utils/env` | identical in both, and sits next to `resolveTuffNexusBaseUrl` / `NEXUS_BASE_URL` which they already shared |
| storage plumbing | per-process | genuinely different — main reads/writes the config file and re-saves only when the migration changed something; the renderer mutates the reactive store and seeds `dev` when absent |
| `setRuntimeServerMode` | renderer only | nothing in main sets it; unifying it would invent a capability |

Deduplicating the plumbing too would have forced one process to pretend to be the other. Only the policy was actually duplicated.

## This is a move, not a rewrite

The line

```ts
const next = current ?? dev.authServer ?? 'production'
```

was present **verbatim in both copies** at origin — checked before extracting, so the shared function reproduces both originals rather than reinterpreting them.

## The behaviour now has tests, which it did not before

12 cases: `authServer` adoption, `runtimeServer` precedence, the production default, that `authServer` is always dropped (including when it was the value adopted), and that unrelated `dev` settings survive.

Plus the one that matters most:

```ts
for (const value of [undefined, null, 0, 1, true, {}, []])
  expect(normalizeTuffNexusRuntimeServer(value)).toBe('production')
```

That guards the failure this policy exists to prevent — a corrupted settings file silently selecting a non-production backend. With two copies, that guarantee held in whichever copy you happened to read.

## Gates

- `npm run typecheck` (node + web): exit 0
- `packages/utils`: **135 files, 1084 passing**
- nexus suites: 2 files, 11 passing
- `eslint --max-warnings=0` in both packages: exit 0