### PR TITLE
fix(core-app): identify deliberate db-write drops by type (#656)

### DIFF
--- a/apps/core-app/src/main/db/db-write-scheduler.ts
+++ b/apps/core-app/src/main/db/db-write-scheduler.ts
@@ -14,6 +14,21 @@ const log = createLogger('DbWriteScheduler')
 
 const taskContext = new AsyncLocalStorage<boolean>()
 
+/**
+ * A write the scheduler deliberately shed — queue pressure, a latest-wins supersede, or an open
+ * circuit breaker. Never a database or driver failure.
+ *
+ * A class rather than a message convention because callers have to tell the two apart to decide
+ * whether to retry: matching on `message.includes('dropped')` also caught real errors worded with
+ * it, such as a driver reporting 'connection dropped', and silently discarded the batch (#656).
+ */
+export class DbWriteDroppedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'DbWriteDroppedError'
+  }
+}
+
 export type DbWritePriority = 'critical' | 'interactive' | 'background' | 'best_effort'
 export type DbWriteDropPolicy = 'none' | 'drop' | 'latest_wins'
 export type DbWriteLane = 'primary' | 'aux'
@@ -494,7 +509,7 @@ export class DbWriteScheduler {
         const waitedMs = Date.now() - queued.enqueuedAt
         this.recordTaskSettled(queued.label, waitedMs, 'dropped')
         queued.reject(
-          new Error(
+          new DbWriteDroppedError(
             `DB write task dropped by latest_wins policy: ${queued.label} (${task.budgetKey})`
           )
         )
@@ -568,7 +583,9 @@ export class DbWriteScheduler {
     }
 
     if (this.shouldRejectByCircuit(task)) {
-      return Promise.reject(new Error(`DB write task dropped by circuit breaker: ${label}`))
+      return Promise.reject(
+        new DbWriteDroppedError(`DB write task dropped by circuit breaker: ${label}`)
+      )
     }
 
     return new Promise<T>((resolve, reject) => {
@@ -938,7 +955,9 @@ export class DbWriteScheduler {
         log.warn(`Dropping stale task after ${waitedMs}ms: ${task.label}`)
         this.recordTaskSettled(task.label, waitedMs, 'dropped')
         task.reject(
-          new Error(`DB write task dropped after ${waitedMs}ms queue wait: ${task.label}`)
+          new DbWriteDroppedError(
+            `DB write task dropped after ${waitedMs}ms queue wait: ${task.label}`
+          )
         )
         laneState.currentTaskLabel = null
         laneState.currentTaskPriority = null
@@ -949,7 +968,9 @@ export class DbWriteScheduler {
 
       if (this.shouldRejectByCircuit(task)) {
         this.recordTaskSettled(task.label, waitedMs, 'dropped')
-        task.reject(new Error(`DB write task dropped by circuit breaker: ${task.label}`))
+        task.reject(
+          new DbWriteDroppedError(`DB write task dropped by circuit breaker: ${task.label}`)
+        )
         laneState.currentTaskLabel = null
         laneState.currentTaskPriority = null
         this.notifyCapacityWaiters()

--- a/apps/core-app/src/main/modules/box-tool/search-engine/usage-stats-queue.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/usage-stats-queue.test.ts
@@ -17,7 +17,9 @@ vi.mock('../../../db/db-write', () => ({
   scheduleDbWrite: mocks.scheduleDbWrite
 }))
 
-vi.mock('../../../db/db-write-scheduler', () => ({
+// importOriginal so DbWriteDroppedError stays the real class; the flush classifies by instanceof.
+vi.mock('../../../db/db-write-scheduler', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   dbWriteScheduler: { getStats: () => ({ queued: mocks.queuedWrites }) }
 }))
 
@@ -25,6 +27,7 @@ vi.mock('../../../utils/logger', () => ({
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() })
 }))
 
+import { DbWriteDroppedError } from '../../../db/db-write-scheduler'
 import { createEmptyTimeBuckets } from './item-time-stats-buckets'
 import { UsageStatsQueue } from './usage-stats-queue'
 
@@ -84,6 +87,59 @@ describe('UsageStatsQueue clear during an in-flight flush', () => {
 
     expect(queue.actionQueue.size).toBe(0)
     expect(queue.pendingActionEvents).toBe(0)
+  })
+
+  it('merges back a real error whose message happens to say dropped', async () => {
+    // #656: classification was `message.includes('dropped')`, so a driver error such as
+    // 'connection dropped' was treated as a deliberate shed and up to 2,000 aggregated search
+    // events were discarded at debug level.
+    const queue = createQueue()
+    queue.searchQueue.set('app-provider:com.apple.Safari', {
+      sourceId: 'app-provider',
+      itemId: 'com.apple.Safari',
+      sourceType: 'app',
+      searchCount: 1,
+      executeCount: 0,
+      cancelCount: 0,
+      clickCount: 0,
+      lastUsed: new Date(),
+      keywords: ['saf'],
+      timeBuckets: createEmptyTimeBuckets()
+    })
+
+    mocks.scheduleDbWrite.mockImplementationOnce(async () => {
+      throw new Error('connection dropped by peer')
+    })
+
+    await queue.flushSearchQueue()
+
+    expect(queue.searchQueue.size).toBe(1)
+  })
+
+  it('discards the batch when the scheduler shed it on purpose', async () => {
+    // The other side: a deliberate drop must still not be merged back, or the queue would grow
+    // without bound exactly when the scheduler is trying to relieve pressure.
+    const queue = createQueue()
+    queue.searchQueue.set('app-provider:com.apple.Safari', {
+      sourceId: 'app-provider',
+      itemId: 'com.apple.Safari',
+      sourceType: 'app',
+      searchCount: 1,
+      executeCount: 0,
+      cancelCount: 0,
+      clickCount: 0,
+      lastUsed: new Date(),
+      keywords: ['saf'],
+      timeBuckets: createEmptyTimeBuckets()
+    })
+
+    mocks.scheduleDbWrite.mockImplementationOnce(async () => {
+      throw new DbWriteDroppedError('DB write task dropped after 10000ms queue wait: search')
+    })
+
+    await queue.flushSearchQueue()
+
+    expect(queue.searchQueue.size).toBe(0)
   })
 
   it('still restores the snapshot when no clear intervened', async () => {

--- a/apps/core-app/src/main/modules/box-tool/search-engine/usage-stats-queue.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/usage-stats-queue.ts
@@ -3,7 +3,7 @@ import type * as schema from '../../../db/schema'
 import type { ScheduleOptions } from '../../../db/db-write-scheduler'
 import type { TimeBuckets } from './item-time-stats-buckets'
 import { and, eq, sql } from 'drizzle-orm'
-import { dbWriteScheduler } from '../../../db/db-write-scheduler'
+import { DbWriteDroppedError, dbWriteScheduler } from '../../../db/db-write-scheduler'
 import { scheduleDbWrite } from '../../../db/db-write'
 import { itemTimeStats, itemUsageStats } from '../../../db/schema'
 import { createLogger } from '../../../utils/logger'
@@ -453,7 +453,7 @@ export class UsageStatsQueue {
         meta: { eventCount, uniqueItems: records.length }
       })
     } catch (error) {
-      const isDropped = error instanceof Error && error.message.includes('dropped')
+      const isDropped = error instanceof DbWriteDroppedError
       if (isDropped) {
         usageStatsQueueLog.debug('Search flush dropped under queue pressure', {
           meta: {

--- a/apps/core-app/src/main/modules/clipboard/clipboard-meta-persistence.test.ts
+++ b/apps/core-app/src/main/modules/clipboard/clipboard-meta-persistence.test.ts
@@ -14,7 +14,10 @@ const mocks = vi.hoisted(() => ({
   logWarn: vi.fn()
 }))
 
-vi.mock('../../db/db-write-scheduler', () => ({
+// importOriginal so DbWriteDroppedError stays the real class — the classification is now an
+// instanceof check, and a stub class would make it pass against a different constructor (#656).
+vi.mock('../../db/db-write-scheduler', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   dbWriteScheduler: {
     schedule: mocks.schedule
   }
@@ -30,6 +33,7 @@ vi.mock('drizzle-orm', () => ({
   inArray: (column: unknown, values: unknown[]) => ({ inArray: [column, values] })
 }))
 
+import { DbWriteDroppedError } from '../../db/db-write-scheduler'
 import {
   ClipboardMetaPersistence,
   isDroppedDbWriteTaskError,
@@ -113,10 +117,15 @@ describe('clipboard-meta-persistence', () => {
   })
 
   it('classifies dropped and foreign-key errors for safe persistence', async () => {
-    expect(isDroppedDbWriteTaskError(new Error('DB write task dropped: clipboard.meta'))).toBe(true)
+    // #656: this used to match on message text, so a driver error worded with 'dropped' was
+    // classified as a deliberate shed. It is the type that decides now.
+    expect(isDroppedDbWriteTaskError(new DbWriteDroppedError('dropped: clipboard.meta'))).toBe(true)
+    expect(isDroppedDbWriteTaskError(new Error('DB write task dropped: clipboard.meta'))).toBe(
+      false
+    )
     expect(isForeignKeyConstraintError(new Error('FOREIGN KEY constraint failed'))).toBe(true)
 
-    mocks.values.mockRejectedValueOnce(new Error('DB write task dropped: clipboard.meta'))
+    mocks.values.mockRejectedValueOnce(new DbWriteDroppedError('dropped: clipboard.meta'))
     const persistence = createPersistence(createDb())
 
     persistence.persistMetaEntriesSafely(8, { tag: 'url' })

--- a/apps/core-app/src/main/modules/clipboard/clipboard-meta-persistence.ts
+++ b/apps/core-app/src/main/modules/clipboard/clipboard-meta-persistence.ts
@@ -4,6 +4,7 @@ import type { ScheduleOptions } from '../../db/db-write-scheduler'
 import type { AuxDbResolver, MainDatabase } from '../../db/db-write'
 import type { LogOptions } from '../../utils/logger'
 import { and, eq, inArray } from 'drizzle-orm'
+import { DbWriteDroppedError } from '../../db/db-write-scheduler'
 import { scheduleAuxWrite } from '../../db/db-write'
 import { clipboardHistoryMeta } from '../../db/schema'
 
@@ -32,9 +33,15 @@ export function isForeignKeyConstraintError(error: unknown): boolean {
   return /foreign key constraint failed/i.test(message)
 }
 
+/**
+ * Whether the scheduler shed this write on purpose, as opposed to it failing.
+ *
+ * Identified by type rather than by message text: the string form also matched real errors that
+ * happen to be worded with it — a driver reporting a dropped connection, for one — and a deliberate
+ * drop is retried differently from a failure (#656).
+ */
 export function isDroppedDbWriteTaskError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error)
-  return message.includes('DB write task dropped')
+  return error instanceof DbWriteDroppedError
 }
 
 export class ClipboardMetaPersistence {


### PR DESCRIPTION
Closes #656.

`scheduleDbWrite` now rejects with a `DbWriteDroppedError` at all **four** drop sites — queue-wait expiry, the circuit breaker in both of its places, and the `latest_wins` supersede — and callers test with `instanceof`.

## A second consumer with the same defect

The issue names the search flush. `clipboard-meta-persistence` exported `isDroppedDbWriteTaskError`, doing `message.includes('DB write task dropped')` — the identical misclassification on the clipboard path. Fixing only the flush would have left it.

## The test mocks needed `importOriginal`

Both consumers' test files mock the scheduler module. A stubbed `DbWriteDroppedError` would make `instanceof` compare against a **different constructor** — passing or failing for reasons unrelated to the code. They now spread `importOriginal()` so the class is the real one.

That is the same class of problem as the string match itself: an identity check that silently isn't.

## One assertion encoded the old contract

`classifies dropped and foreign-key errors for safe persistence` asserted that a **plain** `Error` worded `'DB write task dropped'` classifies as dropped. That is precisely what should stop being true, so it now asserts both directions — the typed error is a drop, the plain one is not.

## Mutation-checked

Restoring `message.includes('dropped')`:

```
× merges back a real error whose message happens to say dropped
✓ discards the batch when the scheduler shed it on purpose
✓ the three clear-generation cases
```

Both directions are covered on purpose: a fix that classified *nothing* as a drop would pass the first test and quietly refill the queue during the pressure the scheduler was shedding.

`typecheck:node` at the baseline 6; 557 tests pass across search-engine and clipboard-meta. (Four files there cannot load in this worktree — broken local electron install — and fail identically on HEAD.)
