### PR TITLE
fix(core-app): never skip the OCR start write (#645)

### DIFF
--- a/apps/core-app/src/main/modules/ocr/ocr-config-policy.ts
+++ b/apps/core-app/src/main/modules/ocr/ocr-config-policy.ts
@@ -7,7 +7,14 @@ export interface OcrConfigPersistOptions {
   skipIfUnchanged?: boolean
 }
 
-export const OCR_START_WRITE_SKIP_QUEUE_DEPTH = 8
+/**
+ * Queue depth past which the droppable OCR breadcrumbs stop being written.
+ *
+ * Named for the config writes it governs, not for the job start write: that one used to share this
+ * threshold and no longer does, because skipping it lost the attempts increment that bounds
+ * retries (#645). These three are `dropPolicy: 'drop'` telemetry and are safe to shed.
+ */
+export const OCR_CONFIG_SKIP_QUEUE_DEPTH = 8
 const OCR_LAST_QUEUED_MIN_PERSIST_INTERVAL_MS = 30 * 1000
 const OCR_LAST_DISPATCH_MIN_PERSIST_INTERVAL_MS = 30 * 1000
 const OCR_LAST_SUCCESS_MIN_PERSIST_INTERVAL_MS = 30 * 1000
@@ -15,19 +22,19 @@ const OCR_LAST_SUCCESS_MIN_PERSIST_INTERVAL_MS = 30 * 1000
 const OCR_CONFIG_PERSIST_OPTIONS: Record<string, OcrConfigPersistOptions> = {
   'ocr:last-queued': {
     minIntervalMs: OCR_LAST_QUEUED_MIN_PERSIST_INTERVAL_MS,
-    skipWhenQueueDepthAtLeast: OCR_START_WRITE_SKIP_QUEUE_DEPTH,
+    skipWhenQueueDepthAtLeast: OCR_CONFIG_SKIP_QUEUE_DEPTH,
     dropPolicy: 'drop',
     maxQueueWaitMs: 10_000
   },
   'ocr:last-dispatch': {
     minIntervalMs: OCR_LAST_DISPATCH_MIN_PERSIST_INTERVAL_MS,
-    skipWhenQueueDepthAtLeast: OCR_START_WRITE_SKIP_QUEUE_DEPTH,
+    skipWhenQueueDepthAtLeast: OCR_CONFIG_SKIP_QUEUE_DEPTH,
     dropPolicy: 'drop',
     maxQueueWaitMs: 10_000
   },
   'ocr:last-success': {
     minIntervalMs: OCR_LAST_SUCCESS_MIN_PERSIST_INTERVAL_MS,
-    skipWhenQueueDepthAtLeast: OCR_START_WRITE_SKIP_QUEUE_DEPTH,
+    skipWhenQueueDepthAtLeast: OCR_CONFIG_SKIP_QUEUE_DEPTH,
     dropPolicy: 'drop',
     maxQueueWaitMs: 10_000
   },

--- a/apps/core-app/src/main/modules/ocr/ocr-service.test.ts
+++ b/apps/core-app/src/main/modules/ocr/ocr-service.test.ts
@@ -422,3 +422,62 @@ describe('OcrService runAgentJob local-first options', () => {
     }
   })
 })
+
+/**
+ * The start write must survive write-queue pressure (#645).
+ *
+ * It used to be skipped whenever the scheduler was backed up, which dropped the attempts
+ * increment. A job whose image crashes the native worker then comes back as pending/attempts=0 on
+ * the next launch, MAX_ATTEMPTS is never reached, and it is re-dispatched every poll forever.
+ */
+describe('ocr dispatch persists the attempt', () => {
+  type Dispatchable = {
+    db: unknown
+    processing: boolean
+    activeJobs: Map<number, Promise<void>>
+    processQueue: () => Promise<void>
+    runAgentJob: (jobId: number, job: unknown) => Promise<void>
+    upsertConfig: (key: string, value: unknown) => Promise<void>
+    isQueueDisabled: () => Promise<boolean>
+    withDbWrite: (label: string, op: unknown, options?: unknown) => Promise<unknown>
+  }
+
+  function readyJobDb(job: Record<string, unknown>) {
+    const builder = {
+      from: () => builder,
+      where: () => builder,
+      orderBy: () => builder,
+      limit: async () => [job]
+    }
+    return { select: () => builder }
+  }
+
+  it('schedules ocr.jobs.start as critical and undroppable, however deep the queue', async () => {
+    const service = ocrService as unknown as Dispatchable
+    const writes: Array<{ label: string; options?: { priority?: string; dropPolicy?: string } }> =
+      []
+
+    service.db = readyJobDb({ id: 42, clipboardId: 7, attempts: 0 })
+    service.processing = false
+    service.activeJobs = new Map()
+    service.isQueueDisabled = async () => false
+    service.upsertConfig = async () => {}
+    service.runAgentJob = async () => {}
+    service.withDbWrite = async (label, _op, options) => {
+      writes.push({ label, options: options as { priority?: string; dropPolicy?: string } })
+      return undefined
+    }
+
+    await service.processQueue()
+
+    const startWrite = writes.find((entry) => entry.label === 'ocr.jobs.start')
+
+    // Positive control: the dispatch path ran at all. Without it an early return would satisfy
+    // every assertion below by never writing anything.
+    expect(writes.length).toBeGreaterThan(0)
+
+    expect(startWrite, 'ocr.jobs.start was not scheduled').toBeDefined()
+    expect(startWrite?.options?.priority).toBe('critical')
+    expect(startWrite?.options?.dropPolicy).toBe('none')
+  })
+})

