### PR TITLE
refactor: one source for the Nexus-managed provider rule (#537)

### DIFF
--- a/apps/core-app/src/main/modules/ai/provider-models.ts
+++ b/apps/core-app/src/main/modules/ai/provider-models.ts
@@ -1,7 +1,7 @@
 import type { IntelligenceProviderConfig } from '@talex-touch/tuff-intelligence'
 import { IntelligenceProviderType } from '@talex-touch/tuff-intelligence'
 import { getNetworkService } from '../network'
-import { isNexusManagedProvider } from './provider-runtime-shared'
+import { isNexusManagedProvider } from '@talex-touch/utils/intelligence/nexus-provider'
 
 const DEFAULT_BASE_URLS: Partial<Record<IntelligenceProviderType, string>> = {
   [IntelligenceProviderType.OPENAI]: 'https://api.openai.com/v1',

--- a/apps/core-app/src/main/modules/ai/provider-runtime-shared.ts
+++ b/apps/core-app/src/main/modules/ai/provider-runtime-shared.ts
@@ -1,8 +1,0 @@
-export const TUFF_NEXUS_PROVIDER_ID = 'tuff-nexus-default'
-
-export function isNexusManagedProvider(provider: {
-  id?: string
-  metadata?: Record<string, unknown> | null
-}): boolean {
-  return provider.id === TUFF_NEXUS_PROVIDER_ID || provider.metadata?.origin === 'tuff-nexus'
-}

--- a/apps/core-app/src/main/modules/ai/provider-runtime.ts
+++ b/apps/core-app/src/main/modules/ai/provider-runtime.ts
@@ -1,7 +1,10 @@
 import type { IntelligenceProviderConfig } from '@talex-touch/tuff-intelligence'
 import { getAuthToken } from '../auth'
 import { resolveProviderCredential } from './provider-credential-runtime'
-import { isNexusManagedProvider, TUFF_NEXUS_PROVIDER_ID } from './provider-runtime-shared'
+import {
+  isNexusManagedProvider,
+  TUFF_NEXUS_PROVIDER_ID
+} from '@talex-touch/utils/intelligence/nexus-provider'
 
 export { isNexusManagedProvider, TUFF_NEXUS_PROVIDER_ID }
 

--- a/apps/core-app/src/renderer/src/modules/intelligence/nexus-provider.ts
+++ b/apps/core-app/src/renderer/src/modules/intelligence/nexus-provider.ts
@@ -1,17 +1,22 @@
 import type { ITuffIcon } from '@talex-touch/utils'
 import TuffLogo from '~/assets/logo.svg'
 
-export const TUFF_NEXUS_PROVIDER_ID = 'tuff-nexus-default'
+/**
+ * Renderer-side Nexus provider module.
+ *
+ * The identity constant and predicate live in @talex-touch/utils so main and renderer cannot
+ * classify a provider differently (#537) — this file re-exports them so the five components that
+ * already import from here keep working, and owns the one piece that is genuinely renderer-only:
+ * the logo, which is a bundled asset.
+ */
+export {
+  isNexusManagedProvider,
+  TUFF_NEXUS_PROVIDER_ID,
+  TUFF_NEXUS_PROVIDER_ORIGIN
+} from '@talex-touch/utils/intelligence/nexus-provider'
 
 export const TUFF_NEXUS_PROVIDER_ICON: ITuffIcon = {
   type: 'url',
   value: TuffLogo,
   colorful: true
-}
-
-export function isNexusManagedProvider(provider: {
-  id?: string
-  metadata?: Record<string, unknown> | null
-}): boolean {
-  return provider.id === TUFF_NEXUS_PROVIDER_ID || provider.metadata?.origin === 'tuff-nexus'
 }

--- a/packages/utils/__tests__/nexus-provider.test.ts
+++ b/packages/utils/__tests__/nexus-provider.test.ts
@@ -1,5 +1,4 @@
-import { execFileSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
@@ -23,24 +22,39 @@ const REPO_ROOT = path.resolve(__dirname, '../../..')
 /** Where the names may be declared. Everywhere else must import them. */
 const DECLARING_FILE = 'packages/utils/intelligence/nexus-provider.ts'
 
+const SEARCH_ROOTS = ['apps', 'packages', 'plugins']
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.git', '.nuxt', '.output', 'coverage'])
+
+function* sourceFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue
+      yield* sourceFiles(path.join(dir, entry.name))
+      continue
+    }
+    if (/\.(ts|tsx|vue|js|mjs)$/.test(entry.name)) yield path.join(dir, entry.name)
+  }
+}
+
+/**
+ * Implemented with node:fs rather than by shelling out. A first version used ripgrep, which is
+ * not installed on the CI runner — the guard then failed as `spawnSync rg ENOENT`, which is the
+ * loud version of a check that cannot run, but a check that cannot run all the same.
+ */
 function declarationsOf(name: string): string[] {
-  const out = execFileSync(
-    'rg',
-    [
-      '--line-number',
-      '--no-heading',
-      '--glob',
-      '!**/node_modules/**',
-      '--glob',
-      '!**/dist/**',
-      `export (const|function) ${name}\\b`,
-      'apps',
-      'packages',
-      'plugins'
-    ],
-    { cwd: REPO_ROOT, encoding: 'utf8' }
-  )
-  return out.split('\n').filter(Boolean)
+  const pattern = new RegExp(`export\\s+(?:const|function)\\s+${name}\\b`)
+  const found: string[] = []
+
+  for (const root of SEARCH_ROOTS) {
+    const absolute = path.join(REPO_ROOT, root)
+    if (!existsSync(absolute)) continue
+    for (const file of sourceFiles(absolute)) {
+      if (pattern.test(readFileSync(file, 'utf8')))
+        found.push(path.relative(REPO_ROOT, file))
+    }
+  }
+
+  return found.sort()
 }
 
 describe('isNexusManagedProvider', () => {
@@ -88,7 +102,7 @@ describe('single declaration', () => {
 
       // Non-empty first: a broken pattern returning nothing would otherwise read as "one place".
       expect(declarations.length).toBeGreaterThan(0)
-      expect(declarations.map((line) => line.split(':')[0])).toEqual([DECLARING_FILE])
+      expect(declarations).toEqual([DECLARING_FILE])
     }
   )
 })

