### PR TITLE
fix(search): observe the gather controller rejection instead of leaking it

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-gather.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-gather.ts
@@ -227,6 +227,17 @@ function createGatherController(
     rejectPromise = reject
   })
 
+  // The only consumer (SearchSession.attachGather) keeps the controller for
+  // .abort() and .signal and never touches .promise, so a rejection here had
+  // nowhere to land and surfaced as an unhandled rejection on the main process.
+  // This keeps the promise available to any future caller — awaiting it still
+  // rethrows — while guaranteeing the rejection is observed exactly once (#668).
+  promise.catch((error) => {
+    gatherLog.debug('Gather failed with no consumer attached', {
+      error: error instanceof Error ? error : new Error(String(error))
+    })
+  })
+
   const resolve = (value: number): void => {
     if (settled) return
     settled = true


### PR DESCRIPTION
Closes #668.

`createGatherController` rejects its `promise` on any gather failure, but the only consumer (`SearchSession.attachGather`) stores the controller for `.abort()` and `.signal` and never reads `.promise`. Nothing anywhere in main does — so the rejection had nowhere to land and surfaced as an unhandled rejection on the main process.

Attaching the handler at creation keeps the promise usable (awaiting it still rethrows) while guaranteeing the rejection is observed once.

### Verified in plain node, not in the suite
Replicating the exact shape gives **1 unhandled rejection without the guard, 0 with it**. A probe on `reject()` also confirms the path is live rather than theoretical — it fires twice across the existing gather suite.

### No test accompanies this, deliberately
Vitest installs its own `unhandledRejection` handler, so a per-test `process.on` listener never fires and any such test passes **identically with and without the fix**. I wrote one, found it green on HEAD, tried a second trigger, found it green too — then removed it rather than ship coverage that proves nothing.

If you want this locked down, it needs a harness that owns the rejection channel (a separate node process, or a vitest config-level hook), which is a bigger change than the one-line guard warrants.

575/575 search-engine tests, `typecheck:node`, `eslint --max-warnings=0` clean.