### PR TITLE
fix(search): stop the diversity quota from under-filling the grid

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.test.ts
@@ -293,6 +293,63 @@ describe('RecommendationEngine', () => {
     expect(key).not.toContain('Asia/Shanghai')
   })
 
+  it('fills the grid when every candidate shares one source type', () => {
+    // maxPerType is ceil(10 * 0.4) = 4 and the half-mark is 5. A homogeneous pool
+    // latches both conditions at once: items 1-5 get in (the 5th because
+    // result.length is still 4), then everything after is skipped forever, so the
+    // empty-query grid came back half full (#672).
+    const engine = new RecommendationEngine(createDbUtils() as never)
+    const diversify = (
+      engine as unknown as {
+        applyDiversityFilter: (scored: unknown[], limit: number) => unknown[]
+      }
+    ).applyDiversityFilter.bind(engine)
+
+    const pool = Array.from({ length: 20 }, (_, i) => ({
+      sourceId: 'app-provider',
+      itemId: `/Applications/App-${i}.app`,
+      sourceType: 'application',
+      score: 1000 - i
+    }))
+
+    const picked = diversify(pool, 10) as Array<{ itemId: string }>
+
+    expect(picked).toHaveLength(10)
+    // Backfill must preserve score order, not append the leftovers arbitrarily.
+    expect(picked.map((item) => item.itemId)).toEqual(pool.slice(0, 10).map((i) => i.itemId))
+  })
+
+  it('still spreads a mixed pool across source types', () => {
+    const engine = new RecommendationEngine(createDbUtils() as never)
+    const diversify = (
+      engine as unknown as {
+        applyDiversityFilter: (scored: unknown[], limit: number) => unknown[]
+      }
+    ).applyDiversityFilter.bind(engine)
+
+    // 12 apps ahead of 4 plugins on score. Without the quota the plugins would
+    // never appear; the backfill must not undo that.
+    const pool = [
+      ...Array.from({ length: 12 }, (_, i) => ({
+        sourceId: 'app-provider',
+        itemId: `app-${i}`,
+        sourceType: 'application',
+        score: 1000 - i
+      })),
+      ...Array.from({ length: 4 }, (_, i) => ({
+        sourceId: 'plugin-recommend',
+        itemId: `plugin-${i}`,
+        sourceType: 'plugin',
+        score: 500 - i
+      }))
+    ]
+
+    const picked = diversify(pool, 10) as Array<{ sourceType: string }>
+
+    expect(picked).toHaveLength(10)
+    expect(picked.filter((item) => item.sourceType === 'plugin').length).toBeGreaterThan(0)
+  })
+
   it('does not reuse memory cache when the time context changes', async () => {
     const dbUtils = createDbUtils()
     const engine = new RecommendationEngine(dbUtils as never)

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.ts
@@ -2720,20 +2720,34 @@ export class RecommendationEngine {
   private applyDiversityFilter(scored: ScoredItem[], limit: number): ScoredItem[] {
     const result: ScoredItem[] = []
     const typeCount = new Map<string, number>()
+    const deferred: ScoredItem[] = []
+
+    // 同类型不超过总数的 40%
+    const maxPerType = Math.ceil(limit * 0.4)
 
     for (const item of scored) {
       if (result.length >= limit) break
 
       const currentCount = typeCount.get(item.sourceType) || 0
 
-      // 同类型不超过总数的 40%
-      const maxPerType = Math.ceil(limit * 0.4)
       if (currentCount >= maxPerType && result.length >= limit / 2) {
+        deferred.push(item)
         continue
       }
 
       result.push(item)
       typeCount.set(item.sourceType, currentCount + 1)
+    }
+
+    // The quota is a preference, not a hard ceiling. A homogeneous candidate pool
+    // — the normal case, since every app candidate carries sourceType
+    // 'application' and getCandidates already drops files — used to latch both
+    // conditions at once and return exactly limit/2 items, half an empty-query
+    // grid. Items skipped for diversity are put back in score order to fill the
+    // remaining slots rather than left on the floor (#672).
+    for (const item of deferred) {
+      if (result.length >= limit) break
+      result.push(item)
     }
 
     return result


### PR DESCRIPTION
Closes #672.

`applyDiversityFilter` stopped accepting a source type once its count hit `ceil(limit*0.4)` **and** the result reached `limit/2`. For a homogeneous pool both latch at the same moment, so the loop returned exactly `limit/2`.

With the default limit of 10 that is 5: items 1-4 are pushed, item 5 gets in because `result.length` is still 4, and every item after is skipped forever. A typical pool *is* homogeneous — every app candidate carries `sourceType: application` and `getCandidates` already drops files — so the empty-query grid came back half full.

The quota is now a **preference rather than a hard ceiling**: items skipped for diversity are kept and put back in score order to fill the remaining slots.

### The mixed case was broken too
The issue framed this as a single-type problem. It is not: with 12 apps and 4 plugins the old filter returns **9 of 10** — 5 apps (quota) + 4 plugins (all there are), then nothing left it is willing to take. Both new tests are red on HEAD, and the mixed one is red for this second reason.

### Verified
- one test pins that the backfill preserves **score order**, not arbitrary append
- the other pins that a mixed pool still gets its plugin slots, so the fix does not just disable the quota

577/577 search-engine tests, `typecheck:node`, `eslint --max-warnings=0` clean.