### PR TITLE
fix(nexus): stop the push worker fighting the PWA worker for scope '/'

### DIFF
--- a/apps/nexus/app/pages/dashboard/notifications.test.ts
+++ b/apps/nexus/app/pages/dashboard/notifications.test.ts
@@ -46,7 +46,12 @@ describe('dashboard notification inbox UI contract', () => {
     expect(page).toContain('window.Notification.requestPermission()')
     expect(page).toContain('new window.Notification')
     expect(page).toContain("tag: 'tuff-dashboard-notification-test'")
-    expect(page).toContain("navigator.serviceWorker.register('/notification-sw.js')")
+    // The page no longer registers the worker itself: doing so with no scope claimed '/' and
+    // fought the PWA worker for it. It delegates instead, and the URL and scope of that
+    // registration are asserted in push-service-worker.test.ts.
+    expect(page).toContain("import { registerPushServiceWorker } from '~/utils/push-service-worker'")
+    expect(page).toContain('registerPushServiceWorker(navigator.serviceWorker)')
+    expect(page).not.toContain('navigator.serviceWorker.register(')
     expect(page).toContain('registration.pushManager.subscribe')
     expect(page).toContain('urlBase64ToArrayBuffer(browserPushPublicKey.value)')
     expect(page).toContain('runtimeConfig.public?.notificationWebPush?.publicKey')

--- a/apps/nexus/app/pages/dashboard/notifications.vue
+++ b/apps/nexus/app/pages/dashboard/notifications.vue
@@ -5,6 +5,7 @@ import { TxRadio, TxRadioGroup, type TxRadioValue } from '@talex-touch/tuffex/ra
 import { TxSpinner } from '@talex-touch/tuffex/spinner'
 import { TxTag } from '@talex-touch/tuffex/tag'
 import { hasWindow } from '@talex-touch/utils/env'
+import { registerPushServiceWorker } from '~/utils/push-service-worker'
 import { requestJson } from '~/utils/request'
 
 const LazyFlipDialog = defineAsyncComponent(() => import('~/components/base/dialog/FlipDialog.vue'))
@@ -231,7 +232,7 @@ async function getServiceWorkerRegistration(): Promise<ServiceWorkerRegistration
     throw new Error(t('dashboard.notifications.browser.errors.serviceWorkerUnsupported', '当前浏览器不支持 Service Worker。'))
   if (!('PushManager' in window))
     throw new Error(t('dashboard.notifications.browser.errors.pushUnsupported', '当前浏览器不支持 Web Push。'))
-  return await navigator.serviceWorker.register('/notification-sw.js')
+  return await registerPushServiceWorker(navigator.serviceWorker)
 }
 
 async function loadBrowserPushSubscriptions() {

--- a/apps/nexus/app/utils/push-service-worker.test.ts
+++ b/apps/nexus/app/utils/push-service-worker.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  PUSH_SERVICE_WORKER_SCOPE,
+  PUSH_SERVICE_WORKER_URL,
+  registerPushServiceWorker,
+} from './push-service-worker'
+
+/**
+ * `/notification-sw.js` was registered with no scope option, so it claimed `/`.
+ * The @vite-pwa worker also owns `/` and re-registers on every page load because
+ * `registerType` is `autoUpdate`. A registration is keyed by (origin, scope), so
+ * the two scripts overwrote each other — and once the generated `sw.js` won, the
+ * surviving push subscription was served by a worker with no `push` listener,
+ * killing delivery silently (#680).
+ */
+
+describe('push service worker registration', () => {
+  it('registers under its own scope rather than the default', async () => {
+    const register = vi.fn(async () => ({}) as ServiceWorkerRegistration)
+
+    await registerPushServiceWorker({ register })
+
+    expect(register).toHaveBeenCalledWith(PUSH_SERVICE_WORKER_URL, {
+      scope: PUSH_SERVICE_WORKER_SCOPE,
+    })
+  })
+
+  it('never claims the root scope the PWA worker owns', () => {
+    // The whole defect is the collision on '/', so pin the value itself: a later
+    // "simplification" back to '/' or to undefined would reintroduce it.
+    expect(PUSH_SERVICE_WORKER_SCOPE).not.toBe('/')
+    expect(PUSH_SERVICE_WORKER_SCOPE).toBeTruthy()
+  })
+
+  it('stays within the scope its own script path allows', () => {
+    // A worker may only take a scope at or below its own directory unless the
+    // server sends Service-Worker-Allowed. notification-sw.js sits at the root,
+    // so anything starting with '/' is permitted — but it must still be a path,
+    // not a cross-origin or relative value, or registration throws at runtime.
+    expect(PUSH_SERVICE_WORKER_SCOPE.startsWith('/')).toBe(true)
+    expect(PUSH_SERVICE_WORKER_URL).toBe('/notification-sw.js')
+  })
+
+  it('passes the registration back to the caller', async () => {
+    const registration = { scope: PUSH_SERVICE_WORKER_SCOPE } as ServiceWorkerRegistration
+    const register = vi.fn(async () => registration)
+
+    await expect(registerPushServiceWorker({ register })).resolves.toBe(registration)
+  })
+})

--- a/apps/nexus/app/utils/push-service-worker.ts
+++ b/apps/nexus/app/utils/push-service-worker.ts
@@ -1,0 +1,31 @@
+/**
+ * Scope for the Web Push service worker.
+ *
+ * Deliberately not `/`. A registration is keyed by (origin, scope), and the
+ * @vite-pwa worker already owns `/` — re-registering on every page load, since
+ * `registerType` is `autoUpdate`. Registering `notification-sw.js` with no scope
+ * option put both scripts on the same key, so whichever ran last replaced the
+ * other. The push subscription survived on the registration but was then served
+ * by the generated `sw.js`, which has no `push` listener, and delivery stopped
+ * with no error anywhere (#680).
+ */
+export const PUSH_SERVICE_WORKER_SCOPE = '/push/'
+
+export const PUSH_SERVICE_WORKER_URL = '/notification-sw.js'
+
+/**
+ * Registers the push worker under its own scope.
+ *
+ * A scope narrower than the script's own path is always permitted, and push
+ * delivery is not scope-limited, so `subscribe()` and `showNotification()` are
+ * unaffected. Keeping a separate worker — rather than folding the push listener
+ * into the PWA one — also means push still works when the PWA is disabled via
+ * NUXT_DISABLE_PWA.
+ */
+export function registerPushServiceWorker(
+  container: Pick<ServiceWorkerContainer, 'register'>,
+): Promise<ServiceWorkerRegistration> {
+  return container.register(PUSH_SERVICE_WORKER_URL, {
+    scope: PUSH_SERVICE_WORKER_SCOPE,
+  })
+}


### PR DESCRIPTION
Closes #680.

`/notification-sw.js` was registered with no `scope` option, so it claimed `/`. The @vite-pwa worker is configured with `scope: "/"` too and re-registers on **every page load** because `registerType` is `autoUpdate`. A registration is keyed by (origin, scope), so the two scripts overwrote each other. The push subscription survived on the registration but was then served by the generated `sw.js`, which has no `push` listener — `public/notification-sw.js` is the only one in the repo — so delivery stopped with no error anywhere.

Registered under its own `/push/` scope instead. A scope narrower than the script's own path is always permitted, and push delivery is not scope-limited, so `subscribe()` and `showNotification()` are unaffected.

### ⚠️ Tradeoff worth a second opinion
The tidier fix is folding the push listener into the PWA worker via `workbox.importScripts` — one worker, no possible collision.

I did not do that because it **breaks push entirely when the PWA is disabled** through `NUXT_DISABLE_PWA`: there would then be no worker at all, where today the page registers its own. Two non-colliding registrations survive that case.

If `NUXT_DISABLE_PWA` is never set in any real deployment, the single-worker version is better and I am happy to redo it that way.

### Why the registration moved to a util
Nexus has no component-mounting test setup, so an SFC-internal function could not be covered without introducing one. `app/utils/push-service-worker.ts` makes the scope assertable. The page imports it explicitly via `~/utils/...`, matching the convention in `pages/docs/[...slug].vue` rather than relying on auto-import.

### Verified
Two of the four new tests are red against the pre-fix shape (scope-less `register()`). 68/68 nexus `app/utils` tests, `eslint --max-warnings=0` clean.

**Nexus typecheck still cannot run in my shell** — mise's `command_not_found` handler kills `nuxi` and `vue-tsc` before the compiler, so both exit non-zero with zero `error TS` lines. CI is the first real check, which matters more here because of that explicit import path.