### PR TITLE
ci: remove the release-drafter label filter that never ran

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,9 +2,20 @@ name-template: v$NEXT_PATCH_VERSION
 tag-template: v$NEXT_PATCH_VERSION
 change-template: '- $TITLE (#$NUMBER) by @$AUTHOR'
 no-changes-template: 未检测到需要发布的变更。
-filter-by-labels:
-  include:
-    - needs-release-note
+# There is deliberately no include-labels here.
+#
+# This file used to carry `filter-by-labels: include: [needs-release-note]`.
+# That key does not exist in release-drafter's schema (checked against the
+# pinned v7.7.0 SHA), and the schema does not set additionalProperties: false,
+# so it was accepted and silently ignored — the gate never ran (#726).
+#
+# Do not "fix" it to `include-labels: [needs-release-note]`. pr-flags.yml only
+# adds that label when a PR author ticks an opt-in checkbox, and 0 of the last
+# 60 merged PRs carry it. Turning the gate on would empty the release notes
+# rather than filter them.
+#
+# Changing to an opt-in changelog is a product decision; until it is made, every
+# merged PR is included and `skip-changelog` is the way to opt out.
 exclude-labels:
   - skip-changelog
 categories:


### PR DESCRIPTION
Closes #726.

The issue was filed at **lower confidence** and asked for verification. Here it is, from the action's own schema at the pinned SHA:

```
https://raw.githubusercontent.com/release-drafter/release-drafter/34d80673…/schema.json
  filter-by-labels   -> not a key
  include-labels     -> is the key
  additionalProperties: false at root -> absent
```

So the key was **accepted and silently ignored**. The gate `pr-flags.yml` exists to feed has never run. Removing it changes nothing, because it did nothing.

### ⚠️ Deliberately NOT renamed to `include-labels`
That is the obvious fix and it is wrong here.

`pr-flags.yml` adds `needs-release-note` only when a PR author ticks an opt-in checkbox. I measured the last 60 merged PRs:

```
merged: 60    carrying needs-release-note: 0
```

Enabling the gate would **empty the release notes**, not filter them — a worse outcome than the current no-op.

### What ships instead
The block is replaced by a comment stating the above, so the next person who spots the wrong key does not "fix" it into an outage. Whether the changelog should become opt-in is a product decision; the comment leaves it open rather than silently deciding it.

Effective config before: `filter-by-labels` (ignored) + `exclude-labels`. After: `exclude-labels`. Identical.
