### PR TITLE
fix(privacy): keep Nexus attribution unspoofable, dedupe the real copy [#716]

### DIFF
--- a/apps/core-app/src/main/modules/ai/providers/nexus-provider.ts
+++ b/apps/core-app/src/main/modules/ai/providers/nexus-provider.ts
@@ -30,6 +30,7 @@ import { getRuntimeNexusBaseUrl } from '../../nexus/runtime-base'
 import { extractTranslatedImageFromSceneRun, runNexusScene } from '../../nexus/scene-client'
 import { normalizeIntelligenceError } from '../intelligence-error-normalizer'
 import { IntelligenceProvider } from '../runtime/base-provider'
+import { isNexusManagedProvider } from '@talex-touch/utils/intelligence/nexus-provider'
 
 interface NexusInvokeResponse<T = unknown> {
   invocation?: {
@@ -231,11 +232,15 @@ function parseJsonResult<T extends object>(value: unknown, fallback: T): T {
   return fallback
 }
 
+/**
+ * Kept as a named export because provider-factory reads better for it, but the rule itself lives in
+ * @talex-touch/utils so all four call sites cannot drift (#716).
+ */
 export function isNexusProviderConfig(config: {
   id?: string
   metadata?: Record<string, unknown>
 }): boolean {
-  return config.id === 'tuff-nexus-default' || config.metadata?.origin === 'tuff-nexus'
+  return isNexusManagedProvider(config)
 }
 
 export class NexusProvider extends IntelligenceProvider {

--- a/apps/core-app/src/main/modules/privacy/provider-disclosure.test.ts
+++ b/apps/core-app/src/main/modules/privacy/provider-disclosure.test.ts
@@ -175,3 +175,73 @@ describe('privacy provider disclosure projection', () => {
     )
   })
 })
+
+/**
+ * The 'nexus-managed' class is deliberately harder to earn here than anywhere else (#716).
+ *
+ * #716 read the four copies of the "is this Nexus" rule, saw this one combine id and origin with
+ * AND where the others use OR, and asked for them to be unified. Unifying them the way it proposed
+ * would let any writer of provider configuration claim the label: 'nexus-managed' is what renders
+ * a provider as "Tuff Nexus" in the privacy panel, so an arbitrary baseUrl would be disclosed to
+ * the user as our own managed endpoint.
+ *
+ * These cases exist so that change fails here rather than in a privacy report.
+ */
+describe('nexus attribution is not spoofable', () => {
+  const disclose = async (provider: Record<string, unknown>) => {
+    const service = createPrivacyProviderDisclosureService({
+      getConfig: () => ({ providers: [provider], capabilities: {} })
+    })
+    const [disclosure] = await service.getProviders()
+    return disclosure
+  }
+
+  const base = { type: 'custom', name: 'x', enabled: true, capabilities: ['text.chat'] }
+
+  it('attributes the real provider to Nexus', async () => {
+    // Positive control. Every assertion below also passes for a classifier that never returns
+    // 'nexus-managed' at all, which would be its own disclosure bug.
+    const disclosure = await disclose({
+      ...base,
+      id: 'tuff-nexus-default',
+      metadata: { origin: 'tuff-nexus' }
+    })
+
+    expect(disclosure).toMatchObject({
+      destinationClass: 'nexus-managed',
+      displayName: 'Tuff Nexus'
+    })
+  })
+
+  it('refuses the label to a config that only carries the origin marker', async () => {
+    const disclosure = await disclose({
+      ...base,
+      id: 'looks-legit',
+      baseUrl: 'https://attacker.invalid/v1',
+      metadata: { origin: 'tuff-nexus' }
+    })
+
+    expect(disclosure).toMatchObject({
+      destinationClass: 'remote',
+      displayName: 'Custom remote endpoint'
+    })
+  })
+
+  it('refuses the label to a config that only carries the reserved id', async () => {
+    const disclosure = await disclose({ ...base, id: 'tuff-nexus-default' })
+
+    expect(disclosure?.destinationClass).toBe('remote')
+  })
+
+  it('costs the shipped provider nothing, because it satisfies both halves', async () => {
+    // The strictness would be a defect if the real record were identified by one marker only, so
+    // this reads DEFAULT_PROVIDERS rather than restating it.
+    const { DEFAULT_PROVIDERS } = await import('@talex-touch/tuff-intelligence')
+    const shipped = DEFAULT_PROVIDERS.find(
+      (provider: { id?: string }) => provider.id === 'tuff-nexus-default'
+    )
+
+    expect(shipped).toBeDefined()
+    expect((shipped as { metadata?: { origin?: string } }).metadata?.origin).toBe('tuff-nexus')
+  })
+})

--- a/apps/core-app/src/main/modules/privacy/provider-disclosure.ts
+++ b/apps/core-app/src/main/modules/privacy/provider-disclosure.ts
@@ -5,6 +5,10 @@ import type {
   PrivacyRetentionCategory
 } from '@talex-touch/utils/transport/events/types'
 import { isProxy } from 'node:util/types'
+import {
+  TUFF_NEXUS_PROVIDER_ID,
+  TUFF_NEXUS_PROVIDER_ORIGIN
+} from '@talex-touch/utils/intelligence/nexus-provider'
 
 export interface PrivacyProviderDisclosureSource {
   getConfig: () => unknown | Promise<unknown>
@@ -91,9 +95,28 @@ function capabilitiesForProvider(
   return Object.freeze([...capabilities].sort())
 }
 
+/**
+ * Whether this provider is the one Nexus manages — deliberately stricter than
+ * `isNexusManagedProvider`, which the rest of the app uses. Do not "unify" the two (#716).
+ *
+ * Everywhere else the question is "should this request go through the Nexus path", and either
+ * marker answering yes is fine. Here the answer becomes a claim shown to the user: the
+ * 'nexus-managed' class is what renders the provider as "Tuff Nexus" and suppresses the "Custom
+ * remote endpoint" wording. Provider records come from user-editable configuration, so anything
+ * that can write `metadata.origin` could make the privacy panel attribute its own baseUrl to us.
+ * Requiring the reserved id as well means a spoofed record is disclosed as what it is —
+ * `provider-disclosure.test.ts` pins that with a provider literally named "Spoofed Nexus".
+ *
+ * The strictness costs nothing against the real provider: DEFAULT_PROVIDERS ships
+ * `tuff-nexus-default` carrying `metadata.origin` too, so both halves hold. Only the combinator
+ * differs from the shared rule — the constants are imported so the values cannot drift apart.
+ *
+ * ownValues is applied first for the same reason: it rejects proxies and prototype-polluted
+ * objects, a guarantee this module makes about every untrusted provider record.
+ */
 function isNexusProvider(provider: Record<string, unknown>): boolean {
   const metadata = ownValues(provider.metadata)
-  return provider.id === 'tuff-nexus-default' && metadata?.origin === 'tuff-nexus'
+  return provider.id === TUFF_NEXUS_PROVIDER_ID && metadata?.origin === TUFF_NEXUS_PROVIDER_ORIGIN
 }
 
 function isLoopbackHost(hostname: string): boolean {


### PR DESCRIPTION
Closes #716.

#716 read four copies of the "is this Nexus provider" rule and asked for the privacy one — which combines the reserved id and the origin marker with `AND` where the others use `OR` — to be unified with the rest. Half of that is right.

## The AND is deliberate, not drift

Everywhere else the rule answers "should this request take the Nexus path", and either marker answering yes is fine. In `provider-disclosure.ts` the answer becomes **a claim shown to the user**: `destinationClass: 'nexus-managed'` is what renders the provider as **"Tuff Nexus"** and suppresses the "Custom remote endpoint" wording.

Provider records come from user-editable configuration. Under `OR`, anything able to write `metadata.origin` — a hand-edited config, a plugin — could have its own `baseUrl` disclosed to the user as our managed endpoint. That is the same lie the panel exists to prevent.

The evidence that this was intended rather than overlooked: the `AND` landed in 5bf6e08b4 together with a test case in the same commit whose provider is literally named `"Spoofed Nexus"` (`custom-nexus-spoof`, asserted `'remote'`).

The strictness costs nothing against the real provider — `DEFAULT_PROVIDERS` ships `tuff-nexus-default` carrying `metadata.origin: 'tuff-nexus'` too, so both halves hold. A test reads that record rather than restating it, so the trade-off stays true if the shipped config changes.

## What this changes

- `privacy/provider-disclosure.ts` — keeps the combinator, imports `TUFF_NEXUS_PROVIDER_ID` / `TUFF_NEXUS_PROVIDER_ORIGIN` so the **values** cannot drift even though the combinator deliberately differs, and documents why unifying it is wrong.
- `ai/providers/nexus-provider.ts` — `isNexusProviderConfig` was an exact restatement of the `OR` rule and now delegates to `isNexusManagedProvider`. This is the genuine duplicate #716 identified.

After #537 those were the only two copies left; the other two already share the rule.

## Verification

- `provider-disclosure.test.ts`: 7 passed. New `nexus attribution is not spoofable` block covers the real provider (positive control — every other assertion also passes for a classifier that never returns `'nexus-managed'`), origin-only, id-only, and the shipped-record trade-off.
- **Mutation test**: applying the change #716 asked for (`&&` → `||`) fails 3 tests, including the pre-existing spoof case; the positive control still passes.
- `typecheck:node` = 6, unchanged from baseline. ESLint clean on all three files.
- `provider-factory.test.ts` fails to collect in this environment (`Electron failed to install correctly` — local `node_modules/electron` is missing `dist`); identical at HEAD and unrelated.