### PR TITLE
fix(core-box): make the view cache actually honour a lowered cap

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/core-box/view-cache.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/core-box/view-cache.test.ts
@@ -98,3 +98,65 @@ describe('ViewCacheManager ownership transfer', () => {
     expect(cachedView.webContents.close).not.toHaveBeenCalled()
   })
 })
+
+describe('ViewCacheManager capacity enforcement', () => {
+  const manager = ViewCacheManager.getInstance()
+  const plugin = (name: string) => ({ name }) as never
+  const feature = { id: 'demo-feature' } as never
+
+  beforeEach(() => {
+    manager.clear()
+    manager.updateConfig({ maxCachedViews: 4, hotCacheDurationMs: 120_000 })
+    vi.clearAllMocks()
+  })
+
+  const fill = (count: number) =>
+    Array.from({ length: count }, (_, i) => {
+      const view = createView(200 + i)
+      manager.set(plugin(`plugin-${i}`), view, `plugin://plugin-${i}/index.html`, feature)
+      return view
+    })
+
+  it('evicts down to a lowered cap instead of only changing the number', () => {
+    const views = fill(4)
+    expect(manager.get(plugin('plugin-3'), feature)).not.toBeNull()
+
+    manager.updateConfig({ maxCachedViews: 1 })
+
+    // Three of the four live WebContentsViews must actually be closed — the
+    // whole point of lowering the setting is reclaiming those processes (#673).
+    const closed = views.filter(
+      (view) =>
+        (view.webContents.close as never as { mock: { calls: unknown[] } }).mock.calls.length > 0
+    )
+    expect(closed).toHaveLength(3)
+  })
+
+  it('caches nothing at all when the cap is zero', () => {
+    manager.updateConfig({ maxCachedViews: 0 })
+
+    const view = createView(300)
+    manager.set(plugin('plugin-zero'), view, 'plugin://plugin-zero/index.html', feature)
+
+    // The stale-cleanup task is unregistered at this cap, so anything admitted
+    // here would never be drained.
+    expect(manager.get(plugin('plugin-zero'), feature)).toBeNull()
+  })
+
+  it('drops every resident view when the cap is lowered to zero', () => {
+    const views = fill(3)
+
+    manager.updateConfig({ maxCachedViews: 0 })
+
+    for (const view of views) {
+      expect(view.webContents.close).toHaveBeenCalled()
+    }
+  })
+
+  it('still keeps the cache filled to a normal cap', () => {
+    fill(4)
+
+    expect(manager.get(plugin('plugin-1'), feature)).not.toBeNull()
+    expect(manager.get(plugin('plugin-3'), feature)).not.toBeNull()
+  })
+})

--- a/apps/core-app/src/main/modules/box-tool/core-box/view-cache.ts
+++ b/apps/core-app/src/main/modules/box-tool/core-box/view-cache.ts
@@ -62,7 +62,27 @@ export class ViewCacheManager {
     log.debug(
       `Config updated: maxCachedViews=${this.config.maxCachedViews}, hotCacheDurationMs=${this.config.hotCacheDurationMs}`
     )
+    // Lowering the cap used to change the number and evict nothing, so views
+    // already resident stayed resident — each one a live WebContentsView, i.e. a
+    // renderer process the user asked to reclaim (#673).
+    this.enforceCapacity()
     this.ensureCleanupTask()
+  }
+
+  /**
+   * Evicts until the cache fits the current cap. `evictLRU` removes exactly one
+   * entry, which is enough to make room for an insert but never enough to shrink
+   * toward a lowered cap.
+   */
+  private enforceCapacity(): void {
+    const cap = Math.max(0, this.config.maxCachedViews)
+    while (this.cache.size > cap) {
+      const before = this.cache.size
+      this.evictLRU()
+      // evictLRU is a no-op on an empty cache; bail rather than spin if it ever
+      // fails to remove anything.
+      if (this.cache.size >= before) break
+    }
   }
 
   private ensureCleanupTask(): void {
@@ -173,8 +193,21 @@ export class ViewCacheManager {
 
     this.removeEntry(key, { close: true })
 
-    if (this.cache.size >= this.config.maxCachedViews) {
+    // Caching disabled. The stale-cleanup task is unregistered at this cap, so
+    // anything admitted here would never be drained; the caller keeps owning the
+    // view either way, this only declines to hold a second reference for reuse.
+    if (this.config.maxCachedViews <= 0) {
+      log.debug(`View caching disabled, not caching: ${key}`)
+      this.ensureCleanupTask()
+      return
+    }
+
+    // Loop, not a single eviction: one evict per insert leaves the size
+    // net-unchanged, which is how an over-cap cache stayed over cap.
+    while (this.cache.size >= this.config.maxCachedViews) {
+      const before = this.cache.size
       this.evictLRU()
+      if (this.cache.size >= before) break
     }
 
     const dispose = this.attachLifecycle(key, webContents)


### PR DESCRIPTION
Closes #673.

`updateConfig` changed `maxCachedViews` and evicted nothing, and `set()` only ever evicted a **single** LRU entry before inserting — leaving the size net-unchanged. Lowering the setting therefore reclaimed nothing, and every resident entry is a live `WebContentsView`, i.e. the renderer process the user was trying to free.

At a cap of **0** it was worse: `ensureCleanupTask` unregisters the stale-cleanup poll, but `set()` had no cap check of its own, so `cache.size >= 0` was always true — evict one, insert one — and the cache kept a live view with nothing left to ever drain it.

Now: `updateConfig` evicts down to the new cap, `set()` loops rather than evicting once, and a cap of 0 declines to cache at all.

### Checked the caller before adding that early return
`plugin-view-controller` owns the view as `this.uiView` and uses the cache only for **reuse**, not ownership — so declining to cache does not orphan anything. The early return also sits *after* the existing `removeEntry`, so a stale entry left over from a higher cap is still cleared rather than stranded.

### Verified
Three of the four new tests are red on HEAD:
- lowering 4 → 1 must actually close 3 WebContentsViews
- a cap of 0 must cache nothing
- lowering to 0 must drop every resident view

The fourth is a control that a normal cap still fills as before.

87/87 core-box tests, `typecheck:node`, `eslint --max-warnings=0` clean.