### PR TITLE
fix(core-app): stop the tolerated migration error from skipping the schema fixups

### DIFF
--- a/apps/core-app/src/main/modules/database/index.ts
+++ b/apps/core-app/src/main/modules/database/index.ts
@@ -1241,13 +1241,25 @@ export class DatabaseModule extends BaseModule {
     })
 
     try {
-      // Use resolved path for migration
-      await timing.cost(
-        async () => migrate(this.db!, { migrationsFolder: migrationsFolderResolved }),
-        {
-          folder: migrationsFolderResolved
+      // Scoped to migrate() alone. The duplicate-column case below is tolerated, and when the
+      // five ensure* fixups shared this try they were skipped along with the rest of the block
+      // -- the app then ran with recommendation/analytics tables and hot-path indexes missing,
+      // which is exactly what those fixups exist to guarantee (#638).
+      try {
+        // Use resolved path for migration
+        await timing.cost(
+          async () => migrate(this.db!, { migrationsFolder: migrationsFolderResolved }),
+          {
+            folder: migrationsFolderResolved
+          }
+        )
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error ?? '')
+        if (!message.includes('duplicate column name: provider_id')) {
+          throw error
         }
-      )
+        dbLog.warn('Migration warning: column `provider_id` already exists')
+      }
 
       await this.ensureKeywordMappingsProviderColumn()
       await this.ensureRecommendationTables()
@@ -1259,24 +1271,18 @@ export class DatabaseModule extends BaseModule {
       const duration = stats ? stats.lastMs.toFixed(2) : 'N/A'
       dbLog.info(`Migrations completed successfully in ${duration}ms`)
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error ?? '')
-      const duplicateColumn = message.includes('duplicate column name: provider_id')
+      // Reaching here is fatal: the tolerated duplicate-column case is absorbed above, so this
+      // is either a real migration failure or a failed fixup. Both leave the schema unusable.
+      dbLog.error('Migration failed', { error })
 
-      if (duplicateColumn) {
-        dbLog.warn('Migration warning: column `provider_id` already exists')
-      } else {
-        dbLog.error('Migration failed', { error })
+      const errorMessage = error instanceof Error ? error.message : String(error ?? 'Unknown error')
+      const errorInstance = error instanceof Error ? error : new Error(errorMessage)
+      await this.showDatabaseErrorDialog(
+        errorInstance,
+        `Database migration failed:\n${errorMessage}\n\nCheck log files for more information.\nLog location: ${app.getPath('userData')}/tuff/logs/`
+      )
 
-        const errorMessage =
-          error instanceof Error ? error.message : String(error ?? 'Unknown error')
-        const errorInstance = error instanceof Error ? error : new Error(errorMessage)
-        await this.showDatabaseErrorDialog(
-          errorInstance,
-          `Database migration failed:\n${errorMessage}\n\nCheck log files for more information.\nLog location: ${app.getPath('userData')}/tuff/logs/`
-        )
-
-        process.exit(1)
-      }
+      process.exit(1)
     }
 
     // Give the search-index worker its own file (search-index.db) before any


### PR DESCRIPTION
Fixes #638.

## The defect

`migrate()` and five `ensure*` fixups shared one `try`. The `catch` tolerates `duplicate column name: provider_id` and lets startup continue — but by the time it runs, the throw has already jumped past all five:

```
ensureKeywordMappingsProviderColumn
ensureRecommendationTables
ensureAnalyticsTables
ensureScanProgressSourceScopeMigration
ensureSearchPerformanceIndexes
```

So **the one case this code goes out of its way to survive is the case where it comes up without the recommendation and analytics tables, without the scan-progress migration, and without any hot-path index** — while logging a warning that reads like everything is fine.

## The fix

The tolerated case is scoped to `migrate()` alone. An inner `catch` rethrows anything that is not the duplicate-column message, so the fixups run on both paths.

The outer `catch` keeps its fatal behaviour unchanged, and now also covers a **failing fixup** — previously a fixup throwing a message containing `duplicate column name: provider_id` would have been swallowed by the tolerant branch.

## No test, and why

Stating it rather than leaving it implied: the block is inline in `onInit`, whose surrounding work resolves migration folders from disk and touches electron app paths, so exercising it means driving that whole chain. The honest way to make it testable is extracting the migration step first — a wider change than this bug warrants, and not one to start at the end of a working session.

Verified by reading the resulting control flow, plus the gates below. The existing suite covers the module's other paths and still passes.

## Gates

- `npm run typecheck:node`: exit 0
- database suites: **3 files, 13 tests passing**
- `eslint --max-warnings=0`: exit 0