### PR TITLE
perf(core-app): bound the time-stats read and chunk composite-key lookups (#653)

### DIFF
--- a/apps/core-app/src/main/db/composite-key-chunking.test.ts
+++ b/apps/core-app/src/main/db/composite-key-chunking.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest'
+
+/**
+ * Composite-key lookups must not exceed SQLite's bound-parameter ceiling (#653).
+ *
+ * getUsageStatsBatch and getItemTimeStatsBatch each build two `inArray` lists, so one key costs two
+ * bound parameters. Past SQLITE_MAX_VARIABLE_NUMBER — 32,766 by default — the statement fails
+ * outright with 'too many SQL variables', which for a user with enough tracked items meant a cold
+ * recommend() erroring rather than degrading.
+ */
+
+vi.mock('./db-write', () => ({
+  resolveCurrentAuxDb: () => null,
+  scheduleAuxWrite: vi.fn()
+}))
+
+vi.mock('../utils/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() })
+}))
+
+import { createDbUtils } from './utils'
+
+/**
+ * drizzle's and/inArray are real here; the fake `where` cannot count their parameters, so the
+ * chunking is asserted through the number of statements instead — one per chunk.
+ */
+function createCountingDb() {
+  const statements: number[] = []
+  let pendingKeys = 0
+
+  const builder = {
+    from: () => builder,
+    where: () => {
+      statements.push(pendingKeys)
+      return Promise.resolve([])
+    },
+    orderBy: () => builder,
+    limit: () => Promise.resolve([])
+  }
+
+  return {
+    statements,
+    setPending: (count: number) => {
+      pendingKeys = count
+    },
+    db: { select: () => builder } as never
+  }
+}
+
+const keysFor = (count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    sourceId: 'app-provider',
+    itemId: `item-${index}`
+  }))
+
+describe('composite-key chunking', () => {
+  it('issues one statement for a small key set', async () => {
+    // Positive control: the split below is only meaningful if the unsplit case is one statement.
+    const { db, statements } = createCountingDb()
+    const utils = createDbUtils(db)
+
+    await utils.getUsageStatsBatch(keysFor(10))
+
+    expect(statements).toHaveLength(1)
+  })
+
+  it('splits a key set that would exceed the parameter ceiling', async () => {
+    const { db, statements } = createCountingDb()
+    const utils = createDbUtils(db)
+
+    // 20,000 keys is 40,000 bound parameters in a single statement — past the 32,766 ceiling.
+    await utils.getUsageStatsBatch(keysFor(20_000))
+
+    expect(statements.length).toBeGreaterThan(1)
+  })
+
+  it('applies the same split to item time stats', async () => {
+    // Identical shape, two definitions apart in the same file.
+    const { db, statements } = createCountingDb()
+    const utils = createDbUtils(db)
+
+    await utils.getItemTimeStatsBatch(keysFor(20_000))
+
+    expect(statements.length).toBeGreaterThan(1)
+  })
+
+  it('still returns nothing for an empty key set', async () => {
+    const { db, statements } = createCountingDb()
+    const utils = createDbUtils(db)
+
+    expect(await utils.getUsageStatsBatch([])).toEqual([])
+    expect(statements).toHaveLength(0)
+  })
+})
+
+describe('getAllItemTimeStats bounds', () => {
+  it('applies a limit rather than reading the whole table', async () => {
+    const calls: Array<{ limited: boolean }> = []
+    const builder = {
+      from: () => builder,
+      orderBy: () => builder,
+      limit: () => {
+        calls.push({ limited: true })
+        return Promise.resolve([])
+      }
+    }
+    const utils = createDbUtils({ select: () => builder } as never)
+
+    await utils.getAllItemTimeStats()
+
+    expect(calls).toEqual([{ limited: true }])
+  })
+})

--- a/apps/core-app/src/main/db/utils.ts
+++ b/apps/core-app/src/main/db/utils.ts
@@ -1,6 +1,25 @@
 import type { LibSQLDatabase } from 'drizzle-orm/libsql'
-import { and, eq, inArray, sql } from 'drizzle-orm'
+import { and, desc, eq, inArray, sql } from 'drizzle-orm'
 import { resolveCurrentAuxDb, scheduleAuxWrite } from './db-write'
+
+/**
+ * Largest number of keys to put in one composite-key lookup.
+ *
+ * Each key contributes two bound parameters (one per inArray), and SQLite refuses a statement past
+ * SQLITE_MAX_VARIABLE_NUMBER — 32,766 by default. A user with 20,000 tracked items exceeded that
+ * on a single call and the query failed outright rather than degrading (#653).
+ */
+const COMPOSITE_KEY_CHUNK_SIZE = 4000
+
+function chunkKeys<T>(keys: T[], size = COMPOSITE_KEY_CHUNK_SIZE): T[][] {
+  if (keys.length <= size) return [keys]
+
+  const chunks: T[][] = []
+  for (let index = 0; index < keys.length; index += size) {
+    chunks.push(keys.slice(index, index + size))
+  }
+  return chunks
+}
 import * as schema from './schema'
 
 export type CoreDatabase = LibSQLDatabase<typeof schema>
