### PR TITLE
perf(search): skip the recommendation cache read on a forced refresh

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.test.ts
@@ -348,6 +348,65 @@ describe('RecommendationEngine', () => {
     expect(getCandidates).toHaveBeenCalledTimes(2)
   })
 
+  it('does not read the recommendation cache it is about to discard', async () => {
+    // recommend() awaited getCachedRecommendations and only then checked
+    // forceRefresh, so the 15-minute background refresh and every user-triggered
+    // refresh paid for a SELECT plus a JSON.parse of up to 10 rendered TuffItems
+    // and threw the result away (#675).
+    const dbUtils = createDbUtils()
+    const engine = new RecommendationEngine(dbUtils as never)
+    const getCandidates = vi.fn(async () => ({
+      items: [
+        {
+          sourceId: 'app-provider',
+          itemId: 'fresh-app',
+          sourceType: 'app',
+          source: 'frequent',
+          usageStats: createUsageStats('fresh-app', { executeCount: 2 })
+        }
+      ],
+      perf: candidatePerf(1)
+    }))
+
+    Object.assign(engine as unknown as Record<string, unknown>, {
+      contextProvider: {
+        getCurrentContext: vi.fn(async () => morningContext),
+        generateCacheKey: (context: ContextSignal) =>
+          `${context.time.timeSlot}|${context.time.dayOfWeek}`
+      },
+      scheduleTrendBackfill: vi.fn(),
+      getPinnedItems: vi.fn(async () => []),
+      getCandidates
+    })
+
+    const forced = await engine.recommend({ limit: 1, forceRefresh: true })
+
+    expect(dbUtils.getRecommendationCache).not.toHaveBeenCalled()
+    expect(forced.items[0]?.id).toBe('fresh-app')
+    expect(getCandidates).toHaveBeenCalledTimes(1)
+  })
+
+  it('still reads the cache on a normal recommend', async () => {
+    const dbUtils = createDbUtils()
+    const engine = new RecommendationEngine(dbUtils as never)
+
+    Object.assign(engine as unknown as Record<string, unknown>, {
+      contextProvider: {
+        getCurrentContext: vi.fn(async () => morningContext),
+        generateCacheKey: (context: ContextSignal) =>
+          `${context.time.timeSlot}|${context.time.dayOfWeek}`
+      },
+      scheduleTrendBackfill: vi.fn(),
+      getPinnedItems: vi.fn(async () => []),
+      getCandidates: vi.fn(async () => ({ items: [], perf: candidatePerf(1) }))
+    })
+
+    await engine.recommend({ limit: 1 })
+
+    // The skip must be conditional on forceRefresh, not a blanket removal.
+    expect(dbUtils.getRecommendationCache).toHaveBeenCalled()
+  })
+
   it('does not reuse persisted recommendation cache across time slots', async () => {
     const dbUtils = createDbUtils()
     dbUtils.getRecommendationCache.mockImplementation(async (cacheKey: string) => {

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.ts
@@ -1084,12 +1084,15 @@ export class RecommendationEngine {
       }
     }
 
-    const cached = await this.getCachedRecommendations(
-      context,
-      semanticSettings,
-      pinnedCacheSignature
-    )
-    if (cached && !options.forceRefresh) {
+    // Skipped outright on a forced refresh rather than read and discarded. The
+    // read is a cache-key build, a SELECT on recommendation_cache (which falls
+    // back to the primary db when the aux row is missing), a JSON.parse of up to
+    // 10 fully-rendered TuffItems and a dedupe pass — all of it thrown away. The
+    // 15-minute background refresh and every user-triggered refresh pay it (#675).
+    const cached = options.forceRefresh
+      ? null
+      : await this.getCachedRecommendations(context, semanticSettings, pinnedCacheSignature)
+    if (cached) {
       const items = await this.applyVolatileContextRerank(
         cached.items,
         context,


### PR DESCRIPTION
Closes #675.

`recommend()` awaited `getCachedRecommendations` unconditionally and only *then* checked `options.forceRefresh`, so a forced refresh paid for a cache-key build, a SELECT on `recommendation_cache` (which falls back to the primary db when the aux row is missing), a `JSON.parse` of up to 10 fully-rendered `TuffItem`s and a dedupe pass — then discarded all of it.

The 15-minute background refresh calls `recommend({forceRefresh: true})`, as does every user-triggered refresh from the CoreBox IPC handler.

### Checked before short-circuiting
`cached` has no uses after the block — only the guard and the rerank inside it — so skipping the read cannot starve anything downstream.

### Verified
- forced-refresh test red on HEAD
- a second test pins that a **normal** `recommend` still reads the cache, so the skip stays conditional rather than turning into a blanket removal

577/577 search-engine tests, `typecheck:node`, `eslint --max-warnings=0` clean.