### PR TITLE
fix(core-app): tolerate corrupt item_time_stats rows (#655)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/time-stats-aggregator.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/time-stats-aggregator.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { toParsedItemTimeStats } from './time-stats-aggregator'
+
+/**
+ * A corrupt row must cost that row its history, not take down every caller (#655).
+ *
+ * hourDistribution / dayOfWeekDistribution / timeSlotDistribution are plain TEXT columns holding
+ * JSON. `parseTimeStats` ran raw JSON.parse on all three, and it sits under the public
+ * getItemTimeStats / getItemTimeStatsBatch API — so one partially written or truncated row threw
+ * out of every consumer at once.
+ */
+
+function row(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    sourceId: 'app-provider',
+    itemId: 'com.apple.Terminal',
+    hourDistribution: JSON.stringify(Array.from({ length: 24 }, (_, index) => index)),
+    dayOfWeekDistribution: JSON.stringify([1, 2, 3, 4, 5, 6, 7]),
+    timeSlotDistribution: JSON.stringify({ morning: 1, afternoon: 2, evening: 3, night: 4 }),
+    lastUpdated: new Date('2026-08-08T00:00:00.000Z'),
+    ...overrides
+  } as never
+}
+
+describe('toParsedItemTimeStats', () => {
+  it('parses a well-formed row', () => {
+    // Positive control: every tolerance assertion below would also hold for a parser that always
+    // returned zeros.
+    const parsed = toParsedItemTimeStats(row())
+
+    expect(parsed.hourDistribution).toHaveLength(24)
+    expect(parsed.hourDistribution[5]).toBe(5)
+    expect(parsed.dayOfWeekDistribution).toEqual([1, 2, 3, 4, 5, 6, 7])
+    expect(parsed.timeSlotDistribution).toEqual({ morning: 1, afternoon: 2, evening: 3, night: 4 })
+    expect(parsed.sourceId).toBe('app-provider')
+  })
+
+  it('does not throw on malformed JSON in any single column', () => {
+    for (const column of [
+      'hourDistribution',
+      'dayOfWeekDistribution',
+      'timeSlotDistribution'
+    ] as const) {
+      expect(() => toParsedItemTimeStats(row({ [column]: '{"truncated' })), column).not.toThrow()
+    }
+  })
+
+  it('keeps the columns it can still read', () => {
+    // The point of per-column tolerance: one bad column must not discard the other two, or a
+    // partial write would silently erase an item's whole history.
+    const parsed = toParsedItemTimeStats(row({ hourDistribution: 'not json at all' }))
+
+    expect(parsed.hourDistribution).toEqual(Array.from({ length: 24 }, () => 0))
+    expect(parsed.dayOfWeekDistribution).toEqual([1, 2, 3, 4, 5, 6, 7])
+    expect(parsed.timeSlotDistribution.night).toBe(4)
+  })
+
+  it('normalises shapes that parse but are not the expected type', () => {
+    // Valid JSON of the wrong shape is the case a try/catch alone would miss.
+    const parsed = toParsedItemTimeStats(
+      row({
+        hourDistribution: JSON.stringify('a string'),
+        dayOfWeekDistribution: JSON.stringify({ not: 'an array' }),
+        timeSlotDistribution: JSON.stringify({ morning: 'lots', night: -3 })
+      })
+    )
+
+    expect(parsed.hourDistribution).toHaveLength(24)
+    expect(parsed.dayOfWeekDistribution).toHaveLength(7)
+    expect(parsed.timeSlotDistribution.morning).toBe(0)
+    expect(parsed.timeSlotDistribution.night).toBe(0)
+  })
+
+  it('tolerates null columns', () => {
+    const parsed = toParsedItemTimeStats(
+      row({ hourDistribution: null, dayOfWeekDistribution: null, timeSlotDistribution: null })
+    )
+
+    expect(parsed.hourDistribution).toHaveLength(24)
+    expect(parsed.timeSlotDistribution).toEqual({
+      morning: 0,
+      afternoon: 0,
+      evening: 0,
+      night: 0
+    })
+  })
+})

