### PR TITLE
docs: point the startup order at index.ts and pin what it cannot state [#611]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,17 @@ This is a pnpm workspace monorepo with the main application in `apps/core-app/`,
 - **OCR** ([modules/ocr/](apps/core-app/src/main/modules/ocr/)): Native OCR via @talex-touch/tuff-native (Apple Vision / Windows OCR) with AI-provider fallback
 - **Clipboard** ([modules/clipboard/](apps/core-app/src/main/modules/clipboard/)): System clipboard operations
 
-**Module Loading Order** (sequential after Electron ready):
-1. DatabaseModule → 2. StorageModule → 3. ShortcutModule → 4. ExtensionLoaderModule → 5. CommonChannelModule → 6. PluginModule → 7. PluginLogModule → 8. CoreBoxModule → 9. TrayHolderModule → 10. AddonOpenerModule → 11. ClipboardModule → 12. TuffDashboardModule → 13. FileSystemWatcher → 14. FileProtocolModule → 15. TerminalModule
+**Module Loading Order**
+
+The order is defined by `foregroundModulesToLoad` and `deferredModulesToLoad` in [src/main/index.ts](apps/core-app/src/main/index.ts) — read those arrays rather than a list here, which goes stale as modules are added. Currently 38 foreground and 2 deferred.
+
+What the arrays alone don't tell you:
+
+- **Two phases.** Foreground modules load sequentially once Electron is ready. Deferred modules (`extensionLoaderModule`, `FileSystemWatcher`) are scheduled via `setImmediate` after the first window is up, so they must not be depended on during startup.
+- **Optional modules.** Members of `optionalModulesToLoad` (currently `trayManagerModule`) log a warning and let startup continue if they fail. Every other module failing to load aborts startup.
+- **Ordering constraints that are load-bearing**, and are marked as such in the array: `permissionModule` must precede `pluginModule`, and `flowBusModule` must follow it. `databaseModule` is first because storage and everything downstream reads through it.
+
+When inserting a module, place it by the dependency you actually have — the array position is the whole contract, and getting it wrong reproduces only at startup.
 
 **Renderer Process (src/renderer/):**
 - Vue 3 application with TypeScript

--- a/apps/core-app/src/main/startup-order-doc.test.ts
+++ b/apps/core-app/src/main/startup-order-doc.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * CLAUDE.md must not contradict the startup arrays (#611).
+ *
+ * The doc used to carry a hand-written 15-step order. By the time it was found it was missing 24
+ * modules, named one that does not exist, and had the relative order of the rest wrong — so a
+ * developer using it to pick an insertion point would land a module before permissionModule and get
+ * an ordering bug that reproduces only at startup.
+ *
+ * The list is now a pointer to index.ts plus the handful of facts the arrays do not state. Those
+ * facts are what this pins: prose cannot be typechecked, and the previous version drifted for long
+ * enough to grow 24 modules out of date without anyone noticing.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..')
+const INDEX = readFileSync(path.join(__dirname, 'index.ts'), 'utf8')
+const CLAUDE_MD = readFileSync(path.join(REPO_ROOT, 'CLAUDE.md'), 'utf8')
+
+function moduleList(name: string): string[] {
+  const block = new RegExp(`const ${name} = \\[(.*?)\\n?\\]`, 's').exec(INDEX)?.[1]
+  if (!block) throw new Error(`${name} not found in index.ts`)
+  return block
+    .replace(/\/\/[^\n]*/g, '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+const foreground = moduleList('foregroundModulesToLoad')
+const deferred = moduleList('deferredModulesToLoad')
+
+describe('startup arrays', () => {
+  it('parses both phases', () => {
+    // Positive control. Every count and ordering assertion below is vacuous against an empty list,
+    // and the first version of this parser did return an empty deferred list — the array is written
+    // on one line, which a per-line regex silently truncates to its first entry.
+    expect(foreground.length).toBeGreaterThan(30)
+    expect(deferred).toEqual(['extensionLoaderModule', 'FileSystemWatcher'])
+    expect(foreground[0]).toBe('databaseModule')
+  })
+
+  it('keeps the constraints the array comments call out', () => {
+    // Not stylistic: permissions must be registered before plugins can be granted them, and the
+    // flow bus binds to plugin-provided transports.
+    expect(foreground.indexOf('permissionModule')).toBeLessThan(foreground.indexOf('pluginModule'))
+    expect(foreground.indexOf('flowBusModule')).toBeGreaterThan(foreground.indexOf('pluginModule'))
+  })
+})
+
+describe('CLAUDE.md startup section', () => {
+  it('quotes the current module counts', () => {
+    // This is the assertion that fails when a module is added — which is the point. Update the
+    // sentence in CLAUDE.md; do not delete the count and leave the prose vague.
+    expect(CLAUDE_MD).toContain(
+      `Currently ${foreground.length} foreground and ${deferred.length} deferred.`
+    )
+  })
+
+  it('names only modules that exist', () => {
+    // 'TrayHolderModule' is what the old list called trayManagerModule; no such symbol has ever
+    // existed. Any *Module identifier the doc mentions in this section must be resolvable.
+    const section = /\*\*Module Loading Order\*\*([\s\S]*?)\n\*\*/.exec(CLAUDE_MD)?.[1] ?? ''
+    expect(section).not.toBe('')
+
+    const mentioned = [...section.matchAll(/`([A-Za-z]+(?:Module|Watcher))`/g)].map(
+      (match) => match[1]!
+    )
+    expect(mentioned.length).toBeGreaterThan(3)
+    for (const name of mentioned) expect(INDEX).toContain(name)
+  })
+
+  it('still describes the optional-module escape hatch', () => {
+    const optional = /optionalModulesToLoad = new Set\(\[(.*?)\]/s.exec(INDEX)?.[1]?.trim()
+
+    expect(optional).toBe('trayManagerModule')
+    expect(CLAUDE_MD).toContain('optionalModulesToLoad')
+  })
+})


### PR DESCRIPTION
Closes #611.

Confirmed. The 15-step list in CLAUDE.md was missing 24 modules, named one that has never existed (`TrayHolderModule` — the symbol is `trayManagerModule`), and had the order of the rest wrong: `fileProtocolModule` loads 5th not 14th, `extensionLoaderModule` is deferred not 4th.

## What replaces it

A pointer to `foregroundModulesToLoad` / `deferredModulesToLoad` as the source of truth — regenerating a 40-item list would just drift again — plus the four things reading those arrays does **not** tell you, which is where the actual risk was:

- **Two phases.** Deferred modules are scheduled via `setImmediate` after the first window, so nothing in startup may depend on them.
- **Optional modules.** `optionalModulesToLoad` members (`trayManagerModule`) warn and continue on failure; every other module aborts startup.
- **Load-bearing constraints.** `permissionModule` before `pluginModule`, `flowBusModule` after it, `databaseModule` first.
- Array position is the whole contract.

## One correction to the issue

The counts are **38 foreground + 2 deferred = 40**, not 37 + 2 = 39. `deferredModulesToLoad` is written on one line, so a per-line scan truncates it to its first entry — my own first parser made the same mistake, which is why the test has a positive control for it.

## Verification

`startup-order-doc.test.ts`, 5 passed: counts, deferred and optional membership, both ordering constraints, and that every `*Module` the section names resolves in `index.ts`. Restoring the old list fails 3 of the 5 — including the `TrayHolderModule` case. ESLint clean.