### PR TITLE
fix(search): stop the race outcome from defeating the fast-layer guard

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-gather.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-gather.ts
@@ -613,7 +613,13 @@ async function runFastLayer(
   ])
   clearTimeout(timeout)
 
-  didTimeout = fastLayerState === 'timeout'
+  // The race resolving 'timeout' does not by itself mean work is outstanding:
+  // resolveTimeout() runs unconditionally, outside the `completed < total` guard
+  // above, and providers can finish in the same tick the timer fires. Overwriting
+  // unconditionally here made that guard dead, so a fast layer that finished at
+  // 79ms with a timeout of 80ms still reported didTimeout and cost the caller an
+  // extra `await completion` plus a second dispatcher round trip (#670).
+  didTimeout = fastLayerState === 'timeout' && completed < total
 
   return {
     immediateResults: results,


### PR DESCRIPTION
Closes #670.

The timer sets `didTimeout` only when providers are still outstanding, but the assignment after the race overwrote it unconditionally from the race outcome — making that guard dead code.

`resolveTimeout('timeout')` runs *outside* the guard, and the `'completed'` branch of the race costs two extra microtask hops (`Promise.all` → `.then` → `.then`) after the last `completed++` lands. A timer firing inside that window skips its own guard yet still wins the race, so `didTimeout` became true with nothing outstanding. `createLayeredSearchController` then computed `hasPendingAfterFast`, withheld `isDone` from the fast emit, and forced an extra `await` plus a second dispatcher round trip.

Now the race outcome can only **confirm** a timeout, never assert one.

### No test accompanies this, deliberately
A probe on the exact condition (`state === 'timeout'` with `completed >= total`) fires **zero times** across the whole search-engine suite, and two attempts to construct the window with fake timers were green on HEAD as well.

The window is real by construction — the microtask gap above is not speculative — but I could not trigger it, so shipping a test would be false coverage rather than proof. Flagging that rather than dressing it up.

575/575 search-engine tests, `typecheck:node`, `eslint --max-warnings=0` clean.