### PR TITLE
fix(tuff-intelligence): stop shipping zod as both a pinned dependency and a peer

### DIFF
--- a/packages/tuff-intelligence/package.json
+++ b/packages/tuff-intelligence/package.json
@@ -57,8 +57,7 @@
   "dependencies": {
     "@langchain/core": "^0.3.80",
     "@langchain/langgraph": "catalog:",
-    "@talex-touch/utils": "workspace:*",
-    "zod": "3.25.76"
+    "@talex-touch/utils": "workspace:*"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260702.1",
@@ -66,7 +65,8 @@
     "rimraf": "^5.0.10",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
-    "vitest": "^3.2.7"
+    "vitest": "^3.2.7",
+    "zod": "3.25.76"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fixes #583.

## The defect

```
dependencies.zod      "3.25.76"     (exact pin)
peerDependencies.zod  "^3.25.32"
```

A consumer on any other 3.x resolves a second copy, and cross-copy `z.ZodType` checks then fail against schemas the consumer built — the failure is silent at install time and confusing at runtime.

## Which declaration to keep is decided by usage, not preference

**Keep the peer**, because zod is in the public type surface:

```ts
// src/tools/types.ts — exported interfaces
inputSchema: z.ZodType<TInput>
outputSchema?: z.ZodType<TOutput>
```

and `src/index.ts:12` does `export * from "./tools/index"`. Consumers building schemas must share one zod instance for those types to be compatible — that is precisely what a peer dependency expresses.

**Drop the dependency**, because zod is never imported as a value:

```
src/tools/types.ts:1   import type { z } from 'zod'      ← the only non-test import
```

The package needs nothing from zod at runtime, so pinning `3.25.76` for every consumer bought nothing and caused the duplicate.

## Tests still need it

They import `z` as a value, so the pinned version moves to `devDependencies` rather than being dropped — **the exact version that was already resolving**, so the test run is unchanged rather than quietly upgraded.

## `peerDependenciesMeta` is absent, and should stay that way

The peer remains required. That is correct here: a consumer of the tool types cannot avoid needing zod, so marking it optional would only hide a missing install.

## Gates

- package tests: **9 files, 35 passing**
- `publish:check`: exit 0
- manifest diff: 3 insertions / 3 deletions