--- a/packages/utils/__tests__/nexus-provider.test.ts
+++ b/packages/utils/__tests__/nexus-provider.test.ts
@@ -1,0 +1,94 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  isNexusManagedProvider,
+  TUFF_NEXUS_PROVIDER_ID,
+  TUFF_NEXUS_PROVIDER_ORIGIN
+} from '../intelligence/nexus-provider'
+
+/**
+ * The Nexus-managed provider rule, and the guarantee that only one module states it (#537).
+ *
+ * Main and renderer both classify providers with this predicate for different reasons — the
+ * renderer decides whether to show the official badge and the edit/delete buttons, main decides
+ * runtime resolution and whether a delete is honoured. They used to hold byte-identical private
+ * copies, so widening the rule on one side would have left the UI offering Delete on a provider
+ * main refuses to delete, and the user would get a silent no-op.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+
+/** Where the names may be declared. Everywhere else must import them. */
+const DECLARING_FILE = 'packages/utils/intelligence/nexus-provider.ts'
+
+function declarationsOf(name: string): string[] {
+  const out = execFileSync(
+    'rg',
+    [
+      '--line-number',
+      '--no-heading',
+      '--glob',
+      '!**/node_modules/**',
+      '--glob',
+      '!**/dist/**',
+      `export (const|function) ${name}\\b`,
+      'apps',
+      'packages',
+      'plugins'
+    ],
+    { cwd: REPO_ROOT, encoding: 'utf8' }
+  )
+  return out.split('\n').filter(Boolean)
+}
+
+describe('isNexusManagedProvider', () => {
+  it('matches the managed provider by id', () => {
+    expect(isNexusManagedProvider({ id: TUFF_NEXUS_PROVIDER_ID })).toBe(true)
+  })
+
+  it('matches any provider carrying the managed origin', () => {
+    // The second arm exists so Nexus can hand out more than one provider; a rule that only
+    // checked the id would classify those as user-owned and offer Delete on them.
+    expect(
+      isNexusManagedProvider({ id: 'something-else', metadata: { origin: TUFF_NEXUS_PROVIDER_ORIGIN } })
+    ).toBe(true)
+  })
+
+  it('leaves user-configured providers alone', () => {
+    expect(isNexusManagedProvider({ id: 'openai' })).toBe(false)
+    expect(isNexusManagedProvider({ id: 'openai', metadata: {} })).toBe(false)
+    expect(isNexusManagedProvider({ id: 'openai', metadata: null })).toBe(false)
+    expect(isNexusManagedProvider({})).toBe(false)
+    expect(isNexusManagedProvider({ metadata: { origin: 'user' } })).toBe(false)
+  })
+
+  it('does not treat a near-miss origin as managed', () => {
+    // Substring or case-insensitive matching here would silently take ownership of a provider the
+    // user configured.
+    expect(isNexusManagedProvider({ metadata: { origin: 'tuff-nexus-mirror' } })).toBe(false)
+    expect(isNexusManagedProvider({ metadata: { origin: 'TUFF-NEXUS' } })).toBe(false)
+    expect(isNexusManagedProvider({ id: 'tuff-nexus-default-2' })).toBe(false)
+  })
+})
+
+describe('single declaration', () => {
+  it('runs against the monorepo', () => {
+    // Positive control: the scans below assert that nothing outside one file declares these
+    // names, which an unreadable tree would satisfy just as well.
+    expect(existsSync(path.join(REPO_ROOT, 'apps'))).toBe(true)
+    expect(existsSync(path.join(REPO_ROOT, DECLARING_FILE))).toBe(true)
+  })
+
+  it.each(['TUFF_NEXUS_PROVIDER_ID', 'isNexusManagedProvider'])(
+    'declares %s exactly once',
+    (name) => {
+      const declarations = declarationsOf(name)
+
+      // Non-empty first: a broken pattern returning nothing would otherwise read as "one place".
+      expect(declarations.length).toBeGreaterThan(0)
+      expect(declarations.map((line) => line.split(':')[0])).toEqual([DECLARING_FILE])
+    }
+  )
+})

