### PR TITLE
fix(core-app): decode terminal output across chunk boundaries (#640)

### DIFF
--- a/apps/core-app/src/main/modules/terminal/terminal.manager.test.ts
+++ b/apps/core-app/src/main/modules/terminal/terminal.manager.test.ts
@@ -25,8 +25,17 @@ vi.mock('../permission/channel-guard', () => ({
   )
 }))
 
+// A stable object: the module resolves the transport once in onInit, so a factory returning a
+// fresh one per call would leave every assertion on an instance the code under test never held.
+const transportMock = vi.hoisted(() => ({
+  on: vi.fn(),
+  // Typed variadic on purpose: inferred as zero-arg, `mock.calls` becomes a tuple of length 0 and
+  // indexing the payload is a compile error rather than a runtime one.
+  sendTo: vi.fn(async (..._args: unknown[]) => {})
+}))
+
 vi.mock('@talex-touch/utils/transport/main', () => ({
-  getTuffTransportMain: vi.fn(() => ({ on: vi.fn(), sendTo: vi.fn(async () => {}) }))
+  getTuffTransportMain: vi.fn(() => transportMock)
 }))
 
 vi.mock('../../core/runtime-accessor', () => ({
@@ -49,11 +58,23 @@ type Testable = {
 
 const terminal = terminalModule as unknown as Testable
 
+/** A stream that records handlers and can replay them, so chunk boundaries can be driven. */
+function fakeStream() {
+  const handlers = new Map<string, Array<(chunk: unknown) => void>>()
+  return {
+    on: vi.fn((event: string, handler: (chunk: unknown) => void) => {
+      handlers.set(event, [...(handlers.get(event) ?? []), handler])
+    }),
+    emit: (event: string, chunk?: unknown) =>
+      handlers.get(event)?.forEach((handler) => handler(chunk))
+  }
+}
+
 function fakeProcess() {
   return {
     stdin: { write: vi.fn() },
-    stdout: { on: vi.fn() },
-    stderr: { on: vi.fn() },
+    stdout: fakeStream(),
+    stderr: fakeStream(),
     on: vi.fn(),
     kill: vi.fn()
   }
@@ -241,5 +262,76 @@ describe('terminal session renderer teardown', () => {
     const { id } = terminal.create({ command: 'ls' }, asWindow(9) as never)
 
     expect(terminal.processes.has(id)).toBe(true)
+  })
+})
+
+describe('terminal output decoding', () => {
+  let proc: ReturnType<typeof fakeProcess>
+
+  /** The text of every chunk sent to the renderer, in order. */
+  const sentText = (): string[] =>
+    transportMock.sendTo.mock.calls
+      .map((call) => (call[2] as { data?: string } | undefined)?.data)
+      .filter((data): data is string => typeof data === 'string')
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    terminal.processes.clear()
+    proc = fakeProcess()
+    spawnSafeMock.mockReturnValue(proc)
+    terminal.onInit({})
+  })
+
+  it('joins a multi-byte character split across two chunks', () => {
+    // #640: '世' is three bytes. Split between reads, each half used to decode to U+FFFD, and
+    // unrecoverably — both halves were already strings before being sent.
+    const bytes = Buffer.from('世界', 'utf8')
+    const { id } = terminal.create({ command: 'cat' }, asWindow(7) as never)
+    expect(id).toBeTruthy()
+
+    proc.stdout.emit('data', bytes.subarray(0, 2))
+    proc.stdout.emit('data', bytes.subarray(2))
+
+    expect(sentText().join('')).toBe('世界')
+    expect(sentText().join('')).not.toContain('\uFFFD')
+  })
+
+  it('does not send an empty chunk while holding a partial character', () => {
+    const bytes = Buffer.from('世', 'utf8')
+    terminal.create({ command: 'cat' }, asWindow(7) as never)
+
+    proc.stdout.emit('data', bytes.subarray(0, 2))
+
+    // The first half decodes to '' — worth holding, not worth a round trip.
+    expect(sentText()).toEqual([])
+
+    proc.stdout.emit('data', bytes.subarray(2))
+    expect(sentText()).toEqual(['世'])
+  })
+
+  it('keeps stdout and stderr decoders separate', () => {
+    // One shared decoder would let a partial sequence on one stream absorb the next chunk from
+    // the other, producing text that never appeared on either.
+    const out = Buffer.from('世', 'utf8')
+    terminal.create({ command: 'cat' }, asWindow(7) as never)
+
+    proc.stdout.emit('data', out.subarray(0, 2))
+    proc.stderr.emit('data', Buffer.from('E', 'utf8'))
+    proc.stdout.emit('data', out.subarray(2))
+
+    expect(sentText()).toEqual(['E', '世'])
+  })
+
+  it('flushes a truncated sequence on end', () => {
+    // Output that really was cut short should surface one replacement character rather than
+    // disappearing into the decoder.
+    terminal.create({ command: 'cat' }, asWindow(7) as never)
+
+    proc.stdout.emit('data', Buffer.from('世', 'utf8').subarray(0, 2))
+    proc.stdout.emit('end')
+
+    // One replacement character for the incomplete sequence, not one per orphaned byte — written
+    // from observed StringDecoder behaviour rather than from what seemed likely.
+    expect(sentText().join('')).toBe('\uFFFD')
   })
 })

--- a/apps/core-app/src/main/modules/terminal/terminal.manager.ts
+++ b/apps/core-app/src/main/modules/terminal/terminal.manager.ts
@@ -3,6 +3,8 @@ import type { HandlerContext } from '@talex-touch/utils/transport/main'
 import type { TerminalCreateRequest } from '@talex-touch/utils/transport/events/terminal'
 import type { WebContents } from 'electron'
 import type { ChildProcess } from 'node:child_process'
+import type { Readable } from 'node:stream'
+import { StringDecoder } from 'node:string_decoder'
 import { spawnSafe } from '@talex-touch/utils/common/utils/safe-shell'
 import { TerminalEvents } from '@talex-touch/utils/transport/events'
 import { getTuffTransportMain } from '@talex-touch/utils/transport/main'
@@ -117,6 +119,33 @@ class TerminalModule extends BaseModule {
   }
 
   /**
+   * Forwards a child stream to the renderer, decoded across chunk boundaries.
+   *
+   * `end` is flushed so a trailing incomplete sequence is reported once, rather than being held
+   * forever — output that really was truncated should show one replacement character, not vanish.
+   */
+  private pipeDecodedOutput(
+    stream: Readable | null | undefined,
+    sender: WebContents | undefined,
+    id: string
+  ): void {
+    if (!stream) return
+
+    const decoder = new StringDecoder('utf8')
+
+    stream.on('data', (chunk: Buffer | string) => {
+      const text = typeof chunk === 'string' ? chunk : decoder.write(chunk)
+      // A chunk that ends mid-character decodes to '', which is not worth a round trip.
+      if (text) this.sendToSender(sender, { id, data: text })
+    })
+
+    stream.on('end', () => {
+      const rest = decoder.end()
+      if (rest) this.sendToSender(sender, { id, data: rest })
+    })
+  }
+
+  /**
    * Kills the session's child when the renderer that asked for it goes away.
    *
    * Returns an unsubscribe so a long-lived renderer does not accumulate one listener per session.
@@ -189,15 +218,12 @@ class TerminalModule extends BaseModule {
 
     this.processes.set(id, { proc, owner, releaseSenderWatch })
 
-    // Listen for data from stdout and stderr
-    proc.stdout?.on('data', (data) => {
-      this.sendToSender(sender, { id, data: data.toString() })
-    })
-
-    proc.stderr?.on('data', (data) => {
-      // Send stderr data as well, perhaps with a flag if needed by the frontend
-      this.sendToSender(sender, { id, data: data.toString() })
-    })
+    // Pipe reads split on byte boundaries, not character ones, so a multi-byte character
+    // straddling a chunk edge decodes to U+FFFD on both sides — and unrecoverably, since both
+    // halves are already strings by the time they are sent (#640). One decoder per stream holds
+    // the trailing partial sequence until its continuation arrives.
+    this.pipeDecodedOutput(proc.stdout, sender, id)
+    this.pipeDecodedOutput(proc.stderr, sender, id)
 
     // Listen for the process to close
     proc.on('close', (code) => {


### PR DESCRIPTION
Closes #640.

One `StringDecoder('utf8')` per stream per process now holds the trailing partial sequence until its continuation arrives.

## Three decisions worth naming

- **Separate decoders for stdout and stderr**, not one shared. A partial sequence held on one stream would otherwise absorb the next chunk from the other and produce text that appeared on neither. Pinned by its own test.
- **`end` is flushed.** Output that really was truncated should surface a replacement character once, rather than disappearing into the decoder.
- **A chunk decoding to `''` is not sent.** That is the normal state while holding half a character; a round trip per partial read is waste.

## Four tests, and two fixtures that had to change first

The fake process streams only recorded handlers, so chunk boundaries could not be driven — they now replay.

The transport mock also had to become a **stable** object. It returned a fresh one per `getTuffTransportMain` call while the module resolves it once in `onInit`, so every assertion landed on an instance the code under test never held. Same shape as the polling mock in #1348.

## Mutation-checked

Putting per-chunk `toString()` back:

```
× joins a multi-byte character split across two chunks
× does not send an empty chunk while holding a partial character
× keeps stdout and stderr decoders separate
✓ the twelve ownership / permission / teardown tests
```

## Two things I got wrong on the way

- I asserted that flushing two orphaned bytes of a three-byte sequence yields **two** replacement characters. It yields **one**. Corrected against observed `StringDecoder` behaviour rather than against what seemed likely, and the test says so.
- `typecheck:node` went to 7 against a baseline of 6: `sendTo: vi.fn(async () => {})` is inferred as zero-arg, so `mock.calls` is a length-0 tuple and indexing the payload is a compile error. The suite was green either way — the error-count diff is what catches this class.

Back to the baseline 6; terminal suite 16 tests; ESLint clean.
