### PR TITLE
build(ci): refuse to send NEXUS_API_KEY to an unrecognised host

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1326,6 +1326,26 @@ jobs:
             exit 1
           fi
 
+          # Every curl below sends the NEXUS_API_KEY bearer token to NEXUS_BASE_URL, and that
+          # value comes from vars.NEXUS_SYNC_BASE_URL — a plaintext repository variable, not a
+          # secret. Nothing validated it, so a typo or a settings change pointed the production
+          # key at an arbitrary host and the first sign would have been the credential already
+          # sent (#732).
+          #
+          # An allowlist rather than a shape check: "is it https" would still accept
+          # https://attacker.example. Localhost is permitted so a self-hosted or tunnelled Nexus
+          # can be exercised without editing this file.
+          case "${NEXUS_BASE_URL}" in
+            https://tuff.tagzxia.com|https://tuff.tagzxia.com/*) ;;
+            http://localhost:*|http://127.0.0.1:*|https://localhost:*|https://127.0.0.1:*) ;;
+            *)
+              echo "Refusing to send NEXUS_API_KEY to an unrecognised host: ${NEXUS_BASE_URL}"
+              echo "vars.NEXUS_SYNC_BASE_URL must name the official Nexus origin or a local one."
+              echo "If a new deployment origin is legitimate, add it to the allowlist in this step."
+              exit 1
+              ;;
+          esac
+
           # Cloudflare Access is optional — both empty means it is not in front of Nexus.
           # Half-configured is not, and it is the state a setup that kept the client secret
           # in a *variable* lands in, because this job now reads it from secrets only (#541).

--- a/scripts/ci/ai-review.mjs
+++ b/scripts/ci/ai-review.mjs
@@ -46,10 +46,19 @@ const allowedAssociations = allowedAssociationsEnv
       .filter(Boolean)
   : ['MEMBER', 'OWNER', 'COLLABORATOR']
 
