### PR TITLE
fix(ci): stop the release-notes gate reporting checks it never performed

### DIFF
--- a/scripts/release-notes-gateway.mjs
+++ b/scripts/release-notes-gateway.mjs
@@ -13,6 +13,13 @@ import {
 const argv = process.argv.slice(2)
 const command = argv[0] || 'verify'
 const repoRoot = path.resolve(getArgValue(argv, '--repo-root', process.cwd()))
+// Tracked separately from the values themselves: when --version is omitted it defaults to
+// the root package.json, and when --tag is omitted it defaults to `v${version}`. The
+// root-version and tag-version checks then compare a value against itself and can never
+// fail. CI reaches this through quality:pr with no flags, so both reported "pass" while
+// testing nothing (#731).
+const versionProvided = getArgValue(argv, '--version', null) !== null
+const tagProvided = getArgValue(argv, '--tag', null) !== null
 const version = getArgValue(argv, '--version', readPackageVersion(repoRoot))
 const tag = getArgValue(argv, '--tag', `v${version}`)
 
@@ -75,19 +82,27 @@ function verify() {
   const checks = [
     {
       name: 'root-version',
-      pass: rootVersion === version,
+      // Not applicable rather than passing: with no --version there is nothing independent
+      // to compare the root package.json against. A PR has no release tag, so this is the
+      // normal CI case, not a misconfiguration.
+      pass: versionProvided ? rootVersion === version : true,
+      applicable: versionProvided,
       expected: version,
       actual: rootVersion,
     },
     {
       name: 'core-version',
+      applicable: true,
       pass: coreVersion === version,
       expected: version,
       actual: coreVersion,
     },
     {
       name: 'tag-version',
-      pass: tag.replace(/^v/, '') === version,
+      // Needs a real tag from outside this process. Defaulting to `v${version}` compares
+      // the derived value with what it was derived from.
+      pass: tagProvided ? tag.replace(/^v/, '') === version : true,
+      applicable: tagProvided,
       expected: version,
       actual: tag.replace(/^v/, ''),
     },

--- a/scripts/release-notes-gateway.test.mjs
+++ b/scripts/release-notes-gateway.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it } from 'vitest'
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptsDir, '..')
+const gateway = path.join(scriptsDir, 'release-notes-gateway.mjs')
+
+function verify(args = []) {
+  // The gate exits non-zero when a check fails, which is the point of it — so read stdout
+  // from the thrown result rather than letting execFileSync swallow the report.
+  try {
+    return JSON.parse(
+      execFileSync('node', [gateway, 'verify', ...args], { cwd: repoRoot, encoding: 'utf8' }),
+    )
+  }
+  catch (error) {
+    return JSON.parse(String(error.stdout ?? ''))
+  }
+}
+
+function check(report, name) {
+  return report.checks.find(entry => entry.name === name)
+}
+
+describe('release notes gateway version checks', () => {
+  it('does not claim to have checked the version when nothing was passed to compare', () => {
+    // CI reaches this through quality:pr with no flags. --version then defaults to the root
+    // package.json and --tag to `v${version}`, so both checks compared a value against
+    // itself and reported pass while testing nothing (#731).
+    const report = verify()
+
+    assert.equal(check(report, 'root-version').applicable, false)
+    assert.equal(check(report, 'tag-version').applicable, false)
+    assert.equal(report.valid, true, 'a PR with no release tag must still pass the gate')
+  })
+
+  it('really compares the tag once one is supplied', () => {
+    // The regression guard: if these ever become tautologies again, a wrong tag passes.
+    const report = verify(['--tag', 'v9.9.9'])
+
+    assert.equal(check(report, 'tag-version').applicable, true)
+    assert.equal(check(report, 'tag-version').pass, false)
+    assert.equal(report.valid, false)
+  })
+
+  it('keeps core-version a real check in both modes', () => {
+    // Control: core-version never depended on a defaulted input, so it must stay applicable
+    // and passing — otherwise this change quietly weakened a check that was working.
+    assert.equal(check(verify(), 'core-version').applicable, true)
+    assert.equal(check(verify(), 'core-version').pass, true)
+  })
+})


### PR DESCRIPTION
Closes #731.

`--version` defaults to the root `package.json` and `--tag` defaults to `` `v${version}` ``, so `root-version` and `tag-version` compared a value **against itself**.

CI reaches this through `ci.yml:153` → `quality:pr` → `release:notes:verify` with **no flags**, so two of the four checks reported `pass` on every PR while testing nothing.

### They are now reported as not applicable, not as passing
That distinction is the fix. A pull request has no release tag, so there genuinely is nothing independent to compare against — the problem was the report *claiming otherwise*.

Both become real checks the moment a value is supplied:

```
no flags        -> root-version n/a, tag-version n/a, exit 0   (CI unchanged)
--tag v9.9.9    -> tag-version applicable, pass=false, exit 1
```

### Tracing the caller changed the fix
My first scan suggested nothing invoked the gate at all — which would have made this cosmetic. But the control I used to trust that scan (`check-action-pins`) turns out not to be referenced by any workflow either, so **the scan proved nothing**.

Re-checked with `actions/checkout` as the control (11 files) and found the real chain through the `quality:pr` script. The gate does run on every PR.

### Control against over-correcting
`core-version` never depended on a defaulted input. A test pins that it stays `applicable: true` and passing, so this change cannot quietly weaken a check that was already working.

Mutation-verified: restoring the tautology turns both new assertions red. **194/194** across `vitest.workspace-scripts.config.mjs`.
