### PR TITLE
fix(core-app): release the Sentry window performance listeners on stop (#534)

### DIFF
--- a/apps/core-app/src/main/modules/sentry/sentry-service.test.ts
+++ b/apps/core-app/src/main/modules/sentry/sentry-service.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { app, BrowserWindow } from 'electron'
 import type { TelemetryUploadStatsRecord } from './telemetry-upload-stats-store'
 import { sanitizeNexusTelemetryEvent, sanitizeSentryEvent } from './telemetry-sanitizer'
 
@@ -6,10 +7,11 @@ vi.mock('electron', () => ({
   app: {
     isPackaged: false,
     on: vi.fn(),
+    off: vi.fn(),
     commandLine: { appendSwitch: vi.fn() }
   },
   BrowserWindow: {
-    getAllWindows: vi.fn(() => [])
+    getAllWindows: vi.fn(() => [] as unknown[])
   },
   ipcMain: {
     handle: vi.fn(),
@@ -68,6 +70,11 @@ vi.mock('../network', () => ({
 }))
 
 import { SentryServiceModule } from './sentry-service'
+
+type TestableWindowPerf = {
+  ensureWindowPerformanceListeners: () => void
+  stopPerformanceMonitors: () => void
+}
 
 type TestableSentryService = {
   getTelemetryStatsStore: () => {
@@ -294,5 +301,97 @@ describe('SentryServiceModule telemetry stats hydration', () => {
         lastFailureMessage: 'runtime failure'
       })
     )
+  })
+})
+
+describe('SentryServiceModule window performance listeners', () => {
+  function fakeWindow(id: number) {
+    return {
+      webContents: { id },
+      on: vi.fn(),
+      off: vi.fn(),
+      isDestroyed: vi.fn(() => false)
+    }
+  }
+
+  beforeEach(() => {
+    vi.mocked(app.on).mockClear()
+    vi.mocked(app.off).mockClear()
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([])
+  })
+
+  it('re-attaches to windows that already existed after a stop/start cycle', () => {
+    // The defect in #534: teardown left `windowPerfListenersReady` set, so a later start
+    // early-returned and never re-ran the getAllWindows loop. Windows open at that moment stopped
+    // being watched for 'unresponsive', and nothing logged the gap.
+    const existing = fakeWindow(1)
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([existing] as never)
+
+    const service = new SentryServiceModule() as unknown as TestableWindowPerf
+
+    service.ensureWindowPerformanceListeners()
+    // Positive control: without this the assertions below would hold over a window that was
+    // never attached in the first place.
+    expect(existing.on).toHaveBeenCalledTimes(3)
+
+    service.stopPerformanceMonitors()
+    existing.on.mockClear()
+
+    service.ensureWindowPerformanceListeners()
+    expect(existing.on).toHaveBeenCalledTimes(3)
+  })
+
+  it('removes what it attached', () => {
+    const existing = fakeWindow(2)
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([existing] as never)
+
+    const service = new SentryServiceModule() as unknown as TestableWindowPerf
+    service.ensureWindowPerformanceListeners()
+
+    // Widened before comparing: app.on is overloaded, so TS narrows the tuple to the first
+    // signature's event name and calls the comparison unreachable.
+    const calls = vi.mocked(app.on).mock.calls as unknown as Array<
+      [string, (...args: unknown[]) => void]
+    >
+    const registered = calls.find(([event]) => event === 'browser-window-created')
+    expect(registered).toBeDefined()
+
+    service.stopPerformanceMonitors()
+
+    // The app-level listener is the one that leaked for the lifetime of the process, attaching
+    // three more handlers to every window created afterwards.
+    expect(vi.mocked(app.off)).toHaveBeenCalledWith('browser-window-created', registered![1])
+    expect(existing.off).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not stack handlers when start is called twice without a stop', () => {
+    const existing = fakeWindow(3)
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([existing] as never)
+
+    const service = new SentryServiceModule() as unknown as TestableWindowPerf
+    service.ensureWindowPerformanceListeners()
+    service.ensureWindowPerformanceListeners()
+
+    // The latch still does its original job — this is what would break if the fix simply
+    // cleared it everywhere.
+    expect(existing.on).toHaveBeenCalledTimes(3)
+  })
+
+  it('skips a window that has already been destroyed', () => {
+    // win.off on a destroyed BrowserWindow throws; teardown has to survive the common case of a
+    // window closing before the module stops.
+    const closed = fakeWindow(4)
+    closed.isDestroyed.mockReturnValue(true)
+    const live = fakeWindow(5)
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([closed, live] as never)
+
+    const service = new SentryServiceModule() as unknown as TestableWindowPerf
+    service.ensureWindowPerformanceListeners()
+
+    expect(() => service.stopPerformanceMonitors()).not.toThrow()
+    expect(closed.off).not.toHaveBeenCalled()
+    // The live window in the same batch proves the skip is selective. Without it, teardown that
+    // bailed out entirely on the first destroyed window would pass this test.
+    expect(live.off).toHaveBeenCalledTimes(3)
   })
 })

--- a/apps/core-app/src/main/modules/sentry/sentry-service.ts
+++ b/apps/core-app/src/main/modules/sentry/sentry-service.ts
@@ -194,6 +194,8 @@ export class SentryServiceModule extends BaseModule {
   private unresponsiveAt = new Map<number, number>()
   private unresponsiveStats = { count: 0, totalMs: 0, maxMs: 0 }
   private windowPerfListenersReady = false
+  /** Undo for everything ensureWindowPerformanceListeners attaches; drained with the latch. */
+  private windowPerfDisposers: Array<() => void> = []
   private readonly pollingService = PollingService.getInstance()
 
   private preInitAttempted = false
@@ -619,8 +621,34 @@ export class SentryServiceModule extends BaseModule {
       }
       this.eventLoopDelay = undefined
     }
+    this.detachWindowPerformanceListeners()
     this.unresponsiveAt.clear()
     this.unresponsiveStats = { count: 0, totalMs: 0, maxMs: 0 }
+  }
+
+  /**
+   * Remove the window listeners and clear the latch together.
+   *
+   * The two used to drift: teardown left both in place, so a re-init early-returned out of
+   * ensureWindowPerformanceListeners and never re-ran its `getAllWindows()` loop. Windows that
+   * already existed stopped being watched while the leaked app-level listener kept attaching
+   * three more handlers to every new one (#534).
+   *
+   * Lives here rather than in onDestroy because startPerformanceMonitors is what attaches, and
+   * this is its partner — which also covers disabling telemetry through config, where the
+   * listeners previously stayed attached for the rest of the process.
+   */
+  private detachWindowPerformanceListeners(): void {
+    for (const dispose of this.windowPerfDisposers.splice(0)) {
+      try {
+        dispose()
+      } catch {
+        sentryLog.debug('Failed to detach a window performance listener', {
+          meta: { code: 'SENTRY_PERF_LISTENER_DETACH_FAILED' }
+        })
+      }
+    }
+    this.windowPerfListenersReady = false
   }
 
   private ensureWindowPerformanceListeners(): void {
@@ -630,11 +658,11 @@ export class SentryServiceModule extends BaseModule {
     const attach = (win: BrowserWindow) => {
       const wcId = win.webContents.id
 
-      win.on('unresponsive', () => {
+      const onUnresponsive = (): void => {
         this.unresponsiveAt.set(wcId, Date.now())
-      })
+      }
 
-      win.on('responsive', () => {
+      const onResponsive = (): void => {
         const startedAt = this.unresponsiveAt.get(wcId)
         if (!startedAt) return
         this.unresponsiveAt.delete(wcId)
@@ -642,16 +670,31 @@ export class SentryServiceModule extends BaseModule {
         this.unresponsiveStats.count += 1
         this.unresponsiveStats.totalMs += durationMs
         this.unresponsiveStats.maxMs = Math.max(this.unresponsiveStats.maxMs, durationMs)
-      })
+      }
 
-      win.on('closed', () => {
+      const onClosed = (): void => {
         this.unresponsiveAt.delete(wcId)
+      }
+
+      win.on('unresponsive', onUnresponsive)
+      win.on('responsive', onResponsive)
+      win.on('closed', onClosed)
+
+      this.windowPerfDisposers.push(() => {
+        // A window that has already closed is destroyed, and removing listeners from it throws.
+        if (win.isDestroyed?.()) return
+        win.off('unresponsive', onUnresponsive)
+        win.off('responsive', onResponsive)
+        win.off('closed', onClosed)
       })
     }
 
-    app.on('browser-window-created', (_event, win) => {
+    const onWindowCreated = (_event: unknown, win: BrowserWindow): void => {
       attach(win)
-    })
+    }
+
+    app.on('browser-window-created', onWindowCreated)
+    this.windowPerfDisposers.push(() => app.off('browser-window-created', onWindowCreated))
 
     for (const win of BrowserWindow.getAllWindows()) {
       attach(win)


### PR DESCRIPTION
Closes #534.

## The fix, and where it goes

Every listener `ensureWindowPerformanceListeners` attaches now pushes its undo onto a disposer list, drained together with the latch so the two cannot drift.

The issue suggests draining in `onDestroy`. I put it in `stopPerformanceMonitors` instead, because `startPerformanceMonitors` is what attaches and stop is its partner — `onDestroy` calls it anyway.

That placement also fixes a path the issue does not mention. `syncPerformanceMonitors` calls `stopPerformanceMonitors` when telemetry is **disabled through config**, so until now:

- disabling telemetry left the window listeners attached for the rest of the process
- re-enabling hit the same stuck latch, so windows open at that moment were never re-attached

Same defect, reachable without any destroy/re-init.

Destroyed windows are skipped on the way out: `removeListener` on a closed `BrowserWindow` throws, and a window closing before the module stops is the ordinary case rather than an edge one.

## Tests

There were none for this code — the electron mock returns no windows, so the attach loop had never executed in a test. Four now:

| test | fails on pre-fix source |
| --- | --- |
| re-attaches to windows that already existed after stop/start | ✅ |
| removes what it attached (app listener + 3 per window) | ✅ |
| does not stack handlers when start is called twice | ❌ by design |
| skips a destroyed window | ❌ by design |

The last two guard the fix rather than the bug, and I want to be explicit about that: they check that the latch still suppresses double-attach, and that one destroyed window does not abort teardown for the rest. The destroyed-window test carries a **live** window in the same batch specifically so it cannot pass over a teardown that bailed out on the first destroyed one — without that it would have been an assertion nothing could fail.

The first test has a positive control: it asserts the window was attached at all before asserting it is re-attached, so it cannot pass over a window that was never watched.

## Checks

- 3 test files / 15 tests pass in `modules/sentry`
- `pnpm typecheck:all` back to the pre-existing 42. It briefly read 43: `app.on` is overloaded, so TS narrowed my `.mock.calls` tuple to the first signature and called the `'browser-window-created'` comparison unreachable. vitest was green either way — worth noting, since the tests do not typecheck.
- ESLint clean under the core-app config