### PR TITLE
fix(core-app): do not resurrect usage rows a clear() erased (#657)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/usage-stats-queue.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/usage-stats-queue.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest'
+
+/**
+ * A failing flush must not resurrect data an explicit clear() erased (#657).
+ *
+ * The snapshot is taken out of the queue before the write, so a failure restores it. If a privacy
+ * or retention reset called clear() inside that window, the restore put back exactly the rows the
+ * user asked to erase — and the `finally` block then scheduled a flush that persisted them.
+ */
+
+const mocks = vi.hoisted(() => ({
+  scheduleDbWrite: vi.fn(async () => undefined),
+  queuedWrites: 0
+}))
+
+vi.mock('../../../db/db-write', () => ({
+  scheduleDbWrite: mocks.scheduleDbWrite
+}))
+
+vi.mock('../../../db/db-write-scheduler', () => ({
+  dbWriteScheduler: { getStats: () => ({ queued: mocks.queuedWrites }) }
+}))
+
+vi.mock('../../../utils/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() })
+}))
+
+import { createEmptyTimeBuckets } from './item-time-stats-buckets'
+import { UsageStatsQueue } from './usage-stats-queue'
+
+type Testable = {
+  actionQueue: Map<string, unknown>
+  searchQueue: Map<string, unknown>
+  pendingActionEvents: number
+  flushActionQueue: () => Promise<void>
+  flushSearchQueue: () => Promise<void>
+  clear: () => void
+}
+
+function createQueue(): Testable {
+  return new UsageStatsQueue({} as never, {
+    searchFlushIntervalMs: 60_000,
+    actionFlushIntervalMs: 60_000
+  }) as unknown as Testable
+}
+
+/** Seeds one aggregate directly, so the test does not depend on the record-event API's shape. */
+function seedAction(queue: Testable, itemId: string): void {
+  queue.actionQueue.set(`app-provider:${itemId}`, {
+    sourceId: 'app-provider',
+    itemId,
+    sourceType: 'app',
+    searchCount: 0,
+    executeCount: 1,
+    cancelCount: 0,
+    clickCount: 0,
+    lastUsed: new Date(),
+    keywords: [],
+    timeBuckets: createEmptyTimeBuckets()
+  })
+  queue.pendingActionEvents = 1
+}
+
+describe('UsageStatsQueue clear during an in-flight flush', () => {
+  it('discards the snapshot when clear() ran while the write was in the air', async () => {
+    const queue = createQueue()
+    seedAction(queue, 'com.apple.Safari')
+
+    let releaseWrite: (() => void) | undefined
+    mocks.scheduleDbWrite.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          releaseWrite = () => reject(new Error('disk full'))
+        }) as never
+    )
+
+    const flushing = queue.flushActionQueue()
+    await Promise.resolve()
+
+    // The user erases their history while the write is still in the air.
+    queue.clear()
+    releaseWrite?.()
+    await flushing
+
+    expect(queue.actionQueue.size).toBe(0)
+    expect(queue.pendingActionEvents).toBe(0)
+  })
+
+  it('still restores the snapshot when no clear intervened', async () => {
+    // The other half. A fix that simply never merged back would satisfy the case above, and would
+    // silently lose usage data on every transient write failure.
+    const queue = createQueue()
+    seedAction(queue, 'com.apple.Terminal')
+
+    mocks.scheduleDbWrite.mockImplementationOnce(async () => {
+      throw new Error('disk full')
+    })
+
+    await queue.flushActionQueue()
+
+    expect(queue.actionQueue.size).toBe(1)
+    expect(queue.pendingActionEvents).toBe(1)
+  })
+
+  it('applies the same rule to the search queue', async () => {
+    const queue = createQueue()
+    queue.searchQueue.set('app-provider:com.apple.Safari', {
+      sourceId: 'app-provider',
+      itemId: 'com.apple.Safari',
+      sourceType: 'app',
+      searchCount: 1,
+      executeCount: 0,
+      cancelCount: 0,
+      clickCount: 0,
+      lastUsed: new Date(),
+      keywords: ['saf'],
+      timeBuckets: createEmptyTimeBuckets()
+    })
+
+    let releaseWrite: (() => void) | undefined
+    mocks.scheduleDbWrite.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          releaseWrite = () => reject(new Error('disk full'))
+        }) as never
+    )
+
+    const flushing = queue.flushSearchQueue()
+    await Promise.resolve()
+    queue.clear()
+    releaseWrite?.()
+    await flushing
+
+    expect(queue.searchQueue.size).toBe(0)
+  })
+})

