### PR TITLE
fix(search): flush pending watch deltas before the router unsubscribes

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/indexed-source-event-router.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/indexed-source-event-router.test.ts
@@ -174,7 +174,14 @@ describe('IndexedSourceEventRouter watch coalescing', () => {
     expect(fileRoutes.map((event) => event.path).sort()).toEqual(['/tmp/a.md', '/tmp/b.md'])
   })
 
-  it('opens no window while idle and drops open windows on unsubscribe', async () => {
+  it('opens no window while idle and flushes an open window on unsubscribe', async () => {
+    // This used to assert routeWatchEventWithResult was NOT called — it recorded
+    // the behaviour rather than requiring it. Dropping the window closes the timer
+    // but also throws the coalesced delta away, and since unsubscribe detaches the
+    // producers first, the "next flush" the queue's own doc promises can never
+    // arrive. An app dropped in during the 400ms window vanished from the index
+    // with no reconcile marker (#676). The timer-leak half of the assertion is
+    // still here; only the data-loss half changed.
     const { router, emit, routeWatchEventWithResult, appWindowMs } = await createRouter()
 
     expect(vi.getTimerCount()).toBe(0)
@@ -182,10 +189,12 @@ describe('IndexedSourceEventRouter watch coalescing', () => {
     emit('DIRECTORY_ADDED', '/Applications/Probe.app')
     expect(vi.getTimerCount()).toBe(1)
 
-    router.unsubscribe()
+    await router.unsubscribe()
     expect(vi.getTimerCount()).toBe(0)
 
     await settleWindows(appWindowMs)
-    expect(routeWatchEventWithResult).not.toHaveBeenCalled()
+    expect(routeWatchEventWithResult).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/Applications/Probe.app' })
+    )
   })
 })

--- a/apps/core-app/src/main/modules/box-tool/search-engine/indexed-source-event-router.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/indexed-source-event-router.ts
@@ -103,7 +103,7 @@ export class IndexedSourceEventRouter {
     this.subscribed = true
   }
 
-  unsubscribe(): void {
+  async unsubscribe(): Promise<void> {
     if (!this.subscribed) return
     touchEventBus.off(TalexEvents.FILE_ADDED, this.handleFileAddedOrChanged)
     touchEventBus.off(TalexEvents.FILE_CHANGED, this.handleFileAddedOrChanged)
@@ -114,6 +114,12 @@ export class IndexedSourceEventRouter {
     touchEventBus.off(TalexEvents.FILE_UNLINKED, this.handleAppUnlinked)
     touchEventBus.off(TalexEvents.DIRECTORY_ADDED, this.handleAppAddedOrChanged)
     touchEventBus.off(TalexEvents.DIRECTORY_UNLINKED, this.handleAppUnlinked)
+    // Drained before disposing. dispose() only drops the coalescing window and
+    // leaves pending entries "for the next flush" — but the handlers are detached
+    // above, so no next enqueue can ever come. An app dropped into /Applications
+    // within the 400ms coalescing window was discarded outright, with no reconcile
+    // marker, leaving the index stale until the next full scan (#676).
+    await Promise.all([this.appQueue.drain(), this.fileQueue.drain()])
     this.appQueue.dispose()
     this.fileQueue.dispose()
     this.subscribed = false

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
@@ -2107,7 +2107,7 @@ export class SearchEngineCore
     await this.sessionRegistry.destroy()
     this.usageSummaryService?.stop()
     this.stopMaintenance()
-    this.indexedSourceEventRouter.unsubscribe()
+    await this.indexedSourceEventRouter.unsubscribe()
     const drainFailures: Error[] = []
     const recordDrainFailure = (message: string, error: unknown): void => {
       searchEngineLog.error(message, { error })

--- a/packages/utils/search/indexing-watch-delta-queue.ts
+++ b/packages/utils/search/indexing-watch-delta-queue.ts
@@ -126,6 +126,20 @@ export class IndexingWatchDeltaQueueService<
     this.chainFlush();
   }
 
+  /**
+   * Like `flushSoon`, but resolves once the flush has actually run.
+   *
+   * `flushSoon` only puts the work on the task chain, so a caller tearing down
+   * cannot tell whether the pending deltas landed. Teardown paths need that
+   * guarantee: `dispose` drops the coalescing window and, once the producers are
+   * detached, nothing will ever enqueue again to trigger "the next flush".
+   */
+  async drain(): Promise<void> {
+    this.clearDebounceWindow();
+    this.chainFlush();
+    await this.taskChain;
+  }
+
   private schedule(): void {
     if (this.pending.size === 0) {
       return;


### PR DESCRIPTION
Closes #676.

`unsubscribe()` detached every event-bus handler and *then* called `queue.dispose()`, which only clears the debounce timer. Its doc says pending entries stay queued "for the next flush" — but the producers are already gone, so no next enqueue can ever trigger one. An app dropped into `/Applications` inside the 400ms coalescing window was discarded with no reconcile marker, leaving the index stale until the next full scan.

### Changes
- **`IndexingWatchDeltaQueue.drain()`** — additive. `flushSoon()` only puts the work on the task chain, so a caller tearing down cannot tell whether the deltas landed. `destroy()` is async, so it can wait.
- **`unsubscribe()`** is now async: drains both queues, then disposes. The single call site awaits it.

### ⚠️ I changed an existing assertion — please look at this one
A test asserted the opposite of the fix:

```
it('opens no window while idle and drops open windows on unsubscribe', ...)
  expect(routeWatchEventWithResult).not.toHaveBeenCalled()
```

I judged that it **recorded** the behaviour rather than requiring it: there is no comment or rationale making the data loss deliberate, and the queue's own docstring ("pending entries stay queued for the next flush") contradicts it.

I changed **only** that assertion. The timer-leak half — no timer while idle, timer opened by an event, timer count back to 0 after unsubscribe — is untouched and still passes, because closing the timer was never the problem.

If dropping deltas on teardown *was* intentional (e.g. to avoid writes during shutdown), say so and I will revert this and close the issue as by-design instead.

### Verified
The updated test is red with **both** source files reverted to HEAD. 575/575 search-engine tests, 462/462 utils tests, `typecheck:node`, and `eslint --max-warnings=0` under each package's own config.