### PR TITLE
fix(ci): the injection checker was blind to single-line run: steps

### DIFF
--- a/scripts/check-workflow-injection.mjs
+++ b/scripts/check-workflow-injection.mjs
@@ -58,6 +58,15 @@ export function findInjections(files, readFile, unsafe = UNSAFE) {
     const text = readFile(file)
     if (!text)
       continue
+
+    // `inputs.` means two different things. In a workflow_dispatch workflow it is text a
+    // user typed into the Actions UI. In a reusable workflow it is a literal written in a
+    // caller workflow committed to this repository — the same trust level as the file doing
+    // the interpolating, and not attacker-influenced. Policing both makes the reusable
+    // package-ci.yml a permanent false positive, which is how a real check gets disabled.
+    const reusableOnly = /^on:[\t\v\f\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]*\n\s+workflow_call:/m.test(text)
+      && !/^\s+workflow_dispatch:/m.test(text)
+    const active = reusableOnly ? unsafe.filter(entry => entry !== 'inputs.') : unsafe
     const lines = text.split('\n')
     let inRun = false
     let runIndent = 0
@@ -69,6 +78,21 @@ export function findInjections(files, readFile, unsafe = UNSAFE) {
         runIndent = indent
         return
       }
+      // A single-line `run: echo ${{ … }}` is a run body too. Only block scalars were
+      // recognised, so every one-line step was invisible to this check — including
+      // package-ci.yml:82, `run: ${{ inputs.typecheck-command }}`. Verified by injecting
+      // github.event.pull_request.title into a real workflow: it parsed, it sat in a run:
+      // step, and the scan still reported clean (#741).
+      const inlineRun = stripped.match(/^-?\s*run:\s*(\S.*)$/)
+      if (inlineRun) {
+        const body = inlineRun[1]
+        if (body.includes('${{')) {
+          const context = active.find(candidate => body.includes(candidate))
+          if (context)
+            problems.push({ file, line: index + 1, context, text: stripped.slice(0, 90) })
+        }
+        return
+      }
       if (inRun && stripped && indent <= runIndent)
         inRun = false
       if (!inRun || !line.includes('${{'))
@@ -76,7 +100,7 @@ export function findInjections(files, readFile, unsafe = UNSAFE) {
       // One finding per line. `github.event.inputs.x` matches both `github.event.inputs.`
       // and `inputs.`, and reporting it twice makes the count meaningless — which the
       // self-test caught before this shipped.
-      const context = unsafe.find(candidate => line.includes(candidate))
+      const context = active.find(candidate => line.includes(candidate))
       if (context)
         problems.push({ file, line: index + 1, context, text: stripped.slice(0, 90) })
     })
@@ -99,6 +123,27 @@ function readWorkflow(file) {
 
 function selfTest() {
   const cases = [
+    {
+      // The blind spot this check shipped with: only `run: |` and `run: >` were treated as
+      // run bodies, so every one-line step was invisible. Proven by injecting this into a
+      // real workflow, which parsed and still scanned clean (#741).
+      name: 'a single-line run: is inspected, not only block scalars',
+      text: '      run: echo "${{ github.event.pull_request.title }}"\n',
+      expect: 1,
+    },
+    {
+      // inputs. means a caller-written literal in a reusable workflow and a user-typed
+      // value in a dispatchable one. Policing the first makes package-ci.yml a permanent
+      // false positive, and a check that always fails gets turned off.
+      name: 'workflow_call inputs are not treated as attacker-influenced',
+      text: 'on:\n  workflow_call:\n    inputs:\n      cmd:\n        type: string\njobs:\n  a:\n    steps:\n      - run: ${{ inputs.cmd }}\n',
+      expect: 0,
+    },
+    {
+      name: 'the same inputs. reference is caught once the workflow is dispatchable',
+      text: 'on:\n  workflow_dispatch:\n  workflow_call:\n    inputs:\n      cmd:\n        type: string\njobs:\n  a:\n    steps:\n      - run: ${{ inputs.cmd }}\n',
+      expect: 1,
+    },
     {
       name: 'a workflow_dispatch input inside run: is caught',
       text: '      run: |\n        X="${{ github.event.inputs.tag }}"\n',


### PR DESCRIPTION
Closes #741 — but not in the direction the issue proposed. Please read the second half.

### The reported pattern is by design, and low risk
`package-ci.yml` interpolates caller command strings into `run:`. Its callers are workflow files **committed to this repository**, and `workflow_call` cannot be invoked from outside. Anyone who can supply those strings can already write arbitrary `run:` steps directly, so this is not a privilege boundary.

Measured usage: 6 caller jobs, of which **5 pass a bare `pnpm lint` / `test` / `build`** and one passes a single `pnpm --filter … run build`. Replacing this with a fixed command set would break that caller for no security gain.

### What I found instead: the injection checker could not see this line at all
`findInjections` only entered run-body mode on a block scalar — `/^-?\s*run:\s*[|>]/` — so a **one-line** `run: echo ${{ … }}` was never inspected.

Proven, not reasoned. I injected `github.event.pull_request.title` — a string on the checker's **own unsafe list** — into `ci.yml`:

```
file parses as YAML:            yes
poisoned run: steps found:      1
check-workflow-injection says:  clean
```

The self-test passed throughout, because every fixture used `run: |`.

### Fixing that alone would have broken CI
With single-line steps inspected, `package-ci.yml` produced 4 findings and the check went red — permanently, on a pattern that is fine.

So the second half separates the two meanings of `inputs.`:
- **workflow_dispatch** — text a user typed into the Actions UI → policed
- **workflow_call** — a literal in an in-repo caller, same trust level as the file interpolating it → not policed

A check that always fails is a check someone turns off.

### Verified
Three new self-test cases pin all of it, and reverting the single-line fix fails two of them:

```
single-line run: inspected                               ok
workflow_call inputs allowed                             ok
same reference caught once the workflow is dispatchable  ok
```

11/11 self-test cases, real workflows scan clean, 188/188 across `vitest.workspace-scripts.config.mjs`.

**This means the injection guarantee I cited in #1386, #1387, #1393, #1394 and #1399 was weaker than stated for single-line steps.** Those PRs add no single-line `run:` interpolation, so the conclusions hold — but the check backing them only becomes real with this PR.
