### PR TITLE
fix(search): escape and bound the query-completion LIKE lookup

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/query-completion-service.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/query-completion-service.test.ts
@@ -1,0 +1,146 @@
+import type { DbUtils } from '../../../db/utils'
+import { createClient, type Client } from '@libsql/client'
+import { drizzle } from 'drizzle-orm/libsql'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { QueryCompletionService } from './query-completion-service'
+
+/**
+ * getSuggestions built its LIKE pattern from raw user text and called .all()
+ * with no LIMIT — the `limit` argument was applied in JS only after every
+ * matching row had been loaded and exp()-scored. Typing '%' matched the whole
+ * table, and injectCompletionWeights runs this on each debounced keystroke of
+ * the interactive search path (#664). Real SQLite, so the assertions are about
+ * what the engine actually returns.
+ */
+
+/** SQL the service issued, in order — lets the tests assert the query shape. */
+type Recorder = { sql: string[] }
+
+function recordingClient(client: Client, recorder: Recorder): Client {
+  return new Proxy(client, {
+    get(target, property, receiver) {
+      if (property === 'execute') {
+        return (statement: unknown, ...rest: unknown[]) => {
+          const text =
+            typeof statement === 'string' ? statement : ((statement as { sql?: string })?.sql ?? '')
+          recorder.sql.push(text)
+          return (target.execute as (...args: unknown[]) => unknown)(statement, ...rest)
+        }
+      }
+      return Reflect.get(target, property, receiver)
+    }
+  }) as Client
+}
+
+async function withService(
+  run: (service: QueryCompletionService, client: Client, recorder: Recorder) => Promise<void>
+): Promise<void> {
+  const directory = await mkdtemp(join(tmpdir(), 'tuff-query-completion-'))
+  let client: Client | undefined
+  try {
+    client = createClient({ url: `file:${join(directory, 'completions.sqlite')}` })
+    await client.execute(`
+      CREATE TABLE query_completions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        prefix TEXT NOT NULL,
+        source_id TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        completion_count INTEGER NOT NULL DEFAULT 1,
+        last_completed INTEGER NOT NULL,
+        avg_query_length REAL NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+      )
+    `)
+    const recorder: Recorder = { sql: [] }
+    const db = drizzle(recordingClient(client, recorder))
+    const dbUtils = { getDb: () => db } as unknown as DbUtils
+    await run(new QueryCompletionService(dbUtils), client, recorder)
+  } finally {
+    client?.close()
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+async function seed(client: Client, prefixes: string[]): Promise<void> {
+  const lastCompleted = Math.floor(new Date('2026-08-01T00:00:00Z').getTime() / 1000)
+  for (const [index, prefix] of prefixes.entries()) {
+    await client.execute({
+      sql: `INSERT INTO query_completions
+              (prefix, source_id, item_id, completion_count, last_completed, avg_query_length)
+            VALUES (?, ?, ?, ?, ?, ?)`,
+      args: [prefix, 'app-provider', `item-${index}`, 1, lastCompleted, prefix.length]
+    })
+  }
+}
+
+describe('QueryCompletionService.getSuggestions', () => {
+  it('treats % as a literal instead of matching the whole table', async () => {
+    await withService(async (service, client) => {
+      await seed(client, ['chrome', 'firefox', 'safari', 'slack'])
+
+      const suggestions = await service.getSuggestions('%%')
+
+      // Before the fix this matched all four rows.
+      expect(suggestions).toEqual([])
+    })
+  })
+
+  it('treats _ as a literal rather than a single-character wildcard', async () => {
+    await withService(async (service, client) => {
+      await seed(client, ['abc', 'a1c', 'a_c'])
+
+      const suggestions = await service.getSuggestions('a_c')
+
+      expect(suggestions.map((s) => s.prefix)).toEqual(['a_c'])
+    })
+  })
+
+  it('bounds how many rows reach the JS scorer', async () => {
+    await withService(async (service, client, recorder) => {
+      await seed(
+        client,
+        Array.from({ length: 640 }, (_, i) => `chrome-${String(i).padStart(4, '0')}`)
+      )
+      recorder.sql.length = 0
+
+      const suggestions = await service.getSuggestions('chrome', 10)
+
+      // All 640 rows share the prefix. Before the fix every one of them was
+      // loaded and exp()-scored; the row cap is what makes the keystroke cheap,
+      // so assert on the statement the service actually issued rather than on
+      // the trimmed result, which looked identical either way.
+      const select = recorder.sql.find((text) => text.includes('query_completions'))
+      expect(select).toBeDefined()
+      expect(select).toMatch(/limit\s+\?/i)
+      expect(suggestions).toHaveLength(10)
+    })
+  })
+
+  it('honours a limit above the scan cap without truncating to it', async () => {
+    await withService(async (service, client) => {
+      await seed(
+        client,
+        Array.from({ length: 300 }, (_, i) => `chrome-${String(i).padStart(4, '0')}`)
+      )
+
+      const suggestions = await service.getSuggestions('chrome', 250)
+
+      // max(limit, SCAN_LIMIT) — a caller asking for more than the cap must not
+      // be silently cut back to 200.
+      expect(suggestions).toHaveLength(250)
+    })
+  })
+
+  it('still returns ordinary prefix matches', async () => {
+    await withService(async (service, client) => {
+      await seed(client, ['chrome', 'chromium', 'firefox'])
+
+      const suggestions = await service.getSuggestions('chrom')
+
+      expect(suggestions.map((s) => s.prefix).sort()).toEqual(['chrome', 'chromium'])
+    })
+  })
+})

--- a/apps/core-app/src/main/modules/box-tool/search-engine/query-completion-service.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/query-completion-service.ts
@@ -1,12 +1,28 @@
 import type { TuffItem } from '@talex-touch/utils'
 import type { DbUtils } from '../../../db/utils'
-import { sql } from 'drizzle-orm'
+import { desc, sql } from 'drizzle-orm'
 import * as schema from '../../../db/schema'
 import { scheduleDbWrite } from '../../../db/db-write'
 import { createLogger } from '../../../utils/logger'
 
 const log = createLogger('QueryCompletionService')
 const MIN_COMPLETION_QUERY_LENGTH = 2
+const LIKE_ESCAPE_CHAR = '\\'
+const SQLITE_LIKE_WILDCARD_REGEX = /[%_\\]/g
+
+/**
+ * Upper bound on rows pulled into JS for scoring. The final ranking is computed
+ * in JS (frequency x recency x match quality), so the SQL LIMIT cannot simply be
+ * `limit` — that would hand the JS sort a different candidate set than the one it
+ * is meant to rank. The scan is ordered by the terms that dominate the score so
+ * the strongest candidates fall inside the window.
+ */
+const COMPLETION_SCAN_LIMIT = 200
+
+/** Neutralises SQLite LIKE metacharacters; pair with `ESCAPE ${LIKE_ESCAPE_CHAR}`. */
+function escapeLikeWildcards(value: string): string {
+  return value.replace(SQLITE_LIKE_WILDCARD_REGEX, (match) => `${LIKE_ESCAPE_CHAR}${match}`)
+}
 
 export interface CompletionSuggestion {
   sourceId: string
@@ -108,10 +124,22 @@ export class QueryCompletionService {
     const prefix = this.normalizePrefix(query)
 
     try {
+      // Escaped and bounded. Previously the pattern came straight from user text,
+      // so typing '%' matched every row, and there was no SQL LIMIT at all — the
+      // `limit` argument was applied only after the whole table had been loaded
+      // and exp()-scored in JS, on every debounced keystroke (#664).
+      const likePattern = `${escapeLikeWildcards(prefix)}%`
       const results = await db
         .select()
         .from(schema.queryCompletions)
-        .where(sql`${schema.queryCompletions.prefix} LIKE ${`${prefix}%`}`)
+        .where(
+          sql`${schema.queryCompletions.prefix} LIKE ${likePattern} ESCAPE ${LIKE_ESCAPE_CHAR}`
+        )
+        .orderBy(
+          desc(schema.queryCompletions.completionCount),
+          desc(schema.queryCompletions.lastCompleted)
+        )
+        .limit(Math.max(limit, COMPLETION_SCAN_LIMIT))
         .all()
 
       if (results.length === 0) {


### PR DESCRIPTION
Closes #664.

`getSuggestions` built its LIKE pattern from raw user text with no escaping and called `.all()` with **no LIMIT**. Typing `%` matched every row of `query_completions`, and `injectCompletionWeights` runs this on each debounced keystroke of the interactive search path — so the whole table was materialised and `exp()`-scored in JS per keystroke.

### The SQL limit is deliberately not `limit`
The final ranking is computed in JS from frequency, recency and match quality. Limiting to the caller's count in SQL would hand the JS sort a *different candidate set* than the one it is meant to rank — the top 10 by SQL order are not the top 10 by score. Instead the scan is capped at `max(limit, 200)` and ordered by the terms that dominate the score, so the strongest candidates fall inside the window.

### Behaviour change worth stating
With more than 200 matching rows, a low-count but very recent row that would previously have surfaced can now fall outside the scan window. That is the cost of bounding an unbounded scan; flagging it rather than burying it.

### Verified against real SQLite
Three of the five new tests are red on HEAD: `%` matching the table, `_` as a wildcard, and the missing row cap.

Note on the third: the cap is asserted **on the statement the service issues**, not on the trimmed result. My first version of that test checked the returned array and passed on HEAD — it proved nothing, because the JS `.slice()` produced the same 10 rows either way.

The remaining two are controls: `limit` above the cap must not be silently cut back to 200, and ordinary prefix matching still works.

580/580 search-engine tests, `typecheck:node`, `eslint --max-warnings=0` clean.