### PR TITLE
build(core-app): drop the store-dir override that splits the pnpm store

### DIFF
--- a/apps/core-app/.npmrc
+++ b/apps/core-app/.npmrc
@@ -1,3 +1,2 @@
 shamefully-hoist=true
 public-hoist-pattern[]=*electron*
-store-dir=../../.pnpm-store


### PR DESCRIPTION
Closes #718.

`apps/core-app/.npmrc` set `store-dir=../../.pnpm-store` as if the path resolved against its own directory. pnpm resolves it against the **workspace root**, so it landed two levels above the repository and created a second, divergent store.

### Removed rather than corrected
`apps/nexus/.npmrc` and `plugins/touch-translation/.npmrc` set **no `store-dir` at all**. Inheriting the root's `store-dir=.pnpm-store` is what the repo already does everywhere else — core-app was the only outlier. Writing a "fixed" relative path would just be a second thing to keep in sync.

### Not theoretical
Both stores exist on this machine: `~/Workspace/.pnpm-store` alongside the intended `~/Workspace/Projects/talex-touch/.pnpm-store`.

I have also hit `ERR_PNPM_UNEXPECTED_STORE` in this checkout — that error is what sent me looking for a `--store-dir` workaround in an earlier session, before I knew this issue existed.

### ⚠️ Not verified
I could not run `pnpm store path` before and after, because **pnpm does not start in this shell** — the mise `command_not_found` handler kills it before the binary runs.

The evidence above is the disk state, the sibling `.npmrc` convention, and an error I actually got. Someone with a working install should confirm that `pnpm -C apps/core-app store path` now matches `pnpm store path`.
