### PR TITLE
fix(tuff-intelligence): declare zod as a peer only (#583)

### DIFF
--- a/packages/tuff-intelligence/package.json
+++ b/packages/tuff-intelligence/package.json
@@ -57,8 +57,7 @@
   "dependencies": {
     "@langchain/core": "^0.3.80",
     "@langchain/langgraph": "catalog:",
-    "@talex-touch/utils": "workspace:*",
-    "zod": "3.25.76"
+    "@talex-touch/utils": "workspace:*"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260702.1",
@@ -66,7 +65,8 @@
     "rimraf": "^5.0.10",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
-    "vitest": "^3.2.7"
+    "vitest": "^3.2.7",
+    "zod": "3.25.76"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1048,9 +1048,6 @@ importers:
       '@talex-touch/utils':
         specifier: workspace:*
         version: link:../utils
-      zod:
-        specifier: 3.25.76
-        version: 3.25.76
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20260702.1
@@ -1070,6 +1067,9 @@ importers:
       vitest:
         specifier: ^3.2.7
         version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.2)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(sass@1.101.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
 
   packages/tuff-native:
     dependencies:


### PR DESCRIPTION
Closes #583.

## Which of the two options, and why the evidence decides it

The issue offers peer-only or dependency-only. The usage picks one:

- **zod is never run by this package.** The only non-test import is `src/tools/types.ts:1` — `import type { z } from 'zod'`. Type-only, erased at build.
- **But the type is on the public surface.** `TuffToolDefinition.inputSchema: z.ZodType<TInput>` is exported through `src/index.ts` → `./tools/index`, so consumers construct the schemas.

A package that never executes zod but requires callers to hand it zod values is the textbook peer case. Shipping a nested exact copy is what creates the identity mismatch the issue describes.

So: removed from `dependencies`, kept as the `^3.25.32` peer, added as a devDependency for the test files that import `z` as a value.

**Pinned the devDependency to exactly `3.25.76`** rather than a caret range: `apps/core-app` pins that version, so the workspace keeps a single copy instead of resolving a second one for this package alone. The lockfile delta is literally the entry moving between blocks — same specifier, same resolved version.

**Safe for the in-repo consumer:** `apps/core-app` declares `zod: 3.25.76` directly, so nothing relied on this package to supply it transitively. (`tool-registry.ts` is the only other value-import of zod in the repo, and it lives in core-app.)

## Two things I found while verifying, reported not fixed

**This package's 9 test files never run.** There is no `test` script in its `package.json`, and `package-tuff-intelligence-ci.yml` sets `run-test: false`. Three of them are the zod ones (`capability-registry`, `tool-kit`, `langchain-tool-adapter`). That does not change this fix — the devDependency is still needed for anyone running them locally — but it is worth knowing that the zod-using tests are not a safety net here.

**I nearly published a meaningless check.** I ran `pnpm -C packages/tuff-intelligence run typecheck` and read "0 errors". There is no `typecheck` script; pnpm printed a *"script not found"* message that simply does not contain the string `error TS`, so my grep counted zero. The package is typechecked only transitively, through core-app importing its raw TS.

## Verification

- `pnpm -C packages/tuff-intelligence lint` — clean (this is one of the two things its CI runs)
- workspace typecheck — node 6 / web 7, matching the branch baseline
- `build` cannot run in this worktree (`node_modules missing` — the worktree has no per-package `node_modules`); it fails **identically with the manifest restored to HEAD**, so it is environmental

The decisive check is `ci / CI - tuff-intelligence`, which installs fresh and runs lint + build against the new manifest — local `node_modules` predates this change and would resolve zod either way.