### PR TITLE
fix(core-app): copy aux hot tables by column name instead of positionally

### DIFF
--- a/apps/core-app/src/main/modules/database/index.ts
+++ b/apps/core-app/src/main/modules/database/index.ts
@@ -761,6 +761,22 @@ export class DatabaseModule extends BaseModule {
     return this.parseCount(first.cnt ?? first['count(*)'])
   }
 
+  /**
+   * Column names of `tableName`, in that database's physical order.
+   *
+   * The aux copy used to be `SELECT *`, which is positional. Physical order is set by the
+   * migration history, not by schema.ts: `ALTER TABLE ... ADD COLUMN` appends, so `next_retry_at`
+   * (0001), `plugin_version` (0007) and `retention_protected` (0008) sit last in the main
+   * database while the freshly written aux DDL places them mid-table. Copying positionally wrote
+   * those values into whichever column happened to share the index (#637).
+   */
+  private async getTableColumns(client: Client, tableName: string): Promise<string[]> {
+    const rs = await client.execute(`PRAGMA table_info(${tableName})`)
+    return (rs.rows ?? [])
+      .map((row) => (row as unknown as Record<string, unknown>).name)
+      .filter((name): name is string => typeof name === 'string' && name.length > 0)
+  }
+
   private async hasAuxMigrationMarker(): Promise<boolean> {
     if (!this.db) return false
     try {
@@ -954,7 +970,32 @@ export class DatabaseModule extends BaseModule {
     await this.auxClient.execute(`ATTACH DATABASE '${escapedMainPath}' AS coredb`)
     try {
       for (const table of AUX_COPY_TABLES) {
-        await this.auxClient.execute(`INSERT OR IGNORE INTO ${table} SELECT * FROM coredb.${table}`)
+        // Copy by name, never positionally. Only columns the two schemas share are moved; one
+        // side having an extra column is survivable, silently shifting values is not.
+        const [targetColumns, sourceColumns] = await Promise.all([
+          this.getTableColumns(this.auxClient, table),
+          this.getTableColumns(this.auxClient, `coredb.${table}`)
+        ])
+        const shared = targetColumns.filter((column) => sourceColumns.includes(column))
+        if (shared.length === 0) {
+          dbLog.warn(`Aux migration found no shared columns for ${table}; skipping copy`, {
+            meta: { targetColumns, sourceColumns }
+          })
+          continue
+        }
+        if (shared.length !== targetColumns.length || shared.length !== sourceColumns.length) {
+          dbLog.warn(`Aux migration copying a column subset for ${table}`, {
+            meta: {
+              copied: shared.length,
+              targetOnly: targetColumns.filter((c) => !sourceColumns.includes(c)),
+              sourceOnly: sourceColumns.filter((c) => !targetColumns.includes(c))
+            }
+          })
+        }
+        const columnList = shared.map((column) => `"${column}"`).join(', ')
+        await this.auxClient.execute(
+          `INSERT OR IGNORE INTO ${table} (${columnList}) SELECT ${columnList} FROM coredb.${table}`
+        )
         const [sourceCount, targetCount] = await Promise.all([
           this.getTableCount(this.auxClient, `coredb.${table}`),
           this.getTableCount(this.auxClient, table)


### PR DESCRIPTION
Fixes #637.

## Reproduced, not argued

`ocr_jobs` built the way the migrations build it — `next_retry_at` appended by `ALTER TABLE` as in `0001` — then copied both ways on real SQLite:

```
positional → next_retry_at: 'hash-abc'   payload_hash: '{"k":1}'
by name    → next_retry_at: 999          payload_hash: 'hash-abc'
```

A text hash lands in an integer timestamp column and JSON metadata lands in the hash column. `INSERT OR IGNORE` raises nothing, and the existing verification only compares **row counts** — which are correct. The copy reports success while every value is one column to the left.

## Why the physical order differs

`ALTER TABLE ... ADD COLUMN` appends. Three of the copied tables gained columns that way:

```
0001  ALTER TABLE `ocr_jobs`          ADD `next_retry_at`
0007  ALTER TABLE `plugin_analytics`  ADD COLUMN `plugin_version`
0008  ALTER TABLE `clipboard_history` ADD `retention_protected`
```

So in the main database those columns are **last**, while the aux DDL — written fresh in `ensureAuxTables` — places them mid-table.

## A wrong comparison worth flagging

Checking the aux DDL against `schema.ts` shows the column orders **matching**, and nearly led me to report #637 as unfounded.

That is the wrong comparison. `schema.ts` is the *logical* order; what `SELECT *` follows is the *physical* order the migration history produced. Anyone re-verifying this should read the migrations, not the schema.

## The fix

`PRAGMA table_info` on both sides, copy the intersection by name. Columns present on only one side are logged rather than silently dropped, and a table with no shared columns is skipped with both lists recorded — that would mean the schemas have diverged past what a copy can bridge, which is worth seeing rather than guessing at.

## Gates

- `npm run typecheck:node`: exit 0
- database suites: **3 files, 13 tests passing**
- `eslint --max-warnings=0`: exit 0