### PR TITLE
fix(core-app): use the session.extensions API Electron 41 points at (#596)

### DIFF
--- a/apps/core-app/src/main/modules/extension-loader.test.ts
+++ b/apps/core-app/src/main/modules/extension-loader.test.ts
@@ -10,8 +10,13 @@ const { loadExtensionMock, removeExtensionMock } = vi.hoisted(() => ({
 vi.mock('electron', () => ({
   session: {
     defaultSession: {
-      loadExtension: loadExtensionMock,
-      removeExtension: removeExtensionMock
+      // Electron 41 moved these onto session.extensions and deprecated the flat ones (#596).
+      // Mocking only the nested shape means a revert to the flat call fails here rather than
+      // silently exercising a method the mock still happens to expose.
+      extensions: {
+        loadExtension: loadExtensionMock,
+        removeExtension: removeExtensionMock
+      }
     }
   }
 }))

--- a/apps/core-app/src/main/modules/extension-loader.ts
+++ b/apps/core-app/src/main/modules/extension-loader.ts
@@ -71,7 +71,7 @@ export class ExtensionLoaderModule extends BaseModule {
 
       const fullPath = path.join(extensionPath, extension)
       try {
-        const loaded = await session.defaultSession.loadExtension(fullPath)
+        const loaded = await session.defaultSession.extensions.loadExtension(fullPath)
         if (this.destroying) {
           this.removeLoadedExtension({
             id: loaded.id,
@@ -108,7 +108,7 @@ export class ExtensionLoaderModule extends BaseModule {
 
   private removeLoadedExtension(extension: LoadedExtensionRecord): void {
     try {
-      session.defaultSession.removeExtension(extension.id)
+      session.defaultSession.extensions.removeExtension(extension.id)
       extensionLoaderLog.info(`Unloaded extension: ${extension.name}`, {
         meta: { id: extension.id, path: extension.path }
       })


### PR DESCRIPTION
Closes #596.

Both call sites move: `session.defaultSession.loadExtension` → `session.defaultSession.extensions.loadExtension`, same for `removeExtension`.

## One correction to the issue

It suggests `extensions.remove`. The actual member is **`extensions.removeExtension`** — the `Extensions` interface keeps the original method names (`loadExtension`, `removeExtension`, `getAllExtensions`, `getExtension`), so the migration is inserting `.extensions` and nothing else.

`getAllExtensions` is deprecated in the same release, as the issue notes, but this codebase never calls it — there is nothing to migrate there.

## The test mock is now a check rather than a formality

It exposed `loadExtension` / `removeExtension` flat. I nested them under `extensions` **and did not keep the flat pair**, so reverting the source fails both cases:

```
× ExtensionLoaderModule > unloads loaded extensions in reverse order on destroy
× ExtensionLoaderModule > only unloads successfully loaded extensions
```

A mock offering both shapes would have passed before and after, which is the failure mode worth avoiding here — the whole point is that the flat call stops existing.

## Verification

- `typecheck:node` stays at the baseline **6**, with no extension-related errors. That is also the evidence that Electron 41’s bundled typings accept `session.defaultSession.extensions.loadExtension` — the deprecated form and the replacement both exist today, so a green typecheck on the new one is meaningful.
- extension-loader suite: 2 tests pass.
- ESLint clean.