--- a/apps/core-app/src/main/modules/box-tool/search-engine/time-stats-aggregator.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/time-stats-aggregator.ts
@@ -2,6 +2,7 @@ import type { DbUtils } from '../../../db/utils'
 import { desc, eq } from 'drizzle-orm'
 import * as schema from '../../../db/schema'
 import { scheduleDbWrite } from '../../../db/db-write'
+import { parseStoredTimeBuckets } from './item-time-stats-buckets'
 import { createLogger } from '../../../utils/logger'
 import { enterPerfContext } from '../../../utils/perf-context'
 import { resolveTimeSlot } from './item-time-stats-buckets'
@@ -188,14 +189,33 @@ export class TimeStatsAggregator {
    * 解析存储的JSON字符串为对象
    */
   private parseTimeStats(raw: typeof schema.itemTimeStats.$inferSelect): ParsedItemTimeStats {
-    return {
-      sourceId: raw.sourceId,
-      itemId: raw.itemId,
-      hourDistribution: JSON.parse(raw.hourDistribution),
-      dayOfWeekDistribution: JSON.parse(raw.dayOfWeekDistribution),
-      timeSlotDistribution: JSON.parse(raw.timeSlotDistribution),
-      lastUpdated: raw.lastUpdated
-    }
+    return toParsedItemTimeStats(raw)
+  }
+}
+
+/**
+ * Builds a ParsedItemTimeStats from a stored row, tolerating malformed columns.
+ *
+ * These three columns are plain TEXT holding JSON. A raw JSON.parse on them threw out of the
+ * public getItemTimeStats / getItemTimeStatsBatch API, so a single corrupt row — a partial write,
+ * a truncated migration — took down every caller rather than costing that one item its history
+ * (#655).
+ *
+ * parseStoredTimeBuckets already handles this per column, zeroing only what it cannot read.
+ * Exported so the recommendation engine can share it instead of repeating the mapping (#649).
+ */
+export function toParsedItemTimeStats(
+  raw: typeof schema.itemTimeStats.$inferSelect
+): ParsedItemTimeStats {
+  const buckets = parseStoredTimeBuckets(raw)
+
+  return {
+    sourceId: raw.sourceId,
+    itemId: raw.itemId,
+    hourDistribution: buckets.hour,
+    dayOfWeekDistribution: buckets.dayOfWeek,
+    timeSlotDistribution: buckets.timeSlot,
+    lastUpdated: raw.lastUpdated
   }
 }
 


### PR DESCRIPTION
Closes #655.

`parseTimeStats` now delegates to `parseStoredTimeBuckets` — the tolerant parser already sitting in the sibling file, which zeroes only the column it cannot read.

## Extracted rather than fixed in place

It is now an exported `toParsedItemTimeStats`, because **#649 is the same defect at a second call site** (`getTimeBasedTopItems` in the recommendation engine). Repeating the mapping there is exactly how the two would drift apart, so #649 will consume this rather than reimplement it.

## Five tests, none of which existed

The first parses a **well-formed** row, deliberately placed before the tolerance cases: without it, every assertion below would also be satisfied by a parser that always returned zeros.

Two go past what a `try/catch` would buy:

- **a bad column must not discard the other two** — a partial write should cost one distribution, not an item's whole history
- **JSON that parses but has the wrong shape** — `'a string'`, `{ not: 'an array' }`, a negative count. A `try/catch` passes all of these straight through; `parseStoredTimeBuckets` normalises them.

## Mutation-checked

Restoring the unguarded `JSON.parse`:

```
✓ parses a well-formed row
× does not throw on malformed JSON in any single column
× keeps the columns it can still read
× normalises shapes that parse but are not the expected type
× tolerates null columns
```

`typecheck:node` at the baseline 6; search-engine suites 534 tests pass. (Four files in that directory cannot load in this worktree — broken local electron install — and fail identically on HEAD.)
