### PR TITLE
fix(search): release first-result metrics on both leaking paths

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
@@ -413,6 +413,28 @@ describe('SearchEngineCore facade contracts', () => {
     if (!lifecycle.destroying) await core.destroy()
   })
 
+  it('releases first-result metrics even when telemetry is disabled', () => {
+    // getSentryService is mocked with isTelemetryEnabled() === false, which is
+    // the privacy default. The delete used to sit after that early return, so
+    // the entry survived every execute on a privacy-default install (#669).
+    const internals = core as unknown as {
+      searchFirstResultMetrics: Map<string, unknown>
+      queueExecuteTelemetry: (sessionId: string, item: unknown, startedAt?: number) => void
+    }
+
+    internals.searchFirstResultMetrics.set('session-1', { sessionId: 'session-1' })
+    expect(internals.searchFirstResultMetrics.has('session-1')).toBe(true)
+
+    internals.queueExecuteTelemetry('session-1', {
+      id: 'item-1',
+      kind: 'app',
+      source: { id: 'app-provider', type: 'application', name: 'App Provider' },
+      render: { mode: 'default', basic: { title: 'Demo' } }
+    })
+
+    expect(internals.searchFirstResultMetrics.has('session-1')).toBe(false)
+  })
+
   it('injects the App runtime delegate through SearchCore initialization', () => {
     expect(state.appProviderRuntimeDelegate).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
@@ -1092,6 +1092,11 @@ export class SearchEngineCore
           // ignore
         }
 
+        // A failed gather never reaches the normal completion path, so without
+        // this the session's entry stayed in the map for the process lifetime —
+        // one per keystroke for a provider that throws on every query (#669).
+        this.searchFirstResultMetrics.delete(sessionId)
+
         const totalDuration = Date.now() - startTime
         this.logSearchTrace({
           event: 'session.error',
@@ -1639,12 +1644,14 @@ export class SearchEngineCore
 
   private queueExecuteTelemetry(sessionId: string, item: TuffItem, startedAt?: number): void {
     try {
+      // Released before the telemetry check, not after: with telemetry off (the
+      // privacy default) the early return used to skip the cleanup entirely.
+      this.searchFirstResultMetrics.delete(sessionId)
+
       const sentryService = getSentryService()
       if (!sentryService.isTelemetryEnabled()) {
         return
       }
-
-      this.searchFirstResultMetrics.delete(sessionId)
 
       const meta = item.meta as Record<string, unknown> | undefined
       const metadata: Record<string, unknown> = {


### PR DESCRIPTION
Closes #669.

`searchFirstResultMetrics` was cleaned up only on normal completion and cancel. **Two** paths leaked:

1. **`queueExecuteTelemetry`** put the delete *after* the `isTelemetryEnabled()` early return, so with telemetry off — the privacy default — no execute ever released its entry. Moved before the check; nothing after it reads the map, so telemetry itself is unaffected.
2. **`finalizeWithError`** never deleted at all, so a failed gather kept its entry for the process lifetime. A provider throwing on every query grew the map by one entry per keystroke.

### Verified
New test is red on HEAD, green here.

Scope of that coverage, stated plainly: it exercises the **telemetry-off** path, which is the privacy-default case the issue leads with. The `finalizeWithError` path is **not** covered — reaching it needs a failing gather pipeline driven through the full session harness, which is a much larger test than the one-line fix justifies. The fix there is a plain `delete` on a path that already runs `gatherController?.abort()`, so the risk is low, but it is unverified.

576/576 search-engine tests, `typecheck:node`, `eslint --max-warnings=0` clean.