### PR TITLE
fix(ocr): claim the processQueue guard before the first await

### DIFF
--- a/apps/core-app/src/main/modules/ocr/ocr-service.test.ts
+++ b/apps/core-app/src/main/modules/ocr/ocr-service.test.ts
@@ -129,6 +129,10 @@ vi.mock('../ai/intelligence-sdk', () => ({
 import { ocrService } from './ocr-service'
 
 interface OcrServiceTestAccess {
+  processQueue: () => Promise<void>
+  processing: boolean
+  isQueueDisabled: () => Promise<boolean>
+  db: unknown
   runAgentJob: (jobId: number, job: Record<string, unknown>) => Promise<void>
   updateClipboardMeta: (...args: unknown[]) => Promise<void>
   normalizeSourceForAgent: (...args: unknown[]) => Promise<{
@@ -479,5 +483,61 @@ describe('ocr dispatch persists the attempt', () => {
     expect(startWrite, 'ocr.jobs.start was not scheduled').toBeDefined()
     expect(startWrite?.options?.priority).toBe('critical')
     expect(startWrite?.options?.dropPolicy).toBe('none')
+  })
+})
+
+describe('OcrService processQueue re-entrancy', () => {
+  it('lets only one concurrent caller past the guard', async () => {
+    const service = ocrService as unknown as OcrServiceTestAccess
+    const originalProcessing = service.processing
+    const originalDb = service.db
+    const originalIsQueueDisabled = service.isQueueDisabled
+
+    let release: (() => void) | null = null
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const isQueueDisabled = vi.fn(async () => {
+      await gate
+      return true // stop before touching the database; the guard is what is under test
+    })
+
+    service.processing = false
+    service.db = {}
+    service.isQueueDisabled = isQueueDisabled
+
+    try {
+      // Both start before either can finish the config read.
+      const first = service.processQueue()
+      const second = service.processQueue()
+      release!()
+      await Promise.all([first, second])
+
+      // The defect: both callers reached the config read, so both went on to dispatch.
+      expect(isQueueDisabled).toHaveBeenCalledTimes(1)
+    } finally {
+      service.processing = originalProcessing
+      service.db = originalDb
+      service.isQueueDisabled = originalIsQueueDisabled
+    }
+  })
+
+  it('releases the guard even when the queue is disabled', async () => {
+    // The claim moved above an early return, so a missed finally would wedge the queue shut.
+    const service = ocrService as unknown as OcrServiceTestAccess
+    const originalDb = service.db
+    const originalIsQueueDisabled = service.isQueueDisabled
+
+    service.processing = false
+    service.db = {}
+    service.isQueueDisabled = vi.fn(async () => true)
+
+    try {
+      await service.processQueue()
+      expect(service.processing).toBe(false)
+    } finally {
+      service.db = originalDb
+      service.isQueueDisabled = originalIsQueueDisabled
+    }
   })
 })

--- a/apps/core-app/src/main/modules/ocr/ocr-service.ts
+++ b/apps/core-app/src/main/modules/ocr/ocr-service.ts
@@ -928,10 +928,15 @@ class OcrService {
   private async processQueue(): Promise<void> {
     if (this.processing) return
     if (!this.db) return
-    if (await this.isQueueDisabled()) return
 
+    // Claimed before the first await. isQueueDisabled() reads config, so two callers arriving
+    // during it both used to pass the check above and both enter the loop, dispatching the same
+    // pending jobs twice (#644). The check and the claim have to be in the same synchronous
+    // step; the disabled check moves inside the try so the finally still releases the guard.
     this.processing = true
     try {
+      if (await this.isQueueDisabled()) return
+
       while (this.activeJobs.size < WORKER_CONCURRENCY) {
         if (await this.isQueueDisabled()) {
           break


### PR DESCRIPTION
Fixes #644.

## The defect

```ts
if (this.processing) return
if (!this.db) return
if (await this.isQueueDisabled()) return   // ← yields

this.processing = true                     // ← too late
```

`isQueueDisabled()` is a config read. Two callers arriving during that await both saw `processing === false`, both set it, and both ran the dispatch loop — the same pending jobs handed to workers twice.

## The fix, and the trap in it

The check and the claim are now one synchronous step. But moving the claim above an early return introduces a second failure mode: if the `isQueueDisabled()` path returns without releasing, the queue is wedged shut for the rest of the session — **worse than the bug being fixed**.

So the disabled check moves *inside* the `try`, where the existing `finally` still releases it. The second test exists specifically to hold that down.

## Verified by mutation

Against the unfixed service:

```
× lets only one concurrent caller past the guard
  → expected "spy" to be called 1 times, but got 2 times
```

Both callers really did get through. The test observes the config read rather than job dispatch, because that is the first thing past the guard and needs no database.

## Gates

- `npm run typecheck:node`: exit 0
- `ocr-service` suite: **10 tests passing**
- `eslint --max-warnings=0`: exit 0