### PR TITLE
ci: serialize release-drafter so one merge cannot race its own draft

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -16,6 +16,7 @@ jobs:
   ai-review:
     name: AI PR Review
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout trusted base commit
         uses: actions/checkout@v7

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -48,6 +48,7 @@ jobs:
   build-and-release:
     name: Build and Release Tuff App
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.sync_tag == ''
     permissions:
       contents: read
@@ -826,6 +827,7 @@ jobs:
     name: Create Release
     needs: build-and-release
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: >
       always() && (
         needs.build-and-release.result == 'success'
@@ -1260,6 +1262,7 @@ jobs:
     name: Sync Nexus Release
     needs: create-release
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     if: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   job1:
     name: Check Not Allowed File Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       release_acceptance: ${{ steps.filter_not_allowed.outputs.release_acceptance }}
       nexus: ${{ steps.filter_not_allowed.outputs.nexus }}
@@ -46,6 +47,7 @@ jobs:
   docs_verify:
     name: Documentation Quality
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: job1
     steps:
       - name: Checkout Code
@@ -75,6 +77,7 @@ jobs:
   job_quality_pr:
     name: PR Quality
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: job1
     steps:
       - name: Checkout Code
@@ -156,6 +159,7 @@ jobs:
   job_typecheck_all:
     name: Typecheck (workspace)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: job1
     steps:
       - name: Checkout Code
@@ -188,6 +192,7 @@ jobs:
   job_release_acceptance:
     name: Release acceptance (macOS)
     runs-on: macos-latest
+    timeout-minutes: 30
     needs: job1
     if: ${{ needs.job1.outputs.release_acceptance == 'true' }}
     steps:
@@ -238,6 +243,7 @@ jobs:
   job_nexus:
     name: Nexus (build + checks)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: job1
     if: ${{ needs.job1.outputs.nexus == 'true' }}
     steps:
@@ -276,6 +282,7 @@ jobs:
   job_app_tests:
     name: App suites (${{ matrix.app }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: job1
     strategy:
       fail-fast: false
@@ -351,6 +358,7 @@ jobs:
   job_integration_tests:
     name: Integration suite (packages/test)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: job1
     steps:
       - name: Checkout Code

--- a/.github/workflows/intelligence.yml
+++ b/.github/workflows/intelligence.yml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7

--- a/.github/workflows/native-protocol.yml
+++ b/.github/workflows/native-protocol.yml
@@ -33,6 +33,7 @@ jobs:
   protocol:
     name: Protocol (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -59,6 +59,7 @@ jobs:
   ci:
     name: CI - ${{ inputs.package-name }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/package-tuff-cli-publish.yml
+++ b/.github/workflows/package-tuff-cli-publish.yml
@@ -31,6 +31,7 @@ jobs:
   publish:
     name: Publish CLI Packages
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     env:

--- a/.github/workflows/package-tuff-intelligence-publish.yml
+++ b/.github/workflows/package-tuff-intelligence-publish.yml
@@ -22,6 +22,7 @@ jobs:
   publish:
     name: Publish - tuff-intelligence
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
 

--- a/.github/workflows/package-tuffex-publish.yml
+++ b/.github/workflows/package-tuffex-publish.yml
@@ -26,6 +26,7 @@ jobs:
   publish:
     name: Publish - tuffex
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
 

--- a/.github/workflows/package-utils-publish.yml
+++ b/.github/workflows/package-utils-publish.yml
@@ -21,6 +21,7 @@ jobs:
   publish:
     name: Publish - utils
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
 

--- a/.github/workflows/pr-flags.yml
+++ b/.github/workflows/pr-flags.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   apply-labels:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Sync labels based on PR template
         uses: actions/github-script@v9

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,6 +17,7 @@ jobs:
   update-release-draft:
     if: github.event_name == 'push' || (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,6 +9,22 @@ on:
     types:
       - closed
 
+# One draft release, one writer. push (on master) and pull_request_target (on
+# merge) both fire for the same merge, and release-drafter mutates the same draft
+# in place — two concurrent runs race on it (#725).
+#
+# Keyed on the TARGET branch, not github.ref. The two triggers report different
+# refs for the same merge — push gives refs/heads/master, pull_request_target
+# gives refs/pull/<n>/merge — so a ref-keyed group lands them in separate buckets
+# and serializes nothing.
+#
+# cancel-in-progress is deliberately false, unlike ci.yml: these runs are not
+# interchangeable rebuilds of a check, they are writes. Cancelling one mid-write
+# is what this is trying to avoid, so they queue instead.
+concurrency:
+  group: release-drafter-${{ github.event.pull_request.base.ref || github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: read


### PR DESCRIPTION
Closes #725.

**Stacked on #1386** (both touch `release-drafter.yml`) — base is `fix/724-workflow-timeouts`, so **#1386 merges first**.

`push` (on master) and `pull_request_target` (on merge) both fire for the same merge, and release-drafter mutates the same draft release **in place**. With no concurrency group the two runs raced on it.

### The key is the target branch, not `github.ref`
My first version used `github.ref` and **would have shipped a no-op**. The two triggers report different refs for the same merge:

```
push                    -> refs/heads/master
pull_request_target     -> refs/pull/<n>/merge
```

A ref-keyed group puts them in separate buckets and serializes nothing — which is the entire point of the issue. Both now resolve to `release-drafter-master`.

### `cancel-in-progress: false`, unlike ci.yml
`ci.yml` sets it to `true` because a superseded check run is worthless. These are **writes**, not interchangeable rebuilds — cancelling one mid-write is exactly the failure this is meant to prevent, so they queue instead.

### Left alone: whether both triggers are needed
They are **not** purely redundant in this repo. PRs merge to `TalexDreamSoul/app-shell-v2`, not master, so the `push` trigger and the `pull_request_target` trigger cover different merges. Removing either changes *which* merges update the draft — a maintainer's call, not a race fix.

### Verified
pyyaml is not installed here, so I used the repo's own parsers: `check-action-pins` and `check-workflow-injection` both read all 18 workflows and report clean.
