### PR TITLE
fix(tool-gateway): scope tuff_read_file consent to the path that was shown

### DIFF
--- a/apps/core-app/src/main/modules/tool-gateway/tool-registry.remember-scope.test.ts
+++ b/apps/core-app/src/main/modules/tool-gateway/tool-registry.remember-scope.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createToolRegistry, resolveUserPath } from './tool-registry'
+
+/**
+ * The gateway keys its confirmation memory on plan.rememberKey, which falls back to the tool
+ * name when a tool has no classify(). tuff_read_file is risk 'read' and therefore rememberable,
+ * so a single approval with 'remember' ticked granted blanket session-wide reads of any path the
+ * user can open (#643).
+ */
+
+function registry() {
+  return createToolRegistry({
+    agentContext: {
+      listMcpTools: vi.fn(async () => [])
+    }
+  } as never)
+}
+
+async function rememberKeyFor(path: string): Promise<string> {
+  const tool = registry().get('tuff_read_file')!
+  const plan = await tool.classify!({ path })
+  return plan.rememberKey
+}
+
+describe('tuff_read_file confirmation scope', () => {
+  it('gives two different files two different remember keys', async () => {
+    const a = await rememberKeyFor('~/notes.md')
+    const b = await rememberKeyFor('~/.ssh/id_rsa')
+
+    // The defect: both were 'tuff_read_file', so approving the first waved through the second.
+    expect(a).not.toBe(b)
+  })
+
+  it('keys on the resolved path, so two spellings of one file share consent', async () => {
+    const viaTilde = await rememberKeyFor('~/notes.md')
+    const viaResolved = await rememberKeyFor(resolveUserPath('~/notes.md'))
+
+    expect(viaTilde).toBe(viaResolved)
+  })
+
+  it('reports read risk so the approval prompt is unchanged', async () => {
+    const tool = registry().get('tuff_read_file')!
+    const plan = await tool.classify!({ path: '~/notes.md' })
+
+    expect(plan.risk).toBe('read')
+    expect(plan.summary).toContain('~/notes.md')
+  })
+
+  it('does not let unresolvable paths collapse into one shared key', async () => {
+    // execute() rejects these anyway; sharing a key would let one remembered yes cover all of them.
+    const a = await rememberKeyFor('')
+    const b = await rememberKeyFor('   ')
+
+    expect(a).not.toBe(b)
+  })
+})

--- a/apps/core-app/src/main/modules/tool-gateway/tool-registry.ts
+++ b/apps/core-app/src/main/modules/tool-gateway/tool-registry.ts
@@ -261,6 +261,26 @@ export function createToolRegistry(options: ToolRegistryOptions): Map<string, To
       name: 'tuff_read_file',
       risk: 'read',
       summarize: (args) => `Read ${readStringArg(args, 'path')}`,
+      // Keyed by the resolved path, not by the tool name. Without this the gateway falls back to
+      // `tool.name`, so one approval with 'remember' ticked granted blanket session-wide reads of
+      // anything the user can open -- ssh keys, browser profiles, other people's documents (#643).
+      // Same reasoning as tuff_mcp_call below: a remembered yes should mean yes to the thing that
+      // was shown, not to the tool that showed it.
+      classify: async (args) => {
+        const requested = readStringArg(args, 'path')
+        const resolved = resolveUserPath(requested)
+        return {
+          risk: 'read',
+          summary: `Read ${requested}`,
+          // Unresolvable paths keep the raw input in the key rather than sharing one bucket.
+          // resolveUserPath returns '' (not null) for these, so `??` would not have caught it and
+          // every empty-ish path would have collapsed onto `tuff_read_file:` -- one remembered
+          // yes covering all of them.
+          rememberKey: resolved
+            ? `tuff_read_file:${resolved}`
+            : `tuff_read_file:unresolved:${requested}`
+        }
+      },
       execute: async (args) => {
         const path = resolveUserPath(readStringArg(args, 'path'))
         if (!path) return { output: 'path is required', isError: true }


### PR DESCRIPTION
Fixes #643.

## The defect

The gateway keys confirmation memory on `plan.rememberKey`, which falls back to `tool.name` when a tool declares no `classify()`. `tuff_read_file` is risk `'read'` and therefore rememberable, so **one approval with 'remember' ticked granted blanket session-wide reads of any path the user can open** — ssh keys, browser profiles, documents that were never part of the prompt they agreed to.

## The fix follows a pattern already in the file

`tuff_mcp_call`, one tool below, documents exactly this reasoning:

> *"Keyed by the proxied tool rather than by `tuff_mcp_call`, so a remembered yes for one read-only tool never waves through another server's destructive one."*

`tuff_read_file` now classifies on the resolved path. A remembered yes means yes to **the thing that was shown**, not to the tool that showed it.

## Scope checked rather than assumed

Four other tools are risk `'read'` with no `classify()`:

| tool | takes an arbitrary path? |
|---|---|
| `tuff_search_files` | no — a `query` over the index |
| `tuff_skill_read` | no — an `id` bounded to imported skills |
| `tuff_mcp_list_tools` | no |
| `tuff_list_features` | no |

`tuff_read_file` is genuinely the only one that accepts an arbitrary filesystem path, so the report's scope holds.

## The fourth test earned its place immediately

My first version keyed on:

```ts
rememberKey: `tuff_read_file:${resolved ?? `unresolved:${requested}`}`
```

`resolveUserPath` returns `''`, not `null`, for empty input — so `??` never fired and every empty-ish path collapsed onto `tuff_read_file:`, one remembered yes covering all of them. The test caught it before commit; the key now uses a falsy check.

That is the whole point of writing the adversarial case rather than only the happy one.

## Verified by mutation

Against the unfixed registry all four cases fail with `tool.classify is not a function`.

## Gates

- `npm run typecheck:node`: exit 0
- tool-gateway suites: **6 files, 69 tests passing**
- `eslint --max-warnings=0`: exit 0