### PR TITLE
fix(core-app): remove the original-fs shim that defeats the ASAR bypass (#595)

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -131,7 +131,6 @@
     "iconv-lite": "^0.7.3",
     "log4js": "^6.9.1",
     "ms": "^2.1.3",
-    "original-fs": "^1.2.0",
     "path-browserify": "^1.0.1",
     "pinia": "catalog:frontend",
     "pinyin-pro": "^3.28.1",

--- a/packages/utils/__tests__/original-fs-shim-absent.test.ts
+++ b/packages/utils/__tests__/original-fs-shim-absent.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The userland `original-fs` package must stay uninstalled (#595).
+ *
+ * `attestation.ts` reads build artifacts through `require('original-fs')` inside a try/catch,
+ * falling back to `node:fs`. That is deliberate: inside Electron the builtin `original-fs` reads
+ * the raw bytes on disk, bypassing the ASAR layer, which is the whole point of hashing them.
+ *
+ * The npm package of that name is one line — `module.exports = require('fs')`. With it installed
+ * the require can never throw, so outside Electron the catch never fires and the attestation
+ * hashes bytes read *through* ASAR while reporting success. The integrity check compares the wrong
+ * bytes and nothing surfaces it.
+ *
+ * The fix is the absence of a package, which is exactly the kind of thing a later `pnpm add` or a
+ * transitive dependency undoes silently — hence a check rather than a comment. It lives here
+ * rather than in core-app because the lockfile is repo-wide and `ci / CI - utils` blocks merges,
+ * while the core-app suite runs under `continue-on-error`.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const LOCKFILE = path.join(REPO_ROOT, 'pnpm-lock.yaml')
+
+describe('original-fs shim', () => {
+  it('reads the lockfile', () => {
+    // Positive control: both assertions below are absence checks, which an unread file passes.
+    const contents = readFileSync(LOCKFILE, 'utf8')
+
+    expect(contents).toContain('lockfileVersion')
+    // A package that IS installed, proving the match would find one if present.
+    expect(contents).toMatch(/^ {2}fs-extra@/m)
+  })
+
+  it('is not installed anywhere in the workspace', () => {
+    const contents = readFileSync(LOCKFILE, 'utf8')
+
+    expect(contents).not.toMatch(/^ {2}original-fs@/m)
+    expect(contents).not.toMatch(/^\s+original-fs:\s/m)
+  })
+
+  it('is not declared by any workspace manifest', () => {
+    // The lockfile check above would catch this too, but only after an install. This catches a
+    // manifest edit on its own.
+    const manifests = ['apps/core-app/package.json', 'package.json']
+    for (const manifest of manifests) {
+      const pkg = JSON.parse(readFileSync(path.join(REPO_ROOT, manifest), 'utf8'))
+      const declared = { ...pkg.dependencies, ...pkg.devDependencies }
+      expect(Object.keys(declared), manifest).not.toContain('original-fs')
+    }
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,9 +411,6 @@ importers:
       ms:
         specifier: ^2.1.3
         version: 2.1.3
-      original-fs:
-        specifier: ^1.2.0
-        version: 1.2.0
       path-browserify:
         specifier: ^1.0.1
         version: 1.0.1
@@ -10920,9 +10917,6 @@ packages:
 
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
-
-  original-fs@1.2.0:
-    resolution: {integrity: sha512-IGo+qFumpIV65oDchJrqL0BOk9kr82fObnTesNJt8t3YgP6vfqcmRs0ofPzg3D9PKMeBHt7lrg1k/6L+oFdS8g==}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -25145,8 +25139,6 @@ snapshots:
       word-wrap: 1.2.5
 
   orderedmap@2.1.1: {}
-
-  original-fs@1.2.0: {}
 
   own-keys@1.0.1:
     dependencies:


### PR DESCRIPTION
Closes #595.

Confirmed exactly as filed. `node_modules/original-fs/index.js` is one line:

```js
'use strict';module.exports=require('fs');
```

so `require('original-fs')` in `attestation.ts` can never throw, the `catch` is dead, and outside Electron the attestation hashes bytes read **through** ASAR while reporting success.

## Which of the two directions, and why

Took **removing the dependency** rather than the explicit `process.versions.electron` check.

The explicit check asserts *Electron implies a working builtin `original-fs`*. That needs verifying for utility processes specifically — the very contexts the issue names — and I could not establish it without running one. Removing the package needs no such answer: the builtin wins where it exists, and the `catch` fires honestly where it does not, in every context.

## Checked before removing

- **Nothing else needs it.** No other package in the lockfile requires `original-fs`; the only importer entry was core-app's own.
- **The bundler does not need it.** The call is `createRequire(import.meta.url)('original-fs')` — a runtime call rollup does not statically resolve. `original-fs` appears in the *renderer* config's `external` list (`electron.vite.config.ts:312/317`), not the main one; the main build relies on `externalizeDepsPlugin`, which externalizes declared dependencies, so this was the case worth testing rather than assuming.

**Verified by building it:** the main process builds fine without the dependency, and the emitted `out/main/index.js` still contains the literal `"original-fs"` inside a `createRequire(...)` call. (The renderer half of that build fails on `@xterm/addon-fit` — #584’s packages are not installed in this worktree — which is unrelated and pre-existing here.)

## The guard, and why it is where it is

The fix *is* the absence of a package. A later `pnpm add original-fs`, or a transitive pull, undoes it with no visible symptom — so it is pinned by a check rather than a comment.

It lives in `packages/utils/__tests__/` deliberately: the lockfile is repo-wide, and `ci / CI - utils` **blocks merges**, whereas the core-app suite runs under `continue-on-error` (#1255). Wrong place for an invariant whose failure means the integrity check silently compares the wrong bytes.

It checks both the lockfile and the manifests — the manifest check catches an edit before anyone installs. Positive control: it asserts `fs-extra@` *is* found in the lockfile, so the absence checks cannot pass over an unread file.

Restoring the lockfile and manifest from HEAD fails both substantive assertions while the control stays green.

`packages/utils` full suite: 138 files / 1088 tests pass.