### PR TITLE
fix(core-app): release the battery powerMonitor listeners on destroy (#532)

### DIFF
--- a/apps/core-app/src/main/channel/common.test.ts
+++ b/apps/core-app/src/main/channel/common.test.ts
@@ -82,14 +82,19 @@ vi.mock('@talex-touch/utils', async (importOriginal) => {
   }
 })
 
+// A stable object, because the thing being mocked is a singleton: common.ts resolves it once at
+// module scope, so a factory returning a fresh object per call makes every assertion land on an
+// instance the code under test never held.
+const pollingInstanceMock = vi.hoisted(() => ({
+  isRegistered: vi.fn(() => false),
+  register: vi.fn(),
+  start: vi.fn(),
+  unregister: vi.fn()
+}))
+
 vi.mock('@talex-touch/utils/common/utils/polling', () => ({
   PollingService: {
-    getInstance: vi.fn(() => ({
-      isRegistered: vi.fn(() => false),
-      register: vi.fn(),
-      start: vi.fn(),
-      unregister: vi.fn()
-    }))
+    getInstance: vi.fn(() => pollingInstanceMock)
   }
 }))
 
@@ -160,7 +165,8 @@ vi.mock('electron', () => ({
     }))
   },
   powerMonitor: {
-    on: vi.fn()
+    on: vi.fn(),
+    off: vi.fn()
   },
   shell: {
     openExternal: vi.fn(),
@@ -492,7 +498,7 @@ vi.mock('../utils/storage-usage', () => ({
   getStorageUsageReport: vi.fn(async () => ({}))
 }))
 
-import { dialog, shell } from 'electron'
+import { dialog, powerMonitor, shell } from 'electron'
 import { APP_SCHEMA, FILE_SCHEMA } from '../config/default'
 import { CommonChannelModule } from './common'
 
@@ -2172,5 +2178,55 @@ describe('createOpenUrlHandler', () => {
     await handler()('#/settings')
     expect(showMessageBox).not.toHaveBeenCalled()
     expect(openExternal).not.toHaveBeenCalled()
+  })
+})
+
+describe('CommonChannelModule battery broadcaster lifecycle', () => {
+  it('releases the powerMonitor listeners and the battery poll on destroy', async () => {
+    // #532: the handlers were registered with no disposer, so after teardown an 'on-battery'
+    // event still ran startPolling() and re-registered a task on the PollingService singleton —
+    // a destroyed module keeping a global timer alive, with nothing to show for it.
+    vi.mocked(powerMonitor.on).mockClear()
+    vi.mocked(powerMonitor.off).mockClear()
+
+    const module = new CommonChannelModule()
+    await module.onInit({
+      app: {
+        window: { window: {}, onMaximizedChanged: () => () => {} },
+        app: { addListener: vi.fn() }
+      }
+    } as never)
+
+    // Widened before comparing: powerMonitor.on is overloaded, so TS narrows the tuple to the
+    // first signature's event name and calls these comparisons unreachable.
+    const calls = vi.mocked(powerMonitor.on).mock.calls as unknown as Array<
+      [string, (...args: unknown[]) => void]
+    >
+    const registered = calls.filter(([event]) => event === 'on-ac' || event === 'on-battery')
+
+    // Positive control: without this the loop below would assert nothing on a module that never
+    // registered anything.
+    expect(registered.map(([event]) => event).sort()).toEqual(['on-ac', 'on-battery'])
+
+    await module.onDestroy()
+
+    for (const [event, handler] of registered)
+      expect(vi.mocked(powerMonitor.off)).toHaveBeenCalledWith(event, handler)
+  })
+
+  it('unregisters the battery poll task from the shared PollingService', async () => {
+    pollingInstanceMock.unregister.mockClear()
+
+    const module = new CommonChannelModule()
+    await module.onInit({
+      app: {
+        window: { window: {}, onMaximizedChanged: () => () => {} },
+        app: { addListener: vi.fn() }
+      }
+    } as never)
+
+    await module.onDestroy()
+
+    expect(pollingInstanceMock.unregister).toHaveBeenCalled()
   })
 })

