### PR TITLE
fix(terminal): contain stdin failures instead of letting them reach the process

### DIFF
--- a/apps/core-app/src/main/modules/terminal/terminal.manager.test.ts
+++ b/apps/core-app/src/main/modules/terminal/terminal.manager.test.ts
@@ -72,7 +72,8 @@ function fakeStream() {
 
 function fakeProcess() {
   return {
-    stdin: { write: vi.fn() },
+    // Mirrors a real ChildProcess.stdin: a stream, so 'error' can be listened for (#641).
+    stdin: { write: vi.fn(), on: vi.fn() },
     stdout: fakeStream(),
     stderr: fakeStream(),
     on: vi.fn(),
@@ -140,6 +141,22 @@ describe('terminal session ownership', () => {
 
     terminal.write({ id, data: 'ok' }, asPlugin('com.a.plugin', 4))
     expect(proc.stdin.write).toHaveBeenCalledWith('ok')
+  })
+
+  it('survives a stdin that fails, and listens for the async failure too', () => {
+    // A child that has exited leaves a broken pipe behind. Both shapes have to be contained:
+    // write() throwing here, and an 'error' arriving on the stream later. Neither may reach
+    // the main process as an unhandled failure (#641).
+    const { id } = terminal.create({ command: 'ls' }, asWindow(1))
+
+    expect(proc.stdin.on).toHaveBeenCalledWith('error', expect.any(Function))
+
+    proc.stdin.write.mockImplementationOnce(() => {
+      const err: NodeJS.ErrnoException = new Error('write EPIPE')
+      err.code = 'EPIPE'
+      throw err
+    })
+    expect(() => terminal.write({ id, data: 'x' }, asWindow(1))).not.toThrow()
   })
 
   it('ignores an id that does not exist without revealing the difference', () => {

--- a/apps/core-app/src/main/modules/terminal/terminal.manager.ts
+++ b/apps/core-app/src/main/modules/terminal/terminal.manager.ts
@@ -232,6 +232,16 @@ class TerminalModule extends BaseModule {
       this.processes.delete(id)
     })
 
+    // The child-level 'error' below covers spawn failures, not stream failures. proc.stdin is a
+    // separate EventEmitter and ships with zero 'error' listeners (verified on node v24), so an
+    // EPIPE there would have nowhere to go (#641).
+    proc.stdin?.on?.('error', (err: NodeJS.ErrnoException) => {
+      terminalLog.warn('Terminal stdin error', {
+        meta: { id, code: err.code },
+        error: err
+      })
+    })
+
     proc.on('error', (err) => {
       terminalLog.error('Failed to start terminal process', {
         meta: {
@@ -260,9 +270,16 @@ class TerminalModule extends BaseModule {
     }
 
     if (session.proc.stdin) {
-      session.proc.stdin.write(data)
-      // Optionally, end the input stream if it's a one-off command
-      // proc.stdin.end();
+      // Guarded as well as listened for: write() can also throw synchronously once the stream is
+      // destroyed, which the 'error' listener above would never see.
+      try {
+        session.proc.stdin.write(data)
+      } catch (error) {
+        terminalLog.warn('Terminal write failed', {
+          meta: { id, code: (error as NodeJS.ErrnoException).code },
+          error
+        })
+      }
     } else {
       terminalLog.warn('Attempted to write to non-writable process', { meta: { id } })
     }


### PR DESCRIPTION
Closes #641.

`proc.stdin` is a stream with its own EventEmitter and ships with **zero** `error` listeners (checked on node v24). The existing `proc.on(error)` handler is on the *child process* — it covers spawn failures, not stream failures. So an EPIPE on a session whose child had exited had nowhere to go. `write()` can also throw synchronously once the stream is destroyed, which no listener would ever see.

Both shapes are now contained and logged. The listener registration is itself optional-called (`stdin?.on?.(...)`) so it cannot become a new crash source.

### Verified
- both guards mutation-tested — removing either turns the new test red, restoring it green
- 9/9 terminal tests, `typecheck:node`, `eslint --max-warnings=0` clean

### Not verified
The issue was filed at lower confidence and asked for a repro. I could not produce one: three attempts to trigger a real unhandled EPIPE from a child stdin on node v24 did not crash the process. **The missing listener is confirmed; the crash is not reproduced.** The guard is cheap and correct regardless, but reviewers should know the severity is unproven.

Also updates the test stdin mock from `{ write }` to `{ write, on }` — the old mock could not represent a stream and so could not exercise this path.