### PR TITLE
perf(core-app): bound and memoise the macOS focus probe (#654)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/context-provider.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/context-provider.test.ts
@@ -6,6 +6,23 @@ import { ContextProvider } from './context-provider'
 
 const getActiveAppMock = vi.hoisted(() => vi.fn())
 
+// getFocusContext spawns `defaults` on darwin. Mocked so the probe can be observed and driven —
+// the point of #654 is how often it runs and what happens when it hangs.
+const execFileMock = vi.hoisted(() =>
+  vi.fn(
+    (
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null, result: { stdout: string; stderr: string }) => void
+    ) => {
+      callback(null, { stdout: 'userPref = 1;', stderr: '' })
+    }
+  )
+)
+
+vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+
 vi.mock('../../../system/active-app', () => ({
   activeAppService: {
     getActiveApp: getActiveAppMock
@@ -320,5 +337,84 @@ describe('ContextProvider timezone change', () => {
     stored.timezoneChangedAt = Date.now() - 49 * 60 * 60 * 1000
 
     expect(await resolveTimezoneChanged(provider, 'Europe/Berlin')).toBe(false)
+  })
+})
+
+describe('ContextProvider focus context', () => {
+  const originalPlatform = process.platform
+
+  function setDarwin(): void {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+  }
+
+  beforeEach(() => {
+    execFileMock.mockClear()
+    setDarwin()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+  })
+
+  it('bounds the defaults read with a timeout', async () => {
+    // #654: no timeout meant a blocked cfprefsd left getCurrentContext unresolved forever, and
+    // the recommendation grid stayed empty with nothing logged.
+    const provider = new ContextProvider() as unknown as {
+      getFocusContext: () => Promise<{ isDNDEnabled: boolean }>
+    }
+
+    await provider.getFocusContext()
+
+    expect(execFileMock).toHaveBeenCalledOnce()
+    const [file, args, options] = execFileMock.mock.calls[0]!
+    expect(file).toBe('defaults')
+    expect(args).toEqual(['read', 'com.apple.ncprefs', 'dnd_prefs'])
+    expect((options as { timeout?: number }).timeout).toBeGreaterThan(0)
+  })
+
+  it('spawns once for repeated reads inside the cache window', async () => {
+    const provider = new ContextProvider() as unknown as {
+      getFocusContext: () => Promise<{ isDNDEnabled: boolean }>
+    }
+
+    const first = await provider.getFocusContext()
+    const second = await provider.getFocusContext()
+
+    // Positive control on the value, so this cannot pass by returning nothing at all.
+    expect(first.isDNDEnabled).toBe(true)
+    expect(second.isDNDEnabled).toBe(true)
+    expect(execFileMock).toHaveBeenCalledOnce()
+  })
+
+  it('caches the failed reading too', async () => {
+    // A machine where the key is absent or the read times out must not retry on every recommend
+    // either — that is the same per-keystroke spawn, just with a worse outcome.
+    execFileMock.mockImplementationOnce((_file, _args, _options, callback) => {
+      callback(new Error('does not exist'), { stdout: '', stderr: '' })
+    })
+
+    const provider = new ContextProvider() as unknown as {
+      getFocusContext: () => Promise<{ available: boolean }>
+    }
+
+    const first = await provider.getFocusContext()
+    const second = await provider.getFocusContext()
+
+    expect(first.available).toBe(false)
+    expect(second.available).toBe(false)
+    expect(execFileMock).toHaveBeenCalledOnce()
+  })
+
+  it('does not spawn anything off darwin', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+
+    const provider = new ContextProvider() as unknown as {
+      getFocusContext: () => Promise<{ focusMode: string }>
+    }
+
+    const result = await provider.getFocusContext()
+
+    expect(result.focusMode).toBe('unknown')
+    expect(execFileMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/context-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/context-provider.ts
@@ -63,11 +63,26 @@ const NEUTRAL_TIME_CONTEXT: TimePattern = {
  * was built from, without the signal ever carrying that content. Duplicating the algorithm at a
  * call site would work until one side changed.
  */
+/** How long a Do Not Disturb reading stays good for. See getFocusContext. */
+const FOCUS_CONTEXT_TTL_MS = 30 * 1000
+
+/** Upper bound on the `defaults` read, so a blocked cfprefsd degrades instead of hanging. */
+const FOCUS_CONTEXT_TIMEOUT_MS = 500
+
 export function hashContextContent(content: string): string {
   return crypto.createHash('sha256').update(content).digest('hex').slice(0, 16)
 }
 
 export class ContextProvider {
+  private focusContextCache: {
+    at: number
+    value: {
+      available: boolean
+      isDNDEnabled: boolean
+      focusMode: 'active' | 'inactive' | 'unknown'
+    }
+  } | null = null
+
   /**
    * Retrieves complete current context signal.
    */
@@ -491,6 +506,17 @@ export class ContextProvider {
     }
   }
 
+  /**
+   * Reads macOS Do Not Disturb, bounded and memoised.
+   *
+   * This spawns `defaults` inside the awaited Promise.all of getCurrentContext, which runs on every
+   * recommend() — the CoreBox-open path. Two problems, and the second is the one that hurts:
+   * tens of milliseconds per open, and no timeout, so if `defaults` blocks on cfprefsd contention
+   * getCurrentContext never resolves and the grid stays empty with nothing logged (#654).
+   *
+   * The cache window is short because Focus is something a user toggles and then expects to matter
+   * within the same sitting; the timeout is what turns a hang into a degraded answer.
+   */
   private async getFocusContext(): Promise<{
     available: boolean
     isDNDEnabled: boolean
@@ -500,17 +526,37 @@ export class ContextProvider {
       return { available: false, isDNDEnabled: false, focusMode: 'unknown' }
     }
 
+    const now = Date.now()
+    if (this.focusContextCache && now - this.focusContextCache.at < FOCUS_CONTEXT_TTL_MS) {
+      return this.focusContextCache.value
+    }
+
+    let value: {
+      available: boolean
+      isDNDEnabled: boolean
+      focusMode: 'active' | 'inactive' | 'unknown'
+    }
+
     try {
-      const { stdout } = await execFileAsync('defaults', ['read', 'com.apple.ncprefs', 'dnd_prefs'])
+      const { stdout } = await execFileAsync(
+        'defaults',
+        ['read', 'com.apple.ncprefs', 'dnd_prefs'],
+        { timeout: FOCUS_CONTEXT_TIMEOUT_MS }
+      )
       const enabled = /\buserPref\s*=\s*1\b|\benabled\s*=\s*1\b/i.test(stdout)
-      return {
+      value = {
         available: true,
         isDNDEnabled: enabled,
         focusMode: enabled ? 'active' : 'inactive'
       }
     } catch {
-      return { available: false, isDNDEnabled: false, focusMode: 'unknown' }
+      value = { available: false, isDNDEnabled: false, focusMode: 'unknown' }
     }
+
+    // Cached either way: a machine where the read times out or the key is absent should not retry
+    // on every keystroke-driven recommend either.
+    this.focusContextCache = { at: now, value }
+    return value
   }
 
   /**


### PR DESCRIPTION
Closes #654.

Both halves of the suggested direction, though they are not equally important.

## The timeout is the part that matters

Without it, a blocked `defaults` (cfprefsd contention, a very large ncprefs plist) leaves the awaited `Promise.all` in `getCurrentContext` unresolved — `recommend()` never returns, the grid stays empty, and nothing is logged. That is a hang, not a slowdown. Bounded at 500ms.

The 30s cache removes the per-open spawn cost, which is the visible-but-survivable half.

## The failed reading is cached too

A machine where the key is absent, or where the read times out, would otherwise retry on **every** keystroke-driven `recommend()` — the same spawn, with a worse outcome. Caching only successes would have left the pathological case uncured.

## Four tests

The cache case asserts the **returned value** as well as the spawn count, so it cannot pass on a probe that returns nothing at all. The off-darwin case pins that nothing is spawned there.

## Mutation-checked separately

One mutation would not have separated the two halves:

| mutation | fails |
| --- | --- |
| remove the timeout | `bounds the defaults read with a timeout` |
| remove the cache | `spawns once for repeated reads`, `caches the failed reading too` |

`typecheck:node` at the baseline 6; recommendation suites 79 tests; ESLint clean.
