### PR TITLE
docs: add the plugin management policy to the English README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Tuff integrates a variety of practical functions to make your desktop smarter an
 - **Bring Your Own LLM:** Allows you to connect to your own private cloud or any self-hosted Large Language Model for ultimate privacy and control.
 - **Unified Download Center:** Centralized download management with progress tracking and resume support.
 
+### Plugin management policy
+
+- Plugins installed from the official marketplace have the `dev` entry in their manifest disabled during installation, so they cannot accidentally connect to a development server.
+- Every plugin's origin is recorded in the database, and uninstalling removes the plugin directory and its cached data along with it.
+
 ## 🍀 Simple and Easy-to-Use Operations
 
 The operation of Tuff is very simple and user-friendly, allowing users to easily complete various tasks. You only need to open the required function through the menu or shortcut keys to enjoy the convenience brought by Tuff.


### PR DESCRIPTION
Fixes the real half of #635.

## What was genuinely missing

The Chinese README documents two behaviours English readers never saw:

- the marketplace installer disables the manifest `dev` entry, so a shipped plugin cannot accidentally reach a development server
- uninstalling removes the plugin directory **and** its cached data, because the plugin's origin is recorded in the database

That is policy a plugin author needs in order to reason about their own package, not marketing copy. Now in both READMEs.

## The second gap is not a gap

#635 also reports a missing cross-platform support caveat. The English README already carries it, worded more fully than the Chinese heading it is compared against:

> *"A stable source version does not imply identical capability maturity or complete OTA acceptance across platforms; unsupported or degraded paths must remain explicit and fail closed."*

— `README.md`, **Release and platform status**

The Chinese version says the same thing under its own `## 🖇️ 跨平台支持` heading. Different heading, different position, same substance. Adding it again would have duplicated a warning rather than translated a missing one — and left two statements of the same policy to drift apart.

## A third asymmetry, deliberately left

`### 绝佳的动画设计` is Chinese-only. It is a GIF gallery prefaced by *"部分动画在最新版本中已被移除"* — porting it would import stale screenshots into the English README rather than any policy. Recording it here so the next comparison does not read it as an oversight.

## Verified after editing

```
en/zh headings                : 18 / 18
en states degraded-path caveat: True
both state the plugin policy  : True
```