### PR TITLE
perf(core-app): remember usage-stats misses instead of re-querying them (#658)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/usage-stats-cache.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/usage-stats-cache.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../utils/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() })
+}))
+
+import { getUsageStatsBatchCached, UsageStatsCache } from './usage-stats-cache'
+
+/**
+ * Keys with no usage row must stop costing a database round trip (#658).
+ *
+ * injectUsageStats runs on every debounced keystroke. A search returning items the user has never
+ * executed produced the same batch of misses each time — a query with two bound parameters per
+ * item that returns nothing, on the interactive path.
+ */
+
+function row(itemId: string) {
+  return {
+    sourceId: 'app-provider',
+    itemId,
+    sourceType: 'app',
+    searchCount: 1,
+    executeCount: 1,
+    clickCount: 0,
+    cancelCount: 0,
+    lastUsed: new Date(),
+    keywords: null,
+    updatedAt: new Date()
+  } as never
+}
+
+function createDbUtils(known: string[]) {
+  const getUsageStatsBatch = vi.fn(async (keys: Array<{ sourceId: string; itemId: string }>) =>
+    keys.filter((key) => known.includes(key.itemId)).map((key) => row(key.itemId))
+  )
+  return { dbUtils: { getUsageStatsBatch } as never, getUsageStatsBatch }
+}
+
+const keysFor = (...itemIds: string[]) =>
+  itemIds.map((itemId) => ({ sourceId: 'app-provider', itemId }))
+
+describe('getUsageStatsBatchCached negative caching', () => {
+  it('does not re-query keys the database had no row for', async () => {
+    const cache = new UsageStatsCache()
+    const { dbUtils, getUsageStatsBatch } = createDbUtils([])
+
+    await getUsageStatsBatchCached(dbUtils, cache, keysFor('a', 'b', 'c'))
+    expect(getUsageStatsBatch).toHaveBeenCalledOnce()
+
+    await getUsageStatsBatchCached(dbUtils, cache, keysFor('a', 'b', 'c'))
+
+    // The regression: this was a second identical query returning zero rows.
+    expect(getUsageStatsBatch).toHaveBeenCalledOnce()
+  })
+
+  it('still returns the rows that do exist', async () => {
+    // Positive control: every assertion about skipped queries would also hold for a cache that
+    // returned nothing at all.
+    const cache = new UsageStatsCache()
+    const { dbUtils } = createDbUtils(['b'])
+
+    const first = await getUsageStatsBatchCached(dbUtils, cache, keysFor('a', 'b'))
+    const second = await getUsageStatsBatchCached(dbUtils, cache, keysFor('a', 'b'))
+
+    expect(first.map((stat) => stat.itemId)).toEqual(['b'])
+    expect(second.map((stat) => stat.itemId)).toEqual(['b'])
+  })
+
+  it('only asks for the keys it has not resolved either way', async () => {
+    const cache = new UsageStatsCache()
+    const { dbUtils, getUsageStatsBatch } = createDbUtils(['b'])
+
+    await getUsageStatsBatchCached(dbUtils, cache, keysFor('a', 'b'))
+    await getUsageStatsBatchCached(dbUtils, cache, keysFor('a', 'b', 'c'))
+
+    // Second call: 'a' is a known absence, 'b' is a cached row, so only 'c' is unknown.
+    expect(getUsageStatsBatch.mock.calls[1]?.[0]).toEqual(keysFor('c'))
+  })
+
+  it('re-queries once the negative entry expires', async () => {
+    // Absences are held briefly on purpose: an item the user runs stops being absent, and although
+    // executeItem invalidates the key directly, the short TTL bounds the damage if it does not.
+    const cache = new UsageStatsCache(10_000, 15 * 60 * 1000, 20)
+    const { dbUtils, getUsageStatsBatch } = createDbUtils([])
+
+    await getUsageStatsBatchCached(dbUtils, cache, keysFor('a'))
+    await new Promise((resolve) => setTimeout(resolve, 40))
+    await getUsageStatsBatchCached(dbUtils, cache, keysFor('a'))
+
+    expect(getUsageStatsBatch).toHaveBeenCalledTimes(2)
+  })
+
+  it('drops the absence when the key is invalidated', async () => {
+    // executeItem calls invalidate() when an item is used, which is what makes a newly created row
+    // visible before the negative TTL elapses.
+    const cache = new UsageStatsCache()
+    const { dbUtils, getUsageStatsBatch } = createDbUtils([])
+
+    await getUsageStatsBatchCached(dbUtils, cache, keysFor('a'))
+    cache.invalidate('app-provider', 'a')
+    await getUsageStatsBatchCached(dbUtils, cache, keysFor('a'))
+
+    expect(getUsageStatsBatch).toHaveBeenCalledTimes(2)
+  })
+
+  it('never reports a tombstone as a usage row', async () => {
+    const cache = new UsageStatsCache()
+    const { dbUtils } = createDbUtils([])
+
+    await getUsageStatsBatchCached(dbUtils, cache, keysFor('a'))
+
+    expect(cache.get('app-provider', 'a')).toBeNull()
+    expect(cache.getBatch(keysFor('a')).size).toBe(0)
+  })
+})

