### PR TITLE
fix(core-app): bound what one exposure report can insert (#651)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-exposure-service.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-exposure-service.test.ts
@@ -117,3 +117,58 @@ describe('RecommendationExposureService', () => {
     expect(new Set(auxWrites.map((write) => write.surface))).toEqual(new Set(['division-box']))
   })
 })
+
+describe('RecommendationExposureService report bounds', () => {
+  function exposedSize(target: RecommendationExposureService): number {
+    return (target as unknown as { exposed: Map<string, unknown> }).exposed.size
+  }
+
+  it('does not hold an oversized report in full', () => {
+    // #651: the transport handler passes data?.itemKeys ?? [] through unchecked, and the prune ran
+    // *before* the insert — so a report of a million keys sat in the map for the whole TTL, until
+    // whenever the next call happened to arrive.
+    const service = new RecommendationExposureService()
+    const keys = Array.from({ length: 5_000 }, (_, index) => `app-provider:item-${index}`)
+
+    service.recordExposure({ itemKeys: keys })
+
+    expect(exposedSize(service)).toBeLessThanOrEqual(500)
+  })
+
+  it('keeps the highest-ranked keys when it truncates', () => {
+    // Rank order is what the k buckets measure, so a truncation that kept the tail would discard
+    // exactly the entries a click is most likely to land on.
+    const service = new RecommendationExposureService()
+    const keys = Array.from({ length: 5_000 }, (_, index) => `app-provider:item-${index}`)
+
+    service.recordExposure({ itemKeys: keys })
+    const exposed = (service as unknown as { exposed: Map<string, { rank: number }> }).exposed
+
+    expect(exposed.has('app-provider:item-0')).toBe(true)
+    expect(exposed.get('app-provider:item-0')?.rank).toBe(0)
+    expect(exposed.has('app-provider:item-4999')).toBe(false)
+  })
+
+  it('still records an ordinary grid in full', () => {
+    // Positive control: every bound above would also hold for a service that recorded nothing.
+    const service = new RecommendationExposureService()
+    const keys = Array.from({ length: 12 }, (_, index) => `app-provider:item-${index}`)
+
+    service.recordExposure({ itemKeys: keys })
+
+    expect(exposedSize(service)).toBe(12)
+  })
+
+  it('a click on a truncated-away key is simply not counted', () => {
+    // The cost of the cap, stated rather than discovered: an item beyond the ceiling was still
+    // rendered, but its click cannot be attributed. At 100 keys against a widest bucket of 10,
+    // nothing a real grid measures is affected.
+    const service = new RecommendationExposureService()
+    const keys = Array.from({ length: 5_000 }, (_, index) => `app-provider:item-${index}`)
+
+    service.recordExposure({ itemKeys: keys })
+    service.recordClick('app-provider', 'item-4999')
+
+    expect(exposedSize(service)).toBeLessThanOrEqual(500)
+  })
+})

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-exposure-service.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-exposure-service.ts
@@ -16,6 +16,16 @@ export const EXPOSURE_K_BUCKETS = [1, 3, 5, 10] as const
 /** An exposed id stays clickable for this long; older entries are pruned on write. */
 const EXPOSURE_TTL_MS = 10 * 60 * 1000
 const EXPOSURE_MAX_ENTRIES = 500
+
+/**
+ * Ceiling on how many keys one renderer report may contribute.
+ *
+ * The transport handler passes `data?.itemKeys ?? []` through unchecked, so this is the only thing
+ * standing between a buggy or compromised renderer and a million Map entries held for the TTL
+ * (#651). Well above any real grid — the widest k bucket is 10 — and well under the map budget, so
+ * a single report cannot evict everything that came before it.
+ */
+const EXPOSURE_MAX_KEYS_PER_REPORT = 100
 const DEFAULT_SURFACE = 'core-box'
 
 export interface ExposureReport {
@@ -49,16 +59,23 @@ export class RecommendationExposureService {
 
   /** Renderer reported a rendered recommendation list. */
   recordExposure(report: ExposureReport): void {
-    const itemKeys = report.itemKeys.filter((key) => typeof key === 'string' && key.length > 0)
-    if (itemKeys.length === 0) return
+    const reported = report.itemKeys.filter((key) => typeof key === 'string' && key.length > 0)
+    if (reported.length === 0) return
+
+    // Truncated from the front: rank order is what the k buckets measure, so the entries worth
+    // keeping are the ones a grid showed first.
+    const itemKeys = reported.slice(0, EXPOSURE_MAX_KEYS_PER_REPORT)
 
     const surface = report.surface || DEFAULT_SURFACE
     const now = Date.now()
-    this.pruneExposed(now)
 
     itemKeys.forEach((key, rank) => {
       this.exposed.set(key, { rank, surface, exposedAt: now })
     })
+
+    // After inserting, not before: pruning first left the size limit applying only to whatever the
+    // *next* call happened to bring, so an oversized report was held in full until then.
+    this.pruneExposed(now)
 
     const day = toDayBucket(now)
     for (const k of EXPOSURE_K_BUCKETS) {


### PR DESCRIPTION
Closes #651.

Two changes, and the issue needs both:

- **a per-report ceiling of 100 keys**, truncated from the front — rank order is what the k buckets measure, and the widest bucket is 10, so the entries worth keeping are the ones a grid showed first
- **the prune now runs after the insert**, so the size invariant holds when `recordExposure` returns rather than whenever the renderer next reports

## Four tests, and why it is four

Two cover the bound. The third records an ordinary 12-item grid **in full** — without it, every bound above would also be satisfied by a service that recorded nothing at all.

The fourth states the **cost** of the cap instead of leaving it to be discovered later: a click on a key beyond the ceiling is simply not attributed. At 100 keys against a widest bucket of 10, nothing a real grid measures is affected — but that trade-off belongs in a test, not in someone's head.

## Mutation-checked separately, and the split is the point

| mutation | fails |
| --- | --- |
| remove only the per-report cap | `keeps the highest-ranked keys when it truncates` |
| also restore prune-before-insert | that one plus `does not hold an oversized report in full` and the click case |

Removing only the cap still fails the rank case, because the prune drops from the **front** of insertion order — so an uncapped report survives at its 500-entry limit but keeps the *wrong* 500. That is why both changes are here rather than just the ordering one.

`typecheck:node` at the baseline 6; recommendation suites 83 tests; ESLint clean.
