### PR TITLE
refactor(renderer): annotate the parameters noImplicitAny would reject [#548]

### DIFF
--- a/apps/core-app/src/renderer/src/components/base/input/FlatInput.vue
+++ b/apps/core-app/src/renderer/src/components/base/input/FlatInput.vue
@@ -28,7 +28,7 @@ const value = computed({
   set: (next: string) => emits('update:modelValue', next)
 })
 
-function onKeyDown(e) {
+function onKeyDown(e: KeyboardEvent) {
   if (!props.password) return
 
   const valueCapsLock = e.keyCode ? e.keyCode : e.which // 按键

--- a/apps/core-app/src/renderer/src/components/download/HistoryCard.vue
+++ b/apps/core-app/src/renderer/src/components/download/HistoryCard.vue
@@ -57,7 +57,7 @@ function getModuleName(module: DownloadModule): string {
 }
 
 function getStatusText(status: DownloadStatus): string {
-  const statusTexts = {
+  const statusTexts: Partial<Record<DownloadStatus, string>> = {
     [DownloadStatus.COMPLETED]: t('download.status_completed'),
     [DownloadStatus.FAILED]: t('download.status_failed'),
     [DownloadStatus.CANCELLED]: t('download.status_cancelled')

--- a/apps/core-app/src/renderer/src/components/menu/TouchMenuItem.vue
+++ b/apps/core-app/src/renderer/src/components/menu/TouchMenuItem.vue
@@ -1,6 +1,7 @@
 <script lang="ts" name="TouchMenuItem" setup>
 // Legacy navigation surface: new CoreApp code should use TuffEx navigation/menu primitives.
 import { computed, inject, onMounted, onUnmounted, ref } from 'vue'
+import type { RouteLocationNormalizedLoaded } from 'vue-router'
 import { useRoute, useRouter } from 'vue-router'
 
 const props = defineProps({
@@ -22,7 +23,7 @@ const props = defineProps({
   },
   doActive: {
     type: Function,
-    default: (route, $route) => {
+    default: (route: string, $route: RouteLocationNormalizedLoaded | undefined) => {
       if (!$route) return false
       // 精确匹配路由路径
       if ($route.path === route) return true
@@ -40,7 +41,7 @@ const active = computed(() => props.doActive(props.route, route))
 
 const changePointer = inject<(el: HTMLElement) => void>('changePointer')
 
-let removeGuard
+let removeGuard: (() => void) | undefined
 
 onMounted(() => {
   removeGuard = router.afterEach((to, _from) => {
@@ -66,7 +67,7 @@ onUnmounted(() => {
   }
 })
 
-function handleClick($event) {
+function handleClick($event: MouseEvent) {
   if (props.disabled) return
 
   if (props.route) router.push(props.route)

--- a/apps/core-app/src/renderer/src/components/render/ItemSubtitle.vue
+++ b/apps/core-app/src/renderer/src/components/render/ItemSubtitle.vue
@@ -16,7 +16,7 @@ const sourceType = computed(() => props.item.source.type)
 
 const { t } = useI18n()
 
-function formatBytes(bytes, decimals = 2) {
+function formatBytes(bytes: number, decimals = 2) {
   if (bytes === 0) return '0 Bytes'
   const k = 1024
   const dm = decimals < 0 ? 0 : decimals


### PR DESCRIPTION
Partial fix for #548 — the flag is **not** enabled yet; see the issue comment for what is left and why.

## Confirmed

`tsc --showConfig` on both configs resolves to `strict: true, noImplicitAny: false`. The explicit `false` in `@electron-toolkit/tsconfig` survives the child's `strict: true`, exactly as reported.

## Measured

| config | baseline | with `--noImplicitAny` | new errors |
|---|---|---|---|
| `tsconfig.node.json` | 7 | 234 | **+227** |
| `tsconfig.web.json` | 10 | 22 | **+12** |

The renderer is the tractable half. Nine of its twelve are plain missing annotations with no judgement involved:

- `FlatInput.vue` — `onKeyDown(e: KeyboardEvent)`
- `ItemSubtitle.vue` — `formatBytes(bytes: number, …)`
- `TouchMenuItem.vue` — the `doActive` prop default, `handleClick($event: MouseEvent)`, and `removeGuard: (() => void) | undefined`
- `HistoryCard.vue` — the status lookup table types as `Partial<Record<DownloadStatus, string>>`, which is what it is: it covers three of the enum's members and already falls back with `|| status`

That takes the renderer's implicit-any count from 12 to 3. No behaviour changes — every edit is an annotation.

## Why the flag is still off

The remaining three need a decision, not an annotation, and I would rather not force them through with casts that could hide a real type problem:

- `modules/tuffex/index.ts:64` — `COMPONENT_IMPORTERS` uses `satisfies`, so `module` is the union of the real import namespaces rather than `TuffexComponentModule`. Annotating it to the declared type compiles there and then breaks `app.use(component)` at :85 with TS2345, so the declared type and the actual one disagree.
- `PluginNew.vue:223,233` — `dev.enable` is a `computed` that reads `plugin.dev.address` from inside `plugin`'s own initializer. `computed<boolean>` does not break the cycle, and annotating the const turns TS7022 into TS2322 plus a new TS2769. Breaking it properly means lifting `address` into its own ref, which is a behavioural change to a form.

Details and a proposed path for both halves are on #548.