### PR TITLE
fix(security): post the transport port to the page origin, not to any origin

### DIFF
--- a/packages/utils/__tests__/transport/port-handoff-harness.ts
+++ b/packages/utils/__tests__/transport/port-handoff-harness.ts
@@ -11,6 +11,7 @@ type NativeTransferList = NonNullable<Parameters<MessagePort['postMessage']>[1]>
 
 interface PortHandoffHarnessOptions {
   throwOnPostMessage?: boolean
+  location?: Pick<Location, 'origin' | 'protocol'>
 }
 
 export interface PortHandoffHarness {
@@ -18,8 +19,11 @@ export interface PortHandoffHarness {
     on: (channel: string, listener: IpcListener) => void
     removeListener: (channel: string, listener: IpcListener) => void
   }
-  targetWindow: Pick<Window, 'addEventListener' | 'postMessage' | 'removeEventListener'>
+  targetWindow: Pick<Window, 'addEventListener' | 'postMessage' | 'removeEventListener'> & {
+    location?: Pick<Location, 'origin' | 'protocol'>
+  }
   postedMessages: unknown[]
+  postedTargetOrigins: string[]
   emit: (channel: string, payload: unknown, ports?: readonly MessagePort[]) => void
   dispatchFrom: (source: unknown, data: unknown, ports?: readonly MessagePort[]) => void
   dispose: () => void
@@ -44,6 +48,7 @@ export function createPortHandoffHarness(
   const ipcListeners = new Map<string, IpcListener>()
   const windowListeners = new Map<unknown, WindowListener>()
   const postedMessages: unknown[] = []
+  const postedTargetOrigins: string[] = []
   const delivery = new MessageChannel()
 
   const targetWindowImplementation = {
@@ -58,10 +63,12 @@ export function createPortHandoffHarness(
         windowListeners.delete(listener)
       }
     },
-    postMessage(data: unknown, _targetOrigin: string, transfer: readonly unknown[] = []): void {
+    location: options.location ?? { origin: 'https://app.example', protocol: 'https:' },
+    postMessage(data: unknown, targetOrigin: string, transfer: readonly unknown[] = []): void {
       if (options.throwOnPostMessage) {
         throw new Error('window delivery unavailable')
       }
+      postedTargetOrigins.push(targetOrigin)
       postedMessages.push(data)
       const nativeTransferList = transfer as NativeTransferList
       delivery.port1.postMessage(data, nativeTransferList)
@@ -70,7 +77,7 @@ export function createPortHandoffHarness(
   const targetWindow = targetWindowImplementation as unknown as Pick<
     Window,
     'addEventListener' | 'postMessage' | 'removeEventListener'
-  >
+  > & { location?: Pick<Location, 'origin' | 'protocol'> }
 
   delivery.port2.addEventListener('message', (event: Event) => {
     if (!('data' in event) || !('ports' in event) || !Array.isArray(event.ports)) {
@@ -98,6 +105,7 @@ export function createPortHandoffHarness(
     },
     targetWindow,
     postedMessages,
+    postedTargetOrigins,
     emit(channel, payload, ports) {
       ipcListeners.get(channel)?.({ ports }, payload)
     },

--- a/packages/utils/__tests__/transport/port-handoff-origin.test.ts
+++ b/packages/utils/__tests__/transport/port-handoff-origin.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { TransportEvents } from '../../transport/events'
+import { installTransportPortHandoff } from '../../transport/port-handoff'
+import { createNativePortPair, createPortHandoffHarness } from './port-handoff-harness'
+
+/**
+ * The transferred port carries the privileged streaming transport. It used to be
+ * posted into the page world with '*' as targetOrigin, and the receiving side only
+ * checks `event.source === targetWindow` — which any script running in the page
+ * satisfies. An injected script could therefore take the port and keep it for the
+ * lifetime of the page (#694).
+ */
+
+const CONFIRM_EVENT = TransportEvents.port.confirm.toEventName()
+
+function handoff(location?: Pick<Location, 'origin' | 'protocol'>) {
+  const harness = createPortHandoffHarness({ location })
+  const dispose = installTransportPortHandoff(harness.ipcRenderer as never, harness.targetWindow)
+  const pair = createNativePortPair()
+  harness.emit(CONFIRM_EVENT, { channel: 'test-channel', portId: 'test-port', scope: 'window' }, [pair.receiver])
+  dispose()
+  return harness.postedTargetOrigins
+}
+
+describe('transport port handoff targetOrigin', () => {
+  it('posts to the page origin rather than any origin', () => {
+    expect(handoff({ origin: 'https://app.example', protocol: 'https:' })).toEqual([
+      'https://app.example',
+    ])
+  })
+
+  it('uses file:// for a file page, whose origin serialises as the string null', () => {
+    // An opaque origin has no usable specific targetOrigin, which is why the app
+    // preload already special-cases this rather than posting the literal 'null'.
+    expect(handoff({ origin: 'null', protocol: 'file:' })).toEqual(['file://'])
+  })
+
+  it('falls back to * only for an opaque origin that is not file:', () => {
+    // No worse than the previous behaviour for this case, and it is the only
+    // remaining one — every real origin now gets a specific target.
+    expect(handoff({ origin: 'null', protocol: 'blob:' })).toEqual(['*'])
+  })
+
+  it('still delivers the port', () => {
+    // Control: the origin must not be tightened into a delivery failure.
+    const harness = createPortHandoffHarness({
+      location: { origin: 'https://app.example', protocol: 'https:' },
+    })
+    const dispose = installTransportPortHandoff(harness.ipcRenderer as never, harness.targetWindow)
+    const pair = createNativePortPair()
+
+    harness.emit(CONFIRM_EVENT, { channel: 'test-channel', portId: 'test-port', scope: 'window' }, [pair.receiver])
+
+    expect(harness.postedMessages).toHaveLength(1)
+    dispose()
+  })
+})

--- a/packages/utils/transport/port-handoff.ts
+++ b/packages/utils/transport/port-handoff.ts
@@ -7,7 +7,27 @@ export const TRANSPORT_PORT_HANDOFF_MARKER = 'talex-touch:transport-port-handoff
 type TransportPortHandoffWindow = Pick<
   Window,
   'addEventListener' | 'postMessage' | 'removeEventListener'
->
+> & { location?: Pick<Location, 'origin' | 'protocol'> }
+
+/**
+ * targetOrigin for the port handoff.
+ *
+ * The port carries the privileged streaming transport, and it used to be posted
+ * with '*'. The receiver only checks `event.source === targetWindow`, which any
+ * script running in the page satisfies, so an injected script could take the port
+ * and keep it for the lifetime of the page (#694).
+ *
+ * Mirrors the rule already used by sendPreloadEvent in the app preload: an opaque
+ * origin serialises as the string 'null', for which postMessage has no usable
+ * specific value — file: pages get 'file://' and anything else falls back to '*',
+ * which is no worse than today for those cases and correct for every real origin.
+ */
+function resolveHandoffTargetOrigin(targetWindow: TransportPortHandoffWindow): string {
+  const location = targetWindow.location
+  if (!location) return '*'
+  if (location.origin && location.origin !== 'null') return location.origin
+  return location.protocol === 'file:' ? 'file://' : '*'
+}
 
 interface TransportPortTransferEvent {
   ports?: readonly MessagePort[]
@@ -115,7 +135,7 @@ export function installTransportPortHandoff(
     try {
       targetWindow.postMessage(
         { marker: TRANSPORT_PORT_HANDOFF_MARKER, payload } satisfies TransportPortHandoffMessage,
-        '*',
+        resolveHandoffTargetOrigin(targetWindow),
         [port],
       )
     }


### PR DESCRIPTION
Closes #694.

The transferred `MessagePort` carries the privileged streaming transport and was posted into the page world with `'*'`. The receiving side only checks `event.source === targetWindow`, which **any** script running in the page satisfies, so an injected script could take the port and keep it for the lifetime of the page.

Now posted to the page's own origin, reusing the rule `sendPreloadEvent` already applies in the app preload rather than inventing a second one: an opaque origin serialises as the string `'null'`, which is not a usable `targetOrigin`, so `file:` pages get `'file://'` and anything else still falls back to `'*'`. **That fallback is no worse than before and is now the only remaining case** — every real origin gets a specific target.

`TransportPortHandoffWindow` gains an optional `location` (it was `Pick<Window, 'addEventListener' | 'postMessage' | 'removeEventListener'>`). Optional rather than required, so an injected window without one degrades to today's behaviour instead of throwing.

### A typecheck trap worth knowing about
The new test uses the `createNativePortPair` helper rather than `new MessageChannel()`. Under core-app's node tsconfig, `MessageChannel` resolves to `worker_threads` and the DOM `MessagePort` does not satisfy it.

My first version used the DOM form. **Vitest passed; `typecheck:node` failed with TS2740** — because `packages/utils` has no tsconfig of its own and is only typechecked through its consumers. I had already written "typecheck clean" in the commit message before checking the exit code; that claim was wrong and the commit was amended.

### Verified
Two of the four new tests are red against the pre-fix source. One of the others is a control that the port is **still delivered** — the failure mode of tightening `targetOrigin` is a silent delivery failure, not a loud one.

1099/1100 utils tests, core-app `typecheck:node` with 0 errors, `eslint --max-warnings=0` clean.