### PR TITLE
ref(search): drop the superseded cleanupOldCompletions

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/query-completion-service.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/query-completion-service.ts
@@ -229,36 +229,6 @@ export class QueryCompletionService {
     }
   }
 
-  /** Remove completion records older than retention period */
-  async cleanupOldCompletions(retentionDays = 90): Promise<number> {
-    const timer = log.time('cleanupOldCompletions')
-    const db = this.dbUtils.getDb()
-
-    try {
-      const expirationDate = new Date()
-      expirationDate.setDate(expirationDate.getDate() - retentionDays)
-
-      await scheduleDbWrite(
-        'query-completions.cleanup',
-        () =>
-          db
-            .delete(schema.queryCompletions)
-            .where(sql`${schema.queryCompletions.lastCompleted} < ${expirationDate}`),
-        { dropPolicy: 'drop', maxQueueWaitMs: 10_000 }
-      )
-
-      timer.end('info')
-      log.info('Cleaned up old completions', {
-        meta: { cutoffDate: expirationDate.toISOString() }
-      })
-
-      return 0
-    } catch (error) {
-      log.error('Failed to cleanup old completions', { error })
-      return 0
-    }
-  }
-
   getStats() {
     return { ...this.stats }
   }


### PR DESCRIPTION
Closes #665.

**Stacked on #1337** (same file) — base is `fix/664-completion-like`, so **#1337 must merge first**.

The issue reported that this method logs success and returns a hard-coded `0` even when the scheduled delete is dropped. Investigating turned up **three reasons the described failure cannot occur**, and one that makes fixing the return value pointless.

### The drop path does not do what the issue says
A dropped write does not resolve — the scheduler calls `task.reject` ([db-write-scheduler.ts:941](apps/core-app/src/main/db/db-write-scheduler.ts#L941)). So the `await` throws, the success log is **skipped**, and control reaches the `catch`, which logs at **error** level. The scheduler additionally logs `Dropping stale task` at warn.

- ~~"unconditionally logs 'Cleaned up old completions'"~~ — false
- ~~"no signal reaches the operator"~~ — false, there are two

### Retention is not this method's job any more
`privacy/owners/search-retention-owner.ts` prunes `query_completions` by `last_completed` and is registered in `privacy-module.ts:83`.

- ~~"Retention past 90 days silently never happens"~~ — false

### So the method is simply dead
`cleanupOldCompletions` has **zero callers anywhere**, including inside its own file. Superseded dead code, so it is deleted rather than having its return contract polished.

### Verified
The caller scan was run with a positive control (`injectCompletionWeights`, 3 hits) to prove the scan works before trusting a zero result. Worth noting my first control was `getSuggestions` and it returned zero — not because the scan was broken, but because its only caller lives in the same file, which my `grep -v` had filtered out. Re-ran with a symbol that genuinely has external callers before concluding.

722/722 search-engine plus privacy tests, `typecheck:node`, `eslint --max-warnings=0` clean.