### PR TITLE
fix(core-app): stop absence of weekday evidence outranking weak evidence (#650)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-utils.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-utils.test.ts
@@ -109,3 +109,48 @@ describe('calculateTimeRelevanceScore hour weighting', () => {
     expect(calculateTimeRelevanceScore(empty, morningNine)).toBe(0)
   })
 })
+
+describe('calculateTimeRelevanceScore weekday evidence', () => {
+  /** Same slot profile for both, so only the weekday distribution differs. */
+  const withWeekdays = (dayOfWeekDistribution: number[]) =>
+    createTimeStats({ dayOfWeekDistribution })
+
+  it('ranks weak weekday evidence above none', () => {
+    // #650: absence gave the neutral factor 1 while a below-average count gave < 1, so an item
+    // never used on a Monday outranked one the user does use on Mondays.
+    const neverOnMonday = withWeekdays([10, 0, 10, 10, 10, 10, 10])
+    const twiceOnMonday = withWeekdays([10, 2, 10, 10, 10, 10, 10])
+
+    expect(calculateTimeRelevanceScore(twiceOnMonday, morningNine)).toBeGreaterThan(
+      calculateTimeRelevanceScore(neverOnMonday, morningNine)
+    )
+  })
+
+  it('still ranks a typical weekday above an atypical one', () => {
+    // Positive control on direction: the factor must remain monotone, not merely non-inverted.
+    const mostlyMonday = withWeekdays([0, 20, 0, 0, 0, 0, 0])
+    const rarelyMonday = withWeekdays([20, 1, 20, 20, 20, 20, 20])
+
+    expect(calculateTimeRelevanceScore(mostlyMonday, morningNine)).toBeGreaterThan(
+      calculateTimeRelevanceScore(rarelyMonday, morningNine)
+    )
+  })
+
+  it('does not erase an item that has never been used on this weekday', () => {
+    // Dividing unconditionally would make the factor 0 and zero the whole score. getTimeBasedTopItems
+    // keeps only timeScore > 0, so the item would vanish from time-based results entirely — worse
+    // than the mis-ranking being fixed.
+    const neverOnMonday = withWeekdays([10, 0, 10, 10, 10, 10, 10])
+
+    expect(calculateTimeRelevanceScore(neverOnMonday, morningNine)).toBeGreaterThan(0)
+  })
+
+  it('is monotone in the weekday count', () => {
+    const scores = [0, 1, 2, 5, 10, 20].map((count) =>
+      calculateTimeRelevanceScore(withWeekdays([10, count, 10, 10, 10, 10, 10]), morningNine)
+    )
+
+    for (let index = 1; index < scores.length; index++)
+      expect(scores[index]).toBeGreaterThan(scores[index - 1]!)
+  })
+})

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-utils.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-utils.ts
@@ -88,6 +88,26 @@ export function calculateHourAffinity(
  * table existed but was never read — an item used every day at 09:00 scored
  * the same at 11:30 as at 09:05 because both fall in the "morning" slot.
  */
+/**
+ * How much today's weekday argues for this item, relative to its own average day.
+ *
+ * Smoothed rather than a bare ratio. The bare form has two failure modes and this sits between
+ * them:
+ *
+ * - the old `dayUsage > 0 ? ratio : 1` made *absence* neutral, so an item never used on a Monday
+ *   (factor 1) outranked one used twice against an average of ten (factor 0.2) — absence of
+ *   evidence beating weak evidence (#650)
+ * - dividing unconditionally makes absence a factor of 0, which zeroes the whole relevance score.
+ *   The caller keeps only `timeScore > 0`, so an item would disappear from time-based results on
+ *   every weekday it has not been used, however strong its hour-of-day affinity
+ *
+ * (dayUsage + 1) / (avgDayUsage + 1) is strictly increasing in dayUsage, so any evidence always
+ * beats none, and it is never 0, so nothing is erased for lack of a weekday sample.
+ */
+function calculateDayFactor(dayUsage: number, avgDayUsage: number): number {
+  return (dayUsage + 1) / (avgDayUsage + 1)
+}
+
 export function calculateTimeRelevanceScore(
   itemTimeStats: ParsedItemTimeStats,
   currentTime: TimePattern
@@ -100,7 +120,7 @@ export function calculateTimeRelevanceScore(
   const slotRatio = slotUsage / totalUsage
   const dayUsage = itemTimeStats.dayOfWeekDistribution[currentTime.dayOfWeek] ?? 0
   const avgDayUsage = itemTimeStats.dayOfWeekDistribution.reduce((a, b) => a + b, 0) / 7
-  const dayFactor = dayUsage > 0 ? dayUsage / (avgDayUsage || 1) : 1
+  const dayFactor = calculateDayFactor(dayUsage, avgDayUsage)
   const boost = calculateTimeContextBoost(itemTimeStats, currentTime)
   const slotScore = slotRatio * TIME_RELEVANCE_SCALE * dayFactor
 


### PR DESCRIPTION
Closes #650.

`dayFactor` is now `(dayUsage + 1) / (avgDayUsage + 1)`.

## Neither suggested option as written

**Dividing unconditionally** makes absence a factor of **0**, which zeroes the whole relevance score. `getTimeBasedTopItems` keeps only `timeScore > 0`, so an item would disappear from time-based results on every weekday it has not been used — however strong its hour-of-day affinity. That trades a mis-ranking for an erasure.

**A fixed floor** cannot work either: a positive count can produce a factor below any constant (`dayUsage = 1`, `avg = 1000` → 0.001), so evidence would still fall under whatever floor absence was given. The property wanted is ordering, and a constant cannot provide it.

Smoothing gives both properties directly: strictly increasing in `dayUsage`, so **any** evidence beats none at any scale; and never 0, so nothing is erased for lack of a weekday sample.

## Mutation-checked against both alternatives

That is what separates them — a single mutation would not have:

| mutation | fails |
| --- | --- |
| the original `dayUsage > 0 ? ratio : 1` | `ranks weak weekday evidence above none`, `is monotone in the weekday count` |
| the unconditional ratio | `does not erase an item that has never been used on this weekday` |

The suite also keeps a direction control — a typical weekday must still outrank an atypical one — so the fix cannot pass by flattening the factor toward neutral.

`typecheck:node` at the baseline 6; recommendation suites 87 tests; ESLint clean.
