### PR TITLE
fix(core-app): remove the powerMonitor handlers when CommonChannelModule is destroyed

### DIFF
--- a/apps/core-app/src/main/channel/common.test.ts
+++ b/apps/core-app/src/main/channel/common.test.ts
@@ -160,7 +160,8 @@ vi.mock('electron', () => ({
     }))
   },
   powerMonitor: {
-    on: vi.fn()
+    on: vi.fn(),
+    off: vi.fn()
   },
   shell: {
     openExternal: vi.fn(),
@@ -497,6 +498,8 @@ import { APP_SCHEMA, FILE_SCHEMA } from '../config/default'
 import { CommonChannelModule } from './common'
 
 type CommonChannelModuleTestInstance = {
+  setupBatteryStatusBroadcast: () => void
+  onDestroy: () => unknown
   createSafeOperationHandler: (transport: {
     on: (
       event: unknown,
@@ -2172,5 +2175,50 @@ describe('createOpenUrlHandler', () => {
     await handler()('#/settings')
     expect(showMessageBox).not.toHaveBeenCalled()
     expect(openExternal).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * powerMonitor is an app-lifetime singleton, so handlers registered on it outlive the module
+ * unless explicitly removed. onDestroy cleared the poll interval and the transport disposers but
+ * left these attached, so an 'on-battery' event after teardown called startPolling() again and
+ * re-armed a task on the global PollingService (#532).
+ */
+describe('CommonChannelModule powerMonitor lifecycle', () => {
+  it('removes both powerMonitor handlers on destroy', async () => {
+    const { powerMonitor } = (await import('electron')) as unknown as {
+      powerMonitor: { on: ReturnType<typeof vi.fn>; off: ReturnType<typeof vi.fn> }
+    }
+    powerMonitor.on.mockClear()
+    powerMonitor.off.mockClear()
+
+    const module = new CommonChannelModule() as unknown as CommonChannelModuleTestInstance
+    module.setupBatteryStatusBroadcast()
+
+    const registered = powerMonitor.on.mock.calls.map((call) => call[0])
+    expect(registered).toEqual(['on-ac', 'on-battery'])
+
+    await module.onDestroy()
+
+    const removed = powerMonitor.off.mock.calls.map((call) => call[0])
+    expect(removed).toEqual(['on-ac', 'on-battery'])
+  })
+
+  it('removes the same function references it registered', async () => {
+    // off() with a different closure is a silent no-op, so identity is the thing that matters.
+    const { powerMonitor } = (await import('electron')) as unknown as {
+      powerMonitor: { on: ReturnType<typeof vi.fn>; off: ReturnType<typeof vi.fn> }
+    }
+    powerMonitor.on.mockClear()
+    powerMonitor.off.mockClear()
+
+    const module = new CommonChannelModule() as unknown as CommonChannelModuleTestInstance
+    module.setupBatteryStatusBroadcast()
+    await module.onDestroy()
+
+    for (const [event, handler] of powerMonitor.on.mock.calls) {
+      const match = powerMonitor.off.mock.calls.find((call) => call[0] === event)
+      expect(match?.[1]).toBe(handler)
+    }
   })
 })

--- a/apps/core-app/src/main/channel/common.ts
+++ b/apps/core-app/src/main/channel/common.ts
@@ -841,6 +841,12 @@ export class CommonChannelModule extends BaseModule {
   private dbUtils: ReturnType<typeof createDbUtils> | null = null
   private transportDisposers: Array<() => void> = []
   private batteryPollTimer: NodeJS.Timeout | undefined
+  /**
+   * powerMonitor is an app-lifetime singleton, so handlers registered on it outlive this module
+   * unless removed. Without this the 'on-battery' handler kept calling startPolling() after
+   * destroy, re-arming a task on the global PollingService (#532).
+   */
+  private powerMonitorDisposers: Array<() => void> = []
   private touchApp: TalexTouch.TouchApp | null = null
 
   constructor() {
@@ -911,15 +917,21 @@ export class CommonChannelModule extends BaseModule {
         startPolling()
       }
 
-      powerMonitor.on('on-ac', () => {
+      const handleOnAc = (): void => {
         stopPolling()
         void broadcastBatteryStatus()
-      })
-
-      powerMonitor.on('on-battery', () => {
+      }
+      const handleOnBattery = (): void => {
         startPolling()
         void broadcastBatteryStatus()
-      })
+      }
+
+      powerMonitor.on('on-ac', handleOnAc)
+      powerMonitor.on('on-battery', handleOnBattery)
+      this.powerMonitorDisposers.push(
+        () => powerMonitor.off('on-ac', handleOnAc),
+        () => powerMonitor.off('on-battery', handleOnBattery)
+      )
     } catch (error) {
       log.warn('Failed to initialize battery status broadcaster:', { error })
     }
@@ -2058,6 +2070,17 @@ export class CommonChannelModule extends BaseModule {
 
   onDestroy(): MaybePromise<void> {
     log.info('CommonChannelModule destroyed')
+
+    // Before clearing the timer: an 'on-battery' event arriving between the two would otherwise
+    // call startPolling() and leave a fresh interval behind.
+    for (const dispose of this.powerMonitorDisposers) {
+      try {
+        dispose()
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+    this.powerMonitorDisposers = []
 
     if (this.batteryPollTimer) {
       clearInterval(this.batteryPollTimer)


### PR DESCRIPTION
Fixes #532.

## The defect

`setupBatteryStatusBroadcast` registered `'on-ac'` and `'on-battery'` on `powerMonitor` without keeping a way to remove them. `powerMonitor` is an **app-lifetime singleton**, so the handlers outlived the module: `onDestroy` cleared the poll interval and the transport disposers, then an `'on-battery'` event arriving afterwards called `startPolling()` again and re-armed a task on the global `PollingService`.

## Follows the shape already in the file

The handlers are captured and removed explicitly, mirroring how `batteryPollTimer` is already handled — a named field cleaned in `onDestroy`, rather than pushed into `transportDisposers`, which is specifically about transport subscriptions.

## Ordering matters, and it is deliberate

Removal runs **before** `clearInterval`. In the other order, an `'on-battery'` event arriving between the two would call `startPolling()` and leave a fresh interval behind — the same leak, just through a smaller window. That is recorded in a comment so the order is not "tidied" later.

## The mock had to be extended too

`vi.mock('electron')` stubbed only `powerMonitor.on`, so calling `off()` would have thrown at teardown. It now stubs both — worth noting because that omission is why nothing caught this.

## Verified by mutation

```
unfixed module -> 2 failed | 26 passed
this change    -> 28 passed
```

The second case is the one that matters:

```ts
for (const [event, handler] of powerMonitor.on.mock.calls) {
  const match = powerMonitor.off.mock.calls.find((call) => call[0] === event)
  expect(match?.[1]).toBe(handler)
}
```

`off()` with a *different* closure is a **silent no-op** — it removes nothing and reports nothing. A test that only checked "off was called twice" would pass against a broken fix, so identity is what gets asserted.

## Gates

- `npm run typecheck:node`: exit 0
- `common.test.ts`: **28 passing**
- `eslint --max-warnings=0`: exit 0