--- a/packages/utils/intelligence/nexus-provider.ts
+++ b/packages/utils/intelligence/nexus-provider.ts
@@ -1,0 +1,35 @@
+/**
+ * Identity of the Nexus-managed AI provider.
+ *
+ * Shared because the two processes ask the same question for different reasons and must agree:
+ * the renderer gates the official badge and the edit/delete affordances on it, while the main
+ * process gates runtime provider resolution and deletion on it. They previously held
+ * byte-identical private copies, so widening the rule on one side — a second managed origin, say —
+ * would have left the UI offering Delete on a provider the main process refuses to delete, with
+ * the user getting a silent no-op (#537).
+ *
+ * Deliberately a standalone file rather than part of the intelligence barrel: both processes
+ * import it, and neither should have to pull in the client for a string comparison.
+ */
+
+/** The id assigned to the provider Nexus manages on the user's behalf. */
+export const TUFF_NEXUS_PROVIDER_ID = 'tuff-nexus-default'
+
+/** The `metadata.origin` marker carried by providers that Nexus owns. */
+export const TUFF_NEXUS_PROVIDER_ORIGIN = 'tuff-nexus'
+
+/**
+ * Whether the given provider is managed by Nexus rather than configured by the user.
+ *
+ * Structural parameter on purpose: main and renderer hold different provider shapes, and both
+ * only need these two fields.
+ */
+export function isNexusManagedProvider(provider: {
+  id?: string
+  metadata?: Record<string, unknown> | null
+}): boolean {
+  return (
+    provider.id === TUFF_NEXUS_PROVIDER_ID
+    || provider.metadata?.origin === TUFF_NEXUS_PROVIDER_ORIGIN
+  )
+}


### PR DESCRIPTION
Closes #537.

Both processes now import `packages/utils/intelligence/nexus-provider`. `provider-runtime-shared.ts` held nothing but these two symbols and is deleted; the renderer module stays because it owns the logo (a bundled asset) and re-exports the rest, so its five importers are untouched.

## Two departures from the suggested direction

**Placed in `intelligence/`, not `env/`.** The issue says "alongside the existing Nexus env helpers", but `env/` is about base URLs and runtime-server selection; this is provider identity. `packages/utils/intelligence/` already exists and is the honest home.

**Kept out of the intelligence barrel.** Both processes import the file directly, so neither pulls in `client.ts` for a string comparison.

I also promoted `'tuff-nexus'` to `TUFF_NEXUS_PROVIDER_ORIGIN`. It was a bare literal in both copies and is the half of the rule most likely to gain a second value — which is the exact scenario the issue describes going wrong.

## The guard is a declaration scan, not a literal scan

My first instinct was to assert `'tuff-nexus-default'` appears once. That would have been wrong: it appears in dozens of default-config entries across `packages/utils/types/intelligence.ts` and `packages/tuff-intelligence`. Those are data, not statements of the rule.

So the scan counts **declarations** of the two names across `apps/`, `packages/` and `plugins/`, and asserts the only one is the shared file. Restoring `provider-runtime-shared.ts` fails both scans; the positive control (the repo tree is readable, the declaring file exists) stays green.

The predicate also gets behavioural tests it never had — notably near-miss origins (`tuff-nexus-mirror`, `TUFF-NEXUS`, `tuff-nexus-default-2`) that substring or case-insensitive matching would wrongly claim as managed.

They live in `packages/utils/__tests__/`, which runs in `ci / CI - utils` — a blocking job, unlike the `continue-on-error` core-app suite.

## Verification, and a correction to my own earlier numbers

- utils full suite: 135 files / 1079 tests pass
- renderer intelligence suites: 3 files / 23 tests pass
- typecheck: **node 6 / web 7, identical with and without the change**

That last line corrects something. My recent PRs quoted a baseline of 42 typecheck errors. That figure was from an older base — re-measuring on this branch by restoring the files to HEAD gives 6/7 both ways. I should have re-measured each time rather than carrying the number forward.

Three `src/main/modules/ai/` suites (`nexus-invoke-smoke`, `mcp-server-admin`, `intelligence-audit-logger-caller-period`) cannot run in this worktree — `Electron failed to install correctly`, because the shared `node_modules/electron` has lost its `dist` and `path.txt`. I confirmed they fail identically with the sources restored to HEAD, so it is environmental rather than this change; CI covers them.