### PR TITLE
fix(ci): stop the pre-commit hook sweeping unrelated package.json edits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,23 @@
+CORE_PKG="apps/core-app/package.json"
+
+# Whether the developer already had unstaged edits here, checked BEFORE the sync runs.
+# sync:core-pkg rewrites five metadata fields, but `git add` stages the whole file — so
+# auto-staging swept an in-progress dependency edit into an unrelated commit (#740).
+if git diff --quiet -- "$CORE_PKG" 2>/dev/null; then
+  CORE_PKG_WAS_CLEAN=1
+else
+  CORE_PKG_WAS_CLEAN=0
+fi
+
 pnpm sync:core-pkg
-git add "apps/core-app/package.json" >/dev/null 2>&1 || true
+
+if [ "$CORE_PKG_WAS_CLEAN" = "1" ]; then
+  # The sync's change is the only change, so staging it cannot capture anything else.
+  git add "$CORE_PKG" >/dev/null 2>&1 || true
+elif ! git diff --quiet -- "$CORE_PKG" 2>/dev/null; then
+  echo "[pre-commit] $CORE_PKG has your own unstaged edits."
+  echo "[pre-commit] Version metadata was synced but NOT staged, so this commit does not"
+  echo "[pre-commit] silently include your other changes. Stage it yourself when ready."
+fi
 
 pnpm lint:staged


### PR DESCRIPTION
Closes #740.

`.husky/pre-commit` ran `sync:core-pkg` and then unconditionally staged `apps/core-app/package.json`. The sync rewrites five metadata fields (`version`, `description`, `author`, `homepage`, `license`), but `git add` stages the whole file — so a developer part-way through editing that file had those edits swept into whatever unrelated commit they were making, silently.

The hook now records whether the file had unstaged edits **before** the sync runs:

- **Clean beforehand** — the sync's change is the only change, staging it cannot capture anything else. Identical to today's behaviour, which is the common case.
- **Dirty beforehand** — the developer has their own work there. The sync still happens, the file is left unstaged, and the hook prints why.

Not staging unconditionally was rejected: that would let version-metadata sync silently miss commits. Silence was the actual defect, so the dirty branch has to speak up.

### Verification

| Scenario | Detection | Behaviour |
|---|---|---|
| File clean | `WAS_CLEAN=1` | auto-stages (unchanged) |
| File carries a pending `__probe740` dependency | `WAS_CLEAN=0` | does not stage, warns |

`sh -n` parses the hook. The commit on this branch was itself produced by the rewritten hook and touches only `.husky/pre-commit`.

**Not verified:** there is no test covering this hook — the repo has no test setup for `.husky/`, and I did not build one. The table above is a manual run, not a regression guard, so this behaviour could be silently reverted later.
