### PR TITLE
fix(search): prefer the source-qualified score key over the bare itemId

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.test.ts
@@ -284,6 +284,73 @@ describe('ItemRebuilder', () => {
     expect(chrome?.scoring?.final).toBe(321)
   })
 
+  it('prefers the candidate whose source matches the item over a bare id collision', async () => {
+    // item_usage_stats still carries both spellings of the app source, so two
+    // candidates can share an itemId and both survive deduplicateCandidates,
+    // which keys on sourceId:itemId. Querying the bare key first returned
+    // whichever happened to be registered last (#667).
+    const dbUtils = {
+      getFilesByBundleIds: vi.fn(async () => []),
+      getFilesByPaths: vi.fn(async () => [
+        {
+          id: 1,
+          path: '/Applications/Demo.app',
+          name: 'Demo',
+          displayName: 'Demo',
+          extension: 'app',
+          size: 0,
+          mtime: new Date(),
+          ctime: new Date(),
+          lastIndexedAt: new Date(),
+          isDir: false,
+          type: 'application',
+          content: null,
+          embeddingStatus: 'none'
+        }
+      ]),
+      getFileExtensionsByFileIds: vi.fn(async () => [])
+    }
+
+    mapAppsToRecommendationItemsMock.mockReturnValue([
+      {
+        id: '/Applications/Demo.app',
+        source: { id: 'app-provider', type: 'application', name: 'App Provider' },
+        kind: 'app',
+        render: { mode: 'default', basic: { title: 'Demo' } },
+        actions: [],
+        meta: {}
+      }
+    ])
+
+    const rebuilder = new ItemRebuilder(dbUtils as never)
+    // Same itemId under both source spellings; the 'application' one is
+    // registered last, so it wins the bare key.
+    const scoredItems: ScoredItem[] = [
+      {
+        sourceId: 'app-provider',
+        itemId: '/Applications/Demo.app',
+        sourceType: 'app',
+        usageStats,
+        source: 'frequent',
+        score: 500
+      },
+      {
+        sourceId: 'application',
+        itemId: '/Applications/Demo.app',
+        sourceType: 'app',
+        usageStats,
+        source: 'frequent',
+        score: 42
+      }
+    ]
+
+    const result = await rebuilder.rebuildItems(scoredItems)
+    const demo = result.find((item) => item.id === '/Applications/Demo.app')
+
+    // The rebuilt item's source is 'app-provider', so it must take that score.
+    expect(demo?.scoring?.final).toBe(500)
+  })
+
   it('preserves plugin recommendation icon metadata and class badge icons', async () => {
     const rebuilder = new ItemRebuilder({} as never)
     const scoredItems: ScoredItem[] = [

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.ts
@@ -554,10 +554,14 @@ export class ItemRebuilder {
 
     for (const item of items) {
       const originalItemId = getMetaString(item, '_originalItemId')
+      // Source-qualified keys are tried before bare ones. scoreMap holds both
+      // spellings, and item_usage_stats still carries two source ids for apps
+      // ('application' and 'app-provider'), so two candidates can share an
+      // itemId; a bare-key hit returns whichever was registered last (#667).
       const scored =
         (originalItemId && scoreMap.get(`${item.source.id}:${originalItemId}`)) ||
-        scoreMap.get(item.id) ||
         scoreMap.get(`${item.source.id}:${item.id}`) ||
+        scoreMap.get(item.id) ||
         this.findScoredByPartialMatch(item, scoredItems)
       if (!scored) continue
 


### PR DESCRIPTION
Closes #667.

**Stacked on #1339** (same file) — base is `fix/666-partial-match`, so **#1339 must merge first**.

`mergeAndEnrichItems` registers each scored candidate under **both** its bare `itemId` and its `sourceId:itemId` key, then queried the bare key first. Two candidates sharing an `itemId` across sources therefore collapsed to whichever was registered last.

That is not hypothetical: `item_usage_stats` still carries both spellings of the app source (`application` and `app-provider` — the reason `usage-source-identity-migration` exists), both candidates keep the app path as `itemId`, and both survive `deduplicateCandidates` because it keys on `sourceId:itemId`. The rebuilt app then took an arbitrary one of the two scores.

Reordered so the qualified key is tried first. The bare key stays as the fallback for candidates recorded without a matching source, so nothing that resolved before stops resolving.

### Verified
New test red on the parent commit, green here. 578/578 search-engine tests, `typecheck:node`, `eslint --max-warnings=0` clean.