### PR TITLE
build(nexus): let @sidebase/nuxt-auth register #auth itself (#598)

### DIFF
--- a/apps/nexus/app/pages/docs/docs-page-performance.test.ts
+++ b/apps/nexus/app/pages/docs/docs-page-performance.test.ts
@@ -192,7 +192,13 @@ describe('docs page performance boundaries', () => {
       /const nextAuthCoreEntry = resolve\([\s\S]*?next-auth[\s\S]*?core\/index\.js/,
     )
     expect.soft(nuxtConfig).toMatch(/alias: \{[\s\S]*'next-auth\/core': nextAuthCoreEntry/)
-    expect.soft(packageJson).toContain('"#auth": "./node_modules/@sidebase/nuxt-auth/dist/runtime/server/services/index.js"')
+    // The #auth alias comes from @sidebase/nuxt-auth itself — its module.mjs sets
+    // nitroConfig.alias['#auth'] — so package.json no longer duplicates it through a hard-coded
+    // node_modules path (#598). Two things still have to hold, and both are stronger than the
+    // literal this replaces: the server route reaches auth through the alias, and no local
+    // imports map re-pins the package's dist internals.
+    expect.soft(authApi).toContain("from '#auth'")
+    expect.soft(packageJson).not.toContain('@sidebase/nuxt-auth/dist/runtime')
     expect.soft(authApi).toContain('const createRequestAuthEvent = () => createAuthEvent()')
     expect.soft(authApi).toContain('let cachedAuthHandler')
     expect.soft(authApi).toContain('function getCachedAuthHandler(event: H3Event)')

--- a/apps/nexus/package.json
+++ b/apps/nexus/package.json
@@ -5,10 +5,6 @@
   "private": true,
   "packageManager": "pnpm@10.34.4",
   "description": "Documentation for Tuff project",
-  "imports": {
-    "#auth": "./node_modules/@sidebase/nuxt-auth/dist/runtime/server/services/index.js",
-    "#auth/*": "./node_modules/@sidebase/nuxt-auth/dist/runtime/server/services/*.js"
-  },
   "scripts": {
     "build": "pnpm -C \"../../packages/tuffex\" run build && node -e \"const os=require('os'); const v8=require('v8'); const gb=n=> (n/1024/1024/1024).toFixed(2); console.log('[build] totalmem_gb', gb(os.totalmem())); console.log('[build] heap_limit_gb', gb(v8.getHeapStatistics().heap_size_limit));\" && NODE_OPTIONS=\"--max-old-space-size=8192\" nuxt build && node build/materialize-docs-index-aliases.mjs && node build/trim-content-assets.mjs",
     "check:api-routes": "node build/check-server-api-route-tree.mjs",


### PR DESCRIPTION
Closes #598.

## The map was redundant

`@sidebase/nuxt-auth`’s own `module.mjs:135` does:

```js
nitroConfig.alias["#auth"] = resolve("./runtime/server/services");
```

So Nitro already has the alias. The `imports` map in `apps/nexus/package.json` duplicated it through a hard-coded `./node_modules/...` path that only resolves because `.npmrc` sets `shamefully-hoist=true`, and only while 0.9.x keeps that dist layout — on a caret range over a pre-1.0 package.

Removing it leaves the module’s own registration as the single source, which is the first of the two directions the issue offers.

## Checked, not assumed, that nothing outside Nitro needed it

`package.json` `imports` applies to Node resolution generally — vitest and tsc included — so the real question was whether anything besides the Nitro build relied on it. With the map removed:

- `pnpm -C apps/nexus typecheck` exits **0**, no `#auth` resolution errors
- suite is **1073/1074**, and the single failure is a test pinning the literal string, not a resolution failure

## The test assertion, replaced with something stronger

`docs-page-performance.test.ts:189` asserted `packageJson` contained the exact `"#auth": "./node_modules/@sidebase/nuxt-auth/dist/runtime/server/services/index.js"`. That only checked a literal was present — which is why this fix showed up as a regression.

It is replaced by two assertions that outlive the mechanism:

```ts
expect.soft(authApi).toContain("from '#auth'")
expect.soft(packageJson).not.toContain('@sidebase/nuxt-auth/dist/runtime')
```

The route must still reach auth through the alias, and package.json must not re-pin the dist internals. (This is the line I flagged on #597 as needing the same treatment.)

## What I could not verify locally — stated plainly

`pnpm -C apps/nexus build` fails **identically with and without this change**: 984 prerender request errors, `Package import specifier "#internal/nuxt/paths" is not defined`, resolved against the *main checkout’s* `.nuxt` cache rather than this worktree’s. That is the symlinked-`node_modules` layout, not the change — I ran the baseline specifically to establish that.

So **`Nexus (build + checks)` is the only real check for the Nitro side**, and it is the one that matters here. If it goes red on this PR, the module’s alias does not cover the build path and the map needs reinstating in a portable form instead — I will follow up rather than leave it merged.