### PR TITLE
build: pin @ungap/structured-clone past the CWE-502 release (#589)

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
       "@sentry/electron>@sentry/core": "10.65.0",
       "@sentry/electron>@sentry/node": "10.65.0",
       "@types/node": "24.13.2",
+      "@ungap/structured-clone": "1.3.1",
       "@xmldom/xmldom": "0.8.13",
       "ajv@^6.0.0": "6.15.0",
       "ajv@^8.0.0": "8.20.0",

--- a/packages/utils/__tests__/lockfile-security-deprecations.test.ts
+++ b/packages/utils/__tests__/lockfile-security-deprecations.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Transitive packages whose own deprecation notice cites a security problem (#589).
+ *
+ * The root `pnpm.overrides` block exists for exactly this: it pins ~70 transitive packages. But
+ * `@ungap/structured-clone@1.3.0` — deprecated with "Potential CWE-502 - Update to 1.3.1 or
+ * higher" — was not among them, so every fresh install kept resolving the flagged version.
+ *
+ * npm's own deprecation text is the signal here, which is narrow: it catches only what a
+ * maintainer chose to write into a publish. It is not an audit, and is not a substitute for one.
+ * What it does is make this class visible and stop it growing quietly.
+ */
+
+const LOCKFILE = path.resolve(__dirname, '../../../pnpm-lock.yaml')
+
+/** Flagged entries that are tracked elsewhere. This list must shrink, never grow. */
+const KNOWN = [
+  // glob 7/10/11 — tracked in #586 (tuff-cli / tuff-cli-core depend on the old line)
+  'glob@10.5.0',
+  'glob@11.1.0',
+  'glob@7.2.3'
+]
+
+const SECURITY_WORDING = /CWE|CVE|vulnerab|security/i
+
+function flaggedPackages(): string[] {
+  const lines = readFileSync(LOCKFILE, 'utf8').split('\n')
+  const found: string[] = []
+  let current: string | null = null
+
+  for (const line of lines) {
+    const header = /^ {2}'?([^':]+@[^':]+)'?:\s*$/.exec(line)
+    if (header) current = header[1]!
+    if (/^\s+deprecated:/.test(line) && SECURITY_WORDING.test(line) && current)
+      found.push(current)
+  }
+
+  return [...new Set(found)].sort()
+}
+
+describe('lockfile security deprecations', () => {
+  it('parses the lockfile', () => {
+    // Positive control. The assertion below is a set comparison that an unparsed file would
+    // satisfy by returning nothing, reading as "all clear".
+    const contents = readFileSync(LOCKFILE, 'utf8')
+
+    expect(contents).toContain('lockfileVersion')
+    expect(contents.split('\n').filter((line) => /^\s+deprecated:/.test(line)).length)
+      .toBeGreaterThan(5)
+    expect(SECURITY_WORDING.test('Potential CWE-502 - Update to 1.3.1 or higher')).toBe(true)
+  })
+
+  it('has no security-flagged package beyond the ones already tracked', () => {
+    expect(flaggedPackages()).toEqual(KNOWN)
+  })
+
+  it('keeps @ungap/structured-clone off the flagged list', () => {
+    // The specific regression #589 was filed for: without the override the resolver picks 1.3.0,
+    // whose published deprecation names CWE-502.
+    expect(flaggedPackages().some((entry) => entry.startsWith('@ungap/structured-clone@'))).toBe(
+      false
+    )
+    expect(readFileSync(LOCKFILE, 'utf8')).not.toContain('@ungap/structured-clone@1.3.0')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,7 @@ overrides:
   '@sentry/electron>@sentry/core': 10.65.0
   '@sentry/electron>@sentry/node': 10.65.0
   '@types/node': 24.13.2
+  '@ungap/structured-clone': 1.3.1
   '@xmldom/xmldom': 0.8.13
   ajv@^6.0.0: 6.15.0
   ajv@^8.0.0: 8.20.0
@@ -6122,9 +6123,8 @@ packages:
     resolution: {integrity: sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@ungap/structured-clone@1.3.0':
-    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@unhead/vue@2.1.15':
     resolution: {integrity: sha512-SSByXfEjhzPn8gXdEdgpYqpLMPSkLUH2HVE0GxZfOtNsJ0GgOHQs0g9T67ZZ1z0kTELLKdtOtYrzrbv9+ffF7g==}
@@ -19394,7 +19394,7 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       eslint-visitor-keys: 5.0.1
 
-  '@ungap/structured-clone@1.3.0': {}
+  '@ungap/structured-clone@1.3.1': {}
 
   '@unhead/vue@2.1.15(vue@3.5.39(typescript@5.9.3))':
     dependencies:
@@ -23453,7 +23453,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
       '@types/unist': 3.0.3
-      '@ungap/structured-clone': 1.3.0
+      '@ungap/structured-clone': 1.3.1
       hast-util-from-parse5: 8.0.3
       hast-util-to-parse5: 8.0.1
       html-void-elements: 3.0.0
@@ -23483,7 +23483,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
-      '@ungap/structured-clone': 1.3.0
+      '@ungap/structured-clone': 1.3.1
       hast-util-phrasing: 3.0.1
       hast-util-to-html: 9.0.5
       hast-util-to-text: 4.0.2
@@ -24598,7 +24598,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
-      '@ungap/structured-clone': 1.3.0
+      '@ungap/structured-clone': 1.3.1
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
@@ -26578,7 +26578,7 @@ snapshots:
   rehype-external-links@3.0.0:
     dependencies:
       '@types/hast': 3.0.5
-      '@ungap/structured-clone': 1.3.0
+      '@ungap/structured-clone': 1.3.1
       hast-util-is-element: 3.0.0
       is-absolute-url: 4.0.1
       space-separated-tokens: 2.0.2


### PR DESCRIPTION
Closes #589.

Confirmed as filed. `pnpm-lock.yaml` carried:

```
'@ungap/structured-clone@1.3.0':
  deprecated: Potential CWE-502 - Update to 1.3.1 or higher
```

with no entry in the 71-item overrides block, so every fresh install kept resolving it.

**Checked the target rather than trusting the notice.** `npm view @ungap/structured-clone@1.3.1 deprecated` returns empty; 1.3.0 returns the CWE text. After the override, the lockfile has **zero** 1.3.0 references and the 1.3.1 entry carries no deprecation at all.

## The guard generalises the issue’s own argument

The issue’s framing is that the overrides block exists for precisely this class and this one slipped through. So rather than pin one package and move on, the guard reads **every** `deprecated:` notice in the lockfile, keeps those whose text cites CWE / CVE / vulnerability / security, and compares that set against a tracked list.

Right now that list is the three `glob` entries (`7.2.3`, `10.5.0`, `11.1.0`) — which are #586, still open. So the list is a real backlog marker, and the next dependency to arrive with a security-worded deprecation fails the run instead of joining quietly.

**Its limits are written into the file, not left implied:** this reads what a maintainer chose to put in a deprecation string, not an advisory database. It is not an audit and does not replace one. I would rather that be stated than have someone later read a green check as "no vulnerable dependencies".

## Verification

- restoring the pre-fix lockfile fails both substantive assertions; the positive control (lockfile parses, >5 deprecation notices found, the pattern matches the real CWE-502 string) stays green
- `packages/utils` full suite: 137 files / 1085 tests, in `ci / CI - utils`, a blocking job
- pure `node:fs`

## Note

Only `package.json` and `pnpm-lock.yaml` change, so this needs `pnpm install` on other machines. The lockfile delta is the resolution moving 1.3.0 → 1.3.1; nothing else re-resolved.