### PR TITLE
fix(core-app): tolerate corrupt time-stats rows in the recommendation loop (#649)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.test.ts
@@ -1451,6 +1451,43 @@ describe('RecommendationEngine', () => {
     expect(candidates).toEqual([])
   })
 
+  it('survives a corrupt item_time_stats row instead of aborting the whole recommendation', async () => {
+    // #649: this loop is inside the unguarded getCandidates chain, so a raw JSON.parse on one bad
+    // row took down recommend() entirely rather than costing that item its time history.
+    const good = {
+      sourceId: 'app-provider',
+      itemId: 'com.apple.Terminal',
+      hourDistribution: JSON.stringify(Array.from({ length: 24 }, () => 5)),
+      dayOfWeekDistribution: JSON.stringify(Array.from({ length: 7 }, () => 5)),
+      timeSlotDistribution: JSON.stringify({ morning: 9, afternoon: 0, evening: 0, night: 0 }),
+      lastUpdated: new Date()
+    }
+    const corrupt = { ...good, itemId: 'com.apple.Safari', hourDistribution: '{"truncated' }
+
+    const dbUtils = {
+      ...createDbUtils(),
+      getAllItemTimeStats: vi.fn(async () => [corrupt, good]),
+      getUsageStatsBatch: vi.fn(async () => [
+        createUsageStats('com.apple.Terminal', { executeCount: 3 }),
+        createUsageStats('com.apple.Safari', { executeCount: 3 })
+      ])
+    }
+    const engine = new RecommendationEngine(dbUtils as never)
+
+    const items = await (
+      engine as unknown as {
+        getTimeBasedTopItems: (
+          pattern: unknown,
+          limit: number
+        ) => Promise<Array<{ itemId: string }>>
+      }
+    ).getTimeBasedTopItems(morningContext.time, 10)
+
+    // Positive control: the healthy row still scores, so this is not passing because the method
+    // returned nothing at all.
+    expect(items.map((item) => item.itemId)).toContain('com.apple.Terminal')
+  })
+
   it('recommends catalog apps on a cold start with no usage history', async () => {
     const dbUtils = createDbUtils()
     const catalogApps = [

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.ts
@@ -14,6 +14,7 @@ import { getStartupDegradeWindowRemainingMs } from '../../../../db/runtime-flags
 import * as schema from '../../../../db/schema'
 import { getSentryService } from '../../../sentry'
 import { ContextProvider, hashContextContent } from './context-provider'
+import { toParsedItemTimeStats } from '../time-stats-aggregator'
 import { ItemRebuilder } from './item-rebuilder'
 import { isSameAppIdentity, matchesAppRule, type AppMatchRule } from './app-identity-match'
 import { recommendationExposureService } from './recommendation-exposure-service'
@@ -1686,14 +1687,10 @@ export class RecommendationEngine {
 
     for (let idx = 0; idx < allTimeStats.length; idx++) {
       const raw = allTimeStats[idx]
-      const parsed: ParsedItemTimeStats = {
-        sourceId: raw.sourceId,
-        itemId: raw.itemId,
-        hourDistribution: JSON.parse(raw.hourDistribution),
-        dayOfWeekDistribution: JSON.parse(raw.dayOfWeekDistribution),
-        timeSlotDistribution: JSON.parse(raw.timeSlotDistribution),
-        lastUpdated: raw.lastUpdated
-      }
+      // Shared with TimeStatsAggregator rather than parsed inline: these are plain TEXT columns,
+      // and a raw JSON.parse here aborted recommend() entirely for one malformed row — this loop
+      // sits inside the unguarded getCandidates chain (#649).
+      const parsed: ParsedItemTimeStats = toParsedItemTimeStats(raw)
 
       const timeScore = this.calculateTimeRelevance(parsed, timePattern)
       if (timeScore > 0) {


### PR DESCRIPTION
Closes #649.

`getTimeBasedTopItems` now calls `toParsedItemTimeStats` — the shared tolerant parser extracted in #1372 for the identical defect in `TimeStatsAggregator` (#655).

## Shared, not repeated

Two inline copies of this mapping is how a tolerant parser (`parseStoredTimeBuckets`) and a raw one came to coexist in the same directory in the first place. Both call sites now go through one function.

## The test drives the real method

Existing tests only ever **stubbed** `getTimeBasedTopItems`, so nothing had exercised this path — which is why an unguarded parse could sit inside the un-caught `getCandidates` chain.

The new one feeds it **one corrupt row ahead of one healthy row**. The ordering matters: a corrupt row first is what threw. And the assertion is on the *survivor* — `com.apple.Terminal` must still score — which doubles as the positive control, since a method that returned nothing at all would otherwise satisfy "did not throw".

## Mutation-checked

Restoring the inline `JSON.parse`:

```
× survives a corrupt item_time_stats row instead of aborting the whole recommendation
  → Unterminated string in JSON at position 11
```

`typecheck:node` at the baseline 6; recommendation suites 73 tests; ESLint clean.
