### PR TITLE
perf(search): page the time-stats rebuild instead of materialising every log

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/time-stats-aggregator.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/time-stats-aggregator.test.ts
@@ -22,16 +22,54 @@ vi.mock('../../../utils/perf-context', () => ({
   enterPerfContext: () => () => {}
 }))
 
+// Enough of the operators to let the fake db see which keyset cursor was asked
+// for. `sql` stays real — the upsert's excluded.* references go through it.
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>()
+  return {
+    ...actual,
+    and: (...conditions: unknown[]) => Object.assign({}, ...conditions.filter(Boolean)),
+    eq: () => ({}),
+    asc: () => ({}),
+    gt: (_column: unknown, value: number) => ({ __afterId: value })
+  }
+})
+
 const transaction = vi.fn()
 const insertedChunks: Array<unknown[]> = []
+/** Rows handed to the aggregator per read, in order — one entry per page. */
+const readPageSizes: number[] = []
 
-function makeDb(logs: Array<{ sourceId: string; itemId: string; timestamp: Date }>) {
+type LogRow = { id: number; sourceId: string; itemId: string; timestamp: Date }
+
+/**
+ * Models keyset pagination rather than returning everything: the aggregator is
+ * expected to walk `id > lastId ... LIMIT n`, so the mock has to honour both or
+ * the paging under test is not actually exercised (#660).
+ */
+function makeDb(logs: LogRow[]) {
+  let pendingAfterId = 0
+  let pendingLimit = Number.POSITIVE_INFINITY
+
   const query = {
     select: () => query,
     from: () => query,
-    where: () => query,
+    where: (condition: unknown) => {
+      pendingAfterId = (condition as { __afterId?: number })?.__afterId ?? 0
+      return query
+    },
     orderBy: () => query,
-    all: async () => logs,
+    limit: (n: number) => {
+      pendingLimit = n
+      return query
+    },
+    all: async () => {
+      const page = logs.filter((row) => row.id > pendingAfterId).slice(0, pendingLimit)
+      readPageSizes.push(page.length)
+      pendingAfterId = 0
+      pendingLimit = Number.POSITIVE_INFINITY
+      return page
+    },
     transaction,
     insert: () => ({
       values: (chunk: unknown[]) => {
@@ -43,8 +81,9 @@ function makeDb(logs: Array<{ sourceId: string; itemId: string; timestamp: Date 
   return query
 }
 
-function makeLogs(itemCount: number) {
+function makeLogs(itemCount: number): LogRow[] {
   return Array.from({ length: itemCount }, (_, i) => ({
+    id: i + 1,
     sourceId: 'source',
     itemId: `item-${i}`,
     timestamp: new Date(2026, 0, 1, 9, 0, 0)
@@ -62,6 +101,24 @@ describe('TimeStatsAggregator rebuild write shape', () => {
     scheduleDbWrite.mockClear()
     transaction.mockClear()
     insertedChunks.length = 0
+    readPageSizes.length = 0
+  })
+
+  it('never materialises the whole log table in one read', async () => {
+    await runRebuild(12_000)
+
+    // 12,000 rows at a 5,000 page cap => 5,000 + 5,000 + 2,000, then stop:
+    // the short final page ends the walk without a further empty round trip.
+    expect(readPageSizes).toEqual([5000, 5000, 2000])
+    for (const size of readPageSizes) {
+      expect(size).toBeLessThanOrEqual(5000)
+    }
+  })
+
+  it('reads one more page when the last one is exactly full', async () => {
+    await runRebuild(10_000)
+
+    expect(readPageSizes).toEqual([5000, 5000, 0])
   })
 
   it('never opens a transaction that spans the whole rebuild', async () => {

--- a/apps/core-app/src/main/modules/box-tool/search-engine/time-stats-aggregator.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/time-stats-aggregator.ts
@@ -1,5 +1,5 @@
 import type { DbUtils } from '../../../db/utils'
-import { desc, eq, sql } from 'drizzle-orm'
+import { and, asc, eq, gt, sql } from 'drizzle-orm'
 import * as schema from '../../../db/schema'
 import { scheduleDbWrite } from '../../../db/db-write'
 import { parseStoredTimeBuckets } from './item-time-stats-buckets'
@@ -14,6 +14,9 @@ const log = createLogger('TimeStatsAggregator')
  * 多行 VALUES 语句无界增长。
  */
 const AGGREGATE_CHUNK_SIZE = 500
+
+/** 一次读进内存的日志行数上限。 */
+const LOG_PAGE_SIZE = 5000
 
 /**
  * Opt-in switch for the destructive full rebuild below. Off by default: the
@@ -59,58 +62,79 @@ export class TimeStatsAggregator {
 
       const db = this.dbUtils.getDb()
 
-      // 1. 查询所有执行日志
-      const logs = await db
-        .select({
-          sourceId: schema.usageLogs.source,
-          itemId: schema.usageLogs.itemId,
-          timestamp: schema.usageLogs.timestamp
-        })
-        .from(schema.usageLogs)
-        .where(eq(schema.usageLogs.action, 'execute'))
-        .orderBy(desc(schema.usageLogs.timestamp))
-        .all()
-
-      log.debug(`Found ${logs.length} execution logs`)
-
-      if (logs.length === 0) return
-
-      // 2. 构建统计数据 — 每 50 行让出事件循环
+      // 1-2. 逐页读取执行日志并就地折叠进桶里。
+      //
+      // 之前是一次 .all() 把整张 usage_logs 的 execute 行物化成数组：保留窗口调大的
+      // 老装机会累积上百万行，而这条路径可以被 IPC 强制触发，等于在主进程里一次性
+      // 建出上百万个行对象。改成按主键 keyset 分页（id > lastId），常驻内存只剩一页
+      // 加上 statsMap —— 后者的规模由「去重后的 item 数」决定，与日志行数无关。
+      //
+      // 没有按 issue 建议改成 SQL GROUP BY：下面的 getHours()/getDay() 取的是本地时区，
+      // 而 SQLite 的 strftime 按 UTC 分组，换过去会静默改变非 UTC 用户的分桶结果。
       const statsMap = new Map<string, ItemTimeStatsData>()
+      let totalLogs = 0
+      let lastId = 0
+      let rowsSinceYield = 0
 
-      for (let i = 0; i < logs.length; i++) {
-        const entry = logs[i]
-        const key = `${entry.sourceId}:${entry.itemId}`
-        const date = new Date(entry.timestamp)
-        const hour = date.getHours()
-        const dayOfWeek = date.getDay()
-        const timeSlot = resolveTimeSlot(hour)
-
-        if (!statsMap.has(key)) {
-          statsMap.set(key, {
-            sourceId: entry.sourceId,
-            itemId: entry.itemId,
-            hourDistribution: Array.from({ length: 24 }, () => 0),
-            dayOfWeekDistribution: Array.from({ length: 7 }, () => 0),
-            timeSlotDistribution: {
-              morning: 0,
-              afternoon: 0,
-              evening: 0,
-              night: 0
-            }
+      for (;;) {
+        const page = await db
+          .select({
+            id: schema.usageLogs.id,
+            sourceId: schema.usageLogs.source,
+            itemId: schema.usageLogs.itemId,
+            timestamp: schema.usageLogs.timestamp
           })
+          .from(schema.usageLogs)
+          .where(and(eq(schema.usageLogs.action, 'execute'), gt(schema.usageLogs.id, lastId)))
+          .orderBy(asc(schema.usageLogs.id))
+          .limit(LOG_PAGE_SIZE)
+          .all()
+
+        if (page.length === 0) break
+
+        lastId = page[page.length - 1].id
+        totalLogs += page.length
+
+        for (const entry of page) {
+          const key = `${entry.sourceId}:${entry.itemId}`
+          const date = new Date(entry.timestamp)
+          const hour = date.getHours()
+          const dayOfWeek = date.getDay()
+          const timeSlot = resolveTimeSlot(hour)
+
+          if (!statsMap.has(key)) {
+            statsMap.set(key, {
+              sourceId: entry.sourceId,
+              itemId: entry.itemId,
+              hourDistribution: Array.from({ length: 24 }, () => 0),
+              dayOfWeekDistribution: Array.from({ length: 7 }, () => 0),
+              timeSlotDistribution: {
+                morning: 0,
+                afternoon: 0,
+                evening: 0,
+                night: 0
+              }
+            })
+          }
+
+          const stats = statsMap.get(key)!
+          stats.hourDistribution[hour]++
+          stats.dayOfWeekDistribution[dayOfWeek]++
+          stats.timeSlotDistribution[timeSlot]++
+
+          // 每 50 行让出事件循环，避免连续同步操作累积阻塞
+          if (++rowsSinceYield >= 50) {
+            rowsSinceYield = 0
+            await new Promise<void>((resolve) => setImmediate(resolve))
+          }
         }
 
-        const stats = statsMap.get(key)!
-        stats.hourDistribution[hour]++
-        stats.dayOfWeekDistribution[dayOfWeek]++
-        stats.timeSlotDistribution[timeSlot]++
-
-        // 每 50 行让出事件循环，避免连续同步操作累积阻塞
-        if ((i + 1) % 50 === 0) {
-          await new Promise<void>((resolve) => setImmediate(resolve))
-        }
+        if (page.length < LOG_PAGE_SIZE) break
       }
+
+      log.debug(`Found ${totalLogs} execution logs`)
+
+      if (totalLogs === 0) return
 
       // 3. 批量写入数据库 — 分块提交，每块自成一次 scheduleDbWrite。
       //    之前这里是「一个事务体内部每 20 条 await setImmediate」：让出事件循环时


### PR DESCRIPTION
Closes #660.

**Stacked on #1331** (same file, same function) — base is `fix/659-time-stats-txn`, so **#1331 must merge first**. GitHub will retarget this to `TalexDreamSoul/app-shell-v2` automatically once it does.

`aggregateTimeStats` selected every execute row of `usage_logs` with `.all()` and built the full array before folding. A long-lived install with a raised retention window reaches ~2M rows, and the IPC repair path forces the rebuild regardless of table size — ~2M row objects built in the main process before the first yield.

Now walked by primary-key keyset pages (`id > lastId ... LIMIT 5000`) and folded in place. Resident memory is one page plus `statsMap`, and `statsMap` is sized by *distinct items*, not by log count.

### Deliberately not the GROUP BY the issue suggested
The buckets come from `getHours()` / `getDay()`, which read **local** time. SQLite's `strftime` groups by **UTC**. Pushing the aggregation into SQL would have silently changed the distributions for every user outside UTC — a correctness regression traded for the memory win. Paging gets the same memory bound with identical results.

### Keyset, not LIMIT/OFFSET
OFFSET rescans on every page, and the old `ORDER BY timestamp DESC` is not a unique order — ties straddling a page boundary could be counted twice or skipped.

### Verified
- the two new paging tests mutation-tested against the unpaged parent commit: both red there, the four chunking tests stay green, all six green here
- 581/581 search-engine tests, `typecheck:node`, `eslint --max-warnings=0` clean