-if (
-  !allowedAssociations.includes('*')
-  && !allowedAssociations.includes(pr.author_association)
-) {
+// No '*' escape hatch. This workflow is pull_request_target, so it runs with repository
+// secrets in scope on pull requests from forks; a wildcard in AI_REVIEW_ALLOWED_ASSOCIATIONS
+// hands any fork author a job holding OPENAI_API_KEY. It reads like a convenience setting
+// and is not one (#733).
+if (allowedAssociations.includes('*')) {
+  console.error(
+    'AI_REVIEW_ALLOWED_ASSOCIATIONS contains "*", which would let fork authors trigger a '
+    + 'pull_request_target job holding OPENAI_API_KEY. List the associations explicitly.',
+  )
+  exit(1)
+}
+
+if (!allowedAssociations.includes(pr.author_association)) {
   console.log(
     `Author association ${pr.author_association} not in allowed list, skip.`,
   )
@@ -77,6 +86,34 @@ if (!openaiKey) {
 
 const baseUrlRaw = env.OPENAI_BASE_URL || 'https://api.openai.com/v1'
 const openaiBaseUrl = normalizeOpenAiBaseUrl(baseUrlRaw)
+
+// OPENAI_BASE_URL is a plaintext repository variable, and normalizeOpenAiBaseUrl only strips
+// a trailing slash, so nothing stopped the OPENAI_API_KEY bearer token going to an arbitrary
+// host. An allowlist rather than a shape check: "starts with https" still accepts
+// https://api.openai.com.evil.test (#733).
+const ALLOWED_OPENAI_HOSTS = new Set([
+  'api.openai.com',
+  'api.deepseek.com',
+  'localhost',
+  '127.0.0.1',
+])
+
+let openaiHost
+try {
+  openaiHost = new URL(openaiBaseUrl).hostname
+}
+catch {
+  console.error(`OPENAI_BASE_URL is not a valid URL: ${openaiBaseUrl}`)
+  exit(1)
+}
+
+if (!ALLOWED_OPENAI_HOSTS.has(openaiHost)) {
+  console.error(
+    `Refusing to send OPENAI_API_KEY to an unrecognised host: ${openaiHost}. `
+    + 'Add it to ALLOWED_OPENAI_HOSTS in scripts/ci/ai-review.mjs if it is legitimate.',
+  )
+  exit(1)
+}
 const completionsPathRaw = env.OPENAI_COMPLETIONS_PATH || '/chat/completions'
 const completionsPath = normalizeOpenAiCompletionsPath(completionsPathRaw)
 const model = env.AI_REVIEW_MODEL || 'gpt-4o-mini'

--- a/scripts/ci/ai-review.test.mjs
+++ b/scripts/ci/ai-review.test.mjs
@@ -117,4 +117,38 @@ describe('aI PR review CI security contract', () => {
       assert.match(result.stdout, message)
     },
   )
+
+  it('has no wildcard escape hatch in the author-association gate', () => {
+    // pull_request_target runs with repository secrets in scope on fork PRs, so a '*' in
+    // AI_REVIEW_ALLOWED_ASSOCIATIONS would hand any fork author a job holding
+    // OPENAI_API_KEY. It reads like a convenience setting and is not one (#733).
+    const source = fs.readFileSync(reviewScriptPath, 'utf8')
+
+    assert.ok(
+      !/!allowedAssociations\.includes\('\*'\)/.test(source),
+      'the wildcard must not be treated as "allow everyone"',
+    )
+    assert.ok(
+      source.includes('List the associations explicitly.'),
+      'a wildcard must be refused with an explanation',
+    )
+  })
+
+  it('constrains where OPENAI_API_KEY may be sent', () => {
+    const source = fs.readFileSync(reviewScriptPath, 'utf8')
+
+    // A host allowlist, not a prefix test: 'starts with https' still accepts
+    // https://api.openai.com.evil.test.
+    assert.ok(source.includes('ALLOWED_OPENAI_HOSTS'), 'expected a host allowlist')
+    assert.match(source, /new URL\(openaiBaseUrl\)\.hostname/)
+    assert.ok(source.includes('Refusing to send OPENAI_API_KEY to an unrecognised host'))
+  })
+
+  it('still runs on pull_request_target, which is what makes both gates load-bearing', () => {
+    // Control. If the trigger ever moves to pull_request, the two assertions above stop
+    // guarding secrets, and that should be revisited rather than silently passing.
+    const workflow = parse(fs.readFileSync(workflowPath, 'utf8'))
+
+    assert.ok(workflow.on.pull_request_target, 'trigger must remain pull_request_target')
+  })
 })

--- a/scripts/release-notes-gateway.mjs
+++ b/scripts/release-notes-gateway.mjs
@@ -13,6 +13,13 @@ import {
 const argv = process.argv.slice(2)
 const command = argv[0] || 'verify'
 const repoRoot = path.resolve(getArgValue(argv, '--repo-root', process.cwd()))
+// Tracked separately from the values themselves: when --version is omitted it defaults to
+// the root package.json, and when --tag is omitted it defaults to `v${version}`. The
+// root-version and tag-version checks then compare a value against itself and can never
+// fail. CI reaches this through quality:pr with no flags, so both reported "pass" while
+// testing nothing (#731).
+const versionProvided = getArgValue(argv, '--version', null) !== null
+const tagProvided = getArgValue(argv, '--tag', null) !== null
 const version = getArgValue(argv, '--version', readPackageVersion(repoRoot))
 const tag = getArgValue(argv, '--tag', `v${version}`)
 
@@ -75,19 +82,27 @@ function verify() {
   const checks = [
     {
       name: 'root-version',
-      pass: rootVersion === version,
+      // Not applicable rather than passing: with no --version there is nothing independent
+      // to compare the root package.json against. A PR has no release tag, so this is the
+      // normal CI case, not a misconfiguration.
+      pass: versionProvided ? rootVersion === version : true,
+      applicable: versionProvided,
       expected: version,
       actual: rootVersion,
     },
     {
       name: 'core-version',
+      applicable: true,
       pass: coreVersion === version,
       expected: version,
       actual: coreVersion,
     },
     {
       name: 'tag-version',
-      pass: tag.replace(/^v/, '') === version,
+      // Needs a real tag from outside this process. Defaulting to `v${version}` compares
+      // the derived value with what it was derived from.
+      pass: tagProvided ? tag.replace(/^v/, '') === version : true,
+      applicable: tagProvided,
       expected: version,
       actual: tag.replace(/^v/, ''),
     },

--- a/scripts/release-notes-gateway.test.mjs
+++ b/scripts/release-notes-gateway.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it } from 'vitest'
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptsDir, '..')
+const gateway = path.join(scriptsDir, 'release-notes-gateway.mjs')
+
+function verify(args = []) {
+  // The gate exits non-zero when a check fails, which is the point of it — so read stdout
+  // from the thrown result rather than letting execFileSync swallow the report.
+  try {
+    return JSON.parse(
+      execFileSync('node', [gateway, 'verify', ...args], { cwd: repoRoot, encoding: 'utf8' }),
+    )
+  }
+  catch (error) {
+    return JSON.parse(String(error.stdout ?? ''))
+  }
+}
+
+function check(report, name) {
+  return report.checks.find(entry => entry.name === name)
+}
+
+describe('release notes gateway version checks', () => {
+  it('does not claim to have checked the version when nothing was passed to compare', () => {
+    // CI reaches this through quality:pr with no flags. --version then defaults to the root
+    // package.json and --tag to `v${version}`, so both checks compared a value against
+    // itself and reported pass while testing nothing (#731).
+    const report = verify()
+
+    assert.equal(check(report, 'root-version').applicable, false)
+    assert.equal(check(report, 'tag-version').applicable, false)
+    assert.equal(report.valid, true, 'a PR with no release tag must still pass the gate')
+  })
+
+  it('really compares the tag once one is supplied', () => {
+    // The regression guard: if these ever become tautologies again, a wrong tag passes.
+    const report = verify(['--tag', 'v9.9.9'])
+
+    assert.equal(check(report, 'tag-version').applicable, true)
+    assert.equal(check(report, 'tag-version').pass, false)
+    assert.equal(report.valid, false)
+  })
+
+  it('keeps core-version a real check in both modes', () => {
+    // Control: core-version never depended on a defaulted input, so it must stay applicable
+    // and passing — otherwise this change quietly weakened a check that was working.
+    assert.equal(check(verify(), 'core-version').applicable, true)
+    assert.equal(check(verify(), 'core-version').pass, true)
+  })
+})


### PR DESCRIPTION
Closes #732.

**Stacked on #1393 → #1392 → #1389 → #1387 → #1386** — all six touch workflow files.

Every `curl` in the release sync job sends the `NEXUS_API_KEY` bearer token to `NEXUS_BASE_URL`, and that value comes from `vars.NEXUS_SYNC_BASE_URL` — a **plaintext repository variable, not a secret**. Nothing validated it, so a typo or a settings change pointed the production key at an arbitrary host, and the first sign would have been the credential *already sent*.

### An allowlist, not a shape check
"Is it https" would still accept `https://attacker.example`. A bare prefix match accepts `https://tuff.tagzxia.com.evil.test`. Both are rejected.

Exercised the `case` directly:

```
ACCEPT  https://tuff.tagzxia.com
ACCEPT  https://tuff.tagzxia.com/api
ACCEPT  http://localhost:3000
REJECT  https://attacker.example
REJECT  https://tuff.tagzxia.com.evil.test
REJECT  (empty)
```

Localhost is permitted so a self-hosted or tunnelled Nexus can still be exercised without editing the workflow.

### Placed in the existing validation step
Added to `Validate Nexus sync credentials` rather than a new step, matching how this job already fails fast on a half-configured Cloudflare Access pair — the comment there about keeping the client secret out of a *variable* (#541) is the same concern applied to the URL.

`bash -n` over every `run: |` body gives 6 unparsable blocks of 42, identical to base.