--- a/apps/core-app/src/main/channel/common.ts
+++ b/apps/core-app/src/main/channel/common.ts
@@ -841,6 +841,14 @@ export class CommonChannelModule extends BaseModule {
   private dbUtils: ReturnType<typeof createDbUtils> | null = null
   private transportDisposers: Array<() => void> = []
   private batteryPollTimer: NodeJS.Timeout | undefined
+  /**
+   * Undo for the powerMonitor listeners and the polling registration they arm.
+   *
+   * Kept apart from transportDisposers because these outlive a transport: they attach to the
+   * process-wide powerMonitor and to the PollingService singleton, so leaving them behind means a
+   * destroyed module can still re-register a global task (#532).
+   */
+  private batteryDisposers: Array<() => void> = []
   private touchApp: TalexTouch.TouchApp | null = null
 
   constructor() {
@@ -911,15 +919,26 @@ export class CommonChannelModule extends BaseModule {
         startPolling()
       }
 
-      powerMonitor.on('on-ac', () => {
+      const handleOnAc = (): void => {
         stopPolling()
         void broadcastBatteryStatus()
-      })
+      }
 
-      powerMonitor.on('on-battery', () => {
+      const handleOnBattery = (): void => {
         startPolling()
         void broadcastBatteryStatus()
-      })
+      }
+
+      powerMonitor.on('on-ac', handleOnAc)
+      powerMonitor.on('on-battery', handleOnBattery)
+
+      // Listeners first, then the poll task: dropping the listeners before unregistering means
+      // an 'on-battery' arriving mid-teardown cannot re-arm what was just released.
+      this.batteryDisposers.push(
+        () => powerMonitor.off('on-ac', handleOnAc),
+        () => powerMonitor.off('on-battery', handleOnBattery),
+        () => stopPolling()
+      )
     } catch (error) {
       log.warn('Failed to initialize battery status broadcaster:', { error })
     }
@@ -2062,6 +2081,14 @@ export class CommonChannelModule extends BaseModule {
     if (this.batteryPollTimer) {
       clearInterval(this.batteryPollTimer)
       this.batteryPollTimer = undefined
+    }
+
+    for (const dispose of this.batteryDisposers.splice(0)) {
+      try {
+        dispose()
+      } catch {
+        // ignore cleanup errors
+      }
     }
 
     for (const dispose of this.transportDisposers) {


### PR DESCRIPTION
Closes #532.

## Fixed both halves, not just the listeners

The handlers now have disposers. But `onDestroy` also never unregistered the poll task, and the issue describes that task re-arming as the *consequence* of the leak — so removing only the listeners would still have left a registered task on the `PollingService` singleton after every normal teardown. Both are released now.

**Order is deliberate and commented:** listeners are dropped *before* the poll is unregistered, so an `on-battery` arriving mid-teardown cannot re-arm what was just released.

The disposers live in their own list rather than `transportDisposers`. These attach to the process-wide `powerMonitor` and to a global singleton — they outlive any transport, which is the reason they were worth separating rather than folding into the existing list.

## Two tests, neither of which existed

Both fail against the pre-fix source.

The first pins that every `powerMonitor` listener registered is removed *with the same handler reference*, and carries a positive control that two were registered at all — otherwise it would assert nothing on a module that never registered anything.

## The mock had to change for the second test to mean anything

`PollingService.getInstance` was mocked as `vi.fn(() => ({ ... }))` — **a fresh object per call**. `common.ts` resolves the singleton once at module scope (`const pollingService = PollingService.getInstance()`), so any assertion I made landed on an instance the code under test never held. My first attempt failed for exactly that reason and would have been easy to "fix" by asserting something weaker.

It is now a stable hoisted object, which is also what the real class does. No existing test asserted on it, so nothing else is affected.

## One thing I got wrong on the way

`typecheck:node` went to 8 against a baseline of 6. `powerMonitor.on` is overloaded, so TS narrowed my `.mock.calls` tuple to the first signature's event name and declared the `'on-ac'` comparison unreachable — the same shape as the `app.on` case in #1300. Fixed by widening before comparing; back to 6.

The suite was green either way. Tests do not typecheck, so the error-count diff is the only thing that catches this class.

## Checks

- `src/main/channel/` suite: 6 files / 74 tests pass
- `typecheck:node` at the baseline 6
- ESLint clean
