### PR TITLE
build: drop the lint globs for the removed workers/ directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "test:release-acceptance": "vitest run --config vitest.release-acceptance.config.mjs",
     "quality:pr": "corepack pnpm release:notes:verify && corepack pnpm lint:changed && corepack pnpm test:targeted && corepack pnpm -C \"apps/core-app\" run typecheck",
     "quality:release": "pnpm lint && pnpm typecheck:all && pnpm test:targeted && pnpm -C apps/core-app exec electron-builder --version && pnpm -F @talex-touch/core-app run build",
-    "lint": "pnpm -r --no-bail --filter \"./apps/core-app\" --filter \"./apps/nexus\" --filter \"./apps/tuff-analyse\" --filter \"./packages/*\" --filter \"./plugins/*\" exec eslint --cache --max-warnings=0 --no-warn-ignored --no-error-on-unmatched-pattern \"**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}\" && eslint --cache --max-warnings=0 --no-warn-ignored --no-error-on-unmatched-pattern \"scripts/**/*.{js,jsx,ts,tsx,mjs,cjs,cts,mts}\" \"workers/**/*.{js,jsx,ts,tsx,mjs,cjs,cts,mts}\" \"plugins/{touch-window-manager,touch-window-presets,touch-dev-toolbox,touch-batch-rename,touch-browser-bookmarks,touch-browser-open,touch-system-actions,touch-text-snippets,touch-snipaste,touch-quick-actions,touch-code-snippets,touch-dictation}/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}\"",
-    "lint:fix": "pnpm -r --no-bail --filter \"./apps/core-app\" --filter \"./apps/nexus\" --filter \"./apps/tuff-analyse\" --filter \"./packages/*\" --filter \"./plugins/*\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored --no-error-on-unmatched-pattern \"**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}\" && eslint --cache --fix --max-warnings=0 --no-warn-ignored --no-error-on-unmatched-pattern \"scripts/**/*.{js,jsx,ts,tsx,mjs,cjs,cts,mts}\" \"workers/**/*.{js,jsx,ts,tsx,mjs,cjs,cts,mts}\" \"plugins/{touch-window-manager,touch-window-presets,touch-dev-toolbox,touch-batch-rename,touch-browser-bookmarks,touch-browser-open,touch-system-actions,touch-text-snippets,touch-snipaste,touch-quick-actions,touch-code-snippets,touch-dictation}/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}\"",
+    "lint": "pnpm -r --no-bail --filter \"./apps/core-app\" --filter \"./apps/nexus\" --filter \"./apps/tuff-analyse\" --filter \"./packages/*\" --filter \"./plugins/*\" exec eslint --cache --max-warnings=0 --no-warn-ignored --no-error-on-unmatched-pattern \"**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}\" && eslint --cache --max-warnings=0 --no-warn-ignored --no-error-on-unmatched-pattern \"scripts/**/*.{js,jsx,ts,tsx,mjs,cjs,cts,mts}\" \"plugins/{touch-window-manager,touch-window-presets,touch-dev-toolbox,touch-batch-rename,touch-browser-bookmarks,touch-browser-open,touch-system-actions,touch-text-snippets,touch-snipaste,touch-quick-actions,touch-code-snippets,touch-dictation}/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}\"",
+    "lint:fix": "pnpm -r --no-bail --filter \"./apps/core-app\" --filter \"./apps/nexus\" --filter \"./apps/tuff-analyse\" --filter \"./packages/*\" --filter \"./plugins/*\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored --no-error-on-unmatched-pattern \"**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}\" && eslint --cache --fix --max-warnings=0 --no-warn-ignored --no-error-on-unmatched-pattern \"scripts/**/*.{js,jsx,ts,tsx,mjs,cjs,cts,mts}\" \"plugins/{touch-window-manager,touch-window-presets,touch-dev-toolbox,touch-batch-rename,touch-browser-bookmarks,touch-browser-open,touch-system-actions,touch-text-snippets,touch-snipaste,touch-quick-actions,touch-code-snippets,touch-dictation}/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}\"",
     "lint:changed": "node scripts/run-eslint-changed.mjs",
     "lint:staged": "lint-staged",
     "check:build-allowlist": "node scripts/check-build-allowlist.mjs",
@@ -269,9 +269,6 @@
       "pnpm -C \"plugins/touch-translation\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored"
     ],
     "scripts/**/*.{js,jsx,ts,tsx,mjs,cjs,cts,mts}": [
-      "eslint --cache --fix --max-warnings=0 --no-warn-ignored"
-    ],
-    "workers/**/*.{js,jsx,ts,tsx,mjs,cjs,cts,mts}": [
       "eslint --cache --fix --max-warnings=0 --no-warn-ignored"
     ]
   }


### PR DESCRIPTION
Closes #720.

The root `lint` and `lint:fix` scripts and one `lint-staged` entry targeted `workers/**`, but there is no `workers/` directory.

It was **deleted in `a828886ed`** — it held `workers/nexus-maintenance` with a `wrangler.toml` — and the globs outlived it.

### Checked before removing
"The directory is absent" is not sufficient on its own, so I ruled out the two ways that could still be wrong:
- `workers/` is **not gitignored**, so it is not a local-only directory
- nothing in the workflows or `scripts/` creates it, and it is **not a pnpm workspace member**

### One reference that looked like a dependency and is not
`scripts/run-eslint-changed.test.mjs` references `workers/index.ts`. That path is a **synthetic fixture** for "a file outside every workspace" — `run-eslint-changed.mjs` never mentions workers at all. That suite still passes.

### Left alone
`@cloudflare/workers-types` is still in the pnpm catalog, also orphaned by that deletion. Removing it needs a lockfile regeneration, and pnpm does not run in this shell — dropping the declaration without regenerating would leave the lockfile inconsistent.

### Verified with the repo's own runner
My first attempt used `node --test`, which fails on this file with `Vitest failed to access its internal state` and made the baseline check meaningless.

**188/188** across `vitest.workspace-scripts.config.mjs`, and `check:plugin-lint-coverage:self-test` passes — including its "the real tree is covered" case, which is the one that would notice a lint glob that no longer matches reality.
