### PR TITLE
fix(core-app): open the copied URL, not its privacy digest (#648)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/context-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/context-provider.ts
@@ -56,6 +56,17 @@ const NEUTRAL_TIME_CONTEXT: TimePattern = {
  * Uses dynamic imports to avoid circular dependencies with clipboard and activeApp modules.
  * This is intentional - see plan.prd for future refactoring.
  */
+/**
+ * The privacy digest used for every content field on a ContextSignal.
+ *
+ * Exported so a consumer can check whether raw content it holds is the same content the signal
+ * was built from, without the signal ever carrying that content. Duplicating the algorithm at a
+ * call site would work until one side changed.
+ */
+export function hashContextContent(content: string): string {
+  return crypto.createHash('sha256').update(content).digest('hex').slice(0, 16)
+}
+
 export class ContextProvider {
   /**
    * Retrieves complete current context signal.
@@ -321,7 +332,7 @@ export class ContextProvider {
    * Generates privacy-safe hash of content.
    */
   private hashContent(content: string): string {
-    return crypto.createHash('sha256').update(content).digest('hex').slice(0, 16)
+    return hashContextContent(content)
   }
 
   private async getContextSources(): Promise<RecommendationContextSources> {

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.test.ts
@@ -1,4 +1,4 @@
-import { ContextProvider, type ContextSignal } from './context-provider'
+import { ContextProvider, type ContextSignal, hashContextContent } from './context-provider'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const intelligenceSdkMock = vi.hoisted(() => ({
@@ -68,6 +68,16 @@ vi.mock('../../../ai/intelligence-sdk', () => ({
     rag: {
       rerank: intelligenceSdkMock.ragRerank
     }
+  }
+}))
+
+// The engine re-reads the clipboard when building the URL candidate, and only trusts it if the
+// content still hashes to the digest carried on the context (#648).
+const clipboardLatest = vi.hoisted(() => ({ current: null as { content: string } | null }))
+
+vi.mock('../../../clipboard', () => ({
+  clipboardModule: {
+    getLatestItem: () => clipboardLatest.current
   }
 }))
 
@@ -1327,17 +1337,21 @@ describe('RecommendationEngine', () => {
   it('never serves a clipboard URL action from the cache after the clipboard changed', async () => {
     const dbUtils = createDbUtils()
     const engine = new RecommendationEngine(dbUtils as never)
-    const clipboardContext = (marker: string): ContextSignal => ({
+    // `content` carries the privacy digest, not the URL — that is what #648 was about. The engine
+    // re-reads the clipboard and matches on this digest, so the fixture has to hash too.
+    const clipboardContext = (url: string): ContextSignal => ({
       ...morningContext,
       clipboard: {
         type: 'text',
-        content: marker,
+        content: hashContextContent(url),
         timestamp: Date.now(),
         contentType: 'url',
         meta: { isUrl: true }
       }
     })
-    const contexts = [clipboardContext('first-url'), clipboardContext('second-url')]
+    const first = 'https://example.com/first'
+    const second = 'https://example.com/second'
+    const contexts = [clipboardContext(first), clipboardContext(second)]
 
     Object.assign(engine as unknown as Record<string, unknown>, {
       contextProvider: {
@@ -1365,12 +1379,76 @@ describe('RecommendationEngine', () => {
       getPluginCandidates: vi.fn(async () => [])
     })
 
+    clipboardLatest.current = { content: first }
     await engine.recommend({ limit: 5 })
+
+    clipboardLatest.current = { content: second }
     const cached = await engine.recommend({ limit: 5 })
 
     expect(cached.fromCache).toBe(true)
     const urlActions = cached.items.filter((item) => item.id.startsWith('clipboard-url-open:'))
-    expect(urlActions.map((item) => item.id)).toEqual(['clipboard-url-open:second-url'])
+    expect(urlActions.map((item) => item.id)).toEqual([`clipboard-url-open:${second}`])
+  })
+
+  it('carries the real URL, not the privacy digest, into the open-url card', async () => {
+    // #648: ContextSignal.clipboard.content is a sha256 prefix. Building the card from it gave a
+    // '打开 URL' entry whose subtitle, id and open-url payload were all '9f2c1a4b8e7d3f01'.
+    const dbUtils = createDbUtils()
+    const engine = new RecommendationEngine(dbUtils as never)
+    const url = 'https://github.com/talex-touch/talex-touch'
+    const digest = hashContextContent(url)
+
+    expect(digest).not.toBe(url)
+
+    clipboardLatest.current = { content: url }
+
+    const candidates = await (
+      engine as unknown as {
+        getClipboardUrlCandidates: (
+          context: ContextSignal
+        ) => Promise<Array<{ pluginCandidate?: { data?: { url?: string }; subtitle?: string } }>>
+      }
+    ).getClipboardUrlCandidates({
+      ...morningContext,
+      clipboard: {
+        type: 'text',
+        content: digest,
+        timestamp: Date.now(),
+        contentType: 'url',
+        meta: { isUrl: true }
+      }
+    })
+
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]?.pluginCandidate?.data?.url).toBe(url)
+    expect(candidates[0]?.pluginCandidate?.subtitle).toContain('github.com')
+    expect(JSON.stringify(candidates[0])).not.toContain(digest)
+  })
+
+  it('produces no card when the clipboard no longer matches the context', async () => {
+    // The race the digest check exists for: between the snapshot and the rebuild the user copied
+    // something else. Opening that instead would be worse than showing nothing.
+    const dbUtils = createDbUtils()
+    const engine = new RecommendationEngine(dbUtils as never)
+
+    clipboardLatest.current = { content: 'https://example.com/something-else' }
+
+    const candidates = await (
+      engine as unknown as {
+        getClipboardUrlCandidates: (context: ContextSignal) => Promise<unknown[]>
+      }
+    ).getClipboardUrlCandidates({
+      ...morningContext,
+      clipboard: {
+        type: 'text',
+        content: hashContextContent('https://example.com/original'),
+        timestamp: Date.now(),
+        contentType: 'url',
+        meta: { isUrl: true }
+      }
+    })
+
+    expect(candidates).toEqual([])
   })
 
   it('recommends catalog apps on a cold start with no usage history', async () => {

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.ts
@@ -13,7 +13,7 @@ import { scheduleAuxWrite, scheduleDbWrite } from '../../../../db/db-write'
 import { getStartupDegradeWindowRemainingMs } from '../../../../db/runtime-flags'
 import * as schema from '../../../../db/schema'
 import { getSentryService } from '../../../sentry'
-import { ContextProvider } from './context-provider'
+import { ContextProvider, hashContextContent } from './context-provider'
 import { ItemRebuilder } from './item-rebuilder'
 import { isSameAppIdentity, matchesAppRule, type AppMatchRule } from './app-identity-match'
 import { recommendationExposureService } from './recommendation-exposure-service'
@@ -1774,10 +1774,19 @@ export class RecommendationEngine {
   /**
    * 内置剪贴板 URL 推荐候选
    */
-  private getClipboardUrlCandidates(context: ContextSignal): CandidateItem[] {
+  private async getClipboardUrlCandidates(context: ContextSignal): Promise<CandidateItem[]> {
     if (!context.clipboard?.meta?.isUrl || !context.clipboard.content) return []
 
-    const url = context.clipboard.content
+    // context.clipboard.content is a privacy digest, not the URL — ContextProvider hashes every
+    // content field on purpose. Building the card from it produced a '打开 URL' entry whose
+    // subtitle, item id and open-url payload were all the hash (#648).
+    //
+    // Re-read rather than adding a raw field to the signal: the point of the digest is that raw
+    // content does not travel through the recommendation pipeline. The hash is then what proves
+    // the clipboard still holds the item this context was built from — if it has changed, the
+    // recommendation is stale and no card is better than the wrong one.
+    const url = await this.readClipboardUrlMatching(context.clipboard.content)
+    if (!url) return []
 
     return [
       {
@@ -1797,6 +1806,25 @@ export class RecommendationEngine {
         }
       }
     ]
+  }
+
+  /**
+   * Reads the current clipboard text, but only returns it if it still hashes to `expectedDigest`.
+   *
+   * Returning null on a mismatch is the point: between the context snapshot and this call the user
+   * may have copied something else, and opening that instead would be worse than showing nothing.
+   */
+  private async readClipboardUrlMatching(expectedDigest: string): Promise<string | null> {
+    try {
+      const { clipboardModule } = await import('../../../clipboard')
+      const latest = clipboardModule.getLatestItem()
+      const content = latest?.content
+
+      if (!content) return null
+      return hashContextContent(content) === expectedDigest ? content : null
+    } catch {
+      return null
+    }
   }
 
   /**
@@ -2340,7 +2368,7 @@ export class RecommendationEngine {
     context: ContextSignal,
     existingItems: TuffItem[]
   ): Promise<TuffItem[]> {
-    const candidates = this.getClipboardUrlCandidates(context)
+    const candidates = await this.getClipboardUrlCandidates(context)
     if (candidates.length === 0) return []
 
     const existingKeys = new Set(existingItems.map((item) => this.getItemIdentity(item)))


### PR DESCRIPTION
Closes #648.

`ContextSignal.clipboard.content` is a sha256 prefix — `ContextProvider` hashes every content field deliberately — but `getClipboardUrlCandidates` used it as the URL. The card's subtitle, item id and `open-url` payload were all the digest.

## Re-read, not a plaintext field

The issue offers either. I took the re-read: the digest exists so raw clipboard content does **not** travel through the recommendation pipeline, and a plaintext field beside it would undo that for every consumer of the signal, not just this call site.

The digest then does real work — it is what proves the clipboard still holds the item the context was built from. **On a mismatch the candidate is dropped**, because between the snapshot and the rebuild the user may have copied something else, and opening *that* is worse than showing nothing. Pinned by its own test.

`hashContextContent` is exported and used by both sides rather than reimplemented at the call site, so the two cannot drift.

## An existing test had encoded the defect

`never serves a clipboard URL action from the cache after the clipboard changed` built contexts with `content: 'first-url'` and asserted the card id was `clipboard-url-open:second-url` — treating the digest field as a URL, exactly the bug.

Its **name** says what it actually guards: that a volatile clipboard action is never served from cache. That intent is kept; only the fixture changed, so it now hashes the URL into `content` and mocks the clipboard the engine re-reads. It still fails if the caching regression returns.

## Mutation-checked

Restoring `const url = context.clipboard.content`:

```
× never serves a clipboard URL action from the cache after the clipboard changed
× carries the real URL, not the privacy digest, into the open-url card
× produces no card when the clipboard no longer matches the context
```

The first new test also asserts the digest appears **nowhere** in the serialised candidate, so a fix that carried both would not pass.

`typecheck:node` at the baseline 6; recommendation suites 72 tests; ESLint clean at `--max-warnings=0`.

(`browser-bookmarks-indexed-source.test.ts` cannot load in this worktree — broken local electron install — and fails identically on HEAD.)
