### PR TITLE
fix(security): only honour the auth deep link while a login is in flight

### DIFF
--- a/apps/core-app/src/main/modules/auth/index.test.ts
+++ b/apps/core-app/src/main/modules/auth/index.test.ts
@@ -714,3 +714,44 @@ describe('forced auth credential persistence', () => {
     )
   })
 })
+
+describe('tuff://auth/callback deep link', () => {
+  it('refuses a callback when no login is in flight', async () => {
+    // The drive-by case: a page navigates the user's browser to
+    // tuff://auth/callback?token=… with nothing pending in the app (#695).
+    const authModule = await importAuthModule()
+    authModule.__test__.resetState()
+    authModule.__test__.setActiveDeviceAuthCode(null)
+
+    await expect(authModule.applyExternalAuthCallback('attacker-token')).resolves.toBe(false)
+    expect(setSecureStoreValueMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses an app_token just the same', async () => {
+    const authModule = await importAuthModule()
+    authModule.__test__.resetState()
+    authModule.__test__.setActiveDeviceAuthCode(null)
+
+    await expect(authModule.applyExternalAuthCallback('', 'attacker-app-token')).resolves.toBe(
+      false
+    )
+    expect(setSecureStoreValueMock).not.toHaveBeenCalled()
+  })
+
+  it('gets past the gate while a login this app started is pending', async () => {
+    // Control: the legitimate deep link races the device-code poll and must not be
+    // blocked. This asserts the gate is passed, not that the whole callback
+    // succeeds — the remote profile fetch is out of scope here.
+    const authModule = await importAuthModule()
+    authModule.__test__.resetState()
+    authModule.__test__.setActiveDeviceAuthCode('device-code-in-flight')
+    authLoggerMock.warn.mockClear()
+
+    await authModule.applyExternalAuthCallback('', 'legitimate-app-token')
+
+    expect(authLoggerMock.warn).not.toHaveBeenCalledWith(
+      'Rejected auth callback with no login in flight',
+      expect.anything()
+    )
+  })
+})

--- a/apps/core-app/src/main/modules/auth/index.ts
+++ b/apps/core-app/src/main/modules/auth/index.ts
@@ -1628,10 +1628,35 @@ function getStepUpToken(): string | null {
   return stepUpToken
 }
 
+/**
+ * Entry point for the `tuff://auth/callback` deep link.
+ *
+ * Only honoured while a browser login this app started is still in flight.
+ * Without that check any page could navigate the user's browser to
+ * `tuff://auth/callback?token=…` and silently swap the session to the
+ * attacker's account — everything written afterwards lands in their account
+ * (#695).
+ *
+ * `activeDeviceAuthCode` is the signal: openLoginPage sets it, and it is
+ * cleared on cancel, on a completed poll and on poll failure, so the window is
+ * bounded by a login the user actually initiated.
+ *
+ * This is not full state binding. It does not tie the callback to *which*
+ * login is in flight, so an attacker who lands one while the user has a
+ * genuine login open still wins. Closing that needs a nonce carried through
+ * the browser round-trip, which means changing the nexus callback URL too —
+ * tracked on the issue rather than half-done here.
+ */
 export async function applyExternalAuthCallback(
   token: string,
   appToken?: string
 ): Promise<boolean> {
+  if (!activeDeviceAuthCode) {
+    authLog.warn('Rejected auth callback with no login in flight', {
+      meta: { hasToken: Boolean(token), hasAppToken: Boolean(appToken) }
+    })
+    return false
+  }
   return handleExternalAuthCallback(token, appToken)
 }
 
@@ -1676,6 +1701,10 @@ function setAuthModuleTestState(nextState: AuthModuleTestState): void {
 export const __test__ = {
   loadAuthToken,
   setAuthToken,
+  /** Lets a test put a browser login "in flight" without running the device flow. */
+  setActiveDeviceAuthCode: (code: string | null): void => {
+    activeDeviceAuthCode = code
+  },
   clearAuthToken,
   initializeAuthState,
   getCachedAuthUser,


### PR DESCRIPTION
Closes #695.

`tuff://auth/callback` pulled `token`/`app_token` from query params and passed them to `setAuthToken` after a non-empty check. **Any page could navigate the user's browser to `tuff://auth/callback?token=<attacker_token>`** and silently swap the session — everything written afterwards lands in the attacker's account.

The callback is now refused unless a browser login **this app started** is still pending. `activeDeviceAuthCode` is that signal: `openLoginPage` sets it, and cancel, a completed poll and poll failure all clear it, so the window is bounded by a login the user actually initiated.

Gated at `applyExternalAuthCallback`, not `handleExternalAuthCallback` — the device-code flow calls the latter directly at `:1103` and must not be blocked.

### ⚠️ This is deliberately not full state binding
It does not tie the callback to *which* login is pending, so an attacker who lands one while a genuine login is open still wins.

Closing that needs a nonce carried through the browser round-trip, which means changing the URL nexus builds in `app-callback.vue` — it currently sends **only** `app_token`, no state parameter at all. That is a two-app auth protocol change; I would rather it be decided than half-implemented here.

### On the mutation test
Reverting the whole file also removed the `__test__` hook the tests use, so all three failed with a `TypeError` — a harness artifact, not evidence. Removing **only the guard** and keeping the hook is the real check: the two rejection tests go red, the in-flight control stays green.

19/19 auth tests, `typecheck:node` with 0 errors, `eslint --max-warnings=0` clean.