### PR TITLE
fix(search): chunk both scan-progress upserts under SQLite's variable cap

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/file-index-persistence-repository.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/file-index-persistence-repository.ts
@@ -5,6 +5,7 @@ import { withSqliteRetry } from '../../../db/sqlite-retry'
 import {
   normalizeScanProgressSourceId,
   resolveScanProgressSchemaShape,
+  SCAN_PROGRESS_UPSERT_CHUNK_ROWS,
   upsertSourceScopedScanProgress
 } from './scan-progress-schema'
 import { normalizeScanProgressUpsert } from './workers/search-index-worker-scan-progress'
@@ -280,21 +281,31 @@ export class SqliteFileIndexPersistenceRepository implements FileIndexPersistenc
       return normalizedUpsert.paths.length
     }
 
-    await withFileIndexPersistenceRetry(
-      () =>
-        this.db.run(sql`
-          INSERT INTO scan_progress (path, last_scanned)
-          VALUES ${sql.join(
-            normalizedUpsert.paths.map(
-              (entryPath) => sql`(${entryPath}, ${normalizedUpsert.lastScanned.getTime()})`
-            ),
-            sql`, `
-          )}
-          ON CONFLICT(path) DO UPDATE SET
-            last_scanned = excluded.last_scanned
-        `),
-      FILE_INDEX_PERSISTENCE_RETRY_LABELS.upsertScanProgress
-    )
+    // Chunked for the same reason as the source-scoped branch: normalizeScanProgressUpsert
+    // dedupes and validates but caps nothing, and two bound parameters per path hits
+    // SQLite's 32766-variable ceiling at 16384 paths (#671).
+    for (
+      let offset = 0;
+      offset < normalizedUpsert.paths.length;
+      offset += SCAN_PROGRESS_UPSERT_CHUNK_ROWS
+    ) {
+      const chunk = normalizedUpsert.paths.slice(offset, offset + SCAN_PROGRESS_UPSERT_CHUNK_ROWS)
+      await withFileIndexPersistenceRetry(
+        () =>
+          this.db.run(sql`
+            INSERT INTO scan_progress (path, last_scanned)
+            VALUES ${sql.join(
+              chunk.map(
+                (entryPath) => sql`(${entryPath}, ${normalizedUpsert.lastScanned.getTime()})`
+              ),
+              sql`, `
+            )}
+            ON CONFLICT(path) DO UPDATE SET
+              last_scanned = excluded.last_scanned
+          `),
+        FILE_INDEX_PERSISTENCE_RETRY_LABELS.upsertScanProgress
+      )
+    }
     return normalizedUpsert.paths.length
   }
 

--- a/apps/core-app/src/main/modules/box-tool/search-engine/scan-progress-chunking.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/scan-progress-chunking.test.ts
@@ -1,0 +1,91 @@
+import { createClient, type Client } from '@libsql/client'
+import { drizzle } from 'drizzle-orm/libsql'
+import { describe, expect, it } from 'vitest'
+import { upsertSourceScopedScanProgress } from './scan-progress-schema'
+
+/**
+ * Both scan-progress upserts built one INSERT with a VALUES row per path and no
+ * cap, while normalizeScanProgressUpsert only dedupes and validates. SQLite
+ * refuses more than 32766 bound parameters — measured against this build, 16383
+ * two-column rows succeed and 16384 fail with "too many SQL variables" — so a
+ * large enough scan lost the entire batch (#671).
+ *
+ * The source-scoped statement binds three per row, putting its real ceiling at
+ * 10922, which is why these use a size above that rather than above 16383.
+ */
+
+const OVER_THE_LIMIT = 12_000
+
+async function withDb(run: (client: Client) => Promise<void>): Promise<void> {
+  const client = createClient({ url: ':memory:' })
+  try {
+    await client.execute(`
+      CREATE TABLE scan_progress (
+        source_id TEXT NOT NULL,
+        path TEXT NOT NULL,
+        last_scanned INTEGER NOT NULL,
+        PRIMARY KEY (source_id, path)
+      )
+    `)
+    await run(client)
+  } finally {
+    client.close()
+  }
+}
+
+describe('scan progress upsert chunking', () => {
+  it('writes a batch larger than SQLite accepts in one statement', async () => {
+    await withDb(async (client) => {
+      const paths = Array.from({ length: OVER_THE_LIMIT }, (_, i) => `/scan/file-${i}`)
+
+      await upsertSourceScopedScanProgress(drizzle(client) as never, {
+        sourceId: 'file-provider',
+        paths,
+        lastScannedAt: 1_700_000_000_000
+      })
+
+      const counted = await client.execute('SELECT COUNT(*) AS n FROM scan_progress')
+      expect(Number(counted.rows[0].n)).toBe(OVER_THE_LIMIT)
+    })
+  })
+
+  it('still upserts rather than duplicating on a second pass', async () => {
+    await withDb(async (client) => {
+      const paths = Array.from({ length: OVER_THE_LIMIT }, (_, i) => `/scan/file-${i}`)
+      const db = drizzle(client) as never
+
+      await upsertSourceScopedScanProgress(db, {
+        sourceId: 'file-provider',
+        paths,
+        lastScannedAt: 1_700_000_000_000
+      })
+      await upsertSourceScopedScanProgress(db, {
+        sourceId: 'file-provider',
+        paths,
+        lastScannedAt: 1_800_000_000_000
+      })
+
+      const counted = await client.execute('SELECT COUNT(*) AS n FROM scan_progress')
+      expect(Number(counted.rows[0].n)).toBe(OVER_THE_LIMIT)
+
+      // Chunking must not break the ON CONFLICT update across chunk boundaries.
+      const stale = await client.execute(
+        'SELECT COUNT(*) AS n FROM scan_progress WHERE last_scanned != 1800000000000'
+      )
+      expect(Number(stale.rows[0].n)).toBe(0)
+    })
+  })
+
+  it('leaves a batch under the ceiling in one piece', async () => {
+    await withDb(async (client) => {
+      await upsertSourceScopedScanProgress(drizzle(client) as never, {
+        sourceId: 'file-provider',
+        paths: ['/scan/a', '/scan/b'],
+        lastScannedAt: 1_700_000_000_000
+      })
+
+      const counted = await client.execute('SELECT COUNT(*) AS n FROM scan_progress')
+      expect(Number(counted.rows[0].n)).toBe(2)
+    })
+  })
+})

