### PR TITLE
fix(utils): publish a loadable entry point [#566]

### DIFF
--- a/packages/utils/__tests__/publish-shape.test.ts
+++ b/packages/utils/__tests__/publish-shape.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The published package must be loadable by Node (#566).
+ *
+ * @talex-touch/utils is public, and its entry was `index.ts` — a raw TypeScript barrel whose
+ * re-exports are extensionless directory specifiers. Node 24 strips the types, reparses as ESM and
+ * then cannot resolve `./account`, so `import '@talex-touch/utils'` failed outright with
+ * ERR_UNSUPPORTED_DIR_IMPORT. Only the in-repo Vite aliases hid it.
+ *
+ * The fix publishes a bundle. What is worth pinning is not that decision but the three things
+ * measured along the way, each of which looks like an improvement and is not:
+ *
+ * 1. Publishing TypeScript can never work, whatever the specifiers say. Even with `./account/index.ts`
+ *    written out in full, Node refuses: ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING. And adding those
+ *    extensions in source breaks the core-app typecheck, which has no allowImportingTsExtensions.
+ * 2. An `exports` map is the usual advice and would be a serious regression here. Subpath patterns
+ *    resolve to exact files: neither Node nor esbuild falls through a fallback array when the first
+ *    target is merely missing. Mapping the wildcard to itself breaks every deep import, and a
+ *    fallback of star-dot-ts then star-slash-index-dot-ts breaks the directory half — measured
+ *    against 144 in-repo subpaths. With no exports map, classic resolution keeps them all working
+ *    exactly as before.
+ * 3. `main` has to be the ESM output. Pointed at the CJS build, `import` goes through
+ *    cjs-module-lexer and yields 2 named exports instead of 610; pointed at `.mjs`, `require()`
+ *    still works because Node ≥22.12 can require ESM, and engines already demands ≥24.15.
+ */
+
+const ROOT = path.resolve(__dirname, '..')
+const manifest = JSON.parse(readFileSync(path.join(ROOT, 'package.json'), 'utf8')) as {
+  main: string
+  files: string[]
+  scripts: Record<string, string>
+  exports?: unknown
+  publishConfig: Record<string, string>
+  engines: { node: string }
+}
+
+describe('published entry points', () => {
+  it('resolves to built JavaScript, not to a source barrel', () => {
+    const { publishConfig } = manifest
+
+    expect(publishConfig.main).toBe('./dist/index.mjs')
+    expect(publishConfig.module).toBe('./dist/index.mjs')
+    expect(publishConfig.types).toBe('./dist/index.d.mts')
+    for (const field of ['main', 'module', 'types']) {
+      expect(publishConfig[field]).not.toMatch(/\.ts$/)
+    }
+  })
+
+  it('keeps the in-repo entry on source, so nothing here changes how the app resolves it', () => {
+    // Positive control, and the reason publishConfig is used at all: every assertion above would
+    // also hold if the package had simply been switched to dist, which would make the app bundle a
+    // prebuilt copy alongside the sources it already compiles — two instances of every singleton.
+    expect(manifest.main).toBe('index.ts')
+    expect(manifest.exports).toBeUndefined()
+  })
+
+  it('publishes through pnpm, which is what applies publishConfig', () => {
+    // npm only understands registry/tag/access there. Run `npm publish` and the tarball keeps
+    // main: "index.ts" — the bug ships again with every field of the fix present in the repo.
+    expect(manifest.scripts.publish).toContain('pnpm publish')
+    expect(manifest.scripts.publish).not.toMatch(/\bnpm publish\b/)
+  })
+
+  it('builds before publishing and ships the result', () => {
+    expect(manifest.scripts.prepublishOnly).toBe('pnpm run build')
+    expect(manifest.scripts.build).toContain('--out-dir dist')
+    expect(manifest.files).toContain('dist')
+  })
+
+  it('requires a Node new enough to require() the ESM entry', () => {
+    // main is .mjs, so CJS consumers depend on require(esm) — Node 22.12+.
+    const minimum = /(\d+)/.exec(manifest.engines.node)?.[1]
+
+    expect(Number(minimum)).toBeGreaterThanOrEqual(23)
+  })
+})
+
+describe('bare specifiers the ESM bundle emits', () => {
+  const source = readFileSync(
+    path.join(ROOT, 'core-box/preview/abilities/time-delta-ability.ts'),
+    'utf8'
+  )
+
+  it('gives dayjs plugin subpaths an explicit extension', () => {
+    // Bundlers resolve `dayjs/plugin/duration`; Node ESM does not, and these stay external in the
+    // bundle. Without the extension the built entry throws ERR_MODULE_NOT_FOUND on import — which
+    // is the same failure #566 reports, just moved one level down.
+    expect(source).toContain('dayjs/plugin/duration.js')
+    expect(source).toContain('dayjs/plugin/relativeTime.js')
+    expect(source).not.toMatch(/["']dayjs\/plugin\/[a-zA-Z]+["']/)
+  })
+
+  it('is reading the file it thinks it is', () => {
+    // The assertion above is three greps; an empty or renamed file would satisfy the negative one.
+    expect(source).toContain('import dayjs from')
+  })
+})

--- a/packages/utils/core-box/preview/abilities/time-delta-ability.ts
+++ b/packages/utils/core-box/preview/abilities/time-delta-ability.ts
@@ -5,8 +5,8 @@ import type {
   PreviewCardPayload,
 } from "../types";
 import dayjs from "dayjs";
-import duration from "dayjs/plugin/duration";
-import relativeTime from "dayjs/plugin/relativeTime";
+import duration from "dayjs/plugin/duration.js";
+import relativeTime from "dayjs/plugin/relativeTime.js";
 import { BasePreviewAbility } from "../sdk";
 
 dayjs.extend(duration);

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,6 +18,7 @@
   "main": "index.ts",
   "module": "./index.ts",
   "files": [
+    "dist",
     "account",
     "analytics",
     "animation",
@@ -49,13 +50,15 @@
     "node": ">=24.15.0"
   },
   "scripts": {
+    "build": "tsup index.ts --format esm --dts --target node24 --platform neutral --clean --out-dir dist --tsconfig tsconfig.build.json",
     "benchmark:preview": "vitest run \"__tests__/core-box/preview-sdk.benchmark.test.ts\" --reporter verbose",
     "lint": "pnpm exec eslint --cache .",
     "lint:fix": "pnpm exec eslint --cache --fix .",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "publish": "npm publish --access public"
+    "publish": "pnpm publish --access public",
+    "prepublishOnly": "pnpm run build"
   },
   "peerDependencies": {
     "electron": "^40.0.0 || ^41.0.0",
@@ -74,7 +77,14 @@
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
     "@vitest/coverage-v8": "^3.2.7",
+    "tsup": "^8.5.1",
     "vitest": "^3.2.7",
     "vue": "^3.5.39"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.mjs",
+    "module": "./dist/index.mjs",
+    "types": "./dist/index.d.mts"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,7 +18,6 @@
   "main": "index.ts",
   "module": "./index.ts",
   "files": [
-    "dist",
     "account",
     "analytics",
     "animation",
@@ -28,6 +27,7 @@
     "cloud-sync",
     "common",
     "core-box",
+    "dist",
     "electron",
     "env",
     "eventbus",

--- a/packages/utils/tsconfig.build.json
+++ b/packages/utils/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "jsx": "preserve",
+    "lib": ["ESNext", "DOM"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "__tests__", "dist"]
+}

--- a/packages/utils/tsconfig.build.json
+++ b/packages/utils/tsconfig.build.json
@@ -1,14 +1,14 @@
 {
   "compilerOptions": {
     "target": "ESNext",
+    "jsx": "preserve",
+    "lib": ["ESNext", "DOM"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "strict": true,
-    "skipLibCheck": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "jsx": "preserve",
-    "lib": ["ESNext", "DOM"]
+    "skipLibCheck": true
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "__tests__", "dist"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1309,6 +1309,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.7
         version: 3.2.7(vitest@3.2.7(@types/debug@4.1.13)(@types/node@24.13.2)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(sass@1.101.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@microsoft/api-extractor@7.55.2(@types/node@24.13.2))(jiti@2.7.0)(postcss@8.5.23)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       vitest:
         specifier: ^3.2.7
         version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.2)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(sass@1.101.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)


### PR DESCRIPTION
Closes #566.

Reproduced on Node 24.18.0 exactly as reported — importing the published package throws `ERR_UNSUPPORTED_DIR_IMPORT`, because `main` is a TypeScript barrel whose re-exports are extensionless directory specifiers. Only the in-repo Vite aliases hid it.

## Approach

A `tsup` build, with the published `main`/`module`/`types` pointed at it **through `publishConfig`**. In-repo resolution is byte-for-byte unchanged — the app keeps compiling the sources it always did, rather than bundling a second prebuilt copy of every singleton alongside them.

## Three measurements that contradicted the obvious fix

**1. Publishing TypeScript cannot be made to work.** Writing the directory specifiers out in full doesn't help: Node refuses with `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` for anything under `node_modules`. And adding `.ts` extensions in source breaks the core-app typecheck, which has no `allowImportingTsExtensions` (TS5097).

**2. An `exports` map — the issue's suggestion — is a regression.** Subpath patterns resolve to exact files, and neither Node nor esbuild falls through a fallback array when the first target is merely missing. Measured against this repo's 144 distinct deep subpaths, using the current published shape as a control:

| `"./*"` form | `intelligence/nexus-provider` | `transport/events/types` |
|---|---|---|
| none (control = today) | OK | OK |
| `"./*"` | FAIL | FAIL |
| `["./*.ts", "./*/index.ts"]` | OK | FAIL |
| `["./*", "./*.ts", "./*/index.ts"]` | FAIL | FAIL |

The file half and the directory half cannot both be served by one pattern. With **no** exports map, classic resolution keeps every subpath working exactly as before.

**3. `main` has to be the ESM output.** Pointed at the CJS build, `import` goes through `cjs-module-lexer` and yields **2** named exports instead of 610. Pointed at `.mjs`, `require()` still works — Node ≥22.12 can require ESM, and `engines` already demands ≥24.15.

Also: the two `dayjs/plugin/*` imports needed an explicit `.js`. They stay external in the bundle, and Node ESM does not resolve those bare subpaths without an extension — the same failure one level down.

## Verification

Packed with `pnpm pack` and installed into a clean project:

```
main= ./dist/index.mjs  types= ./dist/index.d.mts  exports= ABSENT
ESM OK — exports: 610
CJS OK — exports: 610
```

- Bundler probe over deep subpaths matches the control exactly (the two probe failures are `node:fs/promises` under `platform: neutral`, present on both sides).
- `packages/utils`: 140 test files, 1095 passed. New `publish-shape.test.ts` (7) pins the entry shape, that the in-repo manifest stays on source, and that publishing goes through **pnpm** — `npm publish` ignores `publishConfig` field replacement, which would silently ship the bug again with every part of the fix present in the repo. Mutation-tested: restoring `main: index.ts` + `npm publish` fails 2.
- `typecheck:node` = 6, unchanged. Positive control: breaking the dayjs specifier drives it to 35, proving the file is in the program.
- `typecheck:web` = 9 on this branch, none in touched files (6 in `tuff-intelligence`, 2 `LogTerminal.vue`, 1 `theme-style.ts`) — pre-existing.
- Lockfile diff is 3 lines: `tsup` added to `packages/utils`, resolved from the existing store.