### PR TITLE
fix(security): install a permission policy on session.defaultSession

### DIFF
--- a/apps/core-app/src/main/core/default-session-permissions.test.ts
+++ b/apps/core-app/src/main/core/default-session-permissions.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  installDefaultSessionPermissionPolicy,
+  isDefaultSessionPermissionAllowed
+} from './default-session-permissions'
+
+/**
+ * defaultSession had no permission handlers, and Electron approves by default, so
+ * the privileged renderer could take camera, microphone, geolocation or
+ * clipboard-read silently (#696).
+ *
+ * The plugin session's blanket deny was not an option here: the renderer really
+ * does use microphone, clipboard and notifications. These pin both halves — that
+ * the dangerous ones are refused, and that the three the app depends on still
+ * work, since the failure mode of getting this wrong is a feature that silently
+ * stops functioning.
+ */
+
+describe('default session permission policy', () => {
+  it('refuses the permissions no caller in the renderer asks for', () => {
+    for (const permission of [
+      'geolocation',
+      'midi',
+      'midiSysex',
+      'usb',
+      'serial',
+      'hid',
+      'bluetooth',
+      'openExternal',
+      'pointerLock',
+      'idle-detection',
+      'window-management',
+      'unknown-future-permission'
+    ]) {
+      expect(isDefaultSessionPermissionAllowed(permission)).toBe(false)
+    }
+  })
+
+  it('allows the three the renderer actually uses', () => {
+    // VoicePanel.vue (getUserMedia), the clipboard callers, and new Notification().
+    expect(isDefaultSessionPermissionAllowed('media', { mediaTypes: ['audio'] })).toBe(true)
+    expect(isDefaultSessionPermissionAllowed('clipboard-read')).toBe(true)
+    expect(isDefaultSessionPermissionAllowed('clipboard-sanitized-write')).toBe(true)
+    expect(isDefaultSessionPermissionAllowed('notifications')).toBe(true)
+  })
+
+  it('refuses the camera even though microphone shares the media permission', () => {
+    // Electron reports both under 'media'. The renderer has no camera caller, so
+    // allowing voice input must not hand over the camera with it.
+    expect(isDefaultSessionPermissionAllowed('media', { mediaTypes: ['video'] })).toBe(false)
+    expect(isDefaultSessionPermissionAllowed('media', { mediaTypes: ['audio', 'video'] })).toBe(
+      false
+    )
+  })
+
+  it('treats a media request with no stated types as allowed audio', () => {
+    // Some callers omit mediaTypes; refusing those would break voice input, and
+    // the video branch above is what actually guards the camera.
+    expect(isDefaultSessionPermissionAllowed('media')).toBe(true)
+  })
+
+  it('installs both handlers, since either one missing falls back to approve', () => {
+    const setPermissionCheckHandler = vi.fn()
+    const setPermissionRequestHandler = vi.fn()
+
+    installDefaultSessionPermissionPolicy({
+      setPermissionCheckHandler,
+      setPermissionRequestHandler
+    })
+
+    expect(setPermissionCheckHandler).toHaveBeenCalledTimes(1)
+    expect(setPermissionRequestHandler).toHaveBeenCalledTimes(1)
+    expect(setPermissionCheckHandler.mock.calls[0]![0]).toBeTypeOf('function')
+    expect(setPermissionRequestHandler.mock.calls[0]![0]).toBeTypeOf('function')
+  })
+
+  it('answers through the handlers it installed, not just through the predicate', () => {
+    let check: ((wc: unknown, p: string, o: string, d: unknown) => boolean) | undefined
+    let request:
+      | ((wc: unknown, p: string, cb: (granted: boolean) => void, d: unknown) => void)
+      | undefined
+    const denied: string[] = []
+
+    installDefaultSessionPermissionPolicy(
+      {
+        setPermissionCheckHandler: (handler) => {
+          check = handler as typeof check
+        },
+        setPermissionRequestHandler: (handler) => {
+          request = handler as typeof request
+        }
+      },
+      { onDenied: (permission) => denied.push(permission) }
+    )
+
+    expect(check!(null, 'geolocation', 'file://', undefined)).toBe(false)
+    expect(check!(null, 'clipboard-read', 'file://', undefined)).toBe(true)
+
+    const granted: boolean[] = []
+    request!(null, 'media', (value) => granted.push(value), { mediaTypes: ['video'] })
+    request!(null, 'media', (value) => granted.push(value), { mediaTypes: ['audio'] })
+
+    expect(granted).toEqual([false, true])
+    expect(denied).toEqual(['geolocation', 'media'])
+  })
+})
+
+describe('default session permission policy wiring', () => {
+  it('is actually applied to session.defaultSession at app ready', async () => {
+    // Positive control on the wiring, not on the policy. Everything above would
+    // pass just as well if this module were never called — which is the whole
+    // failure mode here, since the pre-existing bug was an absent handler rather
+    // than a wrong one.
+    //
+    // Asserted against the source because precore installs it inside
+    // app.whenReady(); importing it would drag in the Electron app lifecycle.
+    const { readFileSync } = await import('node:fs')
+    const { dirname, resolve } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+
+    const precore = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), 'precore.ts'),
+      'utf8'
+    )
+
+    expect(precore).toContain('installDefaultSessionPermissionPolicy(session.defaultSession')
+    // Before whenReady there is no session; after modules load, windows already
+    // exist. The call has to sit inside the whenReady handler.
+    const readyIndex = precore.indexOf('app.whenReady()')
+    const installIndex = precore.indexOf('installDefaultSessionPermissionPolicy(')
+    expect(readyIndex).toBeGreaterThan(-1)
+    expect(installIndex).toBeGreaterThan(readyIndex)
+  })
+})

