### PR TITLE
fix(ci): make commitlint state one type-case policy

### DIFF
--- a/commitlint.config.cts
+++ b/commitlint.config.cts
@@ -28,16 +28,10 @@ export default {
         'upg', // Upgrade
       ],
     ],
-    'type-case': [
-      2,
-      'always',
-      [
-        'pascal-case', // PascalCase
-        'lower-case', // lowercase
-        'sentence-case', // Sentence case
-        'start-case', // Start Case
-      ],
-    ],
+    // 只允许 lowercase：type-enum 是精确字符串匹配，且上面每一项都是小写，
+    // 所以 PascalCase / Sentence case / Start Case 的 type 永远过不了 enum。
+    // 保留它们只会让配置宣称一套、实际执行另一套。
+    'type-case': [2, 'always', ['lower-case']],
     'subject-case': [0],
     'subject-empty': [2, 'never'],
     'body-max-line-length': [0],


### PR DESCRIPTION
Closes #737.

`type-case` permitted `pascal-case`, `sentence-case` and `start-case`, but `type-enum` is an exact string match against an all-lowercase list. No capitalised type could ever satisfy both rules, so the config advertised a permission that did not exist.

Confirmed against the real binary before changing anything:

```
$ echo "Feat: add search filter" | commitlint
✖   type must be one of [change, update, feat, …] [type-enum]
✖   found 1 problems
```

One error, from `type-enum` only — `type-case` waved it through, exactly as the issue describes.

After restricting `type-case` to `lower-case`:

```
✖   type must be lower-case [type-case]
✖   type must be one of [change, update, feat, …] [type-enum]
✖   found 2 problems
```

The message now names the rule the contributor actually broke, instead of only handing them a 21-entry list.

### No regression

All **40** most recent commit subjects still pass.

That sweep was itself verified rather than trusted — the same mechanism correctly rejects `Feat: add search filter`, `refactor: rename thing` (`refactor` is not in this repo's type-enum; it uses `ref`) and a bare unprefixed line. A scan that finds nothing only means something once it has been shown capable of finding something.
