### PR TITLE
build: raise every declared Node floor to the root'\''s >=24.15.0 (#591)

### DIFF
--- a/packages/tuff-cli-core/package.json
+++ b/packages/tuff-cli-core/package.json
@@ -18,7 +18,7 @@
     "src"
   ],
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=24.15.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/tuff-cli/package.json
+++ b/packages/tuff-cli/package.json
@@ -19,7 +19,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=24.15.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/tuff-core/package.json
+++ b/packages/tuff-core/package.json
@@ -16,7 +16,7 @@
     "src"
   ],
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=24.15.0"
   },
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --splitting --clean --target node24 --platform node",

--- a/packages/tuff-intelligence/package.json
+++ b/packages/tuff-intelligence/package.json
@@ -42,7 +42,7 @@
     "src"
   ],
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=24.15.0"
   },
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --splitting --clean --target node24 --platform node && tsup src/client.ts --format cjs --target node24 --platform node",

--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -2,7 +2,7 @@
   "name": "@talex-touch/tuffex",
   "version": "0.3.9",
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=24.15.0"
   },
   "author": "TalexDreamSoul<TalexDreamSoul@gmail.com>",
   "description": "TuffEx - Vue 3 UI source package for the Tuff ecosystem.",

--- a/packages/unplugin-export-plugin/package.json
+++ b/packages/unplugin-export-plugin/package.json
@@ -56,7 +56,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=24.15.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/utils/__tests__/workspace-engines.test.ts
+++ b/packages/utils/__tests__/workspace-engines.test.ts
@@ -1,0 +1,77 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * A published package must not advertise a Node floor the repo never tests (#591).
+ *
+ * Six packages declared `>=24.0.0` while the root declares `>=24.15.0` and every workflow pins
+ * `.node-version` (24.18.0), so 24.0–24.14 was an advertised support window that nothing had ever
+ * run. A consumer on 24.0 installs without an EBADENGINE warning and meets whatever 24.x
+ * behaviour the code assumes.
+ *
+ * The rule is deliberately "if you declare it, match the root" rather than "everyone must declare
+ * it": apps/core-app and apps/nexus carry no engines field, and requiring one would be a different
+ * decision than this issue asked for.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const PACKAGE_ROOTS = ['packages', 'apps', 'plugins']
+
+function rootEngine(): string {
+  const root = JSON.parse(readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'))
+  return root.engines?.node
+}
+
+function declaredEngines(): Array<{ manifest: string; node: string }> {
+  const found: Array<{ manifest: string; node: string }> = []
+
+  for (const group of PACKAGE_ROOTS) {
+    const dir = path.join(REPO_ROOT, group)
+    if (!existsSync(dir)) continue
+
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+      const manifest = path.join(dir, entry.name, 'package.json')
+      if (!existsSync(manifest)) continue
+
+      const node = JSON.parse(readFileSync(manifest, 'utf8')).engines?.node
+      if (typeof node === 'string')
+        found.push({ manifest: path.relative(REPO_ROOT, manifest), node })
+    }
+  }
+
+  return found
+}
+
+describe('workspace engines', () => {
+  it('reads the manifests it claims to check', () => {
+    // Positive control: the assertion below is "nothing disagrees", which an empty list satisfies.
+    const declared = declaredEngines()
+
+    expect(rootEngine()).toMatch(/^>=\d+\.\d+\.\d+$/)
+    expect(declared.length).toBeGreaterThan(3)
+    expect(declared.map((entry) => entry.manifest)).toContain('packages/utils/package.json')
+  })
+
+  it('agrees with the root floor wherever engines.node is declared', () => {
+    const expected = rootEngine()
+    const disagreeing = declaredEngines().filter((entry) => entry.node !== expected)
+
+    expect(disagreeing.map((entry) => `${entry.manifest}: ${entry.node}`)).toEqual([])
+  })
+
+  it('keeps the root floor within the pinned toolchain version', () => {
+    // The floor is only meaningful if CI actually runs at or above it. .node-version is what every
+    // workflow resolves through `node-version-file`.
+    const pinned = readFileSync(path.join(REPO_ROOT, '.node-version'), 'utf8').trim()
+    const floor = rootEngine().replace('>=', '')
+
+    const toParts = (value: string): number[] => value.split('.').map(Number)
+    const [pinnedMajor, pinnedMinor] = toParts(pinned)
+    const [floorMajor, floorMinor] = toParts(floor)
+
+    expect(pinnedMajor).toBe(floorMajor)
+    expect(pinnedMinor).toBeGreaterThanOrEqual(floorMinor!)
+  })
+})

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -46,7 +46,7 @@
     "types"
   ],
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=24.15.0"
   },
   "scripts": {
     "benchmark:preview": "vitest run \"__tests__/core-box/preview-sdk.benchmark.test.ts\" --reporter verbose",


### PR DESCRIPTION
Closes #591.

## The issue undercounts: seven, not four

It names `tuff-cli`, `tuff-cli-core`, `tuff-core` and `tuff-intelligence`. Also declaring `>=24.0.0`:

- `packages/utils`
- `packages/tuffex`
- `packages/unplugin-export-plugin`

All seven are raised. Fixing only the four named would not produce the consistency the issue is asking for, and would leave the guard below red.

## How the seventh was found, which is the point

My own survey missed `unplugin-export-plugin` as well — I checked a hand-typed list of paths, the same way the issue evidently did.

The guard enumerates every `package.json` under `packages/`, `apps/` and `plugins/` instead of naming them, and it **failed on its first run, before I had made any adversarial edit**. That is what caught the seventh. A guard written to confirm the fix instead found the fix incomplete.

## What the rule is, deliberately

**"If you declare `engines.node`, match the root"** — not "everyone must declare it". `apps/core-app` and `apps/nexus` carry no engines field; requiring one is a different decision than this issue asked for, so the guard does not force it.

A third assertion ties the root floor to `.node-version`. A floor *above* the pinned toolchain would be untested in the other direction, and nothing else checks that.

## Verification

- guard fails when any single manifest is reverted to `>=24.0.0` (checked against `tuff-core`), and its positive control — root floor parses, more than three manifests found, `packages/utils` among them — stays green
- `packages/utils` full suite: 136 files / 1082 tests pass, in `ci / CI - utils`, a blocking job
- pure `node:fs`, no shelled-out binaries, after the `rg`-on-the-runner failure in #1306

## Worth knowing before merge

Raising a published package’s floor is a semver-visible change for anyone on Node 24.0–24.14. That window was never tested and never will be, which is the issue’s argument — but `@talex-touch/utils` (1.0.50) and `tuffex` are published, so it is a real if small audience.