### PR TITLE
fix(search): stop the semantic tokenizer from erasing non-ASCII app names

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/semantic-profile.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/semantic-profile.test.ts
@@ -63,6 +63,45 @@ describe('recommendation semantic profile', () => {
     )
   })
 
+  it('keeps non-ASCII app names as tokens instead of erasing them', () => {
+    // splitIdentifier used to strip everything outside [a-zA-Z0-9], so each of
+    // these collapsed to the same profile — only the ASCII path segment survived
+    // and 'app' is a stop token. They then scored identically for every context
+    // under calculateLocalSemanticScore (#661).
+    const wechat = buildCandidateSemanticProfile({
+      sourceId: 'app-provider',
+      itemId: '/Applications/微信.app',
+      sourceType: 'app'
+    })
+    const netease = buildCandidateSemanticProfile({
+      sourceId: 'app-provider',
+      itemId: '/Applications/网易云音乐.app',
+      sourceType: 'app'
+    })
+
+    expect(wechat.text).toContain('微信')
+    expect(netease.text).toContain('网易云音乐')
+    expect(wechat.text).not.toBe(netease.text)
+  })
+
+  it('tokenises Cyrillic and accented Latin names too', () => {
+    const cyrillic = buildCandidateSemanticProfile({
+      sourceId: 'app-provider',
+      itemId: '/Applications/Телеграм.app',
+      sourceType: 'app'
+    })
+    const accented = buildCandidateSemanticProfile({
+      sourceId: 'app-provider',
+      itemId: '/Applications/Café Résumé.app',
+      sourceType: 'app'
+    })
+
+    expect(cyrillic.text).toContain('телеграм')
+    // The accent must survive rather than splitting 'café' into 'caf'.
+    expect(accented.text).toContain('café')
+    expect(accented.text).toContain('résumé')
+  })
+
   it('does not include raw private network, location, or timezone values in profile text', () => {
     const contextProfile = buildRecommendationSemanticProfile(devFocusContext)
 

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/semantic-profile.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/semantic-profile.ts
@@ -300,12 +300,17 @@ function isPreferenceToken(token: string): boolean {
 
 function splitIdentifier(value?: string): string[] {
   if (!value) return []
-  return value
-    .replace(/([a-z])([A-Z])/g, '$1 $2')
-    .replace(/[^a-zA-Z0-9]+/g, ' ')
-    .split(/\s+/)
-    .map((part) => part.trim().toLowerCase())
-    .filter((part) => part.length > 1 && !STOP_TOKENS.has(part))
+  return (
+    value
+      .replace(/([a-z])([A-Z])/g, '$1 $2')
+      // Unicode-aware: the old [^a-zA-Z0-9] class erased CJK, Cyrillic and accented
+      // Latin wholesale, so every non-ASCII-named app produced the same empty
+      // profile and scored identically (#661).
+      .replace(/[^\p{L}\p{N}]+/gu, ' ')
+      .split(/\s+/)
+      .map((part) => part.trim().toLowerCase())
+      .filter((part) => part.length > 1 && !STOP_TOKENS.has(part))
+  )
 }
 
 function inferAppCategoryTokens(identifier: string): string[] {


### PR DESCRIPTION
Closes #661.

`splitIdentifier` replaced everything outside `[a-zA-Z0-9]` with whitespace, so identifiers in Chinese, Japanese, Korean, Cyrillic or accented Latin contributed **zero** tokens. `/Applications/微信.app` yielded only `applications` (`app` is a stop token), giving it a profile identical to every other CJK-named app — so `calculateLocalSemanticScore` (weight `6e5`, the largest non-context term) ranked 微信, 网易云音乐 and 迅雷 the same for every context.

Switched to `/[^\p{L}\p{N}]+/u`, matching the charset widening the search keyword path already had.

### Known residual, deliberately out of scope
- CJK still yields **one token per unbroken run**, not segmented words — `网易云音乐` is a single token.
- A **single-character CJK name** is still dropped by the existing `length > 1` filter, even though one character is a whole word there.

Both need a real segmenter, not a character class. Flagging rather than widening the fix; say the word if you want a follow-up issue.

### Verified
- both new tests mutation-tested against HEAD: red there, green here
- 577/577 search-engine tests, `typecheck:node` clean
- `eslint --max-warnings=0` clean — the file was at 0 warnings before this change and is back to 0 (the comment insertion tripped prettier's chain wrapping; fixed in place)