### PR TITLE
docs: split the channel API by process and give each its real signatures [#612]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,20 +272,30 @@ The application uses a custom channel system abstracting Electron IPC:
 - `ChannelType.MAIN`: Main process ↔ renderer communication
 - `ChannelType.PLUGIN`: Plugin-specific isolated communication
 
-**Key APIs:**
-```typescript
-// Register handlers
-regChannel(type: ChannelType, eventName: string, callback): () => void
+**Key APIs** — two classes, not one surface. Every main-process call carries a `ChannelType`; no renderer call does.
 
-// Send messages
-send(eventName: string, arg?: any): Promise<any>
-sendTo(window: BrowserWindow, eventName: string, arg?: any): Promise<any>
-sendPlugin(pluginName: string, eventName: string, arg?: any): Promise<any>
+Main process ([core/channel-core.ts](apps/core-app/src/main/core/channel-core.ts)):
+```typescript
+regChannel(type: ChannelType, eventName: string, callback: ChannelCallback): () => void
+
+send(type: ChannelType, eventName: string, arg: unknown): Promise<unknown>
+sendTo(win: Electron.BrowserWindow, type: ChannelType, eventName: string, arg: unknown): Promise<unknown>
+sendPlugin(pluginName: string, eventName: string, arg?: unknown): Promise<unknown>
 
 // Key management (encryption for plugin isolation)
-requestKey(name: string): string
+requestKey(name: string, activation?: Pick<PluginActivationIdentity, 'pluginInstanceId' | 'activationGeneration'>): string
 revokeKey(key: string): boolean
 ```
+
+Renderer ([modules/channel/channel-core.ts](apps/core-app/src/renderer/src/modules/channel/channel-core.ts)) — the whole surface is three methods; there is no `sendTo`, `sendPlugin`, `requestKey` or `revokeKey`:
+```typescript
+regChannel<TRequest = unknown>(eventName: string, callback: (data: TRequest) => Promise<unknown> | unknown): () => void
+unRegChannel<TRequest = unknown>(eventName: string, callback: (data: TRequest) => Promise<unknown> | unknown): boolean
+
+send<TRequest = unknown, TResponse = unknown>(eventName: string, arg?: TRequest): Promise<TResponse>
+```
+
+The two `regChannel` signatures are the trap: passing a `ChannelType` to the renderer's registers a handler under that value as the event name, which type-checks and then never fires.
 
 **Implementation Notes:**
 - Uses IPC listeners on `@main-process-message` and `@plugin-process-message`

--- a/apps/core-app/src/main/core/channel-api-doc.test.ts
+++ b/apps/core-app/src/main/core/channel-api-doc.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The channel API block in CLAUDE.md must match the class it describes (#612).
+ *
+ * Six methods were listed as one surface. They come from two classes: every main-process call takes
+ * a ChannelType the doc omitted, no renderer call takes one, and four of the six do not exist in
+ * the renderer at all. The `sendTo(window, eventName, arg)` form it showed matched neither side.
+ *
+ * Copying either half cost something different — `send('evt', payload)` is rejected by the compiler
+ * in main, while `regChannel(ChannelType.MAIN, 'evt', cb)` in the renderer type-checks and
+ * registers the handler under the ChannelType as its event name, so it simply never fires.
+ *
+ * Each documented signature is checked against the declaration it claims to describe, and the
+ * renderer's absences are asserted as absences.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../../..')
+const MAIN = readFileSync(path.join(__dirname, 'channel-core.ts'), 'utf8')
+const RENDERER = readFileSync(
+  path.join(REPO_ROOT, 'apps/core-app/src/renderer/src/modules/channel/channel-core.ts'),
+  'utf8'
+)
+const CLAUDE_MD = readFileSync(path.join(REPO_ROOT, 'CLAUDE.md'), 'utf8')
+
+/**
+ * Collapses a multi-line signature to one line so it can be compared with the documented form.
+ *
+ * The padding inside the parentheses has to go too: the source wraps its longer signatures, which
+ * flattens to `sendTo( win: …`, while the doc writes them on a single line.
+ */
+function flatten(source: string): string {
+  return source.replace(/\s+/g, ' ').replace(/\(\s+/g, '(').replace(/\s+\)/g, ')')
+}
+
+const flatMain = flatten(MAIN)
+const flatRenderer = flatten(RENDERER)
+
+describe('documented main-process signatures', () => {
+  const signatures = [
+    'regChannel(type: ChannelType, eventName: string, callback: ChannelCallback): () => void',
+    'send(type: ChannelType, eventName: string, arg: unknown): Promise<unknown>',
+    'sendTo(win: Electron.BrowserWindow, type: ChannelType, eventName: string, arg: unknown): Promise<unknown>',
+    'sendPlugin(pluginName: string, eventName: string, arg?: unknown): Promise<unknown>',
+    'revokeKey(key: string): boolean'
+  ]
+
+  it('exist in channel-core.ts', () => {
+    // Positive control on the source side: a path typo would make every absence check below pass.
+    expect(flatMain).toContain('class TouchChannel')
+    for (const signature of signatures) expect(flatMain).toContain(signature)
+  })
+
+  it('are what CLAUDE.md shows', () => {
+    const documented = flatten(CLAUDE_MD)
+    for (const signature of signatures) {
+      expect(documented).toContain(flatten(signature))
+    }
+  })
+
+  it('never appear in CLAUDE.md without their ChannelType', () => {
+    // The specific defect: `send(eventName: string, arg?: any)` attributed to the main process.
+    expect(CLAUDE_MD).not.toContain('sendTo(window: BrowserWindow, eventName: string')
+    expect(CLAUDE_MD).not.toMatch(/^send\(eventName: string/m)
+  })
+})
+
+describe('documented renderer signatures', () => {
+  it('match the renderer class', () => {
+    for (const signature of [
+      'regChannel<TRequest = unknown>(eventName: string, callback: (data: TRequest) => Promise<unknown> | unknown): () => void',
+      'send<TRequest = unknown, TResponse = unknown>(eventName: string, arg?: TRequest): Promise<TResponse>'
+    ]) {
+      expect(flatRenderer).toContain(signature)
+      expect(flatten(CLAUDE_MD)).toContain(flatten(signature))
+    }
+  })
+
+  it('omit the four methods the renderer does not have', () => {
+    // Asserted against the class body, not against the doc, so the doc cannot define its own truth.
+    for (const absent of ['sendTo', 'sendPlugin', 'requestKey', 'revokeKey']) {
+      expect(flatRenderer).not.toContain(`${absent}(`)
+    }
+    expect(CLAUDE_MD).toContain('there is no `sendTo`, `sendPlugin`, `requestKey` or `revokeKey`')
+  })
+
+  it('proves the absence check can fail', () => {
+    // Control for the block above: the same query finds these methods where they do exist.
+    for (const present of ['sendTo', 'sendPlugin', 'requestKey', 'revokeKey']) {
+      expect(flatMain).toContain(`${present}(`)
+    }
+  })
+})


### PR DESCRIPTION
Closes #612.

Confirmed against both classes. Every claim in the report checks out: main's `send` and `sendTo` require a `ChannelType` the doc omitted, the renderer's `regChannel` takes none, and `sendTo` / `sendPlugin` / `requestKey` / `revokeKey` do not exist in the renderer at all — so the documented `sendTo(window, eventName, arg)` matched neither side.

Took the suggested direction: two subsections with the real signatures, and the phantom `sendTo` form dropped.

## Why this survived

The two halves fail differently. In main, `send('evt', payload)` is rejected by the compiler — annoying, but self-announcing. In the renderer, `regChannel(ChannelType.MAIN, 'evt', cb)` **type-checks**: the `ChannelType` lands in the `eventName` slot, the handler registers under that value, and it simply never fires. That asymmetry is now stated in the doc, since it is the part that costs debugging time.

Also corrected while there: `requestKey` has a second parameter (`activation?: Pick<PluginActivationIdentity, …>`), and the renderer's `unRegChannel` was missing from the doc entirely.

## Verification

`channel-api-doc.test.ts`, 6 passed. Each documented signature is compared with the declaration it claims to describe, after normalising the source's line wrapping. The renderer's four absences are asserted against the **class body**, not the doc, so the doc cannot define its own truth — with a control proving the same query finds those methods in main, where they do exist.

Restoring the previous block fails **4 of the 6**. ESLint clean.