### PR TITLE
docs: describe the real module startup shape in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,33 @@ This is a pnpm workspace monorepo with the main application in `apps/core-app/`,
 - **OCR** ([modules/ocr/](apps/core-app/src/main/modules/ocr/)): Native OCR via @talex-touch/tuff-native (Apple Vision / Windows OCR) with AI-provider fallback
 - **Clipboard** ([modules/clipboard/](apps/core-app/src/main/modules/clipboard/)): System clipboard operations
 
-**Module Loading Order** (sequential after Electron ready):
-1. DatabaseModule → 2. StorageModule → 3. ShortcutModule → 4. ExtensionLoaderModule → 5. CommonChannelModule → 6. PluginModule → 7. PluginLogModule → 8. CoreBoxModule → 9. TrayHolderModule → 10. AddonOpenerModule → 11. ClipboardModule → 12. TuffDashboardModule → 13. FileSystemWatcher → 14. FileProtocolModule → 15. TerminalModule
+**Module Loading Order:** startup is not one flat sequence. `main/index.ts` loads three groups
+through `loadStartupModules` (`main/core/startup-module-loader.ts`):
+
+- **Foreground** (`foregroundModulesToLoad`, `index.ts:171`) — 38 modules loaded in array order
+  before the renderer is released. The order encodes real dependencies, and two of them carry a
+  comment saying so: `permissionModule` must precede `pluginModule`, and `flowBusModule` must
+  follow it.
+
+  databaseModule → conversationModule → toolGatewayModule → storageModule → fileProtocolModule →
+  shortcutModule → commonChannelModule → trayManagerModule → nativeCapabilitiesModule →
+  networkModule → catalogModule → analyticsModule → platformPermissionModule → permissionModule →
+  screenshotSessionModule → notificationModule → quickOpsModule → sentryModule →
+  buildVerificationModule → updateServiceModule → systemUpdateModule → intelligenceModule →
+  voiceModule → pluginModule → pluginLogModule → authModule → syncModule → flowBusModule →
+  divisionBoxModule → coreBoxModule → omniPanelModule → assistantModule → addonOpenerModule →
+  clipboardModule → privacyLifecycleModule → tuffDashboardModule → terminalModule →
+  downloadCenterModule
+
+- **Deferred** (`deferredModulesToLoad`, `index.ts:212`) — loaded after the window is up:
+  `extensionLoaderModule`, `FileSystemWatcher`.
+
+- **Optional** (`optionalModulesToLoad`, `index.ts:215`) — `trayManagerModule`. It is also in the
+  foreground list; membership here means a load failure is logged and startup continues rather
+  than aborting.
+
+Read the arrays rather than this list when the order matters — it is the kind of thing that
+drifts silently.
 
 **Renderer Process (src/renderer/):**
 - Vue 3 application with TypeScript


### PR DESCRIPTION
Fixes #611.

## Why this one matters more than a typical doc fix

`CLAUDE.md` is the file that steers future work in this repo. A wrong startup order there does not just mislead a reader once — it gets acted on.

## What was wrong

The doc described startup as one flat sequence of 15 modules. It is three groups:

| group | where | contents |
|---|---|---|
| foreground | `index.ts:171` | **38 modules**, loaded in array order before the renderer is released |
| deferred | `index.ts:212` | `extensionLoaderModule`, `FileSystemWatcher` — after the window is up |
| optional | `index.ts:215` | `trayManagerModule` — failure logs and startup continues |

Wrong in every dimension the issue names:

- **15 listed, 40 exist**
- **`TrayHolderModule` does not exist** — 0 occurrences in `src/main`; the real module is `trayManagerModule`
- **`ExtensionLoaderModule` was listed 4th**, ahead of `CommonChannelModule` and `PluginModule`. It is actually *deferred until after the window opens*. That is the most misleading part, because it inverts when extensions become available relative to plugins.

## What replaces it

Both source arrays named with line numbers, the three groups distinguished, and the two ordering constraints the code itself comments on recorded:

```ts
permissionModule,  // Plugin permission management - before plugin module
flowBusModule,     // Flow Transfer system - after plugin module
```

It also tells the reader to check the arrays when order matters, rather than trusting the prose — this list drifted silently once already.

## Verified, not transcribed

The 38 names and their order were extracted from `index.ts` and compared against what I wrote:

```
real foreground modules : 38
documented in the chain : 38
order matches exactly   : True
```

Copying a list of 38 names by hand is exactly where an off-by-one slips in, so it is checked mechanically rather than by eye.