### PR TITLE
test: record that macOS builds no publishable artifact (#594)

### DIFF
--- a/packages/utils/__tests__/release-target-coverage.test.ts
+++ b/packages/utils/__tests__/release-target-coverage.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Every platform electron-builder builds must produce something the release actually publishes
+ * (#594).
+ *
+ * The macOS target is `dir`, which emits `dist/mac-arm64/tuff.app` and nothing else. The release
+ * workflow's artifact *check* passes on that, because it counts `.app` directories — but the
+ * Upload Artifacts step globs only `*.dmg` / `*.zip` / `*.exe` / `*.AppImage` / `*.deb` / `*.snap`
+ * and the release file selection does the same. So a release ships Windows and Linux and silently
+ * omits macOS: nothing fails, and nothing says so.
+ *
+ * Which way to resolve it is a product decision — build dmg/zip and add x64, or state that macOS
+ * is arm64-unpacked-only — so this records the gap rather than asserting either outcome. It fails
+ * if a *new* platform joins the same state, and it fails once macOS leaves it, which is the prompt
+ * to update the release expectations at the same time.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const BUILDER_CONFIG = path.join(REPO_ROOT, 'apps/core-app/electron-builder.yml')
+const RELEASE_WORKFLOW = path.join(REPO_ROOT, '.github/workflows/build-and-release.yml')
+
+/** electron-builder target names that yield no installable file. */
+const UNPACKED_TARGETS = new Set(['dir'])
+
+/** Platforms currently building only unpacked output. Shrink, never grow — see #594. */
+const KNOWN_UNPUBLISHABLE = ['mac']
+
+function targetsFor(platform: string): string[] {
+  const config = readFileSync(BUILDER_CONFIG, 'utf8')
+  const block = new RegExp(`^${platform}:\\n((?:[ ].*\\n|\\n)*)`, 'm').exec(config)
+  if (!block) return []
+
+  const targetSection = /^ {2}target:\n((?: {4}.*\n)+)/m.exec(block[1]!)
+  if (!targetSection) return []
+
+  return [...targetSection[1]!.matchAll(/^ {4}(?:- target: )?- ?([\w-]+)$/gm)]
+    .map((match) => match[1]!)
+    .concat(
+      [...targetSection[1]!.matchAll(/^ {4}- target: ([\w-]+)$/gm)].map((match) => match[1]!)
+    )
+}
+
+describe('release target coverage', () => {
+  it('reads both files', () => {
+    // Positive control: every assertion below is about content, and an unread file would make the
+    // target lists empty — which would read as "no platform is unpublishable".
+    expect(readFileSync(BUILDER_CONFIG, 'utf8')).toContain('appId:')
+    expect(readFileSync(RELEASE_WORKFLOW, 'utf8')).toContain('if-no-files-found: error')
+    expect(targetsFor('win').length).toBeGreaterThan(0)
+    expect(targetsFor('linux').length).toBeGreaterThan(0)
+  })
+
+  it('publishes an installable artifact for every platform except the known gap', () => {
+    const unpublishable = ['mac', 'win', 'linux'].filter((platform) => {
+      const targets = targetsFor(platform)
+      return targets.length > 0 && targets.every((target) => UNPACKED_TARGETS.has(target))
+    })
+
+    expect(unpublishable).toEqual(KNOWN_UNPUBLISHABLE)
+  })
+
+  it('keeps the upload globs and the release selection in agreement', () => {
+    // These two lists are what decide whether a built artifact reaches the release. They are
+    // maintained separately, and a platform added to one but not the other fails the same way
+    // macOS does now — quietly.
+    const workflow = readFileSync(RELEASE_WORKFLOW, 'utf8')
+
+    for (const extension of ['dmg', 'zip', 'AppImage', 'deb', 'snap']) {
+      expect(workflow, `upload glob for .${extension}`).toContain(`*.${extension}`)
+      expect(workflow, `release selection for .${extension}`).toContain(`-name "*.${extension}"`)
+    }
+  })
+})


### PR DESCRIPTION
Partial for #594 — deliberately not closing it. Both directions the issue offers decide **what users receive**, so the choice is yours; this ships the half that is correct either way.

## Confirmed, by a different route than the issue gives

The issue says `DMG_COUNT` and `ZIP_COUNT` are 0 so the release publishes nothing for macOS. The conclusion is right, the mechanism is not:

- the artifact **check** does not fail on a `dir` target — it also counts `.app` directories (`build-and-release.yml:585`), so `ARTIFACTS_FOUND=true` and the step passes
- what actually drops macOS is the next two steps: **Upload Artifacts** globs only `*.dmg` / `*.zip` / `*.exe` / `*.AppImage` / `*.deb` / `*.snap`, and the **release file selection** uses the same list

So a release ships Windows and Linux and omits macOS. Nothing fails; nothing says so. Worth stating precisely, because someone reading the issue might try to fix the check step and find it already passing.

Current targets, read from the config by the guard itself: `mac → [dir]`, `win → [nsis]`, `linux → [AppImage, deb]`.

## What this PR does

Records mac as the single known gap. It fails if another platform joins that state, **and** it fails when macOS leaves it — which is exactly when the release expectations need updating in the same change rather than a release later.

A third assertion pins that the Upload globs and the release selection still list the same extensions. Those two lists are maintained separately, and a platform added to one but not the other fails the same silent way.

## Verification

- adversarial both directions: giving mac a `dmg` target fails the run; the parser is shown to read real target names rather than matching nothing (which would have made "no platform is unpublishable" vacuously true)
- positive control on both file reads
- `packages/utils` suite: 139 files / 1091 tests, in `ci / CI - utils`, a blocking job

## The decision I am not making

1. **Build installers** — set mac to `dmg`/`zip` and add x64 or universal. Ships macOS again, but pulls in notarization and signing questions (`notarize: false`, `forceCodeSigning: false` today) and roughly doubles mac build time for a second arch.
2. **Document arm64-unpacked-only** — delete the inert `dmg:` block and say so. Cheap, but Intel Macs and every macOS user of the GitHub release stay unserved.

Tell me which and I will do it in one pass.
