### PR TITLE
fix(search): make both shutdown guards actually hold after teardown

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.gather-ordering.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.gather-ordering.test.ts
@@ -339,6 +339,8 @@ interface SearchCoreOrderingHarness {
   }
   cancelSearch: (searchId: string, caller: { kind: 'core-box'; id: string }) => boolean
   destroy: () => Promise<void>
+  destroying: boolean
+  sessionRegistry: unknown
   orchestrateSearchQuery: () => Promise<{
     providerFilter?: string
     cacheKey: string
@@ -379,6 +381,15 @@ describe('search-core gather completion ordering', () => {
 
   beforeEach(async () => {
     await core.destroy()
+    // destroy() is terminal in production: `destroying` is set once and never
+    // cleared, and the singleton is never replaced. This suite uses it purely to
+    // reset shared state between cases, so it has to rewind the flag explicitly —
+    // otherwise every case after the first searches a core that has declared
+    // itself shut down (#678).
+    core.destroying = false
+    // Same for the registry's own latch, which the core holds as a readonly field
+    // and so cannot be swapped out for a fresh one here.
+    ;(core.sessionRegistry as unknown as { destroyed: boolean }).destroyed = false
     gatherAggregatorMock.mockReset()
     sentEvents.length = 0
     mergeSettled = false

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
@@ -781,6 +781,13 @@ export class SearchEngineCore
   }
 
   startSearch(query: TuffQuery, context?: SearchRequestContext): SearchExecution {
+    // The CoreBox window outlives module teardown ordering, so a renderer search
+    // stream can arrive after destroy(). Without this it built a live session
+    // against dbUtils/indexWriter handles that were already closed (#678).
+    if (this.destroying) {
+      throw new Error('Search engine is shutting down')
+    }
+
     const onboardingDecision = onboardingGate.evaluate()
     if (onboardingDecision.state !== 'allowed') {
       throw new OnboardingGateError(onboardingDecision)

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-session.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-session.test.ts
@@ -150,3 +150,25 @@ describe('SearchSessionRegistry', () => {
     expect(registry.size).toBe(0)
   })
 })
+
+describe('SearchSessionRegistry shutdown guard', () => {
+  it('keeps refusing new sessions after the drain finishes', async () => {
+    // destroyPromise is nulled in a finally so repeat destroy() calls re-drain.
+    // That also reopened the shutdown guard the moment the drain completed, so a
+    // late request built a live session against torn-down services (#678).
+    const registry = new SearchSessionRegistry()
+
+    await registry.destroy()
+
+    expect(() => registry.create({ caller: coreBoxCaller, query, activations: [] })).toThrow(
+      /shutting down/
+    )
+  })
+
+  it('still accepts sessions before any destroy', () => {
+    // Control: the latch must not be set at construction.
+    const registry = new SearchSessionRegistry()
+
+    expect(() => registry.create({ caller: coreBoxCaller, query, activations: [] })).not.toThrow()
+  })
+})

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-session.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-session.ts
@@ -311,6 +311,12 @@ export class SearchSessionRegistry {
   private readonly sessions = new Map<string, SearchSession>()
   private readonly completedTraces = new Map<string, SearchSessionTrace>()
   private destroyPromise: Promise<void> | null = null
+  /**
+   * Latches on the first destroy() and never clears. destroyPromise cannot carry
+   * this on its own: it is nulled in a finally so repeat calls re-drain, which
+   * left the shutdown guard open again the moment the drain finished (#678).
+   */
+  private destroyed = false
 
   constructor(
     private readonly options: {
@@ -324,7 +330,7 @@ export class SearchSessionRegistry {
     activations: readonly IProviderActivate[] | null
     sink?: SearchSink
   }): SearchSession {
-    if (this.destroyPromise) {
+    if (this.destroyed || this.destroyPromise) {
       throw new Error('Search session registry is shutting down')
     }
 
@@ -383,6 +389,7 @@ export class SearchSessionRegistry {
   destroy(): Promise<void> {
     if (this.destroyPromise) return this.destroyPromise
 
+    this.destroyed = true
     const sessions = [...this.sessions.values()]
     this.destroyPromise = (async () => {
       for (const session of sessions) session.cancel()


### PR DESCRIPTION
Closes #678.

`SearchSessionRegistry.destroy()` nulls `destroyPromise` in a `finally` so repeat calls re-drain — which also **reopened** the "registry is shutting down" guard the moment the drain finished. `SearchEngineCore.startSearch` never checked `this.destroying` at all, so a renderer stream arriving after teardown (the CoreBox window outlives module teardown ordering) built a live session against `dbUtils`/`indexWriter` handles that were already closed.

The registry now latches a separate `destroyed` flag that never clears, and `startSearch` refuses once the core is tearing down.

### Why a permanent latch is the right shape
It matches what production already does: the core sets `destroying` once and **never resets it**, `_instance` is never cleared, and lines 356/364/383 already bail on it. Nothing reuses a destroyed core.

### ⚠️ This surfaced a test using destroy() as a reset
`search-core.gather-ordering.test.ts` calls `await core.destroy()` in `beforeEach` to reset shared singleton state, then runs searches.

Worth being precise about what changed: that suite was **already** running against a core with `destroying === true` — the existing guards at 356/364/383 were silently no-ops for it — and only kept working because `startSearch` had no check. My change made the pre-existing situation visible rather than creating it.

The harness now rewinds both latches explicitly, with a comment saying why. I did **not** weaken the production guards to accommodate the test.

### Verified
The new test is red with both source files reverted. I also wrote a during-the-drain case and dropped it: that window was already guarded on HEAD so it proved nothing, and it deadlocked the harness because `destroy()` awaits `session.completed`.

577/577 search-engine tests, `typecheck:node`, `eslint --max-warnings=0` clean.