### PR TITLE
build(core-app): migrate the terminal components to the @xterm scope (#584)

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -110,6 +110,8 @@
     "@talex-touch/tuffex": "workspace:^",
     "@talex-touch/utils": "workspace:^",
     "@vue/compiler-sfc": "^3.5.39",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "@vueuse/core": "catalog:frontend",
     "chalk": "^5.6.2",
     "chokidar": "^4.0.3",
@@ -142,9 +144,7 @@
     "vue-i18n": "^11.4.0",
     "vue-router": "^4.6.4",
     "vue-sonner": "^2.0.9",
-    "xterm": "^5.3.0",
-    "xterm-addon-fit": "^0.8.0",
-    "zod": "3.25.76"
+            "zod": "3.25.76"
   },
   "optionalDependencies": {
     "@crosscopy/clipboard": "^0.3.6",

--- a/apps/core-app/src/renderer/src/components/terminal/InteractiveTerminal.vue
+++ b/apps/core-app/src/renderer/src/components/terminal/InteractiveTerminal.vue
@@ -1,12 +1,8 @@
 <script name="InteractiveTerminal" setup>
 import { onMounted, onUnmounted, ref } from 'vue'
-import { Terminal } from 'xterm'
-import { FitAddon } from 'xterm-addon-fit'
-import 'xterm/css/xterm.css'
-import 'xterm/lib/xterm.js'
-// import * as TerminalFit from "xterm-addon-fit";
-
-// Terminal.applyAddon(TerminalFit);
+import { FitAddon } from '@xterm/addon-fit'
+import { Terminal } from '@xterm/xterm'
+import '@xterm/xterm/css/xterm.css'
 
 const terminal = ref()
 const term = new Terminal({

--- a/apps/core-app/src/renderer/src/components/terminal/LogTerminal.vue
+++ b/apps/core-app/src/renderer/src/components/terminal/LogTerminal.vue
@@ -1,8 +1,8 @@
 <script lang="ts" name="LogTerminal" setup>
 import { onMounted, onUnmounted, ref, watch } from 'vue'
-import { Terminal } from 'xterm'
-import * as TerminalFit from 'xterm-addon-fit'
-import 'xterm/css/xterm.css'
+import * as TerminalFit from '@xterm/addon-fit'
+import { Terminal } from '@xterm/xterm'
+import '@xterm/xterm/css/xterm.css'
 
 const props = defineProps({
   logs: {
@@ -14,8 +14,6 @@ const props = defineProps({
     default: true
   }
 })
-
-// Terminal.applyAddon(TerminalFit)
 
 const terminal = ref()
 const term = new Terminal({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,6 +354,12 @@ importers:
       '@vueuse/core':
         specifier: catalog:frontend
         version: 14.3.0(vue@3.5.39(typescript@5.9.3))
+      '@xterm/addon-fit':
+        specifier: ^0.10.0
+        version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/xterm':
+        specifier: ^5.5.0
+        version: 5.5.0
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -447,12 +453,6 @@ importers:
       vue-sonner:
         specifier: ^2.0.9
         version: 2.0.9(@nuxt/kit@4.4.8(magicast@0.5.3))(@nuxt/schema@4.4.8)(nuxt@4.4.8(bc90f1595c7cc9bc6b08337d210bd65b))
-      xterm:
-        specifier: ^5.3.0
-        version: 5.3.0
-      xterm-addon-fit:
-        specifier: ^0.8.0
-        version: 0.8.0(xterm@5.3.0)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -6554,6 +6554,14 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+
+  '@xterm/addon-fit@0.10.0':
+    resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/xterm@5.5.0':
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -13747,16 +13755,6 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
-  xterm-addon-fit@0.8.0:
-    resolution: {integrity: sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==}
-    deprecated: This package is now deprecated. Move to @xterm/addon-fit instead.
-    peerDependencies:
-      xterm: ^5.0.0
-
-  xterm@5.3.0:
-    resolution: {integrity: sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==}
-    deprecated: This package is now deprecated. Move to @xterm/xterm instead.
-
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
@@ -19772,6 +19770,12 @@ snapshots:
   '@webcontainer/env@1.1.1': {}
 
   '@xmldom/xmldom@0.8.13': {}
+
+  '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/xterm@5.5.0': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -28650,12 +28654,6 @@ snapshots:
   xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
-
-  xterm-addon-fit@0.8.0(xterm@5.3.0):
-    dependencies:
-      xterm: 5.3.0
-
-  xterm@5.3.0: {}
 
   xxhash-wasm@1.1.0: {}
 


### PR DESCRIPTION
Closes #584.

## Version choice: ^5.5.0, not the current 6.0.0

5.5 is the direct rename the deprecation notice asks for and carries exactly the fixes the issue names, which keeps this a **rename rather than a major upgrade**. That matters here specifically: these two components have no test coverage and cannot be exercised outside a running Electron window, so a smaller delta is worth more than a newer version.

6.0.0 is API-identical for everything used here — I checked both — so that step stays available and separate rather than being smuggled into a deprecation fix.

## API surface checked against the real packages

Not assumed from a changelog. Against `@xterm/xterm@5.5.0` and `@xterm/addon-fit@0.10.0`:

| checked | result |
| --- | --- |
| `Terminal` class | declared |
| options `cursorBlink`, `disableStdin`, `fontSize`, `lineHeight` | all present |
| methods `loadAddon`, `open`, `writeln`, `focus`, `dispose` | all present |
| `FitAddon` with `fit()` | declared |
| `css/xterm.css` at the same path | present |

The same check passes on 6.0.0.

## Two pieces of dead code removed with the imports

- `import 'xterm/lib/xterm.js'` — `xterm`'s `main` **is** `lib/xterm.js`, so this re-imported the package entry and did nothing.
- two commented-out `Terminal.applyAddon(TerminalFit)` lines, referencing an API removed back in xterm 4. Left alone they would have become stale references to a package no longer installed.

## Verification is partial — stating it plainly

The worktree's `node_modules` is symlinked from the main checkout and has not been reinstalled, so `typecheck:web` reports `TS2307: Cannot find module '@xterm/xterm'` for both specifiers. That is the environment, not the change.

The signal that *is* usable is the delta: **9 errors against a baseline of 7, and the two extra are exactly those module-resolution errors** — so nothing else broke. Combined with the static API check above, that is as far as local verification goes.

No test imports either component (`rg -l "InteractiveTerminal|LogTerminal" --glob "*.test.ts"` is empty), so `App suites` will not exercise them either. **`Typecheck (workspace)` on a fresh install is the decisive check**, and the runtime rendering behaviour genuinely needs someone to open the terminal panel once.

Lockfile: deprecated entries **17 → 15**, no `xterm` / `xterm-addon-fit` entries left anywhere.