### PR TITLE
fix(security): apply the external-url scheme allowlist to blocked navigations

### DIFF
--- a/apps/core-app/src/main/channel/common.test.ts
+++ b/apps/core-app/src/main/channel/common.test.ts
@@ -2153,6 +2153,30 @@ describe('createOpenUrlHandler', () => {
     expect(openExternal).toHaveBeenCalledWith('https://example.test/docs')
   })
 
+  it('refuses a scheme the external-url policy does not allow', async () => {
+    // #910 made the confirm branch actually confirm, but every remaining protocol
+    // still reached shell.openExternal once the user clicked through — and a dialog
+    // is a poor place to judge whether an unknown handler scheme is safe (#691).
+    answer(true)
+    await handler()('smb://attacker.example.com/share/payload.exe')
+    expect(showMessageBox).not.toHaveBeenCalled()
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
+  it('still prompts for file:, which is confirm-gated on purpose', async () => {
+    // Control. file: is absent from the allowlist, but #910 routed it to the prompt
+    // deliberately; the allowlist must not quietly turn that into a hard refusal.
+    answer(false)
+    await handler()('file:///etc/passwd')
+    expect(showMessageBox).toHaveBeenCalledTimes(1)
+  })
+
+  it('still prompts for an ordinary https URL', async () => {
+    answer(false)
+    await handler()('https://example.com/docs')
+    expect(showMessageBox).toHaveBeenCalledTimes(1)
+  })
+
   it('refuses when the confirmation dialog itself fails', async () => {
     // Fail closed: a dialog that cannot be shown must not be read as approval.
     showMessageBox.mockRejectedValue(new Error('no window'))

--- a/apps/core-app/src/main/channel/common.ts
+++ b/apps/core-app/src/main/channel/common.ts
@@ -42,6 +42,7 @@ import type {
   TraySettingsUpdateRequest,
   TraySettingsUpdateResponse
 } from '@talex-touch/utils/transport/events/types'
+import { validateExternalUrl } from '../utils/external-url-policy'
 import type { Locale } from '../utils/i18n-helper'
 import { Buffer } from 'node:buffer'
 import { createHash } from 'node:crypto'
@@ -1096,6 +1097,27 @@ export class CommonChannelModule extends BaseModule {
           return 'skip'
         }
         return 'confirm'
+      }
+
+      // Scheme allowlist, not just a confirmation. #910 made the 'confirm' branch
+      // actually confirm, which removed the silent open — but every remaining
+      // protocol still reached shell.openExternal if the user clicked through, and
+      // a dialog is a poor place to judge whether `smb:` or a third-party handler
+      // scheme is safe. validateExternalUrl already encodes that decision
+      // (http/https/mailto/tel/tuff) and is used at a dozen other call sites; this
+      // was the one that forwarded renderer-controlled URLs without it (#691).
+      // `file:` keeps its prompt. #910 deliberately routed it to 'confirm' rather
+      // than opening it, and two tests are named for that behaviour, so it is a
+      // decision to preserve — not an omission to tighten. It is absent from the
+      // allowlist because that list governs unattended opens elsewhere.
+      if (protocol !== 'file') {
+        const decision = validateExternalUrl(url)
+        if (!decision.allowed) {
+          log.warn('Blocked external navigation with a disallowed scheme', {
+            meta: { reason: decision.reason, protocol: decision.protocol }
+          })
+          return 'skip'
+        }
       }
 
       return 'confirm'


### PR DESCRIPTION
Closes #691.

`will-navigate` on every TouchWindow forwards renderer-controlled URLs here.

**#910 already fixed half of what this issue reports** — the `'confirm'` branch genuinely prompts now, defaults to cancel, and treats a dialog failure as refusal. But the other half stood: `validateExternalUrl` was never applied, so **any** protocol reached `shell.openExternal` once the user clicked through. A dialog is a poor place to judge whether `smb:` or a third-party handler scheme is safe.

The allowlist (http/https/mailto/tel/tuff) is now consulted before the prompt, matching the dozen other call sites that already use it.

### ⚠️ file: is exempt, and that is deliberate
My first version applied the allowlist uniformly and broke two existing tests:

- `asks before opening a file: URL instead of handing it straight to the OS`
- `opens a file: URL once the prompt is accepted`

Those names describe a **decision from #910**, not an omission. `file:` is absent from the allowlist because that list governs unattended opens elsewhere; here it is confirm-gated on purpose. So the prompt path is preserved rather than quietly tightened into a hard refusal.

### Verified
The new allowlist test is red on HEAD. **Two of the three tests I added are controls** — `file:` still prompts, `https` still prompts — because the failure mode of this change is refusing too much, not too little.

77/77 channel tests, `typecheck:node`, `eslint --max-warnings=0` clean.