### PR TITLE
test(nexus): pin that telemetry ingestion ignores a body userId

### DIFF
--- a/apps/nexus/test/api/telemetryBodyUserId.test.ts
+++ b/apps/nexus/test/api/telemetryBodyUserId.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Both telemetry ingestion routes are unauthenticated, so a `userId` in the body
+ * is a claim anyone can make about anyone. #901 removed those reads and replaced
+ * them with `resolveTelemetryUserId(event)`, which derives identity from the
+ * bearer token or session cookie.
+ *
+ * Nothing pinned that. Reintroducing `body.userId` into record.post.ts passes the
+ * entire suite — 266/266 — because the existing telemetryIdentity tests cover the
+ * resolver in isolation and never assert what the endpoints feed it (#700).
+ *
+ * This is a source-level guard, and its limits are worth stating: it proves the
+ * body value is not read, not that the resolver is correct. The resolver has its
+ * own tests. What it catches is the specific regression of someone re-adding
+ * `userId` to the destructured body — which is how the hole existed originally.
+ */
+
+const SERVER_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../server')
+
+const ROUTES = ['api/telemetry/record.post.ts', 'api/telemetry/batch.post.ts'] as const
+
+function source(route: string): string {
+  return readFileSync(resolve(SERVER_ROOT, route), 'utf8')
+}
+
+describe('telemetry ingestion identity', () => {
+  it.each(ROUTES)('%s resolves the user from credentials, not from the body', (route) => {
+    expect(source(route)).toContain('resolveTelemetryUserId(event)')
+  })
+
+  it.each(ROUTES)('%s never destructures userId out of the request body', (route) => {
+    const text = source(route)
+
+    // The original defect: `const { eventType, userId, ... } = body`. Also catches
+    // the property-access form, which is how I reintroduced it while checking that
+    // this gap was real.
+    expect(text).not.toMatch(/^\s*userId,\s*$/m)
+    expect(text).not.toMatch(/\bbody\s*\.\s*userId\b/)
+    expect(text).not.toMatch(/\bbody\s*(?:as[^)]*)?\)?\s*\.\s*userId\b/)
+  })
+
+  it('batch resolves once per request rather than once per event', () => {
+    // Credentials belong to the connection, so a single batch must not attribute
+    // different events to different people.
+    const text = source('api/telemetry/batch.post.ts')
+    const resolveCalls = text.match(/resolveTelemetryUserId\(/g) ?? []
+
+    expect(resolveCalls).toHaveLength(1)
+    // The call has to sit above the per-event map, not inside it.
+    expect(text.indexOf('resolveTelemetryUserId(')).toBeLessThan(
+      text.indexOf('eventsToProcess.map'),
+    )
+  })
+
+  it('finds the routes it claims to be checking', () => {
+    // Positive control. A moved or renamed route would otherwise make every
+    // assertion above vacuous rather than failing.
+    for (const route of ROUTES) {
+      expect(source(route).length).toBeGreaterThan(200)
+    }
+  })
+})


### PR DESCRIPTION
Closes #700.

**The reported defect was already fixed under #901** (CLOSED/COMPLETED). Both `/api/telemetry/record` and `/api/telemetry/batch` derive identity through `resolveTelemetryUserId(event)` instead of reading `userId` from the body, and batch resolves **once per request** rather than once per event, so a single batch cannot attribute events to different people.

### But nothing pinned it
Reintroducing `body.userId` into `record.post.ts` passes the **entire suite — 266/266**. The existing `telemetryIdentity.test.ts` covers the resolver in isolation and never asserts what the endpoints feed it. The fix was one careless edit away from being silently undone.

That gap is what this PR closes. No production code changed.

### What the guard does and does not prove
Source-level, and the test says so: it proves the body value is not read, **not** that the resolver is correct — the resolver has its own tests.

Verified against **both shapes** of the regression:
- the destructured `userId,` in the body pattern, which is how the hole existed originally
- the `body.userId` property access I used to confirm the gap was real

Each turns the guard red on its own. A positive control asserts the routes are still where the test looks, so a rename fails loudly instead of making every assertion vacuous.

272/272 nexus suite, `eslint --max-warnings=0` clean.
