### PR TITLE
fix(core-app): reap terminal children when their renderer goes away (#639)

### DIFF
--- a/apps/core-app/src/main/modules/terminal/terminal.manager.test.ts
+++ b/apps/core-app/src/main/modules/terminal/terminal.manager.test.ts
@@ -150,3 +150,96 @@ describe('terminal handler registration', () => {
     expect(permissionIds).toEqual(['system.shell', 'system.shell', 'system.shell'])
   })
 })
+
+/**
+ * A renderer that can actually be torn down (#639).
+ *
+ * The ownership tests above use a plain `{ id, isDestroyed }` stub, which has no emitter API — so
+ * they exercise the tolerant branch of watchSenderTeardown and prove the watcher does not require
+ * one. These need the real shape.
+ */
+function asLiveWindow(id: number) {
+  const listeners = new Map<string, Array<() => void>>()
+  const sender = {
+    id,
+    isDestroyed: () => false,
+    once(event: string, handler: () => void) {
+      listeners.set(event, [...(listeners.get(event) ?? []), handler])
+    },
+    off(event: string, handler: () => void) {
+      listeners.set(
+        event,
+        (listeners.get(event) ?? []).filter((entry) => entry !== handler)
+      )
+    }
+  }
+  return {
+    context: { sender, eventName: 'x' },
+    destroy: () => listeners.get('destroyed')?.forEach((handler) => handler()),
+    listenerCount: () => (listeners.get('destroyed') ?? []).length
+  }
+}
+
+describe('terminal session renderer teardown', () => {
+  let proc: ReturnType<typeof fakeProcess>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    terminal.processes.clear()
+    proc = fakeProcess()
+    spawnSafeMock.mockReturnValue(proc)
+  })
+
+  it('kills the child when the renderer that started it goes away', () => {
+    const window = asLiveWindow(7)
+    const { id } = terminal.create({ command: 'tail' }, window.context as never)
+
+    // Positive control: nothing has killed it yet, so the assertion below is about the teardown
+    // rather than about a process that was already gone.
+    expect(terminal.processes.has(id)).toBe(true)
+    expect(proc.kill).not.toHaveBeenCalled()
+
+    window.destroy()
+
+    expect(proc.kill).toHaveBeenCalledTimes(1)
+    expect(terminal.processes.has(id)).toBe(false)
+  })
+
+  it('detaches the watcher when the process exits on its own', () => {
+    const window = asLiveWindow(7)
+    terminal.create({ command: 'ls' }, window.context as never)
+    expect(window.listenerCount()).toBe(1)
+
+    // The process closing first is the ordinary case; leaving the listener attached would put one
+    // per session on a renderer that stays open all day. fakeProcess records handlers rather than
+    // emitting, so the registered one is invoked directly.
+    const closeHandler = proc.on.mock.calls.find(([event]) => event === 'close')?.[1] as
+      | ((code: number) => void)
+      | undefined
+    expect(closeHandler).toBeTypeOf('function')
+    closeHandler?.(0)
+
+    expect(window.listenerCount()).toBe(0)
+  })
+
+  it('does not kill a session the renderer already replaced', () => {
+    const window = asLiveWindow(7)
+    const { id } = terminal.create({ command: 'ls' }, window.context as never)
+
+    terminal.kill({ id }, window.context as never)
+    expect(proc.kill).toHaveBeenCalledTimes(1)
+
+    // Teardown after an explicit kill must not kill twice, nor touch whatever now owns that id.
+    window.destroy()
+
+    expect(proc.kill).toHaveBeenCalledTimes(1)
+  })
+
+  it('tolerates a sender without the emitter API', () => {
+    // The permission tests drive create() with a bare stub; module-level onDestroy is the backstop
+    // there. This pins that create() does not throw on it.
+    const { id } = terminal.create({ command: 'ls' }, asWindow(9) as never)
+
+    expect(terminal.processes.has(id)).toBe(true)
+  })
+})

