### PR TITLE
build: fail publish validation when a runtime entry is a raw TypeScript file

### DIFF
--- a/scripts/validate-publish-manifests.mjs
+++ b/scripts/validate-publish-manifests.mjs
@@ -161,17 +161,49 @@ function assertPublishConfig(packages) {
   return issues
 }
 
+/**
+ * A published package whose runtime entry is a raw .ts file cannot be loaded by Node: it strips
+ * the types, treats the file as ESM, then fails on the extensionless directory specifiers these
+ * entries use -- ERR_UNSUPPORTED_DIR_IMPORT (#566).
+ *
+ * `types` pointing at a .d.ts is correct and deliberately not flagged; this is only about
+ * main/module, which are runtime entries.
+ */
+function findRawTypeScriptEntryIssues({ manifest, manifestPath, packageInfo }) {
+  const offending = ['main', 'module'].filter((field) => {
+    const value = manifest[field]
+    return typeof value === 'string' && value.endsWith('.ts') && !value.endsWith('.d.ts')
+  })
+
+  if (offending.length === 0)
+    return []
+
+  return [{
+    package: packageInfo.name,
+    manifestPath: toPosixPath(path.relative(repoRoot, manifestPath)),
+    phase: 'source',
+    field: offending.join(', '),
+    spec: offending.map(field => manifest[field]).join(', '),
+    reason:
+      'published runtime entry points at a raw TypeScript file, which Node cannot load; build '
+      + 'the package and point main/module at the build output',
+  }]
+}
+
 function getSourceIssues(packages) {
   return packages.flatMap((packageInfo) => {
     const manifestPath = path.join(repoRoot, packageInfo.path, 'package.json')
     const manifest = readJson(manifestPath)
-    return findForbiddenSpecIssues({
-      manifest,
-      manifestPath,
-      packageInfo,
-      forbiddenProtocols: sourceForbiddenProtocols,
-      phase: 'source',
-    })
+    return [
+      ...findForbiddenSpecIssues({
+        manifest,
+        manifestPath,
+        packageInfo,
+        forbiddenProtocols: sourceForbiddenProtocols,
+        phase: 'source',
+      }),
+      ...findRawTypeScriptEntryIssues({ manifest, manifestPath, packageInfo }),
+    ]
   })
 }
 


### PR DESCRIPTION
Detects the defect in #566. **Does not fix the packaging** — see the last section.

## The defect

`@talex-touch/utils` is published (`private: false`, v1.0.50) with `main: "index.ts"`, and that file uses extensionless directory specifiers:

```ts
export * from './account'
export * from './analytics'
```

Node strips the types, treats the file as ESM, and cannot resolve the directory re-exports. An external consumer installing from npm gets a package that will not load.

There is also **no build script** in `packages/utils` at all — so this is not a stale `main`, it is the intended shape.

## Nothing detected it

The publish validator checked dependency protocols only. A package could declare a raw `.ts` runtime entry and pass clean.

## Adding the check found a second package #566 does not mention

```
- @talex-touch/utils            main, module -> index.ts
- @talex-touch/tuff-intelligence main, module -> src/index.ts
```

Same problem, same consequence.

## `types` pointing at a .d.ts is not flagged

Deliberate. `types: "dist/index.d.ts"` is correct, and four published packages use it. Without that distinction the check would fire on packages that are fine — which would be worse than no check, since the noise trains people to ignore it.

## This makes `publish:check` red, on purpose

Publishing either package today produces something Node cannot load, so the gate failing *is* the gate working.

Scope of that: `publish:check` is **not wired into CI** (checked), so this does not redden the build. It fails the manual pre-publish gate — which is exactly the moment the failure is worth knowing about, rather than after a broken version is on npm.

## Not fixed here

The packaging itself. Giving `@talex-touch/utils` a build and an `exports` map affects **26 shipped subdirectories** and every subpath consumer (`/env`, `/transport`, `/plugin`, …). That is its own task and #566 stays open for it.

In-repo consumers are unaffected either way: plugins depend via `workspace:^` and bundle through vite, which resolves TypeScript directly. The breakage is specific to external npm consumers using Node.

## Gates

`eslint --max-warnings=0`: exit 0