### PR TITLE
fix(i18n): add the download destination failure message and ratchet the gap [#502]

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -2730,7 +2730,8 @@
         "defaultsRestored": "Default settings restored",
         "tempCleaned": "Temporary files cleaned up",
         "tempCleanFailed": "Failed to cleanup temporary files",
-        "tempDirSelectFailed": "Failed to select temporary directory"
+        "tempDirSelectFailed": "Failed to select temporary directory",
+        "destinationSelectFailed": "Failed to select download location"
       }
     },
     "settingNetwork": {

--- a/apps/core-app/src/renderer/src/modules/lang/translation-coverage.test.ts
+++ b/apps/core-app/src/renderer/src/modules/lang/translation-coverage.test.ts
@@ -1,0 +1,162 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * A `t()` call whose key is in neither locale renders the key itself (#502).
+ *
+ * The download-folder failure path did exactly that: a user whose picker failed saw the literal
+ * string `settings.settingDownload.messages.destinationSelectFailed` in a toast. Nothing catches
+ * this — `t()` returns the key rather than throwing, so the only symptom is in the UI, on an error
+ * path, in the moment the user is already stuck.
+ *
+ * Rather than pin the one key, this is a ratchet over the whole renderer: the two inventories below
+ * are the gaps that exist today, and the assertions are that nothing outside them is broken *and*
+ * that everything inside them is still broken. A new gap fails the first; fixing a listed one fails
+ * the second, so the lists cannot rot into a permanent excuse.
+ *
+ * Only statically written keys are covered. `t(\`a.${b}\`)` cannot be resolved by reading source,
+ * and there is no attempt to pretend otherwise.
+ */
+
+const LANG_DIR = __dirname
+const RENDERER_SRC = path.resolve(__dirname, '../..')
+
+/**
+ * Keys the renderer passes to `t()` that resolve to no string in either locale.
+ *
+ * Mostly plain absences, tracked by #487, #491 and #503. `download.status` is the other shape:
+ * it exists in both files as a *namespace* holding pending/downloading/paused/…, so `t()` is
+ * handed an object and the label renders as the key. Absent and non-leaf are the same defect
+ * from the user's side, so they are listed together.
+ */
+const MISSING_FROM_BOTH = [
+  'common.back',
+  'download.status',
+  'coreBox.intelligence.assistantLabel',
+  'coreBox.intelligence.userLabel',
+  'download.view_logs',
+  'intelligence.builtin',
+  'intelligence.builtinPrompts',
+  'intelligence.createNewPrompt',
+  'intelligence.custom',
+  'intelligence.customPrompts',
+  'intelligence.info.configurationPanel',
+  'intelligence.item.selectProvider',
+  'intelligence.managePrompts',
+  'intelligence.promptSelectedHint',
+  'intelligence.search.clear',
+  'intelligence.selectPrompt',
+  'settingMessages.desc',
+  'settingMessages.empty',
+  'settingMessages.loading',
+  'settingMessages.markAllRead',
+  'settingMessages.markRead',
+  'settingMessages.refresh',
+  'settingMessages.title',
+  'settingMessages.unread',
+  'settingMessages.unreadTag',
+  'settingUser.stepUp',
+  'settingUser.syncSecurity',
+  'store.official',
+  'system.unknownError',
+  'systemPermission.requiredPermission',
+  'userProfile.overview',
+  'userProfile.security',
+  'userProfile.securityActions'
+]
+
+/** Keys defined in en-US but not zh-CN, so a Chinese user sees English. Tracked by #503. */
+const ENGLISH_ONLY = [
+  'settings.intelligence.addBinding',
+  'settings.intelligence.addFirstModel',
+  'settings.intelligence.dragToReorder',
+  'settings.intelligence.modelOrder',
+  'settings.intelligence.modelSelection',
+  'settings.intelligence.noModelsConfigured',
+  'settings.intelligence.providerSelection',
+  'settings.intelligence.removeBinding',
+  'settings.settingAISDK.promptVariablesLabel',
+  'settings.settingAISDK.promptVariablesPlaceholder',
+  'settings.settingAISDK.userMessageLabel',
+  'settings.settingAISDK.userMessagePlaceholder'
+]
+
+function loadLocale(name: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path.join(LANG_DIR, `${name}.json`), 'utf8'))
+}
+
+function flatten(value: Record<string, unknown>, prefix = ''): Set<string> {
+  const keys = new Set<string>()
+  for (const [key, child] of Object.entries(value)) {
+    const full = prefix ? `${prefix}.${key}` : key
+    if (child && typeof child === 'object' && !Array.isArray(child)) {
+      for (const nested of flatten(child as Record<string, unknown>, full)) keys.add(nested)
+    } else {
+      keys.add(full)
+    }
+  }
+  return keys
+}
+
+function sourceFiles(dir: string): string[] {
+  const found: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (full !== LANG_DIR) found.push(...sourceFiles(full))
+      continue
+    }
+    if (/\.(?:vue|ts)$/.test(entry) && !/\.test\.ts$/.test(entry)) found.push(full)
+  }
+  return found
+}
+
+const enUS = flatten(loadLocale('en-US'))
+const zhCN = flatten(loadLocale('zh-CN'))
+
+const usedKeys = (() => {
+  const keys = new Set<string>()
+  for (const file of sourceFiles(RENDERER_SRC)) {
+    const source = readFileSync(file, 'utf8')
+    for (const match of source.matchAll(/(?:\$t|\bt|i18n\.t)\(\s*'([a-z][\w.]*\.[\w.]+)'/gi)) {
+      keys.add(match[1]!)
+    }
+  }
+  return keys
+})()
+
+describe('translation coverage', () => {
+  it('scans a plausible amount of the renderer', () => {
+    // Positive control. Both ratchets are satisfied by an empty scan, which is what a wrong root or
+    // a broken pattern produces — and `$t(` appears nowhere, so a `t(`-only pattern is complete.
+    expect(usedKeys.size).toBeGreaterThan(2000)
+    expect(enUS.size).toBeGreaterThan(4000)
+    expect(usedKeys.has('settings.settingDownload.messages.saveFailed')).toBe(true)
+  })
+
+  it('resolves the download destination failure message', () => {
+    // #502 itself: the toast a user sees when the folder picker fails.
+    const key = 'settings.settingDownload.messages.destinationSelectFailed'
+
+    expect(usedKeys.has(key)).toBe(true)
+    expect(enUS.has(key)).toBe(true)
+    expect(zhCN.has(key)).toBe(true)
+  })
+
+  it('introduces no key that resolves to nothing in both locales', () => {
+    // flatten() keeps leaves only, so a key pointing at a namespace counts as unresolved — which
+    // is what it is: t() returns no string for it.
+    const missing = [...usedKeys].filter((key) => !enUS.has(key) && !zhCN.has(key)).sort()
+
+    expect(missing).toEqual([...MISSING_FROM_BOTH].sort())
+  })
+
+  it('introduces no key that only one locale has', () => {
+    const asymmetric = [...enUS].filter((key) => !zhCN.has(key)).sort()
+
+    expect(asymmetric).toEqual([...ENGLISH_ONLY].sort())
+    // The other direction is already clean and must stay that way.
+    expect([...zhCN].filter((key) => !enUS.has(key))).toEqual([])
+  })
+})

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -2706,7 +2706,8 @@
         "defaultsRestored": "已恢复默认设置",
         "tempCleaned": "临时文件已清理",
         "tempCleanFailed": "清理临时文件失败",
-        "tempDirSelectFailed": "选择临时目录失败"
+        "tempDirSelectFailed": "选择临时目录失败",
+        "destinationSelectFailed": "选择下载位置失败"
       }
     },
     "settingNetwork": {


### PR DESCRIPTION
Closes #502.

Confirmed: `settings.settingDownload.messages.destinationSelectFailed` is used at `SettingDownload.vue:162` and exists in neither locale. Added to both, worded off the sibling `tempDirSelectFailed` and the existing `defaultDestination` label:

- en-US — `Failed to select download location`
- zh-CN — `选择下载位置失败`

## Why the guard is a ratchet, not a pin

Nothing catches this class of defect. `t()` returns the key rather than throwing, so the only symptom is in the UI, on an error path, at the moment the user is already stuck. So the test scans the whole renderer — **2938 static keys** — and carries the gaps that exist today as two inventories:

- **33 keys resolve to nothing in either locale** (tracked by #487, #491)
- **12 keys exist only in en-US**, so a Chinese user sees English (tracked by #503)
- **0 keys exist only in zh-CN**, and that direction is asserted to stay clean

Nothing outside those lists may break, and everything inside them must **still** be broken — so fixing a listed key fails the test until the list is updated, and the inventories shrink as those issues land instead of becoming a standing excuse.

## One adjacent defect, named rather than fixed

`download.status`, used at `TaskDetailsDialog.vue:152`, exists in both locales as a **namespace** holding `pending`/`downloading`/`paused`/…, so `t()` is handed an object and the label renders as the key. Not this issue's scope, so it is listed rather than fixed — but it is the same defect from the user's side, and it would otherwise stay invisible. Worth its own issue if you want one.

## Verification

4 passed. Mutation-tested both directions: removing the new en-US key fails 2 cases, and pointing the same call at a fresh nonexistent key fails 2. Positive controls guard the scan itself — key count, locale size, and a known-good key — since an empty scan satisfies every ratchet. ESLint clean; the locale JSONs are outside the lint config.