### PR TITLE
build(nexus): locate the aliased packages through the resolver (#597)

### DIFF
--- a/apps/nexus/app/pages/docs/docs-page-performance.test.ts
+++ b/apps/nexus/app/pages/docs/docs-page-performance.test.ts
@@ -184,7 +184,13 @@ describe('docs page performance boundaries', () => {
     expect.soft(nuxtConfig).toContain("'@sidebase/nuxt-auth'")
     expect.soft(nuxtConfig).toContain("baseURL: '/api/auth'")
     expect.soft(nuxtConfig).toContain("type: 'authjs'")
-    expect.soft(nuxtConfig).toContain("const nextAuthCoreEntry = resolve(currentDir, 'node_modules/next-auth/core/index.js')")
+    // Matched by shape rather than by the exact line: what this guards is that the alias still
+    // targets next-auth's internal core/index.js, not how the path is derived. It used to pin the
+    // literal `resolve(currentDir, 'node_modules/...')`, which made #597 — locating the package
+    // through the resolver instead of assuming shamefully-hoist — read as a regression.
+    expect.soft(nuxtConfig).toMatch(
+      /const nextAuthCoreEntry = resolve\([\s\S]*?next-auth[\s\S]*?core\/index\.js/,
+    )
     expect.soft(nuxtConfig).toMatch(/alias: \{[\s\S]*'next-auth\/core': nextAuthCoreEntry/)
     expect.soft(packageJson).toContain('"#auth": "./node_modules/@sidebase/nuxt-auth/dist/runtime/server/services/index.js"')
     expect.soft(authApi).toContain('const createRequestAuthEvent = () => createAuthEvent()')

--- a/apps/nexus/nuxt.config.ts
+++ b/apps/nexus/nuxt.config.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module'
 import { dirname, resolve } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
@@ -44,8 +45,28 @@ const tuffexUtilsEntry = resolve(currentDir, '../../packages/tuffex/packages/uti
 const tuffexDistUtilsEntry = useWorkspaceSource
   ? tuffexUtilsEntry
   : resolve(tuffexDistRoot, 'utils/index.js')
-const hkdfCompatEntry = resolve(workspaceRoot, 'node_modules/@panva/hkdf/dist/node/cjs/index.js')
-const nextAuthCoreEntry = resolve(currentDir, 'node_modules/next-auth/core/index.js')
+const requireFromConfig = createRequire(import.meta.url)
+
+/**
+ * Both aliases deliberately reach past a package's own resolution, and must keep doing so:
+ *
+ * - @panva/hkdf's exports map sends `worker`/`workerd` to dist/web/index.js. The Cloudflare build
+ *   needs the node/cjs build instead (44c406d2a), so resolving the bare specifier here would undo
+ *   that fix rather than tidy it up.
+ * - next-auth v4 does not export ./core at all — the alias exists precisely to reach an internal.
+ *
+ * What they must not do is assume `shamefully-hoist=true` has placed the package at a literal
+ * path. Locating the package through the resolver and joining the subpath keeps the intent while
+ * working under a strict pnpm layout too (#597).
+ */
+const hkdfCompatEntry = resolve(
+  dirname(requireFromConfig.resolve('@panva/hkdf/package.json')),
+  'dist/node/cjs/index.js',
+)
+const nextAuthCoreEntry = resolve(
+  dirname(requireFromConfig.resolve('next-auth')),
+  'core/index.js',
+)
 const vueDevtoolsApiNoopEntry = resolve(currentDir, 'app/utils/vue-devtools-api-noop.ts')
 const isProd = process.env.NODE_ENV === 'production'
 const useVueDevtoolsApiNoop = isDev && process.env.NUXT_DISABLE_VUE_DEVTOOLS_API_NOOP !== 'true'


### PR DESCRIPTION
Closes #597.

The fixable half of this is the **hoisting assumption**, and that is what changed. Both aliases now locate the package via `createRequire(import.meta.url).resolve(...)` and join the subpath, instead of assuming `.npmrc`’s `shamefully-hoist=true` has put the files at a literal path.

Demonstrated rather than asserted — the new expressions resolve into the store, not the hoisted root:

```
hkdf -> .../node_modules/.pnpm/@panva+hkdf@1.2.1/node_modules/@panva/hkdf/dist/node/cjs/index.js
core -> .../node_modules/.pnpm/next-auth@4.24.14_.../node_modules/next-auth/core/index.js
```

## Why the rest of the suggested direction is not safe

The issue says to "stop reaching past the packages’ exports maps". Both aliases exist **precisely** to do that, and following it would break them:

- **`@panva/hkdf`** — its exports map sends `worker` / `workerd` to `dist/web/index.js`. `44c406d2a fix(nexus): stabilize oauth hkdf runtime on cloudflare` added this alias to force the node/cjs build on Cloudflare. Resolving the bare specifier reinstates the workerd condition and reverts that fix.
- **`next-auth/core`** — v4.24.14 exports only `.`, `./adapters`, `./jwt`, `./react`, `./next`, `./middleware`, `./client/_utils`, `./providers/*`. `require.resolve('next-auth/core')` fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`. Reaching the internal *is* the alias’s purpose; that cannot change without a next-auth upgrade.

The dist-layout assumption therefore remains — which is also why the root override pins `@panva/hkdf` to 1.2.1, as the issue itself observes.

## A test that pinned the old line

`docs-page-performance.test.ts:187` asserted the config contained the literal string `const nextAuthCoreEntry = resolve(currentDir, 'node_modules/next-auth/core/index.js')`. So a legitimate refactor read as a regression.

Its name — *"keeps auth runtime coverage on explicit auth and protected route matrix"* — says what it actually guards, so I kept that intent and matched by shape: the entry must still resolve to next-auth’s `core/index.js`, however the path is derived. **Checked that it still fails when the alias is pointed elsewhere**, so the looser form did not cost the guarantee.

## Verification

- nexus suite: **193 files / 1074 tests pass**
- `pnpm -C apps/nexus typecheck` exits **0**, and that run loads `nuxt.config.ts` through Nuxt’s prepare step — so the new resolution executed inside a real Nuxt context, not just in an isolated script
- `Nexus (build + checks)` on CI is the decisive check for the Cloudflare preset build

## Related

`docs-page-performance.test.ts:189` pins the `#auth` imports-map literal in the same way. That is #598’s subject, and whoever takes it will need the same treatment.