### PR TITLE
build(touch-music): drop the unused xterm dependencies

### DIFF
--- a/plugins/touch-music/package.json
+++ b/plugins/touch-music/package.json
@@ -22,9 +22,7 @@
     "rgbaster": "^2.1.1",
     "typescript": "^5.9.3",
     "vue": "^3.5.39",
-    "wavesurfer.js": "^7.12.10",
-    "xterm": "^5.3.0",
-    "xterm-addon-fit": "^0.8.0"
+    "wavesurfer.js": "^7.12.10"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.7",


### PR DESCRIPTION
Fixes #585 — but not the way it is framed.

## Not the same defect as #584

#585 says touch-music *"also pins deprecated xterm"*, grouping it with #584. They are different problems:

| | uses xterm? | correct fix |
|---|---|---|
| `apps/core-app` (#584) | **yes** — `InteractiveTerminal.vue`, `LogTerminal.vue` | migrate to the `@xterm` scope |
| `plugins/touch-music` (#585) | **no** — zero references | remove |

Migrating touch-music to `@xterm/*` would have kept an unused dependency and made it look deliberate — a music plugin carrying a terminal emulator, now with a current version number so nothing flags it again.

## Verified before removing

Every reference to `xterm` in `plugins/touch-music`, any syntax, was the two manifest lines removed here. No `peerDependencies` declare them either.

Checked with a **positive control**, so that "no references" could not simply mean a search that finds nothing:

```
howler → plugins/touch-music/src/modules/entity/song-manager.ts
         plugins/touch-music/src/modules/entity/song-resolver.ts
xterm  → (nothing outside package.json)
```

## Gates

- plugin `eslint --max-warnings=0`: exit 0
- manifest diff: 1 insertion / 3 deletions, 12 dependencies remain