### PR TITLE
fix(tool-gateway): join an in-flight start instead of binding a second port

### DIFF
--- a/apps/core-app/src/main/modules/tool-gateway/index.ts
+++ b/apps/core-app/src/main/modules/tool-gateway/index.ts
@@ -51,6 +51,13 @@ export class ToolGatewayModule extends BaseModule<TalexEvents> {
 
   private disposers: Array<() => void> = []
   private handle: ToolGatewayHandle | null = null
+  /**
+   * The in-flight start, so overlapping callers join it instead of each binding a port.
+   * `handle` alone cannot guard this: it is only assigned once startToolGateway() resolves,
+   * so two setEnabled(true) calls both passed the check, both bound, and the second assignment
+   * dropped the first server on the floor still listening (#642).
+   */
+  private starting: Promise<ToolGatewayHandle> | null = null
   private enabled = false
   private pending = new Map<string, (decision: ConfirmationDecision) => void>()
   /**
@@ -121,8 +128,12 @@ export class ToolGatewayModule extends BaseModule<TalexEvents> {
     broadcast: (event: unknown, payload: unknown) => unknown
   }): Promise<void> {
     if (this.handle) return
+    if (this.starting) {
+      await this.starting
+      return
+    }
 
-    this.handle = await startToolGateway({
+    this.starting = startToolGateway({
       tools: createToolRegistry(this.registryOptions()),
       onLog: (message) => toolLog.info(message),
       confirm: async (request) => {
@@ -151,6 +162,13 @@ export class ToolGatewayModule extends BaseModule<TalexEvents> {
         })
       }
     })
+
+    try {
+      this.handle = await this.starting
+    } finally {
+      // Cleared on failure too, so a start that throws does not wedge every later attempt.
+      this.starting = null
+    }
 
     toolLog.info(`Tool gateway listening on ${this.handle.url}`)
   }


### PR DESCRIPTION
Fixes #642.

## The defect

```ts
if (this.handle) return
this.handle = await startToolGateway({ ... })   // assigned only after it resolves
```

Two overlapping `setEnabled(true)` calls both passed the guard, both bound a port, and the second assignment dropped the first server — **still listening, no longer referenced, so nothing could ever close it**.

## The fix, and the failure path it has to avoid

A `starting` promise holds the in-flight attempt; later callers await the same one.

It is cleared in a `finally`, not on success. If a start throws — `EADDRINUSE` is the obvious case — leaving the rejected promise in place would make every later attempt short-circuit on it, turning a transient bind failure into a **permanently disabled gateway**. That is the same shape as the trap in #644, where moving a guard earlier risked wedging the queue shut.

## No test, and the reason is specific

The module imports `BaseModule`, the runtime accessor and three `ai/*` stores. Mocking that chain did not converge: `electron` kept resolving for real through one of the transitive imports even after widening the mock to cover `app`, `shell`, `ipcMain` and `BrowserWindow`.

Building that harness is worth doing — `index.ts` has no test file at all — but as its own change, not rushed alongside a race fix. I removed the half-working test rather than leaving it skipped.

Verified by typecheck and by reading the resulting control flow. The existing gateway suites still pass.

## Gates

- `npm run typecheck:node`: exit 0
- tool-gateway suites: **5 files, 65 tests passing**
- `eslint --max-warnings=0`: exit 0