### PR TITLE
docs: stop the active-task table shipping dead links and finished work [#630]

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,7 @@
 
 ---
 
-## 📁 活跃 Trellis 任务全景（24 个）
+## 📁 活跃 Trellis 任务全景（22 个）
 
 优先级与状态以各任务 `task.json` / `prd.md` 为准。父子任务缩进展示。
 
@@ -73,11 +73,9 @@
 | ├ [ota-one-click-background-update](.trellis/tasks/07-22-ota-one-click-background-update/prd.md) | P2 | 🔄 in_progress |
 | └ [bilingual-whats-changed](.trellis/tasks/07-27-bilingual-whats-changed/prd.md) | P2 | 🔄 in_progress |
 | [harden-app-icon-self-healing](.trellis/tasks/07-24-harden-app-icon-self-healing/prd.md) | P2 | 🔄 real-profile evidence ready；N+1 release 开放 |
-| [install-launch-v2-4-13-beta-23](.trellis/tasks/07-26-install-launch-v2-4-13-beta-23/prd.md) | P2 | 🔄 in_progress |
-| [audit-plugin-privileged-security](.trellis/tasks/07-27-audit-plugin-privileged-security/prd.md) | P2 | planning |
+| install-launch-v2-4-13-beta-23 <sup>本地任务，未入库</sup> | P2 | 🔄 in_progress |
 | [base-anchor-liquid-animation](.trellis/tasks/07-27-base-anchor-liquid-animation/prd.md) | P2 | 🔄 in_progress（AC 验收中） |
 | [fix-plugin-folder-button](.trellis/tasks/07-27-fix-plugin-folder-button/prd.md) | P2 | 🔄 in_progress |
-| [tuffex-docs-audit](.trellis/tasks/07-28-tuffex-docs-audit/prd.md) | P2 | 🔄 审计进行中 |
 | [docs-roadmap-consolidation-cleanup](.trellis/tasks/07-30-docs-roadmap-consolidation-cleanup/prd.md) | P2 | 🔄 in_progress（本任务） |
 | [expose-plugin-search-sdk](.trellis/tasks/07-27-expose-plugin-search-sdk/prd.md) | P3 | planning |
 

--- a/apps/core-app/src/main/roadmap-task-links.test.ts
+++ b/apps/core-app/src/main/roadmap-task-links.test.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The active-task table must not ship dead links or finished work (#630).
+ *
+ * ROADMAP.md says its own statuses come from each task's `task.json`, but nothing enforced that, so
+ * rows outlived the tasks they point at. A maintainer picking up something marked in_progress got a
+ * 404 and no way to tell whether the task had been completed, renamed, or lost.
+ *
+ * Two rules, both derived from the table rather than from a copy of it: every link resolves, and a
+ * task whose committed status is `completed` does not sit in a table of active work. The second is
+ * deliberately one-directional — it demands removal when a task is finished and stays quiet
+ * otherwise, so an author whose local task.json is mid-edit does not get a spurious failure.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..')
+const ROADMAP = readFileSync(path.join(REPO_ROOT, 'ROADMAP.md'), 'utf8')
+
+const activeTable = (() => {
+  const lines = ROADMAP.split('\n')
+  const header = lines.findIndex((line) => line.startsWith('| 任务 |'))
+  if (header === -1) return []
+  const rows: string[] = []
+  for (const line of lines.slice(header + 2)) {
+    if (!line.startsWith('|')) break
+    rows.push(line)
+  }
+  return rows
+})()
+
+function linkedTasks(rows: string[]): Array<{ slug: string; row: string }> {
+  return rows.flatMap((row) => {
+    const match = /\]\(\.trellis\/tasks\/([^/]+)\/prd\.md\)/.exec(row)
+    return match ? [{ slug: match[1]!, row }] : []
+  })
+}
+
+function committedStatus(slug: string): string | null {
+  const file = path.join(REPO_ROOT, '.trellis/tasks', slug, 'task.json')
+  if (!existsSync(file)) return null
+  return (JSON.parse(readFileSync(file, 'utf8')) as { status?: string }).status ?? null
+}
+
+describe('ROADMAP active-task table', () => {
+  it('is found and populated', () => {
+    // Positive control: both rules below are vacuous against an empty table, which is exactly what
+    // a parser that missed the header would produce.
+    expect(activeTable.length).toBeGreaterThan(10)
+    expect(linkedTasks(activeTable).length).toBeGreaterThan(10)
+  })
+
+  it('agrees with the count in its own heading', () => {
+    const declared = /活跃 Trellis 任务全景（(\d+) 个）/.exec(ROADMAP)?.[1]
+
+    expect(Number(declared)).toBe(activeTable.length)
+  })
+
+  it('links only to tasks that exist in the repository', () => {
+    // A row may be unlinked — one task is kept out of version control via .git/info/exclude, so it
+    // is listed as plain text rather than as a link that 404s for every other clone.
+    const dead = linkedTasks(activeTable).filter(
+      ({ slug }) => !existsSync(path.join(REPO_ROOT, '.trellis/tasks', slug, 'prd.md'))
+    )
+
+    expect(dead.map(({ slug }) => slug)).toEqual([])
+  })
+
+  it('does not keep completed tasks in a table of active work', () => {
+    const finished = linkedTasks(activeTable).filter(
+      ({ slug }) => committedStatus(slug) === 'completed'
+    )
+
+    expect(finished.map(({ slug }) => slug)).toEqual([])
+  })
+
+  it('reads task.json for the rows it checks', () => {
+    // Third control, on the data rather than the parser: if every task.json were unreadable the
+    // rule above would pass by finding nothing.
+    const statuses = linkedTasks(activeTable).map(({ slug }) => committedStatus(slug))
+
+    expect(statuses.filter(Boolean).length).toBe(statuses.length)
+  })
+})


### PR DESCRIPTION
Closes #630.

The premise is right — the table drifts from the tasks it links — but **all three rows this issue names have already been dropped** since it was filed on 2026-08-05. Re-scanned all 27 task links on the current base; here is what is actually wrong.

## 1. Two completed tasks are listed as active

`audit-plugin-privileged-security` and `tuffex-docs-audit` are `completed` in the committed `task.json`, while the table shows `planning` and `🔄 审计进行中`. Removed; heading count follows, 24 → 22.

> Worth flagging: in the maintainer's **local** working copy those two read `planning` and `in_progress`. This PR follows the committed `task.json`, which is what ROADMAP itself declares authoritative and the only thing a reader of the repo can see. If the local state is the intended one, the task records are what should move, not the table.

## 2. One row is not a stale archive link — it was never in the repo

`install-launch-v2-4-13-beta-23` has **no git history at all**. It is excluded via `.git/info/exclude`, which is per-clone and not distributed, so the row 404s for every clone but its author's — while resolving fine locally, which is why it survived. The task is real and still `in_progress`, so I kept the row and dropped the link rather than deleting work from the roadmap.

Verified with a positive control before trusting the absence: a sibling task in the same directory is tracked (62 task directories are), and `git check-ignore -v` names the exclude line.

## Verification

`roadmap-task-links.test.ts`, 5 passed. Every link resolves; no completed task sits in the active table; the heading count matches the row count. Three controls guard the scan itself — non-empty table, non-empty link set, and every `task.json` actually readable, since "found nothing" is what a broken parser reports.

Restoring the previous table fails 3 of the 5. ESLint clean.