--- a/apps/core-app/src/main/modules/terminal/terminal.manager.ts
+++ b/apps/core-app/src/main/modules/terminal/terminal.manager.ts
@@ -19,6 +19,8 @@ interface TerminalSession {
   proc: ChildProcess
   /** Who may write to and kill this session. See ownerKeyOf. */
   owner: string
+  /** Detaches the renderer-teardown watcher. Called once the process is gone. */
+  releaseSenderWatch: () => void
 }
 
 /**
@@ -115,6 +117,37 @@ class TerminalModule extends BaseModule {
   }
 
   /**
+   * Kills the session's child when the renderer that asked for it goes away.
+   *
+   * Returns an unsubscribe so a long-lived renderer does not accumulate one listener per session.
+   * Tolerates a sender without the emitter API — the permission tests drive create() with a plain
+   * `{ id, isDestroyed }` stub — in which case there is nothing to watch and the module-level
+   * onDestroy remains the backstop.
+   */
+  private watchSenderTeardown(sender: WebContents | undefined, id: string): () => void {
+    if (!sender || typeof sender.once !== 'function' || typeof sender.off !== 'function') {
+      return () => {}
+    }
+
+    const onSenderDestroyed = (): void => {
+      const session = this.processes.get(id)
+      if (!session) return
+      this.processes.delete(id)
+      try {
+        session.proc.kill()
+      } catch (error) {
+        terminalLog.warn('Failed to kill terminal process after renderer teardown', {
+          meta: { id },
+          error
+        })
+      }
+    }
+
+    sender.once('destroyed', onSenderDestroyed)
+    return () => sender.off('destroyed', onSenderDestroyed)
+  }
+
+  /**
    * Creates a new child process to execute a command.
    * Expects data to contain { command: string, args: string[] }.
    * Sends back { id: string } on success.
@@ -149,7 +182,12 @@ class TerminalModule extends BaseModule {
       throw new Error('Terminal session requires an identifiable caller')
     }
 
-    this.processes.set(id, { proc, owner })
+    // Nothing else notices a renderer going away: sendToSender short-circuits on isDestroyed, so
+    // output is silently dropped while the child keeps running and holding its pipes, and the id
+    // needed to kill it left with the renderer (#639).
+    const releaseSenderWatch = this.watchSenderTeardown(sender, id)
+
+    this.processes.set(id, { proc, owner, releaseSenderWatch })
 
     // Listen for data from stdout and stderr
     proc.stdout?.on('data', (data) => {
@@ -164,6 +202,7 @@ class TerminalModule extends BaseModule {
     // Listen for the process to close
     proc.on('close', (code) => {
       this.sendToSender(sender, { id, exitCode: code ?? null })
+      releaseSenderWatch()
       this.processes.delete(id)
     })
 
@@ -177,6 +216,7 @@ class TerminalModule extends BaseModule {
       })
       this.sendToSender(sender, { id, data: `Error: ${err.message}\n` })
       this.sendToSender(sender, { id, exitCode: -1 })
+      releaseSenderWatch()
       this.processes.delete(id)
     })
 


### PR DESCRIPTION
Closes #639.

Each session now watches its requesting `WebContents` for `'destroyed'` and kills the child there. The subscription is released when the process exits on its own, so a renderer that stays open all day does not accumulate one listener per session.

## What was already covered, and what was not

`onDestroy` **does** kill every process, so module teardown was never the gap. The hole is specifically a renderer dying while the app keeps running — a reload or a closed window — which is the common case, and the one where `sendToSender`'s `isDestroyed()` short-circuit makes it silent: output is discarded, the child keeps its pipes, and the id needed to kill it left with the renderer.

## One deliberate tolerance

`watchSenderTeardown` accepts a sender without `once`/`off` instead of requiring the emitter API. The existing ownership tests drive `create()` with a plain `{ id, isDestroyed }` stub, and demanding the full shape would have meant rewriting tests that have nothing to do with this fix. That branch has its own case so it is pinned rather than merely tolerated — and on that path module-level `onDestroy` remains the backstop.

## Mutation-checked, not just diffed against HEAD

Reverting the file would fail the new tests for the trivial reason that the code is absent. So I made the watcher a **no-op** while leaving everything else in place:

```
× kills the child when the renderer that started it goes away
× detaches the watcher when the process exits on its own
✓ ownership / permission tests (8)
✓ tolerates a sender without the emitter API
```

Exactly the two cases that name the watcher fail. The first of them also carries a positive control — it asserts the process is alive and unkilled *before* the teardown — so it cannot pass over a session that was already gone.

`typecheck:node` at the baseline 6; terminal suite 12 tests; ESLint clean.
