### PR TITLE
test(core-app): mock electron so the plugin-log guard can run (#533)

### DIFF
--- a/apps/core-app/src/main/service/plugin-log.service.test.ts
+++ b/apps/core-app/src/main/service/plugin-log.service.test.ts
@@ -20,6 +20,16 @@ vi.mock('@talex-touch/utils/transport/main', () => ({
   getTuffTransportMain: vi.fn()
 }))
 
+// plugin-log.service imports `shell` at module scope. Without this the suite loads the real
+// electron entry point, which throws outside a packaged Electron install and reports as
+// "Tests: no tests" rather than a failure — a guard that cannot run.
+vi.mock('electron', () => ({ shell: { openPath: vi.fn(), showItemInFolder: vi.fn() } }))
+
+// plugin-log.service imports `shell` at module scope. Without this the suite loads the real
+// electron entry point, which throws outside a packaged Electron install and reports as
+// "Tests: no tests" rather than a failure — a guard that cannot run.
+vi.mock('electron', () => ({ shell: { openPath: vi.fn(), showItemInFolder: vi.fn() } }))
+
 vi.mock('../modules/plugin/plugin-module', () => ({
   pluginModule: { registerUninstallAuthorityInvalidator: vi.fn(() => vi.fn()) }
 }))


### PR DESCRIPTION
Follow-up to #1304, which fixed #533.

## The guard could not run

`plugin-log.service.ts` imports `shell` from electron at module scope. The new test file did not mock electron, so loading it outside a packaged Electron install throws — and vitest reports that as **`Tests: no tests`**, not as a failure. The guard for eight leaked disposers was inert.

Adding the mock makes it executable. Once it runs it discriminates: against the pre-#1304 service all three cases fail.

```
× releases every transport handler it registered
× removes the event-bus listener with the same handler reference
× does not release the same disposer twice on a repeated destroy
```

## Why this was not caught

`App suites (core-app)` was green on #1304 — but that job carries `continue-on-error` (#1255), so a suite that never ran reports success either way. This only surfaced because the file failed loudly on a machine whose local electron install is broken; on a healthy one it would have silently contributed zero tests.

That is the same shape as the finding in #1255 itself, arriving through a different door.
