### PR TITLE
perf(search): poll plugin recommendation providers concurrently

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.test.ts
@@ -1787,4 +1787,102 @@ describe('RecommendationEngine', () => {
     // is promoted because the foreground app is an IDE.
     expect(result.items[0]?.id).toBe('/Applications/Terminal.app')
   })
+
+  it('polls plugin recommendation providers concurrently, not one after another', async () => {
+    // Awaiting each provider in a for-of made PLUGIN_PROVIDER_TIMEOUT_MS a
+    // per-provider budget: six slow plugins meant 1.2s of empty grid on every
+    // uncached open of the CoreBox empty-query path (#674).
+    const engine = new RecommendationEngine(createDbUtils() as never)
+    const DELAY = 60
+    const PROVIDERS = 4
+
+    let live = 0
+    let peakConcurrent = 0
+
+    for (let i = 0; i < PROVIDERS; i++) {
+      engine.registerPluginProvider('demo-plugin', {
+        id: `provider-${i}`,
+        canProvide: () => true,
+        getCandidates: async () => {
+          live += 1
+          peakConcurrent = Math.max(peakConcurrent, live)
+          await new Promise((resolve) => setTimeout(resolve, DELAY))
+          live -= 1
+          return [{ id: `candidate-${i}`, title: `Candidate ${i}`, action: 'open' }]
+        }
+      } as never)
+    }
+
+    const startedAt = Date.now()
+    const candidates = await (
+      engine as unknown as {
+        getPluginCandidates: (context: unknown) => Promise<unknown[]>
+      }
+    ).getPluginCandidates(morningContext)
+    const elapsed = Date.now() - startedAt
+
+    expect(candidates).toHaveLength(PROVIDERS)
+    // All four in flight at once rather than a queue of one.
+    expect(peakConcurrent).toBe(PROVIDERS)
+    // Sequential would be >= 4 * 60ms; concurrent stays near one delay.
+    expect(elapsed).toBeLessThan(DELAY * PROVIDERS)
+  })
+
+  it('clears the timeout timer when a provider answers in time', async () => {
+    // The race armed a 200ms setTimeout per provider and never cleared it on the
+    // winning path, leaving a pending timer per call keeping the loop awake (#674).
+    vi.useFakeTimers()
+    try {
+      const engine = new RecommendationEngine(createDbUtils() as never)
+
+      for (let i = 0; i < 3; i++) {
+        engine.registerPluginProvider('demo-plugin', {
+          id: `prompt-${i}`,
+          canProvide: () => true,
+          getCandidates: async () => [{ id: `c-${i}`, title: `C ${i}`, action: 'open' }]
+        } as never)
+      }
+
+      const before = vi.getTimerCount()
+      await (
+        engine as unknown as {
+          getPluginCandidates: (context: unknown) => Promise<unknown[]>
+        }
+      ).getPluginCandidates(morningContext)
+
+      expect(vi.getTimerCount()).toBe(before)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('preserves provider registration order in the candidate list', async () => {
+    const engine = new RecommendationEngine(createDbUtils() as never)
+
+    // Deliberately inverted delays: if order followed completion rather than
+    // registration, this would come back reversed.
+    for (const [index, delay] of [90, 60, 30, 0].entries()) {
+      engine.registerPluginProvider('demo-plugin', {
+        id: `ordered-${index}`,
+        canProvide: () => true,
+        getCandidates: async () => {
+          await new Promise((resolve) => setTimeout(resolve, delay))
+          return [{ id: `candidate-${index}`, title: `Candidate ${index}`, action: 'open' }]
+        }
+      } as never)
+    }
+
+    const candidates = (await (
+      engine as unknown as {
+        getPluginCandidates: (context: unknown) => Promise<Array<{ itemId: string }>>
+      }
+    ).getPluginCandidates(morningContext)) as Array<{ itemId: string }>
+
+    expect(candidates.map((c) => c.itemId)).toEqual([
+      'candidate-0',
+      'candidate-1',
+      'candidate-2',
+      'candidate-3'
+    ])
+  })
 })

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.ts
@@ -1748,43 +1748,51 @@ export class RecommendationEngine {
   private async getPluginCandidates(context: ContextSignal): Promise<CandidateItem[]> {
     if (this.pluginProviders.size === 0) return []
 
-    const candidates: CandidateItem[] = []
+    // Providers run concurrently. Awaiting them in a for-of made
+    // PLUGIN_PROVIDER_TIMEOUT_MS a per-provider budget rather than a shared one,
+    // so six slow plugins blocked the empty-query grid for 1.2s on every open
+    // (#674). Promise.all preserves order, so the candidate sequence is unchanged.
+    const settled = await Promise.all(
+      Array.from(this.pluginProviders.values(), async ({ provider }) => {
+        if (!provider.canProvide(context)) return []
 
-    for (const [_id, { provider }] of this.pluginProviders) {
-      try {
-        if (!provider.canProvide(context)) continue
+        // The timer is cleared when the provider wins. Left armed, each call
+        // leaked a pending 200ms timeout that kept the event loop awake.
+        let timer: ReturnType<typeof setTimeout> | undefined
+        try {
+          const result = await Promise.race([
+            Promise.resolve(provider.getCandidates(context)),
+            new Promise<PluginRecommendCandidate[]>((_, reject) => {
+              timer = setTimeout(
+                () => reject(new Error(`Provider ${provider.id} timed out`)),
+                PLUGIN_PROVIDER_TIMEOUT_MS
+              )
+            })
+          ])
 
-        const result = await Promise.race([
-          Promise.resolve(provider.getCandidates(context)),
-          new Promise<PluginRecommendCandidate[]>((_, reject) =>
-            setTimeout(
-              () => reject(new Error(`Provider ${provider.id} timed out`)),
-              PLUGIN_PROVIDER_TIMEOUT_MS
-            )
-          )
-        ])
-
-        for (const candidate of result) {
-          candidates.push({
+          return result.map((candidate) => ({
             sourceId: `plugin-recommend:${provider.id}`,
             itemId: candidate.id,
-            sourceType: 'plugin-recommend',
+            sourceType: 'plugin-recommend' as const,
             usageStats: EMPTY_USAGE_STATS,
-            source: 'plugin',
+            source: 'plugin' as const,
             pluginCandidate: {
               ...candidate,
               providerId: provider.id
             }
+          }))
+        } catch (error) {
+          recommendationLog.warn('Plugin recommendation provider failed', {
+            meta: { providerId: provider.id, ...toErrorMeta(error) }
           })
+          return []
+        } finally {
+          if (timer) clearTimeout(timer)
         }
-      } catch (error) {
-        recommendationLog.warn('Plugin recommendation provider failed', {
-          meta: { providerId: provider.id, ...toErrorMeta(error) }
-        })
-      }
-    }
+      })
+    )
 
-    return candidates
+    return settled.flat()
   }
 
   /**


### PR DESCRIPTION
Closes #674.

`getPluginCandidates` awaited each provider inside a `for-of`, so `PLUGIN_PROVIDER_TIMEOUT_MS` was a **per-provider** budget rather than a shared one. Six plugins each taking the full 200ms blocked `getCandidates` for **1.2s on every uncached `recommend()`** — the CoreBox empty-query path, so the user watched an empty grid for over a second on every open.

The `setTimeout` arming each race was also never cleared when the provider won, leaving one pending 200ms timer per provider per call.

Providers now run under `Promise.all` with the timer cleared in a `finally`.

### Ordering is unchanged, and pinned
`Promise.all` preserves array order, so the candidate sequence is identical to the sequential version. There is a test with **deliberately inverted delays** (90/60/30/0ms) that would come back reversed if ordering had quietly started following completion instead of registration.

### Verified
- **concurrency test** red on HEAD — the sequential run measures ~250ms for 4×60ms of work
- **timer test** red on HEAD — the pending timer count stays raised after the call returns
- **ordering test** green on both, which is exactly what a control should do

578/578 search-engine tests, `typecheck:node`, `eslint --max-warnings=0` clean.