### PR TITLE
refactor(core-app): one capability slot on TouchPlugin instead of ten (#530)

### DIFF
--- a/apps/core-app/src/main/modules/plugin/plugin-module.test.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-module.test.ts
@@ -168,18 +168,9 @@ const mocks = vi.hoisted(() => {
     runtimeDispose: vi.fn(async () => undefined),
     runtimeOptions: null as Record<string, unknown> | null,
     runtimeResolve: vi.fn(),
-    setBrowserDataCapabilityFactory: vi.fn(),
-    setBrowserOpenCapabilityFactory: vi.fn(),
-    setIntelligenceContextCapabilityFactory: vi.fn(),
-    setRuntimeService: vi.fn(),
+    setCapabilities: vi.fn(),
     setSecureStoreValue: vi.fn(),
-    setSnipasteProcessCapabilityFactory: vi.fn(),
-    setSystemActionCapabilityFactory: vi.fn(),
-    setTranslationCapabilityFactory: vi.fn(),
     setTransport: vi.fn(),
-    setWindowManagerCapabilityFactory: vi.fn(),
-    setWindowPresetCapabilityFactory: vi.fn(),
-    setWorkspaceScriptCapabilityFactory: vi.fn(),
     startUpdateScheduler: vi.fn(),
     stopUpdateScheduler: vi.fn(),
     transportOn
@@ -459,16 +450,7 @@ vi.mock('./install-queue', () => ({
 vi.mock('./plugin', () => ({
   TouchPlugin: class {
     static setTransport = mocks.setTransport
-    static setRuntimeService = mocks.setRuntimeService
-    static setSnipasteProcessCapabilityFactory = mocks.setSnipasteProcessCapabilityFactory
-    static setSystemActionCapabilityFactory = mocks.setSystemActionCapabilityFactory
-    static setBrowserOpenCapabilityFactory = mocks.setBrowserOpenCapabilityFactory
-    static setBrowserDataCapabilityFactory = mocks.setBrowserDataCapabilityFactory
-    static setTranslationCapabilityFactory = mocks.setTranslationCapabilityFactory
-    static setIntelligenceContextCapabilityFactory = mocks.setIntelligenceContextCapabilityFactory
-    static setWindowManagerCapabilityFactory = mocks.setWindowManagerCapabilityFactory
-    static setWindowPresetCapabilityFactory = mocks.setWindowPresetCapabilityFactory
-    static setWorkspaceScriptCapabilityFactory = mocks.setWorkspaceScriptCapabilityFactory
+    static setCapabilities = mocks.setCapabilities
   }
 }))
 vi.mock('./plugin-installer', () => ({ PluginInstaller: class {} }))
@@ -746,16 +728,7 @@ describe('PluginModule facade', () => {
     mocks.mainBrowserWindow.restore.mockReset()
     mocks.mainBrowserWindow.show.mockReset()
     mocks.mainBrowserWindow.focus.mockReset()
-    mocks.setRuntimeService.mockReset()
-    mocks.setSnipasteProcessCapabilityFactory.mockReset()
-    mocks.setSystemActionCapabilityFactory.mockReset()
-    mocks.setBrowserOpenCapabilityFactory.mockReset()
-    mocks.setBrowserDataCapabilityFactory.mockReset()
-    mocks.setTranslationCapabilityFactory.mockReset()
-    mocks.setIntelligenceContextCapabilityFactory.mockReset()
-    mocks.setWindowManagerCapabilityFactory.mockReset()
-    mocks.setWindowPresetCapabilityFactory.mockReset()
-    mocks.setWorkspaceScriptCapabilityFactory.mockReset()
+    mocks.setCapabilities.mockReset()
     mocks.setTransport.mockReset()
     mocks.startUpdateScheduler.mockReset()
     mocks.stopUpdateScheduler.mockReset()
@@ -898,28 +871,24 @@ describe('PluginModule facade', () => {
     )
     expect(definitions?.map((definition) => definition.id)).not.toContain('system.invoke')
     expect(Object.isFrozen(definitions)).toBe(true)
-    expect(mocks.setRuntimeService).toHaveBeenCalledWith(null)
-    expect(mocks.setRuntimeService).toHaveBeenLastCalledWith(expect.any(Object))
-    expect(mocks.setWindowPresetCapabilityFactory.mock.calls[0]).toEqual([null])
-    expect(mocks.setBrowserOpenCapabilityFactory.mock.calls[0]).toEqual([null])
-    expect(mocks.setBrowserDataCapabilityFactory.mock.calls[0]).toEqual([null])
-    expect(mocks.setTranslationCapabilityFactory.mock.calls[0]).toEqual([null])
-    expect(mocks.setIntelligenceContextCapabilityFactory.mock.calls[0]).toEqual([null])
-    expect(mocks.setWindowManagerCapabilityFactory.mock.calls[0]).toEqual([null])
-    expect(mocks.setWorkspaceScriptCapabilityFactory.mock.calls[0]).toEqual([null])
-    expect(mocks.setSnipasteProcessCapabilityFactory).toHaveBeenLastCalledWith(expect.any(Function))
-    expect(mocks.setSystemActionCapabilityFactory).toHaveBeenLastCalledWith(expect.any(Function))
-    expect(mocks.setBrowserOpenCapabilityFactory).toHaveBeenLastCalledWith(expect.any(Function))
-    expect(mocks.setBrowserDataCapabilityFactory).toHaveBeenLastCalledWith(expect.any(Function))
-    expect(mocks.setTranslationCapabilityFactory).toHaveBeenLastCalledWith(expect.any(Function))
-    expect(mocks.setIntelligenceContextCapabilityFactory).toHaveBeenLastCalledWith(
-      expect.any(Function)
-    )
-    expect(mocks.setWindowManagerCapabilityFactory).toHaveBeenLastCalledWith(expect.any(Function))
-    expect(mocks.setWindowPresetCapabilityFactory).toHaveBeenLastCalledWith(expect.any(Function))
-    expect(mocks.setWorkspaceScriptCapabilityFactory).toHaveBeenLastCalledWith(expect.any(Function))
+    // One call each way, so this covers what nine separate assertions used to. Compared
+    // exhaustively rather than field by field: an eleventh capability that the install block
+    // forgets fails here as an unexpected shape, not just at the type level.
+    expect(mocks.setCapabilities.mock.calls[0]).toEqual([null])
+    expect(mocks.setCapabilities).toHaveBeenLastCalledWith({
+      snipasteProcess: expect.any(Function),
+      systemAction: expect.any(Function),
+      browserOpen: expect.any(Function),
+      browserData: expect.any(Function),
+      translation: expect.any(Function),
+      intelligenceContext: expect.any(Function),
+      windowManager: expect.any(Function),
+      windowPreset: expect.any(Function),
+      workspaceScript: expect.any(Function),
+      runtimeService: expect.any(Object)
+    })
 
-    const contextFactory = mocks.setIntelligenceContextCapabilityFactory.mock.calls.at(-1)?.[0] as
+    const contextFactory = mocks.setCapabilities.mock.calls.at(-1)?.[0]?.intelligenceContext as
       | ((activation: {
           name: string
           pluginInstanceId: string
@@ -989,7 +958,7 @@ describe('PluginModule facade', () => {
       })
       mocks.keyResolveCurrentIdentity.mockReturnValue(activation)
       mocks.runtimeResolve.mockReturnValue({ owner: { hostGeneration: 7 } })
-      const factory = mocks.setSystemActionCapabilityFactory.mock.calls.at(-1)?.[0] as
+      const factory = mocks.setCapabilities.mock.calls.at(-1)?.[0]?.systemAction as
         | ((input: typeof activation) => {
             definitions: ReadonlyArray<{
               invoke(
@@ -1071,7 +1040,7 @@ describe('PluginModule facade', () => {
     mocks.runtimeResolve.mockReturnValue({ owner: { hostGeneration: 9 } })
     mocks.browserWindowFromId.mockReturnValue(mocks.mainBrowserWindow)
     mocks.mainBrowserWindow.isMinimized.mockReturnValue(true)
-    const factory = mocks.setSystemActionCapabilityFactory.mock.calls.at(-1)?.[0] as
+    const factory = mocks.setCapabilities.mock.calls.at(-1)?.[0]?.systemAction as
       | ((input: typeof activation) => {
           definitions: ReadonlyArray<{
             invoke(
@@ -1127,7 +1096,7 @@ describe('PluginModule facade', () => {
     mocks.mainBrowserWindow.restore.mockImplementationOnce(() => {
       mocks.runtimeResolve.mockReturnValue({ owner: { hostGeneration: 10 } })
     })
-    const factory = mocks.setSystemActionCapabilityFactory.mock.calls.at(-1)?.[0] as
+    const factory = mocks.setCapabilities.mock.calls.at(-1)?.[0]?.systemAction as
       | ((input: typeof activation) => {
           definitions: ReadonlyArray<{
             invoke(
@@ -1282,16 +1251,9 @@ describe('PluginModule facade', () => {
     expect(mocks.runtimeDispose).toHaveBeenCalledOnce()
     expect(closeBusiness).toHaveBeenCalledOnce()
     expect(closeSqlite).toHaveBeenCalledOnce()
-    expect(mocks.setRuntimeService).toHaveBeenLastCalledWith(null)
-    expect(mocks.setSnipasteProcessCapabilityFactory).toHaveBeenLastCalledWith(null)
-    expect(mocks.setSystemActionCapabilityFactory).toHaveBeenLastCalledWith(null)
-    expect(mocks.setBrowserOpenCapabilityFactory).toHaveBeenLastCalledWith(null)
-    expect(mocks.setBrowserDataCapabilityFactory).toHaveBeenLastCalledWith(null)
-    expect(mocks.setTranslationCapabilityFactory).toHaveBeenLastCalledWith(null)
-    expect(mocks.setIntelligenceContextCapabilityFactory).toHaveBeenLastCalledWith(null)
-    expect(mocks.setWindowManagerCapabilityFactory).toHaveBeenLastCalledWith(null)
-    expect(mocks.setWindowPresetCapabilityFactory).toHaveBeenLastCalledWith(null)
-    expect(mocks.setWorkspaceScriptCapabilityFactory).toHaveBeenLastCalledWith(null)
+    // Teardown is one call now, so nine assertions collapse into the one that actually matters:
+    // whatever was installed is cleared, whether that is ten capabilities or eleven.
+    expect(mocks.setCapabilities).toHaveBeenLastCalledWith(null)
     expect(mocks.setTransport).toHaveBeenLastCalledWith(null)
     expect(mocks.healthMonitor.destroy).toHaveBeenCalledOnce()
     expect(mocks.stopUpdateScheduler).toHaveBeenCalledOnce()

--- a/apps/core-app/src/main/modules/plugin/plugin-module.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-module.ts
@@ -1875,16 +1875,7 @@ export class PluginModule extends BaseModule {
     this.transport = ioRuntime.transport
     this.secureStoreRootPath = ctx.app.rootPath
     TouchPlugin.setTransport(ioRuntime.transport)
-    TouchPlugin.setRuntimeService(null)
-    TouchPlugin.setSnipasteProcessCapabilityFactory(null)
-    TouchPlugin.setSystemActionCapabilityFactory(null)
-    TouchPlugin.setBrowserOpenCapabilityFactory(null)
-    TouchPlugin.setBrowserDataCapabilityFactory(null)
-    TouchPlugin.setTranslationCapabilityFactory(null)
-    TouchPlugin.setIntelligenceContextCapabilityFactory(null)
-    TouchPlugin.setWindowManagerCapabilityFactory(null)
-    TouchPlugin.setWindowPresetCapabilityFactory(null)
-    TouchPlugin.setWorkspaceScriptCapabilityFactory(null)
+    TouchPlugin.setCapabilities(null)
 
     const pluginRuntime = buildPluginManagerRuntime({
       pluginRootDir: file.dirPath!,
@@ -2501,36 +2492,18 @@ export class PluginModule extends BaseModule {
         await this.pluginBusinessCapabilities?.closeActivation(activation)
       }
     })
-    TouchPlugin.setSnipasteProcessCapabilityFactory((activation) =>
-      createSnipasteProcessCapability(activation)
-    )
-    TouchPlugin.setSystemActionCapabilityFactory((activation) =>
-      createSystemActionCapability(activation)
-    )
-    TouchPlugin.setBrowserOpenCapabilityFactory((activation) =>
-      createBrowserOpenCapability(activation)
-    )
-    TouchPlugin.setBrowserDataCapabilityFactory((activation) =>
-      createBrowserDataCapability(activation)
-    )
-    TouchPlugin.setTranslationCapabilityFactory((activation) =>
-      createTranslationCapability(activation)
-    )
-    TouchPlugin.setIntelligenceContextCapabilityFactory((activation) =>
-      createIntelligenceContextCapability(activation)
-    )
-    TouchPlugin.setWindowManagerCapabilityFactory((activation) =>
-      createWindowManagerCapability(activation)
-    )
-    TouchPlugin.setWindowPresetCapabilityFactory((activation) =>
-      createWindowPresetCapability(activation)
-    )
-    TouchPlugin.setWorkspaceScriptCapabilityFactory((activation) =>
-      createWorkspaceScriptCapability(activation)
-    )
-    TouchPlugin.setRuntimeService(
-      shouldInstallPluginRuntimeServiceByDefault() ? this.runtimeService : null
-    )
+    TouchPlugin.setCapabilities({
+      snipasteProcess: (activation) => createSnipasteProcessCapability(activation),
+      systemAction: (activation) => createSystemActionCapability(activation),
+      browserOpen: (activation) => createBrowserOpenCapability(activation),
+      browserData: (activation) => createBrowserDataCapability(activation),
+      translation: (activation) => createTranslationCapability(activation),
+      intelligenceContext: (activation) => createIntelligenceContextCapability(activation),
+      windowManager: (activation) => createWindowManagerCapability(activation),
+      windowPreset: (activation) => createWindowPresetCapability(activation),
+      workspaceScript: (activation) => createWorkspaceScriptCapability(activation),
+      runtimeService: shouldInstallPluginRuntimeServiceByDefault() ? this.runtimeService : null
+    })
     this.storageTeardownDisposer?.()
     this.storageTeardownDisposer = registerPluginStorageTeardown(async (pluginName) => {
       const results = await Promise.allSettled([
@@ -2666,16 +2639,7 @@ export class PluginModule extends BaseModule {
       cleanupErrors.push(error)
     }
 
-    runCleanup(() => TouchPlugin.setSnipasteProcessCapabilityFactory(null))
-    runCleanup(() => TouchPlugin.setSystemActionCapabilityFactory(null))
-    runCleanup(() => TouchPlugin.setBrowserOpenCapabilityFactory(null))
-    runCleanup(() => TouchPlugin.setBrowserDataCapabilityFactory(null))
-    runCleanup(() => TouchPlugin.setTranslationCapabilityFactory(null))
-    runCleanup(() => TouchPlugin.setIntelligenceContextCapabilityFactory(null))
-    runCleanup(() => TouchPlugin.setWindowManagerCapabilityFactory(null))
-    runCleanup(() => TouchPlugin.setWindowPresetCapabilityFactory(null))
-    runCleanup(() => TouchPlugin.setWorkspaceScriptCapabilityFactory(null))
-    runCleanup(() => TouchPlugin.setRuntimeService(null))
+    runCleanup(() => TouchPlugin.setCapabilities(null))
     runCleanup(() => TouchPlugin.setTransport(null))
     this.transport = null
     try {

--- a/apps/core-app/src/main/modules/plugin/plugin.test.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin.test.ts
@@ -21,7 +21,8 @@ import { TuffIconImpl } from '../../core/tuff-icon'
 import { getCoreBoxWindow } from '../box-tool/core-box'
 import type { PluginRuntimeActivationOptions } from './host/plugin-runtime-service'
 import { PluginRuntimeHostError } from './host/plugin-runtime-host'
-import { TouchPlugin } from './plugin'
+import type { TouchPluginRuntimeCapabilities } from './plugin'
+import { emptyTouchPluginRuntimeCapabilities, TouchPlugin } from './plugin'
 import { widgetManager } from './widget/widget-manager'
 
 const permissionModuleMock = vi.hoisted(() => ({
@@ -235,6 +236,19 @@ function clearBoxItemMocks(): void {
   coreBoxManagerMock.exitUIMode.mockClear()
   coreBoxManagerMock.getCurrentFeature.mockReset()
   appSettingsMock.value = {}
+}
+
+let installedCapabilities = emptyTouchPluginRuntimeCapabilities()
+
+/**
+ * Install one capability, leaving the rest as they were.
+ *
+ * Production installs the whole set in a single call (#530); only tests build it up a piece at a
+ * time, so the accumulation lives here rather than widening the production API back out.
+ */
+function installCapability(partial: Partial<TouchPluginRuntimeCapabilities>): void {
+  installedCapabilities = { ...installedCapabilities, ...partial }
+  TouchPlugin.setCapabilities(installedCapabilities)
 }
 
 describe('touchPlugin.triggerFeature', () => {
@@ -2158,16 +2172,8 @@ describe('touchPlugin.setRuntime', () => {
 describe('touchPlugin.enable', () => {
   afterEach(() => {
     TouchPlugin.setTransport(null)
-    TouchPlugin.setRuntimeService(null)
-    TouchPlugin.setSnipasteProcessCapabilityFactory(null)
-    TouchPlugin.setSystemActionCapabilityFactory(null)
-    TouchPlugin.setBrowserOpenCapabilityFactory(null)
-    TouchPlugin.setBrowserDataCapabilityFactory(null)
-    TouchPlugin.setTranslationCapabilityFactory(null)
-    TouchPlugin.setIntelligenceContextCapabilityFactory(null)
-    TouchPlugin.setWindowManagerCapabilityFactory(null)
-    TouchPlugin.setWindowPresetCapabilityFactory(null)
-    TouchPlugin.setWorkspaceScriptCapabilityFactory(null)
+    installedCapabilities = emptyTouchPluginRuntimeCapabilities()
+    TouchPlugin.setCapabilities(null)
     clearBoxItemMocks()
     vi.restoreAllMocks()
   })
@@ -2196,7 +2202,7 @@ describe('touchPlugin.enable', () => {
       keyManager: { requestKey, revokeKey: vi.fn(() => true) },
       sendToPlugin: vi.fn().mockResolvedValue(undefined)
     } as unknown as ITuffTransportMain)
-    TouchPlugin.setRuntimeService(runtime as never)
+    installCapability({ runtimeService: runtime as never })
     const plugin = new TouchPlugin(
       'empty-plugin',
       { type: 'class', value: 'i-ri-test-tube-line' },
@@ -2263,7 +2269,7 @@ describe('touchPlugin.enable', () => {
         },
         sendToPlugin: vi.fn().mockResolvedValue(undefined)
       } as unknown as ITuffTransportMain)
-      TouchPlugin.setRuntimeService(runtime as never)
+      installCapability({ runtimeService: runtime as never })
       const plugin = new TouchPlugin(
         'touch-batch-rename',
         { type: 'class', value: 'i-ri-file-edit-line' },
@@ -2325,13 +2331,13 @@ describe('touchPlugin.enable', () => {
         },
         sendToPlugin: vi.fn().mockResolvedValue(undefined)
       } as unknown as ITuffTransportMain)
-      TouchPlugin.setRuntimeService(runtime as never)
+      installCapability({ runtimeService: runtime as never })
       const factory = vi.fn((_activation: PluginRuntimeActivationOptions['activation']) => ({
         definitions: Object.freeze([
           { id: 'intelligence.invoke', permission: 'intelligence.basic' }
         ])
       }))
-      TouchPlugin.setTranslationCapabilityFactory(factory as never)
+      installCapability({ translation: factory as never })
 
       const translation = new TouchPlugin(
         'touch-translation',
@@ -2362,7 +2368,7 @@ describe('touchPlugin.enable', () => {
       )
 
       const otherRuntime = createRuntimeServiceMock()
-      TouchPlugin.setRuntimeService(otherRuntime as never)
+      installCapability({ runtimeService: otherRuntime as never })
       const other = new TouchPlugin(
         'other-plugin',
         { type: 'class', value: 'i-ri-plug-line' },
@@ -2399,7 +2405,7 @@ describe('touchPlugin.enable', () => {
         },
         sendToPlugin: vi.fn().mockResolvedValue(undefined)
       } as unknown as ITuffTransportMain)
-      TouchPlugin.setRuntimeService(runtime as never)
+      installCapability({ runtimeService: runtime as never })
       const factory = vi.fn((_activation: PluginRuntimeActivationOptions['activation']) => ({
         definitions: Object.freeze([
           {
@@ -2414,7 +2420,7 @@ describe('touchPlugin.enable', () => {
           }
         ])
       }))
-      TouchPlugin.setIntelligenceContextCapabilityFactory(factory as never)
+      installCapability({ intelligenceContext: factory as never })
 
       const intelligence = new TouchPlugin(
         'touch-intelligence',
@@ -2454,7 +2460,7 @@ describe('touchPlugin.enable', () => {
       expect(factory).toHaveBeenCalledOnce()
 
       const otherRuntime = createRuntimeServiceMock()
-      TouchPlugin.setRuntimeService(otherRuntime as never)
+      installCapability({ runtimeService: otherRuntime as never })
       const other = new TouchPlugin(
         'other-plugin',
         { type: 'class', value: 'i-ri-plug-line' },
@@ -2494,11 +2500,11 @@ describe('touchPlugin.enable', () => {
           keyManager: { requestKey, revokeKey: vi.fn(() => true) },
           sendToPlugin: vi.fn().mockResolvedValue(undefined)
         } as unknown as ITuffTransportMain)
-        TouchPlugin.setRuntimeService(runtime as never)
+        installCapability({ runtimeService: runtime as never })
         const factory = vi.fn((_activation: PluginRuntimeActivationOptions['activation']) => ({
           definitions: Object.freeze([{ id: 'system.invoke' }])
         }))
-        TouchPlugin.setSystemActionCapabilityFactory(factory as never)
+        installCapability({ systemAction: factory as never })
         const plugin = new TouchPlugin(
           pluginName,
           { type: 'class', value: 'i-ri-settings-3-line' },
@@ -2558,7 +2564,7 @@ describe('touchPlugin.enable', () => {
         keyManager: { requestKey, revokeKey: vi.fn(() => true) },
         sendToPlugin: vi.fn().mockResolvedValue(undefined)
       } as unknown as ITuffTransportMain)
-      TouchPlugin.setRuntimeService(runtime as never)
+      installCapability({ runtimeService: runtime as never })
       const closes: Array<ReturnType<typeof vi.fn>> = []
       const factory = vi.fn((_activation: PluginRuntimeActivationOptions['activation']) => {
         const close = vi.fn(async () => undefined)
@@ -2568,7 +2574,7 @@ describe('touchPlugin.enable', () => {
           close
         }
       })
-      TouchPlugin.setWindowManagerCapabilityFactory(factory as never)
+      installCapability({ windowManager: factory as never })
       const plugin = new TouchPlugin(
         'touch-window-manager',
         { type: 'class', value: 'i-ri-window-line' },
@@ -2628,17 +2634,17 @@ describe('touchPlugin.enable', () => {
         },
         sendToPlugin: vi.fn().mockResolvedValue(undefined)
       } as unknown as ITuffTransportMain)
-      TouchPlugin.setRuntimeService(runtime as never)
+      installCapability({ runtimeService: runtime as never })
       const close = vi
         .fn<() => Promise<void>>()
         .mockRejectedValueOnce(new Error('/private/plugin/close-detail'))
         .mockResolvedValue(undefined)
-      TouchPlugin.setWindowManagerCapabilityFactory(
-        vi.fn(() => ({
+      installCapability({
+        windowManager: vi.fn(() => ({
           definitions: Object.freeze([{ id: 'system.window-manager', permission: 'system.shell' }]),
           close
         })) as never
-      )
+      })
       const plugin = new TouchPlugin(
         'touch-window-manager',
         { type: 'class', value: 'i-ri-window-line' },
@@ -2679,7 +2685,7 @@ describe('touchPlugin.enable', () => {
         keyManager: { requestKey, revokeKey: vi.fn(() => true) },
         sendToPlugin: vi.fn().mockResolvedValue(undefined)
       } as unknown as ITuffTransportMain)
-      TouchPlugin.setRuntimeService(runtime as never)
+      installCapability({ runtimeService: runtime as never })
       const closes: Array<ReturnType<typeof vi.fn>> = []
       const factory = vi.fn((_activation: PluginRuntimeActivationOptions['activation']) => {
         const close = vi.fn(async () => undefined)
@@ -2689,7 +2695,7 @@ describe('touchPlugin.enable', () => {
           close
         }
       })
-      TouchPlugin.setWindowPresetCapabilityFactory(factory as never)
+      installCapability({ windowPreset: factory as never })
       const plugin = new TouchPlugin(
         'touch-window-presets',
         { type: 'class', value: 'i-ri-layout-column-line' },
@@ -2748,7 +2754,7 @@ describe('touchPlugin.enable', () => {
         keyManager: { requestKey, revokeKey: vi.fn(() => true) },
         sendToPlugin: vi.fn().mockResolvedValue(undefined)
       } as unknown as ITuffTransportMain)
-      TouchPlugin.setRuntimeService(runtime as never)
+      installCapability({ runtimeService: runtime as never })
       const closes: Array<ReturnType<typeof vi.fn>> = []
       const factory = vi.fn((_activation: PluginRuntimeActivationOptions['activation']) => {
         const close = vi.fn(async () => undefined)
@@ -2758,7 +2764,7 @@ describe('touchPlugin.enable', () => {
           close
         }
       })
-      TouchPlugin.setBrowserOpenCapabilityFactory(factory as never)
+      installCapability({ browserOpen: factory as never })
       const plugin = new TouchPlugin(
         'touch-browser-open',
         { type: 'class', value: 'i-ri-global-line' },
@@ -2817,7 +2823,7 @@ describe('touchPlugin.enable', () => {
         keyManager: { requestKey, revokeKey: vi.fn(() => true) },
         sendToPlugin: vi.fn().mockResolvedValue(undefined)
       } as unknown as ITuffTransportMain)
-      TouchPlugin.setRuntimeService(runtime as never)
+      installCapability({ runtimeService: runtime as never })
       const closes: Array<ReturnType<typeof vi.fn>> = []
       const factory = vi.fn((_activation: PluginRuntimeActivationOptions['activation']) => {
         const close = vi.fn(async () => undefined)
@@ -2827,7 +2833,7 @@ describe('touchPlugin.enable', () => {
           close
         }
       })
-      TouchPlugin.setBrowserDataCapabilityFactory(factory as never)
+      installCapability({ browserData: factory as never })
       const plugin = new TouchPlugin(
         'touch-browser-data',
         { type: 'emoji', value: 'browser' },
@@ -2882,7 +2888,7 @@ describe('touchPlugin.enable', () => {
         keyManager: { requestKey, revokeKey: vi.fn(() => true) },
         sendToPlugin: vi.fn().mockResolvedValue(undefined)
       } as unknown as ITuffTransportMain)
-      TouchPlugin.setRuntimeService(runtime as never)
+      installCapability({ runtimeService: runtime as never })
       const closes: Array<ReturnType<typeof vi.fn>> = []
       const factory = vi.fn((_activation: PluginRuntimeActivationOptions['activation']) => {
         const close = vi.fn(async () => undefined)
@@ -2892,7 +2898,7 @@ describe('touchPlugin.enable', () => {
           close
         }
       })
-      TouchPlugin.setWorkspaceScriptCapabilityFactory(factory as never)
+      installCapability({ workspaceScript: factory as never })
       const plugin = new TouchPlugin(
         'touch-workspace-scripts',
         { type: 'class', value: 'i-ri-terminal-box-line' },
@@ -2951,7 +2957,7 @@ describe('touchPlugin.enable', () => {
         keyManager: { requestKey, revokeKey: vi.fn(() => true) },
         sendToPlugin: vi.fn().mockResolvedValue(undefined)
       } as unknown as ITuffTransportMain)
-      TouchPlugin.setRuntimeService(runtime as never)
+      installCapability({ runtimeService: runtime as never })
       const closes: Array<ReturnType<typeof vi.fn>> = []
       const factory = vi.fn((_activation: PluginRuntimeActivationOptions['activation']) => {
         const close = vi.fn(async () => undefined)
@@ -2961,7 +2967,7 @@ describe('touchPlugin.enable', () => {
           close
         }
       })
-      TouchPlugin.setSnipasteProcessCapabilityFactory(factory as never)
+      installCapability({ snipasteProcess: factory as never })
       const plugin = new TouchPlugin(
         'touch-snipaste',
         { type: 'class', value: 'i-ri-screenshot-line' },
@@ -3023,7 +3029,7 @@ describe('touchPlugin.enable', () => {
         },
         sendToPlugin: vi.fn().mockResolvedValue(undefined)
       } as unknown as ITuffTransportMain)
-      TouchPlugin.setRuntimeService(runtime as never)
+      installCapability({ runtimeService: runtime as never })
       const plugin = new TouchPlugin(
         'clipboard-history',
         { type: 'class', value: 'i-ri-test-tube-line' },
@@ -3065,7 +3071,7 @@ describe('touchPlugin.enable', () => {
         },
         sendToPlugin: vi.fn().mockResolvedValue(undefined)
       } as unknown as ITuffTransportMain)
-      TouchPlugin.setRuntimeService(runtime as never)
+      installCapability({ runtimeService: runtime as never })
       const plugin = new TouchPlugin(
         'clipboard-history',
         { type: 'class', value: 'i-ri-test-tube-line' },
@@ -3118,7 +3124,7 @@ describe('touchPlugin.enable', () => {
       keyManager: { requestKey: vi.fn(() => 'activation-key-1'), revokeKey: vi.fn(() => true) },
       sendToPlugin: vi.fn().mockResolvedValue(undefined)
     } as unknown as ITuffTransportMain)
-    TouchPlugin.setRuntimeService(runtime as never)
+    installCapability({ runtimeService: runtime as never })
     const plugin = new TouchPlugin(
       'owner-plugin',
       { type: 'file', value: '/private/owner-plugin/icon.png' },
@@ -3275,7 +3281,7 @@ describe('touchPlugin.enable', () => {
       keyManager: { requestKey: vi.fn(() => 'secret-key'), revokeKey },
       sendToPlugin: vi.fn().mockResolvedValue(undefined)
     } as unknown as ITuffTransportMain)
-    TouchPlugin.setRuntimeService(runtime as never)
+    installCapability({ runtimeService: runtime as never })
     const plugin = new TouchPlugin(
       'failed-plugin',
       { type: 'class', value: 'i-ri-test-tube-line' },
@@ -3323,7 +3329,7 @@ describe('touchPlugin.enable', () => {
       },
       sendToPlugin: vi.fn().mockResolvedValue(undefined)
     } as unknown as ITuffTransportMain)
-    TouchPlugin.setRuntimeService(runtime as never)
+    installCapability({ runtimeService: runtime as never })
     const plugin = new TouchPlugin(
       'barrier-plugin',
       { type: 'class', value: 'i-ri-test-tube-line' },
@@ -3371,7 +3377,7 @@ describe('touchPlugin.enable', () => {
       },
       sendToPlugin: vi.fn().mockResolvedValue(undefined)
     } as unknown as ITuffTransportMain)
-    TouchPlugin.setRuntimeService(runtime as never)
+    installCapability({ runtimeService: runtime as never })
     const plugin = new TouchPlugin(
       'cleanup-failure-plugin',
       { type: 'class', value: 'i-ri-test-tube-line' },
@@ -3411,7 +3417,7 @@ describe('touchPlugin.enable', () => {
       sendToPlugin: vi.fn().mockResolvedValue(undefined)
     } as unknown as ITuffTransportMain
     TouchPlugin.setTransport(transport)
-    TouchPlugin.setRuntimeService(createRuntimeServiceMock() as never)
+    installCapability({ runtimeService: createRuntimeServiceMock() as never })
 
     const plugin = new TouchPlugin(
       'rotating-plugin',
@@ -3481,7 +3487,7 @@ describe('touchPlugin.enable', () => {
       },
       sendToPlugin: vi.fn().mockResolvedValue(undefined)
     } as unknown as ITuffTransportMain)
-    TouchPlugin.setRuntimeService(runtime as never)
+    installCapability({ runtimeService: runtime as never })
     const plugin = new TouchPlugin(
       'resource-plugin',
       { type: 'class', value: 'i-ri-test-tube-line' },

--- a/apps/core-app/src/main/modules/plugin/plugin.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin.ts
@@ -479,99 +479,76 @@ const INTELLIGENCE_RUNTIME_CAPABILITIES = Object.freeze([
 /**
  * Plugin implementation
  */
+/**
+ * Everything plugin-module installs on TouchPlugin for the lifetime of one module generation.
+ *
+ * Held in a single slot so install and teardown are one call each. Transport keeps its own
+ * slot: it is installed earlier in the module lifecycle than these are, and tests set it on
+ * its own in about twenty places.
+ */
+export interface TouchPluginRuntimeCapabilities {
+  runtimeService: PluginRuntimeService | null
+  snipasteProcess:
+    | ((activation: PluginActivationIdentity) => PluginSnipasteProcessCapability)
+    | null
+  systemAction: ((activation: PluginActivationIdentity) => PluginSystemActionCapabilities) | null
+  browserOpen: ((activation: PluginActivationIdentity) => PluginBrowserOpenCapabilities) | null
+  browserData: ((activation: PluginActivationIdentity) => PluginBrowserDataCapabilities) | null
+  translation: ((activation: PluginActivationIdentity) => PluginIntelligenceCapabilities) | null
+  intelligenceContext:
+    | ((activation: PluginActivationIdentity) => PluginIntelligenceContextCapabilities)
+    | null
+  windowManager: ((activation: PluginActivationIdentity) => PluginWindowManagerCapabilities) | null
+  windowPreset: ((activation: PluginActivationIdentity) => PluginWindowPresetCapabilities) | null
+  workspaceScript:
+    | ((activation: PluginActivationIdentity) => PluginWorkspaceScriptCapabilities)
+    | null
+}
+/**
+ * A capability set with nothing installed.
+ *
+ * A base for callers that only need a subset — chiefly tests. The return type is the full
+ * interface, so an added capability is a compile error here rather than a silently missing key.
+ */
+export function emptyTouchPluginRuntimeCapabilities(): TouchPluginRuntimeCapabilities {
+  return {
+    runtimeService: null,
+    snipasteProcess: null,
+    systemAction: null,
+    browserOpen: null,
+    browserData: null,
+    translation: null,
+    intelligenceContext: null,
+    windowManager: null,
+    windowPreset: null,
+    workspaceScript: null
+  }
+}
+
 export class TouchPlugin implements ITouchPlugin {
   private static _transport: ITuffTransportMain | null = null
-  private static _runtimeService: PluginRuntimeService | null = null
-  private static _snipasteProcessCapabilityFactory:
-    | ((activation: PluginActivationIdentity) => PluginSnipasteProcessCapability)
-    | null = null
-  private static _systemActionCapabilityFactory:
-    | ((activation: PluginActivationIdentity) => PluginSystemActionCapabilities)
-    | null = null
-  private static _browserOpenCapabilityFactory:
-    | ((activation: PluginActivationIdentity) => PluginBrowserOpenCapabilities)
-    | null = null
-  private static _browserDataCapabilityFactory:
-    | ((activation: PluginActivationIdentity) => PluginBrowserDataCapabilities)
-    | null = null
-  private static _translationCapabilityFactory:
-    | ((activation: PluginActivationIdentity) => PluginIntelligenceCapabilities)
-    | null = null
-  private static _intelligenceContextCapabilityFactory:
-    | ((activation: PluginActivationIdentity) => PluginIntelligenceContextCapabilities)
-    | null = null
-  private static _windowManagerCapabilityFactory:
-    | ((activation: PluginActivationIdentity) => PluginWindowManagerCapabilities)
-    | null = null
-  private static _windowPresetCapabilityFactory:
-    | ((activation: PluginActivationIdentity) => PluginWindowPresetCapabilities)
-    | null = null
-  private static _workspaceScriptCapabilityFactory:
-    | ((activation: PluginActivationIdentity) => PluginWorkspaceScriptCapabilities)
-    | null = null
+  private static _capabilities: TouchPluginRuntimeCapabilities | null = null
 
   static setTransport(transport: ITuffTransportMain | null): void {
     TouchPlugin._transport = transport
   }
 
-  static setRuntimeService(runtimeService: PluginRuntimeService | null): void {
-    TouchPlugin._runtimeService = runtimeService
+  /**
+   * Install, or clear, everything plugin-module owns on this class for one module generation.
+   *
+   * One slot rather than ten, so init and destroy cannot fall out of step: every field is
+   * required, so adding an eleventh capability fails to compile at the install site until it is
+   * supplied, and teardown is `setCapabilities(null)` regardless of how many there are (#530).
+   */
+  static setCapabilities(capabilities: TouchPluginRuntimeCapabilities | null): void {
+    TouchPlugin._capabilities = capabilities
   }
 
-  static setSnipasteProcessCapabilityFactory(
-    factory: ((activation: PluginActivationIdentity) => PluginSnipasteProcessCapability) | null
-  ): void {
-    TouchPlugin._snipasteProcessCapabilityFactory = factory
-  }
-
-  static setSystemActionCapabilityFactory(
-    factory: ((activation: PluginActivationIdentity) => PluginSystemActionCapabilities) | null
-  ): void {
-    TouchPlugin._systemActionCapabilityFactory = factory
-  }
-
-  static setBrowserOpenCapabilityFactory(
-    factory: ((activation: PluginActivationIdentity) => PluginBrowserOpenCapabilities) | null
-  ): void {
-    TouchPlugin._browserOpenCapabilityFactory = factory
-  }
-
-  static setBrowserDataCapabilityFactory(
-    factory: ((activation: PluginActivationIdentity) => PluginBrowserDataCapabilities) | null
-  ): void {
-    TouchPlugin._browserDataCapabilityFactory = factory
-  }
-
-  static setTranslationCapabilityFactory(
-    factory: ((activation: PluginActivationIdentity) => PluginIntelligenceCapabilities) | null
-  ): void {
-    TouchPlugin._translationCapabilityFactory = factory
-  }
-
-  static setIntelligenceContextCapabilityFactory(
-    factory:
-      | ((activation: PluginActivationIdentity) => PluginIntelligenceContextCapabilities)
-      | null
-  ): void {
-    TouchPlugin._intelligenceContextCapabilityFactory = factory
-  }
-
-  static setWindowManagerCapabilityFactory(
-    factory: ((activation: PluginActivationIdentity) => PluginWindowManagerCapabilities) | null
-  ): void {
-    TouchPlugin._windowManagerCapabilityFactory = factory
-  }
-
-  static setWindowPresetCapabilityFactory(
-    factory: ((activation: PluginActivationIdentity) => PluginWindowPresetCapabilities) | null
-  ): void {
-    TouchPlugin._windowPresetCapabilityFactory = factory
-  }
-
-  static setWorkspaceScriptCapabilityFactory(
-    factory: ((activation: PluginActivationIdentity) => PluginWorkspaceScriptCapabilities) | null
-  ): void {
-    TouchPlugin._workspaceScriptCapabilityFactory = factory
+  /** Read one installed capability, or null when no module generation is active. */
+  private static capability<K extends keyof TouchPluginRuntimeCapabilities>(
+    key: K
+  ): TouchPluginRuntimeCapabilities[K] | null {
+    return TouchPlugin._capabilities?.[key] ?? null
   }
 
   private get transport(): ITuffTransportMain | null {
@@ -1427,7 +1404,8 @@ export class TouchPlugin implements ITouchPlugin {
   }
 
   private resolveRuntimeService(): PluginRuntimeService {
-    if (TouchPlugin._runtimeService) return TouchPlugin._runtimeService
+    const runtimeService = TouchPlugin.capability('runtimeService')
+    if (runtimeService) return runtimeService
     throw Object.assign(new Error('PLUGIN_RUNTIME_SERVICE_CLOSED'), {
       code: 'PLUGIN_RUNTIME_SERVICE_CLOSED'
     })
@@ -2082,7 +2060,7 @@ export class TouchPlugin implements ITouchPlugin {
     activation: PluginActivationIdentity
   ): PluginSnipasteProcessCapability | null {
     if (this.name !== 'touch-snipaste') return null
-    const factory = TouchPlugin._snipasteProcessCapabilityFactory
+    const factory = TouchPlugin.capability('snipasteProcess')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_SNIPASTE_PROCESS_CAPABILITY_UNAVAILABLE'), {
         code: 'PLUGIN_SNIPASTE_PROCESS_CAPABILITY_UNAVAILABLE'
@@ -2095,7 +2073,7 @@ export class TouchPlugin implements ITouchPlugin {
     activation: PluginActivationIdentity
   ): PluginSystemActionCapabilities | null {
     if (this.name !== 'touch-quick-actions' && this.name !== 'touch-system-actions') return null
-    const factory = TouchPlugin._systemActionCapabilityFactory
+    const factory = TouchPlugin.capability('systemAction')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_SYSTEM_ACTION_CAPABILITY_UNAVAILABLE'), {
         code: 'PLUGIN_SYSTEM_ACTION_CAPABILITY_UNAVAILABLE'
@@ -2108,7 +2086,7 @@ export class TouchPlugin implements ITouchPlugin {
     activation: PluginActivationIdentity
   ): PluginBrowserOpenCapabilities | null {
     if (this.name !== 'touch-browser-open') return null
-    const factory = TouchPlugin._browserOpenCapabilityFactory
+    const factory = TouchPlugin.capability('browserOpen')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_BROWSER_OPEN_CAPABILITY_UNAVAILABLE'), {
         code: 'PLUGIN_BROWSER_OPEN_CAPABILITY_UNAVAILABLE'
@@ -2121,7 +2099,7 @@ export class TouchPlugin implements ITouchPlugin {
     activation: PluginActivationIdentity
   ): PluginBrowserDataCapabilities | null {
     if (this.name !== 'touch-browser-data') return null
-    const factory = TouchPlugin._browserDataCapabilityFactory
+    const factory = TouchPlugin.capability('browserData')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_BROWSER_DATA_CAPABILITY_UNAVAILABLE'), {
         code: 'PLUGIN_BROWSER_DATA_CAPABILITY_UNAVAILABLE'
@@ -2134,7 +2112,7 @@ export class TouchPlugin implements ITouchPlugin {
     activation: PluginActivationIdentity
   ): PluginIntelligenceCapabilities | null {
     if (this.name !== 'touch-translation') return null
-    const factory = TouchPlugin._translationCapabilityFactory
+    const factory = TouchPlugin.capability('translation')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_TRANSLATION_CAPABILITY_UNAVAILABLE'), {
         code: 'PLUGIN_TRANSLATION_CAPABILITY_UNAVAILABLE'
@@ -2147,7 +2125,7 @@ export class TouchPlugin implements ITouchPlugin {
     activation: PluginActivationIdentity
   ): PluginIntelligenceContextCapabilities | null {
     if (this.name !== 'touch-intelligence') return null
-    const factory = TouchPlugin._intelligenceContextCapabilityFactory
+    const factory = TouchPlugin.capability('intelligenceContext')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_INTELLIGENCE_CONTEXT_CAPABILITY_UNAVAILABLE'), {
         code: 'PLUGIN_INTELLIGENCE_CONTEXT_CAPABILITY_UNAVAILABLE'
@@ -2160,7 +2138,7 @@ export class TouchPlugin implements ITouchPlugin {
     activation: PluginActivationIdentity
   ): PluginWindowManagerCapabilities | null {
     if (this.name !== 'touch-window-manager') return null
-    const factory = TouchPlugin._windowManagerCapabilityFactory
+    const factory = TouchPlugin.capability('windowManager')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_WINDOW_MANAGER_CAPABILITY_UNAVAILABLE'), {
         code: 'PLUGIN_WINDOW_MANAGER_CAPABILITY_UNAVAILABLE'
@@ -2173,7 +2151,7 @@ export class TouchPlugin implements ITouchPlugin {
     activation: PluginActivationIdentity
   ): PluginWindowPresetCapabilities | null {
     if (this.name !== 'touch-window-presets') return null
-    const factory = TouchPlugin._windowPresetCapabilityFactory
+    const factory = TouchPlugin.capability('windowPreset')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_WINDOW_PRESET_CAPABILITY_UNAVAILABLE'), {
         code: 'PLUGIN_WINDOW_PRESET_CAPABILITY_UNAVAILABLE'
@@ -2186,7 +2164,7 @@ export class TouchPlugin implements ITouchPlugin {
     activation: PluginActivationIdentity
   ): PluginWorkspaceScriptCapabilities | null {
     if (this.name !== 'touch-workspace-scripts') return null
-    const factory = TouchPlugin._workspaceScriptCapabilityFactory
+    const factory = TouchPlugin.capability('workspaceScript')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_WORKSPACE_SCRIPT_CAPABILITY_UNAVAILABLE'), {
         code: 'PLUGIN_WORKSPACE_SCRIPT_CAPABILITY_UNAVAILABLE'
@@ -2483,7 +2461,9 @@ export class TouchPlugin implements ITouchPlugin {
     if (activation.key) {
       this.revokeActivationAuthority(activation)
       try {
-        await TouchPlugin._runtimeService?.stopActivation(activation, { runDestroy: true })
+        await TouchPlugin.capability('runtimeService')?.stopActivation(activation, {
+          runDestroy: true
+        })
       } catch {
         teardownFailed = true
         teardownIssueRecorded = true


### PR DESCRIPTION
Closes #530. Net −88 lines.

## The guarantee, demonstrated rather than asserted

The point of the refactor is that adding a capability *cannot* desynchronize init and destroy. I checked that by adding an eleventh field to `TouchPluginRuntimeCapabilities` and compiling:

```
plugin-module.ts(2495,33): Property 'elevenththing' is missing ... but required in type 'TouchPluginRuntimeCapabilities'
plugin.ts(509,3):          Property 'elevenththing' is missing ... but required in type 'TouchPluginRuntimeCapabilities'
```

Exactly the two sites that must change — the install block and the empty-capabilities helper — and **teardown needs no edit at all**, because it is `setCapabilities(null)` however many capabilities exist. That is the failure mode in the issue, made impossible rather than merely unlikely.

## There were five hand-synced lists, not three

The issue names three in `plugin-module.ts`. The other two are in tests, and would have desynchronized the same way:

- `plugin.test.ts` had a teardown block clearing all ten by name
- `plugin-module.test.ts` carried the surface three more times — the hoisted mocks, the mock class, a `mockReset` block — plus nine-way assertions on both install and teardown

All are now one line each. The install assertion compares the whole object, so a capability the install block forgets fails the test as well as the compile.

## Transport deliberately keeps its own slot

Folding it in looked tidier but is worse. It is installed earlier in the lifecycle than the capability set (`plugin-module.ts:1877` vs `:2495`), and `plugin.test.ts` sets it alone in **43** places — each would have had to build a full capability object to change one field.

For the same reason the production API stays strict: only `plugin.test.ts` installs capabilities one at a time, so the accumulating helper lives there rather than widening `setCapabilities` to accept partials. A partial-accepting setter would have re-admitted exactly the desync this issue is about.

## One thing the mechanical transform got wrong, and how it surfaced

`resolveRuntimeService` was `if (TouchPlugin._runtimeService) return TouchPlugin._runtimeService`. Turning a field read into a method call broke the narrowing, and `pnpm typecheck:all` caught it as a real new error — 43 against a baseline of 42. Fixed by narrowing through a local. Worth noting because vitest was green either way; the tests do not typecheck.

## Verification

- eleventh-capability compile check above
- 88 test files / 1194 tests pass across `modules/plugin`
- `pnpm typecheck:all` at 42, and diffing the error set against the baseline shows only line-number shifts from the deleted lines
- ESLint clean under the core-app config