--- a/apps/core-app/src/main/modules/box-tool/search-engine/scan-progress-schema.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/scan-progress-schema.ts
@@ -78,6 +78,16 @@ export function normalizeScanProgressSourceId(sourceId: unknown): string {
   return typeof sourceId === 'string' && sourceId.trim().length > 0 ? sourceId : 'file-provider'
 }
 
+/**
+ * Rows per INSERT for scan-progress upserts.
+ *
+ * SQLite caps bound parameters at 32766 — measured against this build, where
+ * 16383 two-column rows succeed and 16384 fail with "too many SQL variables".
+ * The source-scoped statement binds three per row, so its true ceiling is 10922.
+ * 4000 leaves headroom under both shapes without making the round trips small.
+ */
+export const SCAN_PROGRESS_UPSERT_CHUNK_ROWS = 4000
+
 export async function upsertSourceScopedScanProgress(
   db: Pick<LibSQLDatabase<typeof schema>, 'run'>,
   input: {
@@ -87,17 +97,19 @@ export async function upsertSourceScopedScanProgress(
   }
 ): Promise<void> {
   if (input.paths.length === 0) return
-  await db.run(sql`
-    INSERT INTO scan_progress (source_id, path, last_scanned)
-    VALUES ${sql.join(
-      input.paths.map(
-        (entryPath) => sql`(${input.sourceId}, ${entryPath}, ${input.lastScannedAt})`
-      ),
-      sql`, `
-    )}
-    ON CONFLICT(source_id, path) DO UPDATE SET
-      last_scanned = excluded.last_scanned
-  `)
+
+  for (let offset = 0; offset < input.paths.length; offset += SCAN_PROGRESS_UPSERT_CHUNK_ROWS) {
+    const chunk = input.paths.slice(offset, offset + SCAN_PROGRESS_UPSERT_CHUNK_ROWS)
+    await db.run(sql`
+      INSERT INTO scan_progress (source_id, path, last_scanned)
+      VALUES ${sql.join(
+        chunk.map((entryPath) => sql`(${input.sourceId}, ${entryPath}, ${input.lastScannedAt})`),
+        sql`, `
+      )}
+      ON CONFLICT(source_id, path) DO UPDATE SET
+        last_scanned = excluded.last_scanned
+    `)
+  }
 }
 
 export type ScanProgressSourceScopeMigrationStatus = 'ready' | 'blocked' | 'not-needed'


### PR DESCRIPTION
Closes #671.

Filed at lower confidence with a request for a repro. **Measured against this libsql build:**

| rows | bound params | result |
|---|---|---|
| 16383 | 32766 | OK |
| 16384 | 32768 | `SQLITE_ERROR: too many SQL variables` |

The 32766 ceiling the issue predicted is exact.

### The issue named the wrong branch — or rather, only half of them
It flagged the legacy (non source-scoped) path. But `upsertSourceScopedScanProgress` in `scan-progress-schema.ts` has the same unbounded `sql.join`, **and it binds three parameters per row**, so its real ceiling is **10922** — lower than the one reported, on the path that is actually taken.

Fixing only the named branch would have left the harm in place. Both are chunked at 4000 rows, which sits under both shapes with headroom.

### Verified
- two of the three new tests are red on HEAD with exactly `SQLITE_ERROR: too many SQL variables`
- the third holds a batch under the ceiling, as a control that chunking did not change small-batch behaviour
- one test re-runs the upsert to confirm chunking did not break `ON CONFLICT` across chunk boundaries

578/578 search-engine tests, `typecheck:node`, `eslint --max-warnings=0` clean.