--- a/apps/core-app/src/main/modules/box-tool/search-engine/usage-stats-cache.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/usage-stats-cache.ts
@@ -8,7 +8,8 @@ const usageStatsCacheLog = createLogger('UsageStatsCache')
  * Usage stats cache entry
  */
 interface CacheEntry {
-  data: typeof schema.itemUsageStats.$inferSelect
+  /** null marks a key the database is known not to have — see markAbsent. */
+  data: typeof schema.itemUsageStats.$inferSelect | null
   timestamp: number
 }
 
@@ -20,10 +21,14 @@ export class UsageStatsCache {
   private readonly maxSize: number
   private readonly ttl: number // Time to live in milliseconds
 
-  constructor(maxSize = 10000, ttl = 15 * 60 * 1000) {
+  /** Negative entries expire sooner than real rows; see markAbsent. */
+  private readonly absenceTtl: number
+
+  constructor(maxSize = 10000, ttl = 15 * 60 * 1000, absenceTtl = 30 * 1000) {
     // 15 minutes default TTL
     this.maxSize = maxSize
     this.ttl = ttl
+    this.absenceTtl = absenceTtl
   }
 
   /**
@@ -46,7 +51,7 @@ export class UsageStatsCache {
 
     // Check if entry is expired
     const now = Date.now()
-    if (now - entry.timestamp > this.ttl) {
+    if (now - entry.timestamp > this.absenceTtlFor(entry)) {
       this.cache.delete(key)
       return null
     }
@@ -72,8 +77,9 @@ export class UsageStatsCache {
       const key = this.getKey(sourceId, itemId)
       const entry = this.cache.get(key)
 
-      if (entry && now - entry.timestamp <= this.ttl) {
-        result.set(key, entry.data)
+      if (entry && now - entry.timestamp <= this.absenceTtlFor(entry)) {
+        // A tombstone is a hit for "do not query again", but not a row to return.
+        if (entry.data) result.set(key, entry.data)
         // Move to end (LRU)
         this.cache.delete(key)
         this.cache.set(key, entry)
@@ -119,6 +125,42 @@ export class UsageStatsCache {
     for (const stat of stats) {
       this.set(stat.sourceId, stat.itemId, stat)
     }
+  }
+
+  /**
+   * Records that the database has no row for these keys.
+   *
+   * Without this, a search returning items the user has never executed re-queried every one of
+   * them on every debounced keystroke — a batch of misses that returns zero rows, on the
+   * interactive path (#658).
+   *
+   * Held for a shorter window than a real row: an absent key becomes present the first time the
+   * user runs the item, and although executeItem invalidates the key directly, the short TTL keeps
+   * the damage bounded if any future writer forgets to.
+   */
+  markAbsent(keys: Array<{ sourceId: string; itemId: string }>): void {
+    const timestamp = Date.now()
+
+    for (const { sourceId, itemId } of keys) {
+      const key = this.getKey(sourceId, itemId)
+      if (this.cache.size >= this.maxSize && !this.cache.has(key)) {
+        const firstKey = this.cache.keys().next().value
+        if (firstKey) this.cache.delete(firstKey)
+      }
+      this.cache.delete(key)
+      this.cache.set(key, { data: null, timestamp })
+    }
+  }
+
+  /** Whether this key is cached as known-absent and still inside the negative TTL. */
+  isKnownAbsent(sourceId: string, itemId: string): boolean {
+    const entry = this.cache.get(this.getKey(sourceId, itemId))
+    if (!entry || entry.data !== null) return false
+    return Date.now() - entry.timestamp <= this.absenceTtl
+  }
+
+  private absenceTtlFor(entry: CacheEntry): number {
+    return entry.data === null ? this.absenceTtl : this.ttl
   }
 
   /**
@@ -174,8 +216,11 @@ export async function getUsageStatsBatchCached(
   const cached = cache.getBatch(keys)
 
   // Find missing keys
+  // Keys the database is already known not to have are not misses — re-querying them is what made
+  // a fresh result set cost a full round trip on every keystroke (#658).
   const missingKeys = keys.filter(
-    ({ sourceId, itemId }) => !cached.has(cache.getKey(sourceId, itemId))
+    ({ sourceId, itemId }) =>
+      !cached.has(cache.getKey(sourceId, itemId)) && !cache.isKnownAbsent(sourceId, itemId)
   )
 
   // If all keys are cached, return immediately
@@ -199,6 +244,12 @@ export async function getUsageStatsBatchCached(
 
   // Cache the results
   cache.setBatch(dbResults)
+
+  // And remember the ones it did not return, so the next keystroke does not ask again.
+  const returned = new Set(dbResults.map((stat) => cache.getKey(stat.sourceId, stat.itemId)))
+  cache.markAbsent(
+    missingKeys.filter(({ sourceId, itemId }) => !returned.has(cache.getKey(sourceId, itemId)))
+  )
 
   // Combine cached and database results
   const resultMap = new Map<string, typeof schema.itemUsageStats.$inferSelect>()


### PR DESCRIPTION
Closes #658.

Absences are recorded as tombstones, so a search full of items the user has never executed stops re-issuing the same zero-row batch on every keystroke.

## Shorter TTL for absences — 30s against 15min

Two reasons, and the second is the one that matters:

- an absent key becomes present the moment the user runs the item
- `executeItem` already calls `statsCache.invalidate(...)` on use, which drops the tombstone directly — but the short TTL **bounds the damage if a future writer forgets to**. A negative cache whose only invalidation is an explicit call from one call site is one refactor away from hiding a user's own usage from them.

## A tombstone is never a row

`get()` returns `null` for it and `getBatch` leaves it out of the result map, so every existing caller sees exactly what it saw before. Only the "should I query this?" decision changed.

## Six tests, and why it is six

Two cover the skipped re-query. The other four exist because those two would **also pass on a cache that returned nothing at all**:

- rows that do exist are still returned, twice
- the second batch asks only for the genuinely unknown key (`'c'`), not for the known-absent one
- the absence expires and the key is re-queried
- `invalidate()` drops it
- a tombstone is never reported as a usage row

## Mutation-checked

Removing the `markAbsent` call:

```
× does not re-query keys the database had no row for
× only asks for the keys it has not resolved either way
✓ the other four
```

`typecheck:node` at the baseline 6; search-engine suites 551 tests pass. (Four files there cannot load in this worktree — broken local electron install — and fail identically on HEAD.)
