### PR TITLE
perf(search): stop holding the WAL writer lock across the time-stats rebuild

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/time-stats-aggregator.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/time-stats-aggregator.test.ts
@@ -1,87 +1,97 @@
-import { describe, expect, it } from 'vitest'
-import { toParsedItemTimeStats } from './time-stats-aggregator'
+import type { DbUtils } from '../../../db/utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
- * A corrupt row must cost that row its history, not take down every caller (#655).
- *
- * hourDistribution / dayOfWeekDistribution / timeSlotDistribution are plain TEXT columns holding
- * JSON. `parseTimeStats` ran raw JSON.parse on all three, and it sits under the public
- * getItemTimeStats / getItemTimeStatsBatch API — so one partially written or truncated row threw
- * out of every consumer at once.
+ * The rebuild used to run every upsert inside one `db.transaction`, awaiting
+ * `setImmediate` every 20 rows. Yielding there keeps the WAL writer lock held
+ * while unrelated main-process work runs, so the search-index worker's
+ * concurrent writes hit SQLITE_BUSY for the whole rebuild rather than for one
+ * short transaction (#659). What these tests pin is the structural property:
+ * bounded chunks, one scheduled write each, and no transaction spanning them.
  */
 
-function row(overrides: Partial<Record<string, unknown>> = {}) {
-  return {
-    sourceId: 'app-provider',
-    itemId: 'com.apple.Terminal',
-    hourDistribution: JSON.stringify(Array.from({ length: 24 }, (_, index) => index)),
-    dayOfWeekDistribution: JSON.stringify([1, 2, 3, 4, 5, 6, 7]),
-    timeSlotDistribution: JSON.stringify({ morning: 1, afternoon: 2, evening: 3, night: 4 }),
-    lastUpdated: new Date('2026-08-08T00:00:00.000Z'),
-    ...overrides
-  } as never
+const scheduleDbWrite = vi.fn(
+  async (_name: string, run: () => unknown | Promise<unknown>) => await run()
+)
+
+vi.mock('../../../db/db-write', () => ({
+  scheduleDbWrite: (...args: Parameters<typeof scheduleDbWrite>) => scheduleDbWrite(...args)
+}))
+
+vi.mock('../../../utils/perf-context', () => ({
+  enterPerfContext: () => () => {}
+}))
+
+const transaction = vi.fn()
+const insertedChunks: Array<unknown[]> = []
+
+function makeDb(logs: Array<{ sourceId: string; itemId: string; timestamp: Date }>) {
+  const query = {
+    select: () => query,
+    from: () => query,
+    where: () => query,
+    orderBy: () => query,
+    all: async () => logs,
+    transaction,
+    insert: () => ({
+      values: (chunk: unknown[]) => {
+        insertedChunks.push(chunk)
+        return { onConflictDoUpdate: async () => undefined }
+      }
+    })
+  }
+  return query
 }
 
-describe('toParsedItemTimeStats', () => {
-  it('parses a well-formed row', () => {
-    // Positive control: every tolerance assertion below would also hold for a parser that always
-    // returned zeros.
-    const parsed = toParsedItemTimeStats(row())
+function makeLogs(itemCount: number) {
+  return Array.from({ length: itemCount }, (_, i) => ({
+    sourceId: 'source',
+    itemId: `item-${i}`,
+    timestamp: new Date(2026, 0, 1, 9, 0, 0)
+  }))
+}
 
-    expect(parsed.hourDistribution).toHaveLength(24)
-    expect(parsed.hourDistribution[5]).toBe(5)
-    expect(parsed.dayOfWeekDistribution).toEqual([1, 2, 3, 4, 5, 6, 7])
-    expect(parsed.timeSlotDistribution).toEqual({ morning: 1, afternoon: 2, evening: 3, night: 4 })
-    expect(parsed.sourceId).toBe('app-provider')
+async function runRebuild(itemCount: number) {
+  const { TimeStatsAggregator } = await import('./time-stats-aggregator')
+  const dbUtils = { getDb: () => makeDb(makeLogs(itemCount)) } as unknown as DbUtils
+  await new TimeStatsAggregator(dbUtils).aggregateTimeStats({ force: true })
+}
+
+describe('TimeStatsAggregator rebuild write shape', () => {
+  beforeEach(() => {
+    scheduleDbWrite.mockClear()
+    transaction.mockClear()
+    insertedChunks.length = 0
   })
 
-  it('does not throw on malformed JSON in any single column', () => {
-    for (const column of [
-      'hourDistribution',
-      'dayOfWeekDistribution',
-      'timeSlotDistribution'
-    ] as const) {
-      expect(() => toParsedItemTimeStats(row({ [column]: '{"truncated' })), column).not.toThrow()
+  it('never opens a transaction that spans the whole rebuild', async () => {
+    await runRebuild(1200)
+    expect(transaction).not.toHaveBeenCalled()
+  })
+
+  it('splits the upserts into bounded chunks, one scheduled write each', async () => {
+    await runRebuild(1200)
+
+    // 1200 distinct items at a 500 chunk cap => 500 + 500 + 200.
+    expect(insertedChunks.map((chunk) => chunk.length)).toEqual([500, 500, 200])
+    expect(scheduleDbWrite).toHaveBeenCalledTimes(3)
+    for (const chunk of insertedChunks) {
+      expect(chunk.length).toBeLessThanOrEqual(500)
     }
   })
 
-  it('keeps the columns it can still read', () => {
-    // The point of per-column tolerance: one bad column must not discard the other two, or a
-    // partial write would silently erase an item's whole history.
-    const parsed = toParsedItemTimeStats(row({ hourDistribution: 'not json at all' }))
+  it('still writes every item exactly once', async () => {
+    await runRebuild(1200)
 
-    expect(parsed.hourDistribution).toEqual(Array.from({ length: 24 }, () => 0))
-    expect(parsed.dayOfWeekDistribution).toEqual([1, 2, 3, 4, 5, 6, 7])
-    expect(parsed.timeSlotDistribution.night).toBe(4)
+    const written = insertedChunks.flat() as Array<{ itemId: string }>
+    expect(written).toHaveLength(1200)
+    expect(new Set(written.map((row) => row.itemId)).size).toBe(1200)
   })
 
-  it('normalises shapes that parse but are not the expected type', () => {
-    // Valid JSON of the wrong shape is the case a try/catch alone would miss.
-    const parsed = toParsedItemTimeStats(
-      row({
-        hourDistribution: JSON.stringify('a string'),
-        dayOfWeekDistribution: JSON.stringify({ not: 'an array' }),
-        timeSlotDistribution: JSON.stringify({ morning: 'lots', night: -3 })
-      })
-    )
+  it('does not chunk a rebuild that fits in one write', async () => {
+    await runRebuild(10)
 
-    expect(parsed.hourDistribution).toHaveLength(24)
-    expect(parsed.dayOfWeekDistribution).toHaveLength(7)
-    expect(parsed.timeSlotDistribution.morning).toBe(0)
-    expect(parsed.timeSlotDistribution.night).toBe(0)
-  })
-
-  it('tolerates null columns', () => {
-    const parsed = toParsedItemTimeStats(
-      row({ hourDistribution: null, dayOfWeekDistribution: null, timeSlotDistribution: null })
-    )
-
-    expect(parsed.hourDistribution).toHaveLength(24)
-    expect(parsed.timeSlotDistribution).toEqual({
-      morning: 0,
-      afternoon: 0,
-      evening: 0,
-      night: 0
-    })
+    expect(scheduleDbWrite).toHaveBeenCalledTimes(1)
+    expect(insertedChunks[0]).toHaveLength(10)
   })
 })

--- a/apps/core-app/src/main/modules/box-tool/search-engine/time-stats-aggregator.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/time-stats-aggregator.ts
@@ -1,5 +1,5 @@
 import type { DbUtils } from '../../../db/utils'
-import { desc, eq } from 'drizzle-orm'
+import { desc, eq, sql } from 'drizzle-orm'
 import * as schema from '../../../db/schema'
 import { scheduleDbWrite } from '../../../db/db-write'
 import { parseStoredTimeBuckets } from './item-time-stats-buckets'
@@ -8,6 +8,12 @@ import { enterPerfContext } from '../../../utils/perf-context'
 import { resolveTimeSlot } from './item-time-stats-buckets'
 
 const log = createLogger('TimeStatsAggregator')
+
+/**
+ * 每次写事务的上限。与 backfillTrendDay 一致：足够摊薄事务开销，又不会让单条
+ * 多行 VALUES 语句无界增长。
+ */
+const AGGREGATE_CHUNK_SIZE = 500
 
 /**
  * Opt-in switch for the destructive full rebuild below. Off by default: the
@@ -106,48 +112,49 @@ export class TimeStatsAggregator {
         }
       }
 
-      // 3. 批量写入数据库 — 抽出事务体，通过统一的单写入队列 (scheduleDbWrite)
-      //    串行化；SQLITE_BUSY 由调度器自身以「延迟重新入队」处理（退避发生在
-      //    排队期间，不占用写循环、不阻塞事件循环）。
+      // 3. 批量写入数据库 — 分块提交，每块自成一次 scheduleDbWrite。
+      //    之前这里是「一个事务体内部每 20 条 await setImmediate」：让出事件循环时
+      //    WAL 写锁仍被握着，整个重建期间 search-index worker 的并发写都会撞
+      //    SQLITE_BUSY。改为 backfillTrendDay 同款分块写法后，写锁只在单块内持有，
+      //    让步发生在两次事务之间。
       let updatedCount = 0
       const allStats = Array.from(statsMap.values())
+      const now = new Date()
+      const values = allStats.map((stats) => ({
+        sourceId: stats.sourceId,
+        itemId: stats.itemId,
+        hourDistribution: JSON.stringify(stats.hourDistribution),
+        dayOfWeekDistribution: JSON.stringify(stats.dayOfWeekDistribution),
+        timeSlotDistribution: JSON.stringify(stats.timeSlotDistribution),
+        lastUpdated: now
+      }))
 
-      const writeAggregatedStats = (): Promise<void> =>
-        db.transaction(async (tx) => {
-          for (let i = 0; i < allStats.length; i++) {
-            const stats = allStats[i]
-            await tx
+      for (let i = 0; i < values.length; i += AGGREGATE_CHUNK_SIZE) {
+        const chunk = values.slice(i, i + AGGREGATE_CHUNK_SIZE)
+        await scheduleDbWrite(
+          'usage.time-stats.aggregate',
+          () =>
+            db
               .insert(schema.itemTimeStats)
-              .values({
-                sourceId: stats.sourceId,
-                itemId: stats.itemId,
-                hourDistribution: JSON.stringify(stats.hourDistribution),
-                dayOfWeekDistribution: JSON.stringify(stats.dayOfWeekDistribution),
-                timeSlotDistribution: JSON.stringify(stats.timeSlotDistribution),
-                lastUpdated: new Date()
-              })
+              .values(chunk)
               .onConflictDoUpdate({
                 target: [schema.itemTimeStats.sourceId, schema.itemTimeStats.itemId],
                 set: {
-                  hourDistribution: JSON.stringify(stats.hourDistribution),
-                  dayOfWeekDistribution: JSON.stringify(stats.dayOfWeekDistribution),
-                  timeSlotDistribution: JSON.stringify(stats.timeSlotDistribution),
-                  lastUpdated: new Date()
+                  hourDistribution: sql`excluded.hour_distribution`,
+                  dayOfWeekDistribution: sql`excluded.day_of_week_distribution`,
+                  timeSlotDistribution: sql`excluded.time_slot_distribution`,
+                  lastUpdated: sql`excluded.last_updated`
                 }
-              })
-            updatedCount++
+              }),
+          { priority: 'background', dropPolicy: 'none' }
+        )
+        updatedCount += chunk.length
 
-            // 每 20 条 upsert 让出事件循环
-            if ((i + 1) % 20 === 0) {
-              await new Promise<void>((resolve) => setImmediate(resolve))
-            }
-          }
-        })
-
-      await scheduleDbWrite('usage.time-stats.aggregate', writeAggregatedStats, {
-        priority: 'background',
-        dropPolicy: 'none'
-      })
+        // 让步放在两次事务之间，此时没有写锁在手。
+        if (i + AGGREGATE_CHUNK_SIZE < values.length) {
+          await new Promise<void>((resolve) => setImmediate(resolve))
+        }
+      }
 
       const duration = performance.now() - startTime
       log.debug(`Aggregation completed. Updated ${updatedCount} items in ${duration.toFixed(2)}ms`)

--- a/apps/core-app/src/main/modules/box-tool/search-engine/time-stats-parse.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/time-stats-parse.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { toParsedItemTimeStats } from './time-stats-aggregator'
+
+/**
+ * A corrupt row must cost that row its history, not take down every caller (#655).
+ *
+ * hourDistribution / dayOfWeekDistribution / timeSlotDistribution are plain TEXT columns holding
+ * JSON. `parseTimeStats` ran raw JSON.parse on all three, and it sits under the public
+ * getItemTimeStats / getItemTimeStatsBatch API — so one partially written or truncated row threw
+ * out of every consumer at once.
+ */
+
+function row(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    sourceId: 'app-provider',
+    itemId: 'com.apple.Terminal',
+    hourDistribution: JSON.stringify(Array.from({ length: 24 }, (_, index) => index)),
+    dayOfWeekDistribution: JSON.stringify([1, 2, 3, 4, 5, 6, 7]),
+    timeSlotDistribution: JSON.stringify({ morning: 1, afternoon: 2, evening: 3, night: 4 }),
+    lastUpdated: new Date('2026-08-08T00:00:00.000Z'),
+    ...overrides
+  } as never
+}
+
+describe('toParsedItemTimeStats', () => {
+  it('parses a well-formed row', () => {
+    // Positive control: every tolerance assertion below would also hold for a parser that always
+    // returned zeros.
+    const parsed = toParsedItemTimeStats(row())
+
+    expect(parsed.hourDistribution).toHaveLength(24)
+    expect(parsed.hourDistribution[5]).toBe(5)
+    expect(parsed.dayOfWeekDistribution).toEqual([1, 2, 3, 4, 5, 6, 7])
+    expect(parsed.timeSlotDistribution).toEqual({ morning: 1, afternoon: 2, evening: 3, night: 4 })
+    expect(parsed.sourceId).toBe('app-provider')
+  })
+
+  it('does not throw on malformed JSON in any single column', () => {
+    for (const column of [
+      'hourDistribution',
+      'dayOfWeekDistribution',
+      'timeSlotDistribution'
+    ] as const) {
+      expect(() => toParsedItemTimeStats(row({ [column]: '{"truncated' })), column).not.toThrow()
+    }
+  })
+
+  it('keeps the columns it can still read', () => {
+    // The point of per-column tolerance: one bad column must not discard the other two, or a
+    // partial write would silently erase an item's whole history.
+    const parsed = toParsedItemTimeStats(row({ hourDistribution: 'not json at all' }))
+
+    expect(parsed.hourDistribution).toEqual(Array.from({ length: 24 }, () => 0))
+    expect(parsed.dayOfWeekDistribution).toEqual([1, 2, 3, 4, 5, 6, 7])
+    expect(parsed.timeSlotDistribution.night).toBe(4)
+  })
+
+  it('normalises shapes that parse but are not the expected type', () => {
+    // Valid JSON of the wrong shape is the case a try/catch alone would miss.
+    const parsed = toParsedItemTimeStats(
+      row({
+        hourDistribution: JSON.stringify('a string'),
+        dayOfWeekDistribution: JSON.stringify({ not: 'an array' }),
+        timeSlotDistribution: JSON.stringify({ morning: 'lots', night: -3 })
+      })
+    )
+
+    expect(parsed.hourDistribution).toHaveLength(24)
+    expect(parsed.dayOfWeekDistribution).toHaveLength(7)
+    expect(parsed.timeSlotDistribution.morning).toBe(0)
+    expect(parsed.timeSlotDistribution.night).toBe(0)
+  })
+
+  it('tolerates null columns', () => {
+    const parsed = toParsedItemTimeStats(
+      row({ hourDistribution: null, dayOfWeekDistribution: null, timeSlotDistribution: null })
+    )
+
+    expect(parsed.hourDistribution).toHaveLength(24)
+    expect(parsed.timeSlotDistribution).toEqual({
+      morning: 0,
+      afternoon: 0,
+      evening: 0,
+      night: 0
+    })
+  })
+})


### PR DESCRIPTION
Closes #659.

The rebuild ran every upsert inside one `db.transaction` and awaited `setImmediate` every 20 rows. Yielding there hands the event loop to unrelated main-process I/O **while the WAL writer lock is still held**, so the search-index worker's concurrent writes hit `SQLITE_BUSY` for the duration of the whole rebuild rather than for one short transaction. At 5,000 items that is 250 yields inside a single open transaction.

Now chunked the way `backfillTrendDay` already does it (the pattern the issue pointed at): bounded chunks of 500, one `scheduleDbWrite` each, yield moved *between* transactions where no lock is held. Each chunk is one multi-row upsert instead of 500 round trips.

### Tradeoff worth stating explicitly
The rebuild is **no longer atomic**. A failure part-way leaves some items on fresh stats and some on stale ones, corrected by the next rebuild. This is derived data recomputed from `usage_logs`, and `backfillTrendDay` accepts the same tradeoff for the same class of data — but it is a real behaviour change, not a pure refactor.

### Verified
- new test file mutation-tested against the HEAD implementation: all 4 red on the old code, green on the new
- 579/579 search-engine tests, `typecheck:node`, `eslint --max-warnings=0` clean

The new tests pin the structural property rather than the timing: no transaction spanning the rebuild, chunks bounded at 500, every item written exactly once, and no chunking when it already fits in one write.