--- a/apps/core-app/src/main/modules/ocr/ocr-service.ts
+++ b/apps/core-app/src/main/modules/ocr/ocr-service.ts
@@ -38,7 +38,6 @@ import { windowManager } from '../box-tool/core-box/window'
 import { databaseModule } from '../database'
 import { notificationModule } from '../notification'
 import {
-  OCR_START_WRITE_SKIP_QUEUE_DEPTH,
   computeOcrConfigPersistSignature,
   getOcrConfigWriteLabel,
   resolveOcrConfigPersistOptions,
@@ -960,10 +959,17 @@ class OcrService {
 
         const attemptCount = (job.attempts ?? 0) + 1
 
-        const skipStartWrite =
-          dbWriteScheduler.getStats().queued >= OCR_START_WRITE_SKIP_QUEUE_DEPTH
-        if (!skipStartWrite) {
-          await this.withDbWrite('ocr.jobs.start', (db) =>
+        // Never skipped, however deep the write queue is. This row is what bounds retries: if the
+        // attempt is not persisted and the process dies before failJob() runs, the job comes back
+        // as pending/attempts=0, MAX_ATTEMPTS is never reached, and an image that crashes the
+        // native worker is re-dispatched every poll, forever, across launches (#645).
+        //
+        // Marked critical and non-droppable rather than bypassing the scheduler, so it still
+        // queues behind ordering rules instead of jumping them. The cost is one UPDATE per
+        // dispatch, and WORKER_CONCURRENCY is 1.
+        await this.withDbWrite(
+          'ocr.jobs.start',
+          (db) =>
             db
               .update(ocrJobs)
               .set({
@@ -973,9 +979,9 @@ class OcrService {
                 lastError: null,
                 nextRetryAt: null
               })
-              .where(eq(ocrJobs.id, job.id!))
-          )
-        }
+              .where(eq(ocrJobs.id, job.id!)),
+          { priority: 'critical', dropPolicy: 'none' }
+        )
 
         job.attempts = attemptCount
 


### PR DESCRIPTION
Closes #645.

The start write is now `priority: 'critical'`, `dropPolicy: 'none'` and is never skipped.

## Why scheduled rather than bypassed

Marking it critical keeps it inside the scheduler's ordering rules instead of jumping them — under pressure it queues rather than vanishing. The throttle it was subject to exists for bulk writes; this is **one UPDATE per dispatch**, and `WORKER_CONCURRENCY` is 1, so it was never the load the throttle was aimed at.

## A rename that the fix forces

`OCR_START_WRITE_SKIP_QUEUE_DEPTH` no longer governs the start write. Its three remaining users are the `ocr:last-queued` / `ocr:last-dispatch` / `ocr:last-success` breadcrumbs, which declare `dropPolicy: 'drop'` and are genuinely safe to shed. Left under that name the constant would describe the opposite of what it does, so it is now `OCR_CONFIG_SKIP_QUEUE_DEPTH`.

## One thing I looked for and did not find

The dispatch loop is `while (this.activeJobs.size < WORKER_CONCURRENCY)`, and the skip left the row `status='pending'` — which looks like it should re-select the same job on the next iteration of the *same* drain, dispatching it twice concurrently. `WORKER_CONCURRENCY` is **1**, so the loop exits first. The defect is only the cross-restart one described in the issue, and I would rather say I checked than leave a plausible-sounding second failure implied.

## Test asserts scheduling, not source text

It drives `processQueue` with a stubbed db and write path and inspects the options the write is scheduled with. Mutation-checked **twice**, because one mutation would not have separated the two halves of the fix:

| mutation | result |
| --- | --- |
| reinstate the queue-depth skip | ✗ fails |
| keep the write, drop `priority`/`dropPolicy` | ✗ fails |

It also carries a positive control — the dispatch path must have written *something* — so an early return cannot satisfy it by writing nothing at all.

`typecheck:node` at the baseline 6; OCR suite 9 tests; ESLint clean.
