### PR TITLE
fix(core-app): cancel the background-refresh jitter timer on stop (#652)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.test.ts
@@ -6,14 +6,18 @@ const intelligenceSdkMock = vi.hoisted(() => ({
   ragRerank: vi.fn()
 }))
 
+// A stable instance: the engine resolves the singleton once, so a factory returning a fresh object
+// per call would leave every assertion on one the code under test never held.
+const pollingMock = vi.hoisted(() => ({
+  isRegistered: vi.fn(() => false),
+  unregister: vi.fn(),
+  register: vi.fn(),
+  start: vi.fn()
+}))
+
 vi.mock('@talex-touch/utils/common/utils/polling', () => ({
   PollingService: {
-    getInstance: () => ({
-      isRegistered: vi.fn(() => false),
-      unregister: vi.fn(),
-      register: vi.fn(),
-      start: vi.fn()
-    })
+    getInstance: () => pollingMock
   }
 }))
 
@@ -1486,6 +1490,59 @@ describe('RecommendationEngine', () => {
     // Positive control: the healthy row still scores, so this is not passing because the method
     // returned nothing at all.
     expect(items.map((item) => item.itemId)).toContain('com.apple.Terminal')
+  })
+
+  it('does not run a refresh after stopBackgroundRefresh cancels the jitter window', async () => {
+    // #652: the polling callback only *schedules* the refresh, through an untracked setTimeout.
+    // stopBackgroundRefresh unregistered the polling task and left that pending, so a full
+    // recommendation pass still ran after shutdown — against a database the owner had torn down.
+    vi.useFakeTimers()
+    try {
+      pollingMock.register.mockClear()
+
+      const engine = new RecommendationEngine(createDbUtils() as never)
+      const runBackgroundRefresh = vi.fn(async () => {})
+      Object.assign(engine as unknown as Record<string, unknown>, { runBackgroundRefresh })
+      ;(engine as unknown as { startBackgroundRefresh: () => void }).startBackgroundRefresh()
+
+      const scheduled = pollingMock.register.mock.calls.find(
+        (call) => typeof call[1] === 'function'
+      )?.[1] as (() => void) | undefined
+
+      // Positive control: the polling task registered a callback at all.
+      expect(scheduled).toBeTypeOf('function')
+
+      scheduled?.()
+      engine.stopBackgroundRefresh()
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      expect(runBackgroundRefresh).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('still refreshes when the jitter window elapses without a stop', async () => {
+    // The other half: a fix that simply never scheduled would pass the test above.
+    vi.useFakeTimers()
+    try {
+      pollingMock.register.mockClear()
+
+      const engine = new RecommendationEngine(createDbUtils() as never)
+      const runBackgroundRefresh = vi.fn(async () => {})
+      Object.assign(engine as unknown as Record<string, unknown>, { runBackgroundRefresh })
+      ;(engine as unknown as { startBackgroundRefresh: () => void }).startBackgroundRefresh()
+      const scheduled = pollingMock.register.mock.calls.find(
+        (call) => typeof call[1] === 'function'
+      )?.[1] as (() => void) | undefined
+
+      scheduled?.()
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      expect(runBackgroundRefresh).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('recommends catalog apps on a cold start with no usage history', async () => {

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.ts
@@ -286,6 +286,14 @@ export class RecommendationEngine {
   private trendBackfillQueue: number[] | null = null
   private trendBackfillCompleted = false
   private usageIdentityMigrationTimer: ReturnType<typeof setTimeout> | null = null
+  /**
+   * The jittered handle for the next background refresh.
+   *
+   * Tracked because the polling callback only *schedules* the refresh: stopBackgroundRefresh
+   * unregistered the polling task but left this pending, so a full recommendation pass could still
+   * run after shutdown, against a database the owner had already torn down (#652).
+   */
+  private refreshJitterTimer: NodeJS.Timeout | null = null
   private usageIdentityMigrationScheduled = false
 
   /** Plugin-registered recommendation providers */
@@ -579,7 +587,8 @@ export class RecommendationEngine {
         }
         this.refreshInFlight = true
         const jitterMs = Math.floor(Math.random() * this.REFRESH_JITTER_MS)
-        setTimeout(() => {
+        this.refreshJitterTimer = setTimeout(() => {
+          this.refreshJitterTimer = null
           void this.runBackgroundRefresh()
         }, jitterMs)
       },
@@ -967,6 +976,13 @@ export class RecommendationEngine {
     this.pollingService.unregister(this.refreshTaskId)
     this.pollingService.unregister(this.trendBackfillTaskId)
     this.pollingService.unregister(this.telemetryTaskId)
+    if (this.refreshJitterTimer) {
+      clearTimeout(this.refreshJitterTimer)
+      this.refreshJitterTimer = null
+    }
+    // Cleared so a stop during the jitter window does not leave the guard latched: the next
+    // startBackgroundRefresh would then schedule nothing at all.
+    this.refreshInFlight = false
     if (this.usageIdentityMigrationTimer) {
       clearTimeout(this.usageIdentityMigrationTimer)
       this.usageIdentityMigrationTimer = null


### PR DESCRIPTION
Closes #652.

The jitter handle is tracked and cleared in `stopBackgroundRefresh`.

## A second part the issue does not mention

`refreshInFlight` is reset with it. The guard is set *before* the jitter window opens, so stopping inside that window used to leave it latched — and the next `startBackgroundRefresh` would then schedule nothing at all. Clearing the timer without clearing the flag trades a leak for a silent stall.

## Two tests, in both directions

A fix that simply never scheduled anything would satisfy the "does not run after stop" case on its own, so the second asserts a refresh **does** still happen when the window elapses without a stop.

The stop case also carries a positive control that a polling callback was registered at all — otherwise it would pass on an engine that never scheduled.

## The polling mock had to be stabilised first

It returned a **fresh object per `getInstance` call** while the engine resolves the singleton once, so nothing could observe what the engine actually registered. Same shape as the mocks corrected in #1348 (polling) and #1363 (transport) — worth noting that this pattern keeps recurring in this codebase's test fixtures.

## Mutation-checked

Removing the `clearTimeout` from `stopBackgroundRefresh`:

```
× does not run a refresh after stopBackgroundRefresh cancels the jitter window
✓ still refreshes when the jitter window elapses without a stop
```

## One thing I got wrong on the way

`typecheck:node` went to 8 against a baseline of 6 — `startBackgroundRefresh` is private, and the test called it directly. Cast at the call site; back to 6. The suite was green either way, which is why the error-count diff is the check that catches this.

Recommendation suites 75 tests; ESLint clean.