--- a/apps/core-app/src/main/modules/box-tool/search-engine/usage-stats-queue.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/usage-stats-queue.ts
@@ -88,6 +88,19 @@ export class UsageStatsQueue {
   private pendingActionEvents = 0
   private searchFlushing = false
   private actionFlushing = false
+
+  /**
+   * Bumped by clear(). A flush captures it before awaiting and refuses to merge its snapshot back
+   * if it has changed since.
+   *
+   * The snapshot is taken out of the queue before the write, so a failing flush restores it. If a
+   * privacy or retention reset called clear() in that window, the restore put back exactly the
+   * rows the user asked to erase — and then scheduled a flush that persisted them (#657).
+   *
+   * A generation rather than clearing searchFlushing/actionFlushing: those guard against a second
+   * concurrent flush, and resetting them would let one start while the first is still in the air.
+   */
+  private clearGeneration = 0
   private readonly db: LibSQLDatabase<typeof schema>
   private readonly options: Required<UsageStatsQueueOptions>
 
@@ -423,6 +436,7 @@ export class UsageStatsQueue {
     }
 
     this.searchFlushing = true
+    const generation = this.clearGeneration
     const records = Array.from(this.searchQueue.values()).map((record) =>
       this.cloneAggregate(record)
     )
@@ -448,6 +462,10 @@ export class UsageStatsQueue {
             queuedWrites: dbWriteScheduler.getStats().queued
           }
         })
+      } else if (generation !== this.clearGeneration) {
+        usageStatsQueueLog.debug('Search flush failed after a clear; snapshot discarded', {
+          meta: { eventCount, uniqueItems: records.length }
+        })
       } else {
         this.mergeBack(records, true)
         this.pendingSearchEvents += this.sumEventCount(records)
@@ -470,6 +488,7 @@ export class UsageStatsQueue {
     }
 
     this.actionFlushing = true
+    const generation = this.clearGeneration
     const records = Array.from(this.actionQueue.values()).map((record) =>
       this.cloneAggregate(record)
     )
@@ -485,6 +504,12 @@ export class UsageStatsQueue {
         meta: { eventCount, uniqueItems: records.length }
       })
     } catch (error) {
+      if (generation !== this.clearGeneration) {
+        usageStatsQueueLog.debug('Action flush failed after a clear; snapshot discarded', {
+          meta: { eventCount, uniqueItems: records.length }
+        })
+        return
+      }
       this.mergeBack(records, false)
       this.pendingActionEvents += this.sumEventCount(records)
       usageStatsQueueLog.error('Failed to flush action queue', {
@@ -529,5 +554,6 @@ export class UsageStatsQueue {
     this.actionQueue.clear()
     this.pendingSearchEvents = 0
     this.pendingActionEvents = 0
+    this.clearGeneration += 1
   }
 }


### PR DESCRIPTION
Closes #657.

A `clearGeneration` counter, as the issue suggests. Each flush captures it before awaiting and refuses to merge its snapshot back if it has changed.

## Why a generation and not the flags

Resetting `searchFlushing` / `actionFlushing` in `clear()` would be the smaller change, but those guard against a **second concurrent flush** — clearing them lets one start while the first is still in the air. The generation leaves that guard intact and only affects the merge-back decision.

## Three tests, none of which existed for this file

Two cover clear-during-flight, on **both** queues — the action path was the one in the issue's scenario, but the search path has the same shape with a different merge-back call.

The third asserts the snapshot **is** still restored when no clear intervened. Without it a fix that simply never merged back would pass, and would silently lose usage data on every transient write failure.

## Mutation-checked

Removing the generation check:

```
× discards the snapshot when clear() ran while the write was in the air
✓ still restores the snapshot when no clear intervened
× applies the same rule to the search queue
```

## Two fixture details, found by failing rather than by reading

Worth recording since they would trip up the next person writing a test here:

- the aggregate needs a real `TimeBuckets` — `cloneAggregate` reads `.hour`
- and a `cancelCount` — `sumEventCount` adds it, so omitting it produced `NaN` rather than a wrong number, which is at least loud

`typecheck:node` at the baseline 6; search-engine suites 545 tests pass. (Four files there cannot load in this worktree — broken local electron install — and fail identically on HEAD.)
