### PR TITLE
fix(search): escape LIKE wildcards in lookupByKeywordPrefix

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-index-service.like-escape.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-index-service.like-escape.test.ts
@@ -1,0 +1,121 @@
+import { createClient, type Client } from '@libsql/client'
+import { drizzle } from 'drizzle-orm/libsql'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { SearchIndexService } from './search-index-service'
+
+/**
+ * lookupByKeywordPrefix built its pattern as `${prefix}%` from raw user text,
+ * with no escaping and no ESCAPE clause — unlike the subsequence sibling. '%'
+ * therefore reached SQLite as a wildcard, so typing it matched every keyword
+ * row for the provider and the search returned unrelated apps as "prefix
+ * matches" (#663). These run against a real SQLite file, not a mock, so the
+ * assertions are about what the engine actually matches.
+ */
+
+const PROVIDER = 'app-provider'
+
+async function withIndexService(
+  run: (service: SearchIndexService, client: Client) => Promise<void>
+): Promise<void> {
+  const directory = await mkdtemp(join(tmpdir(), 'tuff-search-index-like-'))
+  let client: Client | undefined
+  try {
+    client = createClient({ url: `file:${join(directory, 'search-index.sqlite')}` })
+    await client.execute(`
+      CREATE TABLE keyword_mappings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        keyword TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        provider_id TEXT NOT NULL DEFAULT '',
+        priority REAL NOT NULL DEFAULT 1.0
+      )
+    `)
+    await client.execute(`
+      CREATE TABLE search_index_meta (
+        provider_id TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        keyword_hash TEXT NOT NULL,
+        updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+        PRIMARY KEY (provider_id, item_id)
+      )
+    `)
+    const service = new SearchIndexService(drizzle(client) as never, {
+      directMode: true,
+      initializationMode: 'writer'
+    })
+    await service.warmup()
+    await run(service, client)
+  } finally {
+    client?.close()
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+async function seed(client: Client, keywords: string[]): Promise<void> {
+  for (const keyword of keywords) {
+    await client.execute({
+      sql: 'INSERT INTO keyword_mappings (keyword, item_id, provider_id, priority) VALUES (?, ?, ?, 1.0)',
+      args: [keyword, `item:${keyword}`, PROVIDER]
+    })
+  }
+}
+
+const prefixOf = (rows: Array<{ itemId: string; keyword: string; priority: number }>): string[] =>
+  rows.map((row) => row.keyword).sort()
+
+describe('lookupByKeywordPrefix LIKE escaping', () => {
+  it('treats % as a literal instead of matching every keyword', async () => {
+    await withIndexService(async (service, client) => {
+      await seed(client, ['chrome', 'firefox', 'safari', '100% orange juice'])
+
+      const rows = await service.lookupByKeywordPrefix(PROVIDER, '%')
+
+      // Before the fix the pattern was '%%', which matches all four rows.
+      expect(prefixOf(rows)).toEqual([])
+    })
+  })
+
+  it('matches a literal % where one genuinely starts the keyword', async () => {
+    await withIndexService(async (service, client) => {
+      await seed(client, ['%battery', 'battery'])
+
+      const rows = await service.lookupByKeywordPrefix(PROVIDER, '%b')
+
+      expect(prefixOf(rows)).toEqual(['%battery'])
+    })
+  })
+
+  it('treats _ as a literal rather than a single-character wildcard', async () => {
+    await withIndexService(async (service, client) => {
+      await seed(client, ['abc', 'a1c', 'a_c'])
+
+      const rows = await service.lookupByKeywordPrefix(PROVIDER, 'a_c')
+
+      // Before the fix 'a_c' also matched 'abc' and 'a1c'.
+      expect(prefixOf(rows)).toEqual(['a_c'])
+    })
+  })
+
+  it('treats a backslash as a literal, not as an escape introducer', async () => {
+    await withIndexService(async (service, client) => {
+      await seed(client, ['back\\slash', 'backslash'])
+
+      const rows = await service.lookupByKeywordPrefix(PROVIDER, 'back\\')
+
+      expect(prefixOf(rows)).toEqual(['back\\slash'])
+    })
+  })
+
+  it('still returns ordinary prefix matches', async () => {
+    await withIndexService(async (service, client) => {
+      await seed(client, ['chrome', 'chromium', 'firefox'])
+
+      const rows = await service.lookupByKeywordPrefix(PROVIDER, 'chrom')
+
+      expect(prefixOf(rows)).toEqual(['chrome', 'chromium'])
+    })
+  })
+})

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-index-service.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-index-service.ts
@@ -789,11 +789,14 @@ export class SearchIndexService {
     if (!prefix) return []
     await this.ensureInitialized()
 
-    const likePattern = `${prefix}%`
+    // Escaped like the subsequence sibling below. Concatenating raw user text let
+    // '%' and '_' through as wildcards: typing '%' produced '%%' and matched every
+    // keyword row for the provider (#663).
+    const likePattern = `${escapeLikeWildcards(prefix)}%`
     const rows = await this.db.all<{ item_id: string; keyword: string; priority: number }>(
       sql`SELECT km.item_id, km.keyword, km.priority
           FROM keyword_mappings km
-          WHERE km.keyword LIKE ${likePattern}
+          WHERE km.keyword LIKE ${likePattern} ESCAPE ${SUBSEQUENCE_LIKE_ESCAPE_CHAR}
             AND km.provider_id = ${providerId}
             AND km.keyword NOT LIKE 'ng:%'
           LIMIT ${limit}`
@@ -1646,13 +1649,21 @@ function subsequenceScore(query: string, target: string): number {
   return coverage * 0.5 + consecutiveBonus * 0.5
 }
 
+/**
+ * Neutralises SQLite LIKE metacharacters so user text is matched literally.
+ * Callers must pair this with `ESCAPE ${SUBSEQUENCE_LIKE_ESCAPE_CHAR}`.
+ */
+function escapeLikeWildcards(value: string): string {
+  return value.replace(
+    SQLITE_LIKE_WILDCARD_REGEX,
+    (match) => `${SUBSEQUENCE_LIKE_ESCAPE_CHAR}${match}`
+  )
+}
+
 function buildSubsequenceLikePattern(query: string): string {
   let pattern = '%'
   for (const char of query) {
-    pattern += char.replace(
-      SQLITE_LIKE_WILDCARD_REGEX,
-      (value) => `${SUBSEQUENCE_LIKE_ESCAPE_CHAR}${value}`
-    )
+    pattern += escapeLikeWildcards(char)
     pattern += '%'
   }
   return pattern


### PR DESCRIPTION
Closes #663.

The prefix pattern was built by concatenating raw user text with **no escaping and no ESCAPE clause**, unlike the sibling `lookupBySubsequence`. Typing `%` produced `%%` and matched every keyword row for the provider — up to 200 arbitrary unrelated apps returned as "prefix matches". `a_c` matched `abc` and `a1c` too.

Factored the escaping out of `buildSubsequenceLikePattern` into `escapeLikeWildcards` so both paths share one rule, and added the missing `ESCAPE` clause.

### Verified against a real SQLite file, not a mock
Of the five new tests, **three are red on HEAD**: `%` matching everything, a literal `%` prefix, and `_` acting as a wildcard.

The other two are deliberate controls, and I want to be precise about what they do and do not prove:
- **backslash case** — green on HEAD *by accident*, since HEAD has no `ESCAPE` clause so `\` was already literal. Kept as a **negative control on this change**: introducing `ESCAPE` is exactly what could have made `\` stop matching itself.
- **ordinary prefix case** — positive control, confirms the fix did not simply break matching.

580/580 search-engine tests, `typecheck:node`, `eslint --max-warnings=0` clean.