### PR TITLE
fix(core-app): make clipboard meta writes replace instead of append (#646)

### DIFF
--- a/apps/core-app/src/main/modules/clipboard/clipboard-history-persistence.ts
+++ b/apps/core-app/src/main/modules/clipboard/clipboard-history-persistence.ts
@@ -164,6 +164,10 @@ export class ClipboardHistoryPersistence {
         .select()
         .from(clipboardHistoryMeta)
         .where(inArray(clipboardHistoryMeta.clipboardId, ids))
+        // Writers now replace instead of appending, but databases created before that still hold
+        // duplicates until each key is next written. Ordering makes last-write-wins true for them
+        // rather than dependent on the query plan (#646).
+        .orderBy(clipboardHistoryMeta.id)
 
       for (const metaRow of metaRows) {
         if (typeof metaRow.clipboardId !== 'number') continue

--- a/apps/core-app/src/main/modules/clipboard/clipboard-meta-persistence.test.ts
+++ b/apps/core-app/src/main/modules/clipboard/clipboard-meta-persistence.test.ts
@@ -9,6 +9,7 @@ async function waitForSafePersistenceCatch(): Promise<void> {
 const mocks = vi.hoisted(() => ({
   schedule: vi.fn(async (_label: string, operation: () => Promise<unknown>) => await operation()),
   values: vi.fn(async () => undefined),
+  deleteWhere: vi.fn(async () => undefined),
   logDebug: vi.fn(),
   logWarn: vi.fn()
 }))
@@ -20,7 +21,13 @@ vi.mock('../../db/db-write-scheduler', () => ({
 }))
 
 vi.mock('../../db/schema', () => ({
-  clipboardHistoryMeta: {}
+  clipboardHistoryMeta: { clipboardId: 'clipboard_id', key: 'key' }
+}))
+
+vi.mock('drizzle-orm', () => ({
+  and: (...parts: unknown[]) => ({ and: parts }),
+  eq: (column: unknown, value: unknown) => ({ eq: [column, value] }),
+  inArray: (column: unknown, values: unknown[]) => ({ inArray: [column, values] })
 }))
 
 import {
@@ -29,11 +36,21 @@ import {
   isForeignKeyConstraintError
 } from './clipboard-meta-persistence'
 
+/**
+ * Models the shape the writer actually uses: a transaction wrapping a delete and an insert.
+ *
+ * Before #646 this only needed `insert`. A stub without `transaction` is why that change first
+ * showed up as "db.transaction is not a function" rather than as a behavioural failure.
+ */
 function createDb() {
+  const tx = {
+    delete: vi.fn(() => ({ where: mocks.deleteWhere })),
+    insert: vi.fn(() => ({ values: mocks.values }))
+  }
   return {
-    insert: vi.fn(() => ({
-      values: mocks.values
-    }))
+    tx,
+    insert: vi.fn(() => ({ values: mocks.values })),
+    transaction: vi.fn(async (run: (handle: typeof tx) => Promise<unknown>) => await run(tx))
   }
 }
 
@@ -66,6 +83,33 @@ describe('clipboard-meta-persistence', () => {
       lane: 'aux'
     })
     expect(mocks.values).toHaveBeenCalledWith([{ clipboardId: 7, key: 'source', value: '"app"' }])
+  })
+
+  it('clears the previous rows for the same keys before inserting', async () => {
+    // #646: without this each update appended a row, and both the hydrate fold and the key/value
+    // filters could then see a superseded value.
+    const db = createDb()
+    const persistence = createPersistence(db)
+
+    await persistence.persistMetaEntries(7, { source: 'app', category: 'image' })
+
+    expect(db.transaction).toHaveBeenCalledOnce()
+    expect(db.tx.delete).toHaveBeenCalledOnce()
+    expect(mocks.deleteWhere).toHaveBeenCalledWith({
+      and: [{ eq: ['clipboard_id', 7] }, { inArray: ['key', ['source', 'category']] }]
+    })
+  })
+
+  it('deletes and inserts in one transaction', async () => {
+    // Two statements outside a transaction would leave a window with the old rows gone and the
+    // new ones not yet written — a concurrent read there sees the key missing entirely.
+    const db = createDb()
+    const persistence = createPersistence(db)
+
+    await persistence.persistMetaEntries(7, { source: 'app' })
+
+    expect(db.insert).not.toHaveBeenCalled()
+    expect(db.tx.insert).toHaveBeenCalledOnce()
   })
 
   it('classifies dropped and foreign-key errors for safe persistence', async () => {

--- a/apps/core-app/src/main/modules/clipboard/clipboard-meta-persistence.ts
+++ b/apps/core-app/src/main/modules/clipboard/clipboard-meta-persistence.ts
@@ -3,6 +3,7 @@ import type * as schema from '../../db/schema'
 import type { ScheduleOptions } from '../../db/db-write-scheduler'
 import type { AuxDbResolver, MainDatabase } from '../../db/db-write'
 import type { LogOptions } from '../../utils/logger'
+import { and, eq, inArray } from 'drizzle-orm'
 import { scheduleAuxWrite } from '../../db/db-write'
 import { clipboardHistoryMeta } from '../../db/schema'
 
@@ -78,9 +79,26 @@ export class ClipboardMetaPersistence {
 
     if (values.length === 0) return
 
+    // Replace rather than append. There is no unique constraint on (clipboard_id, key), so a
+    // plain insert leaves one row per update: the hydrate read folds rows into a map with no
+    // ordering, and the key/value filters further down this module match on *any* row — so a
+    // clipboard item keeps matching a category it no longer has (#646).
+    const keys = [...new Set(values.map((entry) => entry.key))]
+
     await this.withDbWrite(
       'clipboard.meta',
-      (db) => db.insert(clipboardHistoryMeta).values(values),
+      (db) =>
+        db.transaction(async (tx) => {
+          await tx
+            .delete(clipboardHistoryMeta)
+            .where(
+              and(
+                eq(clipboardHistoryMeta.clipboardId, clipboardId),
+                inArray(clipboardHistoryMeta.key, keys)
+              )
+            )
+          await tx.insert(clipboardHistoryMeta).values(values)
+        }),
       options
     )
   }

--- a/apps/core-app/src/main/modules/ocr/ocr-service.ts
+++ b/apps/core-app/src/main/modules/ocr/ocr-service.ts
@@ -1538,6 +1538,18 @@ class OcrService {
     await this.withDbWrite('ocr.clipboard.meta', async (db) =>
       db.transaction(async (tx) => {
         if (insertValues.length > 0) {
+          // Same replace-not-append rule as clipboard-meta-persistence (#646). ocr_status walks
+          // queued -> processing -> retrying -> completed, so appending leaves four rows for one
+          // key and a stale 'processing' can win the read.
+          await tx.delete(clipboardHistoryMeta).where(
+            and(
+              eq(clipboardHistoryMeta.clipboardId, clipboardId),
+              inArray(
+                clipboardHistoryMeta.key,
+                insertValues.map((entry) => entry.key)
+              )
+            )
+          )
           await tx.insert(clipboardHistoryMeta).values(insertValues)
         }
 


### PR DESCRIPTION
Closes #646.

Both writers now delete the rows for the keys they are about to write, inside the same transaction as the insert.

## Why not the unique index

The suggested `unique(clipboard_id, key)` + `onConflictDoUpdate` is the better end state, but it cannot land as a code change:

- it needs a migration, and **adding the index to an existing database fails outright** on the duplicates already there
- cleaning those first is a data migration against user data
- `db:generate` cannot produce a correct migration while the drizzle snapshot baseline is stuck at `0014` (#1303)

Delete-then-insert needs no schema change and fixes the same defect. The index remains worth doing once #1303 is resolved.

## A second consequence the issue does not mention

`clipboard-history-persistence` also filters on key **and value** directly — `source = 'custom'` (line 355), `category = X` (line 368) — and those match **any** row for that clipboard id. With duplicates, an item kept matching a category it no longer had.

This matters for the choice of fix: **`.orderBy(id)` alone would not have covered it.** Ordering fixes the hydrate fold; only replacing on write fixes a filter that matches history.

Ordering is still added, for databases that already hold duplicates — those survive until each key is next written, and until then last-write-wins is whatever the query plan decides.

## The test stub was thinner than the code

It only had `insert`, which is why this first appeared as `db.transaction is not a function` rather than as a behavioural failure. It now models the transaction and asserts two things:

- the delete targets **exactly the keys being written** — not the whole clipboard id, which would drop unrelated metadata
- both statements run **inside** the transaction; two statements outside one would leave a window where the key is missing entirely, and a concurrent read there sees nothing rather than the old value

## Mutation-checked

Removing the delete while keeping the transaction fails only `clears the previous rows for the same keys before inserting`, leaving the other three passing.

`typecheck:node` at the baseline 6; clipboard-meta, clipboard-history and OCR suites 18 tests pass.

(`clipboard-service.test.ts` and `clipboard-capture-freshness.test.ts` cannot load in this worktree — the local electron install is broken — and fail identically on HEAD.)