@@ -444,16 +463,40 @@ function createDbUtilsInternal(
       const sourceIds = keys.map((k) => k.sourceId)
       const itemIds = keys.map((k) => k.itemId)
 
-      // 使用 IN 查询优化（预过滤）
-      return db
-        .select()
-        .from(schema.itemUsageStats)
-        .where(
-          and(
-            inArray(schema.itemUsageStats.sourceId, sourceIds),
-            inArray(schema.itemUsageStats.itemId, itemIds)
+      // 使用 IN 查询优化（预过滤），分批以免超出 SQLite 的绑定参数上限
+      const chunks = chunkKeys(keys)
+      if (chunks.length === 1) {
+        return db
+          .select()
+          .from(schema.itemUsageStats)
+          .where(
+            and(
+              inArray(schema.itemUsageStats.sourceId, sourceIds),
+              inArray(schema.itemUsageStats.itemId, itemIds)
+            )
           )
-        )
+      }
+
+      const rows: Array<typeof schema.itemUsageStats.$inferSelect> = []
+      for (const chunk of chunks) {
+        const batch = await db
+          .select()
+          .from(schema.itemUsageStats)
+          .where(
+            and(
+              inArray(
+                schema.itemUsageStats.sourceId,
+                chunk.map((key) => key.sourceId)
+              ),
+              inArray(
+                schema.itemUsageStats.itemId,
+                chunk.map((key) => key.itemId)
+              )
+            )
+          )
+        rows.push(...batch)
+      }
+      return rows
     },
 
     async getUsageStatsBySource(sourceId: string) {
@@ -470,19 +513,56 @@ function createDbUtilsInternal(
       const sourceIds = keys.map((k) => k.sourceId)
       const itemIds = keys.map((k) => k.itemId)
 
+      // Same bound-parameter ceiling as getUsageStatsBatch — identical shape, two definitions apart.
+      const chunks = chunkKeys(keys)
+      if (chunks.length === 1) {
+        return db
+          .select()
+          .from(schema.itemTimeStats)
+          .where(
+            and(
+              inArray(schema.itemTimeStats.sourceId, sourceIds),
+              inArray(schema.itemTimeStats.itemId, itemIds)
+            )
+          )
+      }
+
+      const rows: Array<typeof schema.itemTimeStats.$inferSelect> = []
+      for (const chunk of chunks) {
+        const batch = await db
+          .select()
+          .from(schema.itemTimeStats)
+          .where(
+            and(
+              inArray(
+                schema.itemTimeStats.sourceId,
+                chunk.map((key) => key.sourceId)
+              ),
+              inArray(
+                schema.itemTimeStats.itemId,
+                chunk.map((key) => key.itemId)
+              )
+            )
+          )
+        rows.push(...batch)
+      }
+      return rows
+    },
+
+    /**
+     * Time stats for scoring, newest first and bounded.
+     *
+     * Unbounded before: every cold recommend() read the whole table, parsed each row and passed one
+     * key per row into a composite lookup, so the work grew with lifetime item count (#653).
+     * Ordering by lastUpdated keeps the rows most likely to win a time slot; the tail it drops is
+     * items the user has not touched in a long time, which is a trade-off rather than a free win.
+     */
+    async getAllItemTimeStats(limit = 2000) {
       return db
         .select()
         .from(schema.itemTimeStats)
-        .where(
-          and(
-            inArray(schema.itemTimeStats.sourceId, sourceIds),
-            inArray(schema.itemTimeStats.itemId, itemIds)
-          )
-        )
-    },
-
-    async getAllItemTimeStats() {
-      return db.select().from(schema.itemTimeStats)
+        .orderBy(desc(schema.itemTimeStats.lastUpdated))
+        .limit(limit)
     },
 
     // Recommendation Cache


### PR DESCRIPTION
Closes #653.

Two changes, addressing different halves of the report.

## Chunking removes the hard failure

`getUsageStatsBatch` binds **two** parameters per key. Past `SQLITE_MAX_VARIABLE_NUMBER` (32,766) the statement fails outright — the user gets an error, not a slow result. It is now split at 4,000 keys per statement.

`getItemTimeStatsBatch` has the **identical shape two definitions away** in the same file, so it shares the helper. Fixing only the reported call would have left the same hard failure reachable through a different one.

## The limit caps the linear work

`getAllItemTimeStats` is bounded at 2,000 rows, ordered by `lastUpdated` descending.

**Stated as a trade-off rather than a free win:** the rows it drops are the items untouched longest. For a user past 2,000 tracked items, a very old item can no longer surface through the time-based path. Ordering by recency keeps the ones most likely to win a slot, but it is a behaviour change, not purely an optimisation.

## Five tests

The chunking cases assert **statement count**, not parameter count — drizzle builds the real `and`/`inArray` conditions and a fake `where` cannot see inside them. A single-statement case comes first so the split is measured against something rather than asserted in isolation.

## Mutation-checked separately

| mutation | fails |
| --- | --- |
| remove the chunking | `splits a key set that would exceed the parameter ceiling` |
| remove the limit | `applies a limit rather than reading the whole table` |

`typecheck:node` at the baseline 6; db and recommendation suites 117 tests pass; ESLint clean.
