### PR TITLE
ci: give every workflow job a timeout-minutes budget

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -16,6 +16,7 @@ jobs:
   ai-review:
     name: AI PR Review
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout trusted base commit
         uses: actions/checkout@v7

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -48,6 +48,7 @@ jobs:
   build-and-release:
     name: Build and Release Tuff App
     runs-on: ${{ matrix.image }}
+    timeout-minutes: 60
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.sync_tag == ''
     permissions:
       contents: read
@@ -838,6 +839,7 @@ jobs:
     name: Create Release
     needs: build-and-release
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: >
       always() && (
         needs.build-and-release.result == 'success'
@@ -1272,6 +1274,7 @@ jobs:
     name: Sync Nexus Release
     needs: create-release
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     if: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   job1:
     name: Check Not Allowed File Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       release_acceptance: ${{ steps.filter_not_allowed.outputs.release_acceptance }}
       nexus: ${{ steps.filter_not_allowed.outputs.nexus }}
@@ -46,6 +47,7 @@ jobs:
   docs_verify:
     name: Documentation Quality
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: job1
     steps:
       - name: Checkout Code
@@ -75,6 +77,7 @@ jobs:
   job_quality_pr:
     name: PR Quality
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: job1
     steps:
       - name: Checkout Code
@@ -156,6 +159,7 @@ jobs:
   job_typecheck_all:
     name: Typecheck (workspace)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: job1
     steps:
       - name: Checkout Code
@@ -188,6 +192,7 @@ jobs:
   job_release_acceptance:
     name: Release acceptance (macOS)
     runs-on: macos-latest
+    timeout-minutes: 30
     needs: job1
     if: ${{ needs.job1.outputs.release_acceptance == 'true' }}
     steps:
@@ -238,6 +243,7 @@ jobs:
   job_nexus:
     name: Nexus (build + checks)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: job1
     if: ${{ needs.job1.outputs.nexus == 'true' }}
     steps:
@@ -276,6 +282,7 @@ jobs:
   job_app_tests:
     name: App suites (${{ matrix.app }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: job1
     strategy:
       fail-fast: false
@@ -351,6 +358,7 @@ jobs:
   job_integration_tests:
     name: Integration suite (packages/test)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: job1
     steps:
       - name: Checkout Code

--- a/.github/workflows/intelligence.yml
+++ b/.github/workflows/intelligence.yml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7

--- a/.github/workflows/native-protocol.yml
+++ b/.github/workflows/native-protocol.yml
@@ -33,6 +33,7 @@ jobs:
   protocol:
     name: Protocol (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -59,6 +59,7 @@ jobs:
   ci:
     name: CI - ${{ inputs.package-name }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/package-tuff-cli-publish.yml
+++ b/.github/workflows/package-tuff-cli-publish.yml
@@ -31,6 +31,7 @@ jobs:
   publish:
     name: Publish CLI Packages
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     env:

--- a/.github/workflows/package-tuff-intelligence-publish.yml
+++ b/.github/workflows/package-tuff-intelligence-publish.yml
@@ -22,6 +22,7 @@ jobs:
   publish:
     name: Publish - tuff-intelligence
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
 

--- a/.github/workflows/package-tuffex-publish.yml
+++ b/.github/workflows/package-tuffex-publish.yml
@@ -26,6 +26,7 @@ jobs:
   publish:
     name: Publish - tuffex
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
 

--- a/.github/workflows/package-utils-publish.yml
+++ b/.github/workflows/package-utils-publish.yml
@@ -21,6 +21,7 @@ jobs:
   publish:
     name: Publish - utils
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
 

--- a/.github/workflows/pr-flags.yml
+++ b/.github/workflows/pr-flags.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   apply-labels:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Sync labels based on PR template
         uses: actions/github-script@v9

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,6 +17,7 @@ jobs:
   update-release-draft:
     if: github.event_name == 'push' || (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         with:


### PR DESCRIPTION
Closes #724.

Only `windows-everything-production.yml` set `timeout-minutes`. The other **21 jobs** — including the Electron release matrix and every publish job — could hang for the runner's 6-hour default.

### Budgets come from measured run history, not a guess
A timeout set too low is worse than none at all, because it kills legitimate slow runs. So each band is ~3–6× the observed maximum:

| workflow | budget | observed |
|---|---|---|
| `build-and-release` | 60m | successful runs at 17.7–18.2 min |
| `ci` | 30m | median 4.3, max 5.5 over 15 runs |
| `package-*` | 20m | 1.3–3.0 min |
| everything else | 15m | sub-minute helpers |

`build-and-release` had **no runs in the last 60 workflow executions**, so its number comes from a workflow-scoped query instead. Successes there are ~18 minutes, so 60 leaves room for the macOS notarization stall the issue is concerned about without being unbounded.

### Verified with the repo's own parsers
pyyaml is not installed here, so instead of a YAML library I used the checks this repo already ships:

- `check-action-pins` — reads all 18 workflows, reports clean
- `check-workflow-injection` — same, reports clean
- both self-tests pass

If either file had been left structurally broken, those parsers would have failed rather than silently skipping.

**22/22 jobs now carry a timeout.**
