### PR TITLE
fix(nexus): give prerendered docs pages a real canonical origin

### DIFF
--- a/apps/nexus/app/pages/docs/[...slug].vue
+++ b/apps/nexus/app/pages/docs/[...slug].vue
@@ -40,6 +40,13 @@ definePageMeta({
 const route = useRoute()
 const router = useRouter()
 const requestUrl = useRequestURL()
+// Canonical/og/hreflang are absolute production URLs by definition — they should
+// not vary with how the page was fetched, and at prerender time there is no
+// request host at all. The configured site URL wins; the request origin stays as
+// a fallback for deployments that leave NUXT_PUBLIC_SITE_URL unset (#679).
+const seoOrigin = computed(
+  () => (useRuntimeConfig().public.siteUrl as string | undefined) || requestUrl.origin,
+)
 const { t, setLocale } = useI18n()
 const activeRoutePath = ref(route.path)
 if (import.meta.client) {
@@ -1047,7 +1054,7 @@ const docSeoHead = computed(() =>
   buildDocsSeoHead({
     appName,
     description: docSeoDescription.value,
-    origin: requestUrl.origin,
+    origin: seoOrigin.value,
     canonicalPath: docCanonicalPath.value,
     locale: docsLocale.value,
     title: docSeoTitleText.value || docDisplayTitle.value,

--- a/apps/nexus/app/pages/docs/[...slug].vue
+++ b/apps/nexus/app/pages/docs/[...slug].vue
@@ -44,8 +44,12 @@ const requestUrl = useRequestURL()
 // not vary with how the page was fetched, and at prerender time there is no
 // request host at all. The configured site URL wins; the request origin stays as
 // a fallback for deployments that leave NUXT_PUBLIC_SITE_URL unset (#679).
+// Resolved during setup, not inside the computed: `docSeoHead` is handed to `useHead`, and
+// unhead resolves those tags after the setup context is gone. Calling a Nuxt composable there
+// throws `[nuxt] instance unavailable`, which failed prerender on every docs page.
+const runtimeConfig = useRuntimeConfig()
 const seoOrigin = computed(
-  () => (useRuntimeConfig().public.siteUrl as string | undefined) || requestUrl.origin,
+  () => (runtimeConfig.public.siteUrl as string | undefined) || requestUrl.origin,
 )
 const { t, setLocale } = useI18n()
 const activeRoutePath = ref(route.path)

--- a/apps/nexus/app/utils/docs-seo-origin.test.ts
+++ b/apps/nexus/app/utils/docs-seo-origin.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it, vi } from 'vitest'
 import { buildDocsSeoHead } from './docs-seo'
 
@@ -48,6 +49,23 @@ describe('docs SEO absolute origin', () => {
     const serialized = JSON.stringify(seo)
     expect(serialized).not.toContain('http://localhost')
     expect(seo.canonicalUrl).toMatch(/^https:\/\//)
+  })
+
+  it('页面在 setup 阶段取 runtimeConfig,而不是在 computed 里', () => {
+    // The first version of this fix called useRuntimeConfig() inside the computed that feeds
+    // useHead. unhead resolves those tags after the setup context is gone, so every prerendered
+    // docs page died with `[nuxt] instance unavailable` and a 500.
+    const page = readFileSync(
+      new URL('../pages/docs/[...slug].vue', import.meta.url),
+      'utf8',
+    )
+
+    // Positive control: the read produced the real page, so the absence check below means
+    // something.
+    expect(page).toContain('const seoOrigin = computed(')
+
+    expect(page).toContain('const runtimeConfig = useRuntimeConfig()')
+    expect(page).not.toMatch(/computed\([\s\S]{0,200}?useRuntimeConfig\(\)/)
   })
 
   it('still honours whatever origin it is handed', () => {

--- a/apps/nexus/app/utils/docs-seo-origin.test.ts
+++ b/apps/nexus/app/utils/docs-seo-origin.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import { buildDocsSeoHead } from './docs-seo'
+
+/**
+ * The docs SEO head was built from `useRequestURL().origin`. During Nitro
+ * prerender there is no real request host, so every prerendered HTML file baked
+ * `http://localhost` into rel=canonical, og:url, all hreflang alternates and the
+ * JSON-LD url/@id — and nothing in nuxt.config.ts supplied a fallback (#679).
+ *
+ * buildDocsSeoHead itself was never the problem: it takes whatever origin it is
+ * handed. So the regression these guard is the *config* half — that an absolute,
+ * non-localhost site URL exists to hand it in the first place.
+ */
+
+async function loadNuxtConfig(): Promise<{
+  runtimeConfig?: { public?: { siteUrl?: string } }
+}> {
+  vi.stubGlobal('defineNuxtConfig', (config: unknown) => config)
+  const module = await import('../../nuxt.config')
+  return module.default as { runtimeConfig?: { public?: { siteUrl?: string } } }
+}
+
+describe('docs SEO absolute origin', () => {
+  it('configures an absolute site URL for prerendered pages to use', async () => {
+    const config = await loadNuxtConfig()
+    const siteUrl = config.runtimeConfig?.public?.siteUrl
+
+    expect(siteUrl).toBeTruthy()
+    expect(siteUrl).toMatch(/^https:\/\//)
+    expect(siteUrl).not.toMatch(/localhost|127\.0\.0\.1/)
+  })
+
+  it('produces no localhost URLs anywhere in the head when given that origin', async () => {
+    const config = await loadNuxtConfig()
+    const seo = buildDocsSeoHead({
+      appName: 'Tuff Docs',
+      description: 'Official docs',
+      origin: config.runtimeConfig?.public?.siteUrl ?? '',
+      canonicalPath: '/docs/index',
+      locale: 'en',
+      title: 'Tuff Docs',
+      hasContent: true,
+      modifiedAt: '2026-06-13T10:00:00.000Z',
+    })
+
+    // Every absolute URL the head emits, not just the canonical: og:url, the
+    // hreflang alternates and the JSON-LD all carried the same bad origin.
+    const serialized = JSON.stringify(seo)
+    expect(serialized).not.toContain('http://localhost')
+    expect(seo.canonicalUrl).toMatch(/^https:\/\//)
+  })
+
+  it('still honours whatever origin it is handed', () => {
+    // Control: the util stays origin-agnostic. The fix belongs in the caller and
+    // the config, not in a hardcoded domain down here.
+    const seo = buildDocsSeoHead({
+      appName: 'Tuff Docs',
+      description: 'Official docs',
+      origin: 'https://preview.example.com',
+      canonicalPath: '/docs/index',
+      locale: 'en',
+      title: 'Tuff Docs',
+      hasContent: true,
+      modifiedAt: '2026-06-13T10:00:00.000Z',
+    })
+
+    expect(seo.canonicalUrl).toBe('https://preview.example.com/en/docs')
+  })
+})

--- a/apps/nexus/nuxt.config.ts
+++ b/apps/nexus/nuxt.config.ts
@@ -322,6 +322,11 @@ export default defineNuxtConfig({
       notificationWebPush: {
         publicKey: process.env.NOTIFICATION_WEB_PUSH_PUBLIC_KEY,
       },
+      // Absolute origin for canonical / og:url / hreflang / JSON-LD. These must not
+      // come from the request: during Nitro prerender there is no real host, so
+      // useRequestURL() yields http://localhost and every prerendered page shipped
+      // that as its canonical (#679).
+      siteUrl: process.env.NUXT_PUBLIC_SITE_URL || 'https://tuff.tagzxia.com',
     },
   },
 


### PR DESCRIPTION
Closes #679.

The docs SEO head was built from `useRequestURL().origin`. During Nitro prerender there is no real request host, so every prerendered HTML file baked `http://localhost` into `rel=canonical`, `og:url`, **all** hreflang alternates and the JSON-LD `url`/`@id`. Nothing in `nuxt.config.ts` supplied a fallback.

Added `public.siteUrl` to `runtimeConfig`, defaulting to the official origin the `runtime-startup-env` docs already name (`https://tuff.tagzxia.com`) and overridable per deployment via `NUXT_PUBLIC_SITE_URL`. The docs page prefers it and keeps the request origin as a fallback.

### Configured origin wins, rather than only patching localhost
Canonical, `og:url` and hreflang are absolute production URLs by definition — they should not vary with how the page happened to be fetched. Sniffing for `localhost` and patching only that case would leave preview hosts emitting preview canonicals.

### Where the tests point
`buildDocsSeoHead` was never at fault — it uses whatever origin it is handed, and its existing tests pass one directly, so they could not have caught this. The new tests target the **config** half instead, plus a control that the util stays origin-agnostic rather than gaining a hardcoded domain.

### Verified
Two of the three new tests are red with `nuxt.config.ts` reverted. 67/67 nexus `app/utils` tests, `eslint --max-warnings=0` clean.

### ⚠️ Not verified: nexus typecheck
Both `nuxi typecheck` and `vue-tsc -p .nuxt/tsconfig.json` die in my shell on the mise `command_not_found` handler **before reaching the compiler** — they exit non-zero with zero `error TS` lines, so neither run means anything either way. Please treat CI as the first real typecheck for the `.vue` change.

I have not run the prerender build either, so the "482 of 496 files" figure in the issue is the reporter's, not re-measured by me.