### PR TITLE
ci: add the missing CI workflow for packages/tuff-core

### DIFF
--- a/.github/workflows/package-tuff-core-ci.yml
+++ b/.github/workflows/package-tuff-core-ci.yml
@@ -1,0 +1,41 @@
+name: Tuff Core Package CI
+
+# @talex-touch/tuff-core is published to npm on push to master by
+# package-tuff-cli-publish.yml, but no CI workflow had packages/tuff-core in its
+# trigger paths — so lint and build first ran at publish time, on a commit that was
+# already being released (#734).
+#
+# Paths mirror the publish workflow's triggers, so anything that can cause a
+# publish also causes a check.
+
+on:
+  pull_request:
+    paths:
+      - "packages/tuff-core/**"
+      - ".github/workflows/package-tuff-core-ci.yml"
+      - ".github/workflows/package-ci.yml"
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - "packages/tuff-core/**"
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: ./.github/workflows/package-ci.yml
+    with:
+      package-name: tuff-core
+      package-path: packages/tuff-core
+      run-lint: true
+      lint-command: pnpm lint
+      # No test script in this package; enabling it would fail on arrival.
+      run-test: false
+      # Unlike utils, this package does have a build (tsup, emitting types via --dts),
+      # and the publish workflow already runs it at line 176. Running it here moves that
+      # from "discovered during release" to "discovered on the PR".
+      run-build: true
+      run-typecheck: false


### PR DESCRIPTION
Closes #734.

`@talex-touch/tuff-core` is published to npm on push to master by `package-tuff-cli-publish.yml`, but **no CI workflow had `packages/tuff-core` in its trigger paths**. Its lint and build first ran at publish time — on a commit that was already being released.

Independent of the other workflow PRs in flight; this adds a new file and touches nothing existing.

### Confirmed with a working control
An empty grep proves nothing on its own, so I scanned both:

```
packages/tuffex     -> 2 non-publish workflows
packages/tuff-core  -> 0        (now 1)
```

### Configured from what the package has, not by copying the utils caller
| input | value | why |
|---|---|---|
| `run-lint` | `true` | eslint over `src`, verified clean today |
| `run-build` | `true` | tsup with `--dts`; the publish workflow **already runs this at line 176**, so the command is known to work — this moves the failure from release time to PR time |
| `run-test` | `false` | there is no `test` script; enabling it would fail on arrival |

Trigger paths mirror the publish workflow's, so anything that can cause a publish now also causes a check.

### Verified
Parsed both files and checked my inputs against the reusable workflow's own `workflow_call` contract — **no unknown inputs, no missing required ones**. `check-action-pins` and `check-workflow-injection` both now read **19** workflows.

**Not verified:** the build itself. `tsup` does not start in this shell (mise `command_not_found`). The evidence it works is that publishing runs the same command and currently succeeds.
