### PR TITLE
docs: correct the channel API block and mark it as the legacy surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,20 +241,30 @@ The application uses a custom channel system abstracting Electron IPC:
 - `ChannelType.MAIN`: Main process ↔ renderer communication
 - `ChannelType.PLUGIN`: Plugin-specific isolated communication
 
-**Key APIs:**
+**Key APIs** (`main/core/channel-core.ts`, class `TouchChannel`):
 ```typescript
 // Register handlers
-regChannel(type: ChannelType, eventName: string, callback): () => void
+regChannel(type: ChannelType, eventName: string, callback: ChannelCallback): () => void
 
-// Send messages
-send(eventName: string, arg?: any): Promise<any>
-sendTo(window: BrowserWindow, eventName: string, arg?: any): Promise<any>
-sendPlugin(pluginName: string, eventName: string, arg?: any): Promise<any>
+// Send messages -- note every one of these takes ChannelType, including sendTo
+send(type: ChannelType, eventName: string, arg: unknown): Promise<unknown>
+sendTo(win: BrowserWindow, type: ChannelType, eventName: string, arg: unknown): Promise<unknown>
+sendPlugin(pluginName: string, eventName: string, arg?: unknown): Promise<unknown>
 
 // Key management (encryption for plugin isolation)
-requestKey(name: string): string
+requestKey(name: string, activation?: Pick<PluginActivationIdentity, 'pluginInstanceId' | 'activationGeneration'>): string
 revokeKey(key: string): boolean
 ```
+
+> **This is the legacy surface.** New main-process code uses the TuffTransport SDK
+> (`@talex-touch/utils/transport`), not `TouchChannel`. Outside `channel-core.ts` and its tests,
+> `regChannel` and `sendPlugin` have no call sites at all, and `requestKey` is only reached
+> through `plugin-channel-key-registry`. What main-process modules actually call is
+> `transport.sendTo(webContents, event, payload)` -- a different method on a different object,
+> taking a typed event rather than a `ChannelType` plus a string.
+>
+> The signatures above drifted from the code precisely because nothing calls them; check
+> `channel-core.ts` before relying on this block.
 
 **Implementation Notes:**
 - Uses IPC listeners on `@main-process-message` and `@plugin-process-message`


### PR DESCRIPTION
Fixes #612.

## Three of six signatures were wrong

| API | documented | actual |
|---|---|---|
| `send` | `(eventName, arg?)` | `(type: ChannelType, eventName, arg)` |
| `sendTo` | `(window, eventName, arg?)` | `(win, type: ChannelType, eventName, arg)` |
| `requestKey` | `(name)` | `(name, activation?)` |

`regChannel`, `sendPlugin` and `revokeKey` were correct.

## The issue's explanation is not what is there

> *"they come from two different classes with incompatible signatures"*

`channel-core.ts` declares **one** class, `TouchChannel`, and all six are its methods. So the two-class framing does not hold — but the drift is real, and it has a more useful cause.

## Nothing calls them

Outside `channel-core.ts` and its own tests:

```
.regChannel(  → 0 hits in apps/core-app/src/main
.sendPlugin(  → 0 hits
.requestKey(  → only via plugin-channel-key-registry
```

What main-process modules actually call is `transport.sendTo(webContents, event, payload)` — the **TuffTransport SDK**, a different method on a different object, taking a typed event instead of a `ChannelType` plus a string.

That is why the signatures drifted: no caller would have broken.

Checked with a positive control, since "0 hits" and "a search that finds nothing" look identical — the same scan resolves `.sendTo(` to three real call sites, all of them on `transport`.

## So the fix is more than corrected parameters

The block now names the class and file it describes, and says plainly that this is the **legacy** surface with TuffTransport as the current one.

Documenting a retired API as *the* channel system is worse than documenting it with wrong parameters: wrong parameters fail loudly the first time someone compiles, whereas a reader who believes this block writes new code against the wrong layer and it works.

## Verified mechanically

Each documented signature was regex-matched against `channel-core.ts` — transcribing six signatures by hand is exactly where a parameter goes missing, which is how this block got here.