### PR TITLE
build(touch-music): drop the unused xterm packages (#585)

### DIFF
--- a/plugins/touch-music/package.json
+++ b/plugins/touch-music/package.json
@@ -22,9 +22,7 @@
     "rgbaster": "^2.1.1",
     "typescript": "^5.9.3",
     "vue": "^3.5.39",
-    "wavesurfer.js": "^7.12.10",
-    "xterm": "^5.3.0",
-    "xterm-addon-fit": "^0.8.0"
+    "wavesurfer.js": "^7.12.10"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1458,12 +1458,6 @@ importers:
       wavesurfer.js:
         specifier: ^7.12.10
         version: 7.12.10
-      xterm:
-        specifier: ^5.3.0
-        version: 5.3.0
-      xterm-addon-fit:
-        specifier: ^0.8.0
-        version: 0.8.0(xterm@5.3.0)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.7


### PR DESCRIPTION
Closes #585.

Unused, as the issue suspects. The scan carries a positive control on the same manifest so "0 references" means absent rather than broken:

| dependency | files referencing it |
| --- | --- |
| axios | 6 |
| howler | 2 |
| gsap | 2 |
| rgbaster | 1 |
| **xterm** | **0** |

## One correction, because it changes what this is worth

The issue says the plugin *"bundles a deprecated, unmaintained terminal emulator (~300KB) into its Surface build"*. It does not — a dependency nothing imports is never bundled by Vite.

The build output is **byte-identical before and after removal**: same chunk hashes, same sizes.

```
dist/assets/index-ZxY3a_6D.js    260.50 kB │ gzip: 95.38 kB   (before)
dist/assets/index-ZxY3a_6D.js    260.50 kB │ gzip: 95.38 kB   (after)
```

So the real cost was install weight and audit noise, not Surface size. Still worth removing — just not for the stated reason, and I would rather the record say so than leave a "~300KB saved" claim that a later reader could not reproduce.

## Scope

core-app genuinely uses both packages (`InteractiveTerminal.vue`, `LogTerminal.vue`), so xterm stays in the lockfile. That migration is #584 and is a real code change rather than a manifest edit.

## Adjacent, deliberately not fixed here

The same scan found **`wavesurfer.js` and `granim` with zero references** anywhere in the plugin — not just in `src`. Neither is deprecated and neither is what this issue is about, so I left them. Flagging rather than folding them in; details on the issue.

Lint clean.