### PR TITLE
fix(core-app): release every PluginLogModule handler on destroy

### DIFF
--- a/apps/core-app/src/main/service/plugin-log.service.test.ts
+++ b/apps/core-app/src/main/service/plugin-log.service.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The service registered one touchEventBus listener and seven transport handlers and discarded
+ * every disposer. onDestroy released only the unrelated uninstall invalidator, so all eight
+ * survived module teardown (#533).
+ */
+
+const eventBusMock = vi.hoisted(() => ({
+  on: vi.fn(),
+  off: vi.fn()
+}))
+
+vi.mock('../core/eventbus/touch-event', () => ({
+  touchEventBus: eventBusMock,
+  TalexEvents: { PLUGIN_LOG_APPEND: 'plugin-log-append' }
+}))
+
+vi.mock('@talex-touch/utils/transport/main', () => ({
+  getTuffTransportMain: vi.fn()
+}))
+
+vi.mock('../modules/plugin/plugin-module', () => ({
+  pluginModule: { registerUninstallAuthorityInvalidator: vi.fn(() => vi.fn()) }
+}))
+
+const { PluginLogModule } = await import('./plugin-log.service')
+
+/** The slice of the module these cases drive; mirrors the pattern in common.test.ts. */
+type PluginLogModuleTestInstance = {
+  listenToLogEvents: () => void
+  setupIpcHandlers: (transport: { on: (...args: unknown[]) => unknown }) => void
+  onDestroy: () => Promise<void>
+}
+
+function createTransport() {
+  const disposers: Array<ReturnType<typeof vi.fn>> = []
+  const transport = {
+    on: vi.fn(() => {
+      const dispose = vi.fn()
+      disposers.push(dispose)
+      return dispose
+    })
+  }
+  return { transport, disposers }
+}
+
+describe('PluginLogModule handler lifecycle', () => {
+  beforeEach(() => {
+    eventBusMock.on.mockClear()
+    eventBusMock.off.mockClear()
+  })
+
+  it('releases every transport handler it registered', async () => {
+    const { transport, disposers } = createTransport()
+    const service = new PluginLogModule() as unknown as PluginLogModuleTestInstance
+
+    service.listenToLogEvents()
+    service.setupIpcHandlers(transport)
+
+    expect(disposers).toHaveLength(7)
+    expect(disposers.every((d) => d.mock.calls.length === 0)).toBe(true)
+
+    await service.onDestroy()
+
+    // The defect: all seven stayed attached.
+    expect(disposers.every((d) => d.mock.calls.length === 1)).toBe(true)
+  })
+
+  it('removes the event-bus listener with the same handler reference', async () => {
+    const { transport } = createTransport()
+    const service = new PluginLogModule() as unknown as PluginLogModuleTestInstance
+
+    service.listenToLogEvents()
+    service.setupIpcHandlers(transport)
+    await service.onDestroy()
+
+    // touchEventBus.on returns boolean|void rather than a disposer, so removal goes through
+    // off() -- and off() with a different closure is a silent no-op, so identity is the thing
+    // that decides whether this works.
+    expect(eventBusMock.off).toHaveBeenCalledTimes(1)
+    expect(eventBusMock.off.mock.calls[0]![1]).toBe(eventBusMock.on.mock.calls[0]![1])
+  })
+
+  it('does not release the same disposer twice on a repeated destroy', async () => {
+    const { transport, disposers } = createTransport()
+    const service = new PluginLogModule() as unknown as PluginLogModuleTestInstance
+
+    service.listenToLogEvents()
+    service.setupIpcHandlers(transport)
+    await service.onDestroy()
+    await service.onDestroy()
+
+    expect(disposers.every((d) => d.mock.calls.length === 1)).toBe(true)
+  })
+})

--- a/apps/core-app/src/main/service/plugin-log.service.ts
+++ b/apps/core-app/src/main/service/plugin-log.service.ts
@@ -74,6 +74,11 @@ export class PluginLogModule extends BaseModule {
   private subscriptions: Map<string, Set<WebContents>> = new Map()
   private transport: ReturnType<typeof getTuffTransportMain> | null = null
   private uninstallInvalidatorDisposer: (() => void) | null = null
+  /**
+   * Every registration made by listenToLogEvents and setupIpcHandlers. All eight were previously
+   * discarded, so they outlived module teardown (#533).
+   */
+  private handlerDisposers: Array<() => void> = []
 
   static key: symbol = Symbol.for('PluginLog')
   name: ModuleKey = PluginLogModule.key
@@ -174,7 +179,7 @@ export class PluginLogModule extends BaseModule {
   }
 
   public listenToLogEvents(): void {
-    touchEventBus.on(TalexEvents.PLUGIN_LOG_APPEND, (event) => {
+    const handleLogAppend = (event: unknown): void => {
       const logEvent = event as PluginLogAppendEvent
       const log = logEvent.log
       const pluginName = log.plugin
@@ -193,13 +198,26 @@ export class PluginLogModule extends BaseModule {
           }
         })
       }
-    })
+    }
+
+    touchEventBus.on(TalexEvents.PLUGIN_LOG_APPEND, handleLogAppend)
+    this.handlerDisposers.push(() =>
+      touchEventBus.off(TalexEvents.PLUGIN_LOG_APPEND, handleLogAppend)
+    )
   }
 
   public setupIpcHandlers(transport: ReturnType<typeof getTuffTransportMain>): void {
     this.transport = transport
 
-    transport.on(pluginLogSubscribeEvent, (payload, context) => {
+    // Records each disposer as it is created, so adding a handler below cannot forget to
+    // register its cleanup -- the previous code dropped all seven return values on the floor.
+    const on: typeof transport.on = (event, handler) => {
+      const dispose = transport.on(event, handler)
+      this.handlerDisposers.push(dispose)
+      return dispose
+    }
+
+    on(pluginLogSubscribeEvent, (payload, context) => {
       const pluginName = payload?.pluginName
       if (!pluginName || !context.sender) return
 
@@ -207,7 +225,7 @@ export class PluginLogModule extends BaseModule {
       this.subscribe(pluginName, sender)
     })
 
-    transport.on(pluginLogUnsubscribeEvent, (payload, context) => {
+    on(pluginLogUnsubscribeEvent, (payload, context) => {
       const pluginName = payload?.pluginName
       if (!pluginName || !context.sender) return
 
@@ -215,7 +233,7 @@ export class PluginLogModule extends BaseModule {
       this.unsubscribe(pluginName, sender)
     })
 
-    transport.on(pluginLogGetSessionsEvent, (payload) => {
+    on(pluginLogGetSessionsEvent, (payload) => {
       const pluginName = payload?.pluginName
       if (!pluginName) return { error: 'pluginName is required' }
 
@@ -270,7 +288,7 @@ export class PluginLogModule extends BaseModule {
       }
     })
 
-    transport.on(pluginLogOpenSessionFileEvent, async (payload) => {
+    on(pluginLogOpenSessionFileEvent, async (payload) => {
       const { pluginName, sessionFolder, session } = payload || {}
       const targetSession = sessionFolder || session
       if (!pluginName || !targetSession)
@@ -304,7 +322,7 @@ export class PluginLogModule extends BaseModule {
       return { success: true } as const
     })
 
-    transport.on(pluginLogOpenDirectoryEvent, async (payload) => {
+    on(pluginLogOpenDirectoryEvent, async (payload) => {
       const pluginName = payload?.pluginName
       if (!pluginName) return { error: 'pluginName is required' }
 
@@ -334,7 +352,7 @@ export class PluginLogModule extends BaseModule {
       return { success: true } as const
     })
 
-    transport.on(pluginLogGetBufferEvent, (payload) => {
+    on(pluginLogGetBufferEvent, (payload) => {
       const pluginName = payload?.pluginName
       if (!pluginName) return { error: 'pluginName is required' }
 
@@ -352,7 +370,7 @@ export class PluginLogModule extends BaseModule {
       return buffer
     })
 
-    transport.on(pluginLogGetSessionLogEvent, async (payload) => {
+    on(pluginLogGetSessionLogEvent, async (payload) => {
       const { pluginName, session } = payload || {}
       if (!pluginName || !session) return { error: 'pluginName and session are required' }
 
@@ -430,6 +448,17 @@ export class PluginLogModule extends BaseModule {
   }
 
   async onDestroy(): Promise<void> {
+    // Released before the subscription map is cleared: a log event arriving in between would
+    // otherwise repopulate it through a handler that is still attached.
+    for (const dispose of this.handlerDisposers) {
+      try {
+        dispose()
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+    this.handlerDisposers = []
+
     this.uninstallInvalidatorDisposer?.()
     this.uninstallInvalidatorDisposer = null
     this.subscriptions.clear()


### PR DESCRIPTION
Fixes #533.

## The defect

One `touchEventBus` listener and seven `transport.on` handlers registered, every disposer discarded. `onDestroy` released only the unrelated uninstall invalidator, so all eight survived teardown.

## The two kinds needed different handling

The issue frames this as *"throwing away every disposer that `transport.on` returns"*. That is true for seven of the eight — but `touchEventBus.on` returns `boolean | void` and **never returned a disposer to throw away**:

```ts
// core/eventbus/touch-event.ts:137
on(event: TalexEvents, handler: EventHandler): boolean | void
```

So that one is now a named handler removed via `touchEventBus.off(...)` with the same reference. Capturing a return value there would have captured `undefined` and silently fixed nothing.

## Why a recording wrapper instead of wrapping each call

Wrapping each site in `this.handlerDisposers.push(transport.on(...))` re-indents the entire handler body. I did it that way first: **178 insertions / 142 deletions** for a lifecycle fix, with the real change buried in re-indentation.

Routing the seven through a local recorder changes one token per site and leaves the bodies untouched — **38 / 9**:

```ts
const on: typeof transport.on = (event, handler) => {
  const dispose = transport.on(event, handler)
  this.handlerDisposers.push(dispose)
  return dispose
}
```

It also means a handler added later cannot forget to register its cleanup, which is the failure that produced this issue.

## Ordering

Disposal runs **before** `subscriptions.clear()`. In the other order a log event arriving between the two would repopulate the map through a handler still attached.

## Verified by mutation

```
unfixed service -> 3 failed
this change     -> 3 passed
```

The case that matters most asserts `off()` receives **the same function reference** `on()` was given. `off()` with a different closure removes nothing and reports nothing, so a test counting calls would pass against a broken fix. A third case checks a repeated `onDestroy` does not double-release.

## Gates

- `npm run typecheck:node`: exit 0
- **3 tests passing** — the service had no test file before this
- `eslint --max-warnings=0`: exit 0