### PR TITLE
fix(search): match app candidates by identity, not substring containment

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.test.ts
@@ -173,6 +173,117 @@ describe('ItemRebuilder', () => {
     expect(result.map((item) => item.scoring?.final)).toEqual([9_000, 120])
   })
 
+  it("does not let one app inherit a longer-named sibling's score", async () => {
+    // 'com.google.Chrome' is a substring of 'com.google.Chrome.canary'. The old
+    // two-way `includes` therefore matched Chrome against Canary's scored entry,
+    // handing Chrome the wrong score and, via _originalItemId, the wrong pin and
+    // dedupe identity (#666).
+    const dbUtils = {
+      getFilesByPaths: vi.fn(async () => []),
+      getFilesByBundleIds: vi.fn(async () => [
+        {
+          id: 1,
+          path: '/Applications/Google Chrome.app',
+          name: 'Google Chrome',
+          displayName: 'Google Chrome',
+          extension: 'app',
+          size: 0,
+          mtime: new Date(),
+          ctime: new Date(),
+          lastIndexedAt: new Date(),
+          isDir: false,
+          type: 'application',
+          content: null,
+          embeddingStatus: 'none'
+        }
+      ]),
+      getFileExtensionsByFileIds: vi.fn(async () => [])
+    }
+
+    mapAppsToRecommendationItemsMock.mockReturnValue([
+      {
+        id: 'com.google.Chrome',
+        source: { id: 'app-provider', type: 'application', name: 'App Provider' },
+        kind: 'app',
+        render: { mode: 'default', basic: { title: 'Google Chrome' } },
+        actions: [],
+        meta: { app: { path: '/Applications/Google Chrome.app', bundleId: 'com.google.Chrome' } }
+      }
+    ])
+
+    const rebuilder = new ItemRebuilder(dbUtils as never)
+    const scoredItems: ScoredItem[] = [
+      {
+        sourceId: 'app-provider',
+        itemId: 'com.google.Chrome.canary',
+        sourceType: 'app',
+        usageStats,
+        source: 'frequent',
+        score: 9_999
+      }
+    ]
+
+    const result = await rebuilder.rebuildItems(scoredItems)
+    const chrome = result.find((item) => item.id === 'com.google.Chrome')
+
+    expect(chrome?.scoring?.final ?? 0).not.toBe(9_999)
+  })
+
+  it('still matches an app recorded under a different identity form', async () => {
+    // The fallback exists because the rebuilt id (appIdentity) and the scored
+    // entry (path) can be different forms of the same app. Equality across the
+    // identity set has to keep that working, or the fix trades one bug for another.
+    const dbUtils = {
+      getFilesByBundleIds: vi.fn(async () => []),
+      getFilesByPaths: vi.fn(async () => [
+        {
+          id: 1,
+          path: '/Applications/Google Chrome.app',
+          name: 'Google Chrome',
+          displayName: 'Google Chrome',
+          extension: 'app',
+          size: 0,
+          mtime: new Date(),
+          ctime: new Date(),
+          lastIndexedAt: new Date(),
+          isDir: false,
+          type: 'application',
+          content: null,
+          embeddingStatus: 'none'
+        }
+      ]),
+      getFileExtensionsByFileIds: vi.fn(async () => [])
+    }
+
+    mapAppsToRecommendationItemsMock.mockReturnValue([
+      {
+        id: 'com.google.Chrome',
+        source: { id: 'app-provider', type: 'application', name: 'App Provider' },
+        kind: 'app',
+        render: { mode: 'default', basic: { title: 'Google Chrome' } },
+        actions: [],
+        meta: { app: { path: '/Applications/Google Chrome.app', bundleId: 'com.google.Chrome' } }
+      }
+    ])
+
+    const rebuilder = new ItemRebuilder(dbUtils as never)
+    const scoredItems: ScoredItem[] = [
+      {
+        sourceId: 'app-provider',
+        itemId: '/Applications/Google Chrome.app',
+        sourceType: 'app',
+        usageStats,
+        source: 'frequent',
+        score: 321
+      }
+    ]
+
+    const result = await rebuilder.rebuildItems(scoredItems)
+    const chrome = result.find((item) => item.id === 'com.google.Chrome')
+
+    expect(chrome?.scoring?.final).toBe(321)
+  })
+
   it('preserves plugin recommendation icon metadata and class badge icons', async () => {
     const rebuilder = new ItemRebuilder({} as never)
     const scoredItems: ScoredItem[] = [

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.test.ts
@@ -284,6 +284,73 @@ describe('ItemRebuilder', () => {
     expect(chrome?.scoring?.final).toBe(321)
   })
 
+  it('prefers the candidate whose source matches the item over a bare id collision', async () => {
+    // item_usage_stats still carries both spellings of the app source, so two
+    // candidates can share an itemId and both survive deduplicateCandidates,
+    // which keys on sourceId:itemId. Querying the bare key first returned
+    // whichever happened to be registered last (#667).
+    const dbUtils = {
+      getFilesByBundleIds: vi.fn(async () => []),
+      getFilesByPaths: vi.fn(async () => [
+        {
+          id: 1,
+          path: '/Applications/Demo.app',
+          name: 'Demo',
+          displayName: 'Demo',
+          extension: 'app',
+          size: 0,
+          mtime: new Date(),
+          ctime: new Date(),
+          lastIndexedAt: new Date(),
+          isDir: false,
+          type: 'application',
+          content: null,
+          embeddingStatus: 'none'
+        }
+      ]),
+      getFileExtensionsByFileIds: vi.fn(async () => [])
+    }
+
+    mapAppsToRecommendationItemsMock.mockReturnValue([
+      {
+        id: '/Applications/Demo.app',
+        source: { id: 'app-provider', type: 'application', name: 'App Provider' },
+        kind: 'app',
+        render: { mode: 'default', basic: { title: 'Demo' } },
+        actions: [],
+        meta: {}
+      }
+    ])
+
+    const rebuilder = new ItemRebuilder(dbUtils as never)
+    // Same itemId under both source spellings; the 'application' one is
+    // registered last, so it wins the bare key.
+    const scoredItems: ScoredItem[] = [
+      {
+        sourceId: 'app-provider',
+        itemId: '/Applications/Demo.app',
+        sourceType: 'app',
+        usageStats,
+        source: 'frequent',
+        score: 500
+      },
+      {
+        sourceId: 'application',
+        itemId: '/Applications/Demo.app',
+        sourceType: 'app',
+        usageStats,
+        source: 'frequent',
+        score: 42
+      }
+    ]
+
+    const result = await rebuilder.rebuildItems(scoredItems)
+    const demo = result.find((item) => item.id === '/Applications/Demo.app')
+
+    // The rebuilt item's source is 'app-provider', so it must take that score.
+    expect(demo?.scoring?.final).toBe(500)
+  })
+
   it('preserves plugin recommendation icon metadata and class badge icons', async () => {
     const rebuilder = new ItemRebuilder({} as never)
     const scoredItems: ScoredItem[] = [

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.ts
@@ -27,6 +27,30 @@ const getMetaString = (item: TuffItem, key: string): string | undefined => {
   return typeof value === 'string' ? value : undefined
 }
 
+/**
+ * Every identifier an app item is legitimately known by. buildProcessedAppItem
+ * ids an app as `appIdentity || path || bundleId`, and a scored candidate may
+ * have been recorded under any of those, so matching has to span the forms —
+ * but only by exact equality, never by containment.
+ */
+const getAppIdentitySet = (item: TuffItem): Set<string> => {
+  const meta = item.meta as Record<string, unknown> | undefined
+  const app = meta?.app as Record<string, unknown> | undefined
+  const identities = new Set<string>()
+
+  for (const value of [
+    item.id,
+    getMetaString(item, '_originalItemId'),
+    typeof app?.path === 'string' ? app.path : undefined,
+    typeof app?.bundleId === 'string' ? app.bundleId : undefined,
+    typeof app?.launchTarget === 'string' ? app.launchTarget : undefined
+  ]) {
+    if (value) identities.add(value)
+  }
+
+  return identities
+}
+
 function normalizePluginRecommendIcon(icon: unknown): TuffBasicIcon {
   if (!icon || typeof icon !== 'object') return { ...DEFAULT_PLUGIN_RECOMMEND_ICON }
 
@@ -499,12 +523,19 @@ export class ItemRebuilder {
       return scoredItems.find((s) => s.itemId.endsWith(`/${itemId}`) || s.itemId === itemId)
     }
 
-    // App provider: match by path or bundleId inclusion
+    // App provider: the rebuilt item and the scored candidate can legitimately
+    // carry different forms of the same app (buildProcessedAppItem ids by
+    // appIdentity || path || bundleId), so this still matches across forms — but
+    // against the item's own identity set, by equality.
+    //
+    // It used to be a two-way `includes`, which made one app inherit another's
+    // score whenever one id was a prefix of the other: 'com.google.Chrome' is a
+    // substring of 'com.google.Chrome.canary', so Chrome was enriched with
+    // Canary's score and, through _originalItemId, deduped and pin-matched as
+    // Canary (#666).
     if (sourceId === 'app-provider' || sourceId === 'application') {
-      return scoredItems.find((s) => {
-        if (itemId.startsWith('/') && s.itemId.startsWith('/')) return itemId === s.itemId
-        return s.itemId.includes(itemId) || itemId.includes(s.itemId)
-      })
+      const identities = getAppIdentitySet(item)
+      return scoredItems.find((s) => identities.has(s.itemId))
     }
 
     return undefined

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.ts
@@ -554,10 +554,14 @@ export class ItemRebuilder {
 
     for (const item of items) {
       const originalItemId = getMetaString(item, '_originalItemId')
+      // Source-qualified keys are tried before bare ones. scoreMap holds both
+      // spellings, and item_usage_stats still carries two source ids for apps
+      // ('application' and 'app-provider'), so two candidates can share an
+      // itemId; a bare-key hit returns whichever was registered last (#667).
       const scored =
         (originalItemId && scoreMap.get(`${item.source.id}:${originalItemId}`)) ||
-        scoreMap.get(item.id) ||
         scoreMap.get(`${item.source.id}:${item.id}`) ||
+        scoreMap.get(item.id) ||
         this.findScoredByPartialMatch(item, scoredItems)
       if (!scored) continue
 


### PR DESCRIPTION
Closes #666.

`findScoredByPartialMatch` resolved an app to a scored candidate with a two-way `includes` whenever either identifier was not a path. `com.google.Chrome` is a substring of `com.google.Chrome.canary`, so Chrome inherited Canary's score and — through `meta._originalItemId` — was deduped and pin-matched **as** Canary. Same for `com.microsoft.VSCode` against `.exploration`.

### Why not plain equality
The issue offered equality as one option, but the exact lookups already run upstream in `mergeAndEnrichItems` (`scoreMap.get(item.id)` etc.). This branch is the *fallback*, and it exists precisely for the case where the rebuilt id and the scored entry are different forms of the same app — `buildProcessedAppItem` ids by `appIdentity || path || bundleId`. Requiring equality on `item.id` alone would have made the whole branch dead code.

So it takes the issue's second option: compare against the item's **identity set** — `id`, `_originalItemId`, `meta.app.path`, `bundleId`, `launchTarget` — by equality.

### The old test failed in both directions
Worth flagging, because it changes how you read the fix: containment did not just over-match, it also **under-matched**. `com.google.Chrome` and `/Applications/Google Chrome.app` contain neither one another, so the legitimate cross-form case never resolved either.

The two new tests are red on HEAD for those two separate reasons — one for the wrong match, one for the missing one.

### Verified
577/577 search-engine tests, `typecheck:node`, `eslint --max-warnings=0` clean.