### PR TITLE
fix(ci): close the plugin permission drift and stop it recurring

### DIFF
--- a/scripts/validate-plugins.mjs
+++ b/scripts/validate-plugins.mjs
@@ -43,6 +43,12 @@ const KNOWN_PERMISSION_IDS = new Set([
   'search.root-results',
   'window.create',
   'window.capture',
+  // Added when the drift below was measured: the registry had 27 ids, this set had 22.
+  'storage.sqlite',
+  'media.read',
+  'i18n.read',
+  'lexicon.read',
+  'lexicon.register',
 ])
 
 function resolveSearchProviderPermissionIds(scopes = []) {
@@ -181,7 +187,10 @@ for (const pluginName of pluginDirs) {
       .forEach(id => declaredPermissionIds.add(id))
     const unknownIds = rawIds.filter(id => typeof id === 'string' && !KNOWN_PERMISSION_IDS.has(id))
     if (unknownIds.length > 0) {
-      logWarn(pluginName, `Unknown permission IDs: ${unknownIds.join(', ')}`)
+      // logError, not logWarn: a warning does not affect the exit code, so a manifest
+      // asking for a permission the runtime does not define passed CI silently. All 24
+      // plugins are clean today, so this fails nothing that currently works (#735).
+      logError(pluginName, `Unknown permission IDs: ${unknownIds.join(', ')}`)
     }
   }
 

--- a/scripts/validate-plugins.permissions.test.mjs
+++ b/scripts/validate-plugins.permissions.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it } from 'vitest'
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptsDir, '..')
+const validatorPath = path.join(scriptsDir, 'validate-plugins.mjs')
+const registryPath = path.join(repoRoot, 'packages/utils/permission/registry.ts')
+
+/**
+ * KNOWN_PERMISSION_IDS is a hand-copied snapshot of the permission registry. It had drifted
+ * to 22 entries against a registry of 27, and unknown ids were reported with logWarn — which
+ * does not affect the exit code, so a manifest requesting an undefined permission passed CI
+ * silently (#735).
+ *
+ * Copying it again would just restart the clock. This fails the moment the two disagree.
+ */
+
+function hardcodedIds() {
+  const source = fs.readFileSync(validatorPath, 'utf8')
+  const block = source.match(/KNOWN_PERMISSION_IDS = new Set\(\[([\s\S]*?)\]\)/)
+  assert.ok(block, 'KNOWN_PERMISSION_IDS block not found — this test needs updating')
+  return new Set([...block[1].matchAll(/'([^']+)'/g)].map(entry => entry[1]))
+}
+
+function registryIds() {
+  // Double quotes in registry.ts, single quotes in the validator. Matching only one of them
+  // reported an empty registry and a drift of 22, which is how this test came to check both.
+  const source = fs.readFileSync(registryPath, 'utf8')
+  return new Set(
+    [...source.matchAll(/id:\s*['"]([\w.-]+)['"]/gi)].map(entry => entry[1]),
+  )
+}
+
+describe('plugin permission validator', () => {
+  it('reads a non-empty registry, so the comparison below is not vacuous', () => {
+    // Control. If the registry regex ever stops matching, every assertion here would pass
+    // against an empty set.
+    assert.ok(registryIds().size > 20, 'expected the registry to define many permissions')
+  })
+
+  it('knows every permission the registry defines', () => {
+    const known = hardcodedIds()
+    const missing = [...registryIds()].filter(id => !known.has(id))
+
+    assert.deepEqual(missing, [], `validator is missing registry permissions: ${missing}`)
+  })
+
+  it('does not invent permissions the registry has never defined', () => {
+    const registry = registryIds()
+    const invented = [...hardcodedIds()].filter(id => !registry.has(id))
+
+    assert.deepEqual(invented, [], `validator lists unknown permissions: ${invented}`)
+  })
+
+  it('fails the run on an unknown permission id rather than warning', () => {
+    // A warning leaves the exit code at 0, which is how this went unnoticed.
+    const source = fs.readFileSync(validatorPath, 'utf8')
+    const site = source.match(/if \(unknownIds\.length > 0\) \{[\s\S]*?\}/)
+
+    assert.ok(site, 'unknown-permission branch not found')
+    assert.match(site[0], /logError\(/)
+    assert.doesNotMatch(site[0], /logWarn\(/)
+  })
+})


### PR DESCRIPTION
Closes #735.

`KNOWN_PERMISSION_IDS` is a hand-copied snapshot of `packages/utils/permission/registry.ts`. Measured against the registry it held **22 of 27** ids, missing `storage.sqlite`, `media.read`, `i18n.read`, `lexicon.read`, `lexicon.register`.

The issue says four; I find five. Most likely one landed after the audit ran on 2026-08-05 rather than the count being wrong — which is itself the argument for a check instead of another hand-copy.

### Unknown ids now fail instead of whispering
They were reported with `logWarn`, which does not touch `hasErrors`, so a manifest requesting a permission the runtime does not define passed `ci.yml:122` **silently**.

Verified this breaks nothing that works today: all **24 plugins validate clean** both before and after.

### A test, not just a refreshed list
Copying the list again restarts the clock. The test fails if the validator misses a registry permission, invents one the registry never had, or if the unknown-id branch goes back to warning.

### The test compares both quote styles on purpose
My first attempt matched only single quotes, found **zero** ids in a registry that uses double quotes, and reported a drift of 22 — wrong enough to notice. A control asserts the registry parses to more than 20 ids so that failure mode cannot come back silently.

Mutation-verified: dropping an id fails the coverage test, reverting to `logWarn` fails the severity test, each leaving the other green. **192/192**.
