### PR TITLE
fix(core-app): bound the file-protocol error-log dedupe set (#647)

### DIFF
--- a/apps/core-app/src/main/modules/file-protocol/index.test.ts
+++ b/apps/core-app/src/main/modules/file-protocol/index.test.ts
@@ -103,3 +103,54 @@ describe('file-protocol canonical tfile parsing', () => {
     )
   })
 })
+
+describe('file-protocol error-log dedupe bound', () => {
+  beforeEach(() => {
+    __test__.loggedErrorPaths.clear()
+  })
+
+  it('logs each path once', () => {
+    // The behaviour the Set exists for, asserted before the bound so a cap that broke dedupe
+    // entirely would fail here rather than look like a memory win.
+    expect(__test__.shouldLogPathOnce('/tmp/missing.png')).toBe(true)
+    expect(__test__.shouldLogPathOnce('/tmp/missing.png')).toBe(false)
+    expect(__test__.shouldLogPathOnce('/tmp/other.png')).toBe(true)
+  })
+
+  it('stops growing once the cap is reached', () => {
+    // #647: unbounded before. A churning result set contributes one retained string per distinct
+    // missing path, for the lifetime of a process expected to run for days.
+    const limit = __test__.LOGGED_ERROR_PATH_LIMIT
+
+    for (let index = 0; index < limit * 2; index++)
+      __test__.shouldLogPathOnce(`/tmp/churn-${index}.png`)
+
+    expect(__test__.loggedErrorPaths.size).toBe(limit)
+  })
+
+  it('evicts oldest first, so a recent path stays deduplicated', () => {
+    const limit = __test__.LOGGED_ERROR_PATH_LIMIT
+    __test__.shouldLogPathOnce('/tmp/oldest.png')
+
+    for (let index = 0; index < limit - 1; index++)
+      __test__.shouldLogPathOnce(`/tmp/filler-${index}.png`)
+
+    // Still inside the window: must not re-log.
+    expect(__test__.shouldLogPathOnce('/tmp/filler-0.png')).toBe(false)
+
+    __test__.shouldLogPathOnce('/tmp/pushes-oldest-out.png')
+
+    // Evicted, so it logs again — one repeated warning is the price of the bound, and pinning it
+    // here means the trade-off is visible rather than discovered later.
+    expect(__test__.shouldLogPathOnce('/tmp/oldest.png')).toBe(true)
+  })
+
+  it('clears the set on destroy', () => {
+    __test__.shouldLogPathOnce('/tmp/before-destroy.png')
+    expect(__test__.loggedErrorPaths.size).toBe(1)
+
+    fileProtocolModule.onDestroy()
+
+    expect(__test__.loggedErrorPaths.size).toBe(0)
+  })
+})

--- a/apps/core-app/src/main/modules/file-protocol/index.ts
+++ b/apps/core-app/src/main/modules/file-protocol/index.ts
@@ -12,8 +12,32 @@ import {
 import { createLogger } from '../../utils/logger'
 import { BaseModule } from '../abstract-base-module'
 
-/** Deduplicate error logs -- only log each failing path once per session. */
+/**
+ * Deduplicate error logs -- only log each failing path once, up to a bound.
+ *
+ * Bounded because the inputs are not: a view rendering thumbnails over a churning result set --
+ * clipboard history whose temp files have been deleted, or a plugin emitting unique tfile URLs --
+ * contributes one retained string per distinct missing path, for the lifetime of a launcher
+ * process that is expected to run for days (#647).
+ *
+ * Insertion-ordered eviction rather than a true LRU: this only decides whether a warning repeats,
+ * so the cheapest bound that keeps recent paths quiet is the right one.
+ */
+const LOGGED_ERROR_PATH_LIMIT = 512
 const loggedErrorPaths = new Set<string>()
+
+/** Records a path and reports whether it is newly seen, evicting the oldest entry past the cap. */
+function shouldLogPathOnce(filePath: string): boolean {
+  if (loggedErrorPaths.has(filePath)) return false
+
+  if (loggedErrorPaths.size >= LOGGED_ERROR_PATH_LIMIT) {
+    const oldest = loggedErrorPaths.values().next().value
+    if (oldest !== undefined) loggedErrorPaths.delete(oldest)
+  }
+
+  loggedErrorPaths.add(filePath)
+  return true
+}
 const fileProtocolLog = createLogger('FileProtocolModule')
 
 /**
@@ -78,6 +102,9 @@ function extractAbsolutePath(rawUrl: string): string | null {
 }
 
 export const __test__ = {
+  shouldLogPathOnce,
+  loggedErrorPaths,
+  LOGGED_ERROR_PATH_LIMIT,
   extractAbsolutePath
 }
 
@@ -108,8 +135,7 @@ class FileProtocolModule extends BaseModule {
       const filePath = normalizeDarwinUsersPath(extractedPath)
       const normalizedPath = normalizeAbsolutePath(filePath)
       if (!normalizedPath || !isAllowedLocalFilePath(normalizedPath, allowedRoots)) {
-        if (!loggedErrorPaths.has(filePath)) {
-          loggedErrorPaths.add(filePath)
+        if (shouldLogPathOnce(filePath)) {
           fileProtocolLog.warn(`Blocked path: ${filePath}`)
         }
         return new Response('Forbidden', { status: 403 })
@@ -120,8 +146,7 @@ class FileProtocolModule extends BaseModule {
       try {
         return await net.fetch(fileUrl, { bypassCustomProtocolHandlers: true })
       } catch (error) {
-        if (!loggedErrorPaths.has(normalizedPath)) {
-          loggedErrorPaths.add(normalizedPath)
+        if (shouldLogPathOnce(normalizedPath)) {
           fileProtocolLog.error('tfile request error', {
             meta: {
               filePath: normalizedPath,
@@ -140,6 +165,7 @@ class FileProtocolModule extends BaseModule {
 
   onDestroy(): MaybePromise<void> {
     session.defaultSession.protocol.unhandle(FILE_SCHEMA)
+    loggedErrorPaths.clear()
   }
 }
 


### PR DESCRIPTION
Closes #647.

`loggedErrorPaths` is capped at **512** with insertion-ordered eviction and cleared in `onDestroy`. Both call sites now go through one `shouldLogPathOnce` helper instead of repeating `has`/`add` — which is also what makes the bound testable.

Not a true LRU, deliberately: this Set only decides whether a warning repeats, so the cheapest bound that keeps recent paths quiet is the right one. A real LRU would cost more and buy nothing here.

## Four tests, ordered so the bound cannot hide a regression

- **dedupe still works** — asserted *before* any bound assertion, so a cap that broke deduplication entirely would fail here rather than read as a memory win
- **stops growing at the cap** — the actual leak
- **evicts oldest first** — and pins the trade-off the bound introduces: an evicted path logs a *second* time. Better stated in a test than discovered later as a mystery duplicate warning
- **cleared on destroy**

## Mutation-checked, because the obvious check was weak

Reverting the whole file fails all four — but only because `__test__.loggedErrorPaths` does not exist there, so `beforeEach` throws. That is failure-by-missing-export, not by behaviour, and it would have looked identical if my bound did nothing.

So I removed **only the eviction block**, keeping the exports:

```
✓ logs each path once
× stops growing once the cap is reached
× evicts oldest first, so a recent path stays deduplicated
✓ clears the set on destroy
```

Exactly the two bound tests fail, and the dedupe and teardown tests keep passing — which is what demonstrates each assertion is attached to the behaviour it names.

`typecheck:node` at the baseline 6; file-protocol suite 11 tests pass; ESLint clean.