--- a/apps/core-app/src/main/core/default-session-permissions.ts
+++ b/apps/core-app/src/main/core/default-session-permissions.ts
@@ -1,0 +1,98 @@
+/**
+ * Permission policy for `session.defaultSession`.
+ *
+ * The only permission handlers in the app were on the per-plugin session, which
+ * denies everything. defaultSession — shared by the main window, CoreBox,
+ * Assistant, Screenshot and OmniPanel — had none, and Electron's default is to
+ * approve, so a script in the privileged renderer could take camera, microphone,
+ * geolocation or clipboard-read with no prompt and no policy (#696).
+ *
+ * An allowlist rather than the plugin session's blanket deny: the renderer does
+ * legitimately use three of these. What it uses was enumerated from the renderer
+ * source, and each entry below names the caller so the list can be re-checked
+ * when those features move.
+ */
+
+/** Permissions the app's own renderer actually needs. */
+const ALLOWED_PERMISSIONS = new Set<string>([
+  // views/assistant/VoicePanel.vue — getUserMedia for voice input. Audio only;
+  // see isVideoRequest below, since Electron's 'media' covers the camera too.
+  'media',
+  // IntelligenceProviderHeader.vue, PluginDetails.vue, PluginFeatures.vue, …
+  'clipboard-read',
+  'clipboard-sanitized-write',
+  // Renderer-side new Notification(...)
+  'notifications'
+])
+
+interface MediaDetails {
+  mediaTypes?: readonly string[]
+}
+
+/**
+ * Electron reports camera and microphone under the single 'media' permission, so
+ * allowing voice input would otherwise allow the camera. The renderer has no
+ * camera caller at all, so any request naming video is refused.
+ */
+function isVideoRequest(permission: string, details?: MediaDetails): boolean {
+  return permission === 'media' && Boolean(details?.mediaTypes?.includes('video'))
+}
+
+export function isDefaultSessionPermissionAllowed(
+  permission: string,
+  details?: MediaDetails
+): boolean {
+  if (!ALLOWED_PERMISSIONS.has(permission)) return false
+  return !isVideoRequest(permission, details)
+}
+
+interface PermissionCapableSession {
+  setPermissionCheckHandler: (
+    handler:
+      | ((
+          webContents: unknown,
+          permission: string,
+          requestingOrigin: string,
+          details: unknown
+        ) => boolean)
+      | null
+  ) => void
+  setPermissionRequestHandler: (
+    handler:
+      | ((
+          webContents: unknown,
+          permission: string,
+          callback: (granted: boolean) => void,
+          details: unknown
+        ) => void)
+      | null
+  ) => void
+}
+
+export interface InstallDefaultSessionPermissionPolicyOptions {
+  onDenied?: (permission: string) => void
+}
+
+/**
+ * Installs both handlers. Both are required: setPermissionRequestHandler covers
+ * the prompt path, setPermissionCheckHandler the synchronous query path, and
+ * leaving either unset falls back to Electron's approve-by-default.
+ */
+export function installDefaultSessionPermissionPolicy(
+  targetSession: PermissionCapableSession,
+  options: InstallDefaultSessionPermissionPolicyOptions = {}
+): void {
+  const decide = (permission: string, details?: MediaDetails): boolean => {
+    const allowed = isDefaultSessionPermissionAllowed(permission, details)
+    if (!allowed) options.onDenied?.(permission)
+    return allowed
+  }
+
+  targetSession.setPermissionCheckHandler((_webContents, permission, _origin, details) =>
+    decide(permission, details as MediaDetails | undefined)
+  )
+
+  targetSession.setPermissionRequestHandler((_webContents, permission, callback, details) => {
+    callback(decide(permission, details as MediaDetails | undefined))
+  })
+}

