### PR TITLE
build(core-app): declare the drizzle-kit the db scripts already call (#592)

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -170,6 +170,7 @@
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitejs/plugin-vue-jsx": "^5.1.5",
     "@vue/test-utils": "^2.4.11",
+    "drizzle-kit": "^0.31.10",
     "electron": "^41.10.4",
     "electron-builder": "^26.15.3",
     "electron-builder-squirrel-windows": "^26.15.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -507,6 +507,9 @@ importers:
       '@vue/test-utils':
         specifier: ^2.4.11
         version: 2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
       electron:
         specifier: ^41.10.4
         version: 41.10.4
@@ -2650,6 +2653,9 @@ packages:
   '@dprint/toml@0.7.0':
     resolution: {integrity: sha512-eFaQTcfxKHB+YyTh83x7GEv+gDPuj9q5NFOTaoj5rZmQTbj6OgjjMxUicmS1R8zYcx8YAq5oA9J3YFa5U6x2gA==}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
   '@dxup/nuxt@0.4.1':
     resolution: {integrity: sha512-gtYffW6OfWNvoLW+XD3Mx/K8uUq08PMGLYJoDxc92EzZAWqR0FhcR5iaLm5r/OxyGTKz+P5f5Y7Aoir9+SjYaw==}
     peerDependencies:
@@ -2795,6 +2801,14 @@ packages:
   '@es-joy/resolve.exports@1.2.0':
     resolution: {integrity: sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==}
     engines: {node: '>=10'}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -8140,6 +8154,10 @@ packages:
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
+
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
+    hasBin: true
 
   drizzle-orm@0.45.2:
     resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
@@ -15628,6 +15646,8 @@ snapshots:
 
   '@dprint/toml@0.7.0': {}
 
+  '@drizzle-team/brocli@0.10.2': {}
+
   '@dxup/nuxt@0.4.1(magicast@0.5.3)(typescript@5.9.3)':
     dependencies:
       '@dxup/unimport': 0.1.2
@@ -15877,6 +15897,16 @@ snapshots:
       jsdoc-type-pratt-parser: 7.2.0
 
   '@es-joy/resolve.exports@1.2.0': {}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.28.1
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.14.0
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -21858,6 +21888,13 @@ snapshots:
   dotenv@16.6.1: {}
 
   dotenv@17.4.2: {}
+
+  drizzle-kit@0.31.10:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.28.1
+      tsx: 4.21.0
 
   drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@libsql/client@0.17.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1):
     optionalDependencies:


### PR DESCRIPTION
Closes #592.

Confirmed empirically, not just by grep:

```
$ pnpm exec drizzle-kit --version
ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "drizzle-kit" not found
```

`grep -c drizzle-kit pnpm-lock.yaml` → 0, with `drizzle-orm` at 34 in the same file as the control that the search works.

## Version chosen by testing, not by guessing

The issue says "matching the drizzle-orm 0.45.x line". Rather than assume, I ran the pair in a sandbox with both packages present:

```
$ pnpm dlx --package drizzle-kit@0.31.10 --package drizzle-orm@0.45.2 -- drizzle-kit check
Reading config file '.../apps/core-app/drizzle.config.ts'
Everything's fine 🐶🔥
```

It reads this project's config and validates the existing migrations. (A first attempt with plain `pnpm dlx drizzle-kit@0.31.10` printed "Please install latest version of drizzle-orm" — that is dlx isolation hiding the project's drizzle-orm, not a version mismatch. Worth noting so nobody re-runs it and draws the wrong conclusion.)

Lockfile delta judged by package set rather than line count: `drizzle-kit@0.31.10` plus `esbuild`, `tsx`, `source-map-support`, `get-tsconfig`. Nothing removed.

## What running the command actually revealed — reported, not fixed here

Checking that `db:generate` works produced a **669-line migration**: 45 `CREATE TABLE`, 81 `CREATE INDEX`, 3 `ALTER TABLE`, 1 `DROP TABLE`.

That is not 45 new tables. The drizzle snapshots stop at `0014_snapshot.json`, last written **2025-12-10**, while migrations run to `0036`, dated **2026-08-05**. The intervening 22 were written by hand — exactly what happens when the generator cannot run. So the generated file is the delta against an eight-month-stale baseline, and its `CREATE TABLE`s are **unguarded** (zero `IF NOT EXISTS`), so applying it to any existing install would fail outright.

I reverted it. This PR is dependency-only. Rebuilding the snapshot baseline so `db:generate` produces a correct delta is a separate piece of work that needs a deliberate decision — details in the issue comment.

## Note

Adding the dependency touches the root lockfile, so this needs `pnpm install` on other machines. `--lockfile-only` was used because this worktree symlinks `node_modules` from the main checkout and a normal `pnpm add` refuses with `ERR_PNPM_UNEXPECTED_VIRTUAL_STORE`.