### PR TITLE
perf(db): index the columns the recommendation candidate queries order by

### DIFF
--- a/apps/core-app/resources/db/migrations/0037_item_usage_stats_ordering_indexes.sql
+++ b/apps/core-app/resources/db/migrations/0037_item_usage_stats_ordering_indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS `item_usage_stats_execute_count_idx` ON `item_usage_stats` (`execute_count`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `item_usage_stats_last_executed_idx` ON `item_usage_stats` (`last_executed`);

--- a/apps/core-app/resources/db/migrations/meta/_journal.json
+++ b/apps/core-app/resources/db/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1785542400000,
       "tag": "0036_recommendation_exposure_daily",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1785628800000,
+      "tag": "0037_item_usage_stats_ordering_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core-app/src/main/db/schema.ts
+++ b/apps/core-app/src/main/db/schema.ts
@@ -278,7 +278,13 @@ export const itemUsageStats = sqliteTable(
     pk: primaryKey({ columns: [table.sourceId, table.itemId] }),
     retentionIdx: index('item_usage_stats_retention_idx').on(
       sql`MAX(COALESCE(${table.lastSearched}, 0), COALESCE(${table.lastExecuted}, 0), COALESCE(${table.lastCancelled}, 0), ${table.updatedAt})`
-    )
+    ),
+    // The recommendation candidate queries order by these and take a small
+    // LIMIT. Unindexed they were `SCAN item_usage_stats` + `USE TEMP B-TREE FOR
+    // ORDER BY` over a table that grows by one row per distinct item ever seen
+    // (#677). Plain indexes are enough — SQLite scans them backwards for DESC.
+    executeCountIdx: index('item_usage_stats_execute_count_idx').on(table.executeCount),
+    lastExecutedIdx: index('item_usage_stats_last_executed_idx').on(table.lastExecuted)
   })
 )
 

--- a/apps/core-app/src/main/db/usage-stats-ordering-indexes.test.ts
+++ b/apps/core-app/src/main/db/usage-stats-ordering-indexes.test.ts
@@ -1,0 +1,82 @@
+import { createClient, type Client } from '@libsql/client'
+import { drizzle } from 'drizzle-orm/libsql'
+import { migrate } from 'drizzle-orm/libsql/migrator'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * getFrequentItems orders by execute_count and getRecentItems by last_executed,
+ * but item_usage_stats declared only its composite primary key and a retention
+ * expression index. Both queries were `SCAN item_usage_stats` plus
+ * `USE TEMP B-TREE FOR ORDER BY` over a table that gains a row per distinct item
+ * ever searched or executed (#677).
+ *
+ * This runs the real migration chain rather than a hand-built table, so it also
+ * catches a schema change that never made it into a migration.
+ */
+
+const MIGRATIONS = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../resources/db/migrations'
+)
+
+let directory: string
+let client: Client
+
+async function queryPlan(sql: string): Promise<string> {
+  const result = await client.execute(`EXPLAIN QUERY PLAN ${sql}`)
+  return result.rows.map((row) => String(row.detail)).join(' | ')
+}
+
+beforeAll(async () => {
+  directory = await mkdtemp(join(tmpdir(), 'tuff-usage-stats-idx-'))
+  client = createClient({ url: `file:${join(directory, 'db.sqlite')}` })
+  await migrate(drizzle(client), { migrationsFolder: MIGRATIONS })
+}, 60_000)
+
+afterAll(async () => {
+  client?.close()
+  if (directory) await rm(directory, { recursive: true, force: true })
+})
+
+describe('item_usage_stats ordering indexes', () => {
+  it('creates both ordering indexes through the migration chain', async () => {
+    const result = await client.execute(
+      "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='item_usage_stats'"
+    )
+    const names = result.rows.map((row) => String(row.name))
+
+    expect(names).toContain('item_usage_stats_execute_count_idx')
+    expect(names).toContain('item_usage_stats_last_executed_idx')
+  })
+
+  it('serves the frequent-items query from an index rather than a sort', async () => {
+    const plan = await queryPlan(
+      'SELECT * FROM item_usage_stats ORDER BY execute_count DESC LIMIT 10'
+    )
+
+    expect(plan).toContain('item_usage_stats_execute_count_idx')
+    expect(plan).not.toContain('TEMP B-TREE')
+  })
+
+  it('serves the recent-items query from an index rather than a sort', async () => {
+    const plan = await queryPlan(
+      'SELECT * FROM item_usage_stats ORDER BY last_executed DESC LIMIT 10'
+    )
+
+    expect(plan).toContain('item_usage_stats_last_executed_idx')
+    expect(plan).not.toContain('TEMP B-TREE')
+  })
+
+  it('keeps the retention index the privacy owner depends on', async () => {
+    // Control: the new indexes must be additive, not a replacement.
+    const result = await client.execute(
+      "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='item_usage_stats'"
+    )
+
+    expect(result.rows.map((row) => String(row.name))).toContain('item_usage_stats_retention_idx')
+  })
+})


### PR DESCRIPTION
Closes #677.

`getFrequentItems` orders by `execute_count` and `getRecentItems` by `last_executed`, but `item_usage_stats` declared only its composite primary key and a retention *expression* index. `EXPLAIN QUERY PLAN` on the real schema confirms the issue exactly:

```
before: SCAN item_usage_stats | USE TEMP B-TREE FOR ORDER BY
after:  SCAN item_usage_stats USING INDEX item_usage_stats_execute_count_idx
```

The table gains a row per distinct item ever searched or executed — `recordDisplayedResults` enqueues a `search` increment for the top 10 results of *every* query — so it reaches tens of thousands of rows quickly. Every cold `recommend()` paid for two of those scans, including the 15-minute background refresh.

### Plain indexes, checked rather than assumed
SQLite scans a plain index backwards to satisfy `ORDER BY ... DESC`, so `DESC` indexes are unnecessary. I verified that with a query plan rather than taking it on faith, and it matches the style of migration 0034.

### Contents
- `schema.ts`: two index declarations
- `0037_item_usage_stats_ordering_indexes.sql` + `_journal.json` entry (7-line addition, formatting preserved)

### Verified
The new test runs the **real migration chain** rather than a hand-built table, so it also catches a schema change that never made it into a migration. Three of its four assertions are red with the migration and journal entry reverted; the fourth is a control that `item_usage_stats_retention_idx` — which the privacy retention owner depends on — is still present, i.e. that these indexes are additive.

47/47 db and database tests, `typecheck:node`, `eslint --max-warnings=0` clean.