--- a/apps/core-app/src/main/core/precore.ts
+++ b/apps/core-app/src/main/core/precore.ts
@@ -6,7 +6,7 @@ import process from 'node:process'
  * This file describes the pre-core of the touch app.
  * Running necessary settings or environment params before startup the touch app.
  */
-import { app, crashReporter, powerMonitor } from 'electron'
+import { app, crashReporter, powerMonitor, session } from 'electron'
 import * as log4js from 'log4js'
 import { AppEvents, getTuffTransportMain } from '@talex-touch/utils/transport/main'
 import { resolveRuntimeRootPath } from '../utils/app-root-path'
@@ -23,6 +23,7 @@ import {
   touchEventBus,
   WindowAllClosedEvent
 } from './eventbus/touch-event'
+import { installDefaultSessionPermissionPolicy } from './default-session-permissions'
 import { getCurrentTouchApp } from './main-runtime-state'
 import { runWithBeforeQuitTimeout } from './before-quit-guard'
 import { ensureUserNormalQuitIntent, getQuitIntent, setQuitIntent } from './quit-intent'
@@ -231,6 +232,17 @@ setupSingleInstanceGuard({
 })
 
 void app.whenReady().then(() => {
+  // Installed here rather than in a module: modules load after this, and some of
+  // them create windows. A window that loads before the handlers are attached
+  // would run under Electron's approve-by-default (#696).
+  installDefaultSessionPermissionPolicy(session.defaultSession, {
+    onDenied: (permission) => {
+      mainLog.warn('Denied a permission request on the default session', {
+        meta: { permission }
+      })
+    }
+  })
+
   powerMonitor.on('shutdown', () => {
     setQuitIntent('system-shutdown', 'power-monitor-shutdown')
     markAppQuitting('power-monitor-shutdown')


### PR DESCRIPTION
Closes #696.

The only permission handlers in the app were on the per-plugin session. `session.defaultSession` — shared by the main window, CoreBox, Assistant, Screenshot and OmniPanel — had **none**, and Electron approves by default, so a script in the privileged renderer could take camera, microphone, geolocation or clipboard-read with no prompt and no policy.

### An allowlist, not the plugin session's blanket deny
The renderer really does use three of these. Enumerated from its own source:

| permission | caller |
|---|---|
| `media` | `views/assistant/VoicePanel.vue` — `getUserMedia` for voice input |
| `clipboard-read` / `clipboard-sanitized-write` | 13 `navigator.clipboard` call sites |
| `notifications` | 8 `new Notification()` call sites |

Copying the plugin session's deny-all would have broken voice input, clipboard reads and notifications.

**Camera:** Electron reports camera and microphone under one `media` permission, so allowing voice input would otherwise allow the camera too. There is no camera caller in the renderer at all, so a request naming `video` is refused while audio passes.

### Install point
Inside `app.whenReady()` in precore, not as a module — modules load after that and some create windows, and a window that loads before the handlers are attached runs under approve-by-default.

### Verified with two mutations
- **removing the install from precore** → the wiring test fails
- **allowing video through** → the camera test and the end-to-end handler test fail

The wiring test matters most: every other assertion would pass just as well if this module were never called, which is exactly the shape of the original bug (an *absent* handler, not a wrong one).

104 core tests — 103 pass. The one failure (`runtime-modules.contract.test.ts`, packaged runtime closure) is **pre-existing**: the same single failure is present on the base branch with these changes stashed. `typecheck:node` 0 errors, `eslint --max-warnings=0` clean.