### PR TITLE
fix(i18n): drop the dead en-US keys and require exact locale parity [#503]

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -2890,11 +2890,7 @@
       "enableCache": "Enable Response Cache",
       "enableCacheDesc": "Cache AI responses to reduce costs and latency",
       "cacheExpiration": "Cache Expiration",
-      "cacheExpirationDesc": "How long to keep cached responses",
-      "userMessageLabel": "User message",
-      "userMessagePlaceholder": "Hello, can you summarize this...",
-      "promptVariablesLabel": "Prompt variables (JSON)",
-      "promptVariablesPlaceholder": "{'{\"name\":\"Talex\"}'}"
+      "cacheExpirationDesc": "How long to keep cached responses"
     },
     "settingFileIndex": {
       "groupTitle": "File Index",
@@ -3584,14 +3580,6 @@
       "activeProviders": "Active Channels",
       "totalBindings": "Total Bindings",
       "configuredModels": "Configured Models",
-      "addBinding": "Add Binding",
-      "removeBinding": "Remove Binding",
-      "modelOrder": "Model Order",
-      "noModelsConfigured": "No models configured",
-      "dragToReorder": "Drag to reorder",
-      "addFirstModel": "Add your first model",
-      "providerSelection": "Provider Selection",
-      "modelSelection": "Model Selection",
       "capabilityTestTitle": "Test Capability",
       "capabilityTestDesc": "Test if this capability works with current configuration",
       "testProvider": "Select Test Provider",

--- a/apps/core-app/src/renderer/src/modules/lang/translation-coverage.test.ts
+++ b/apps/core-app/src/renderer/src/modules/lang/translation-coverage.test.ts
@@ -10,10 +10,11 @@ import { describe, expect, it } from 'vitest'
  * this — `t()` returns the key rather than throwing, so the only symptom is in the UI, on an error
  * path, in the moment the user is already stuck.
  *
- * Rather than pin the one key, this is a ratchet over the whole renderer: the two inventories below
- * are the gaps that exist today, and the assertions are that nothing outside them is broken *and*
- * that everything inside them is still broken. A new gap fails the first; fixing a listed one fails
- * the second, so the lists cannot rot into a permanent excuse.
+ * Rather than pin the one key, this is a ratchet over the whole renderer: the inventory below
+ * is the gap that exists today, and the assertions are that nothing outside it is broken *and* that
+ * everything inside it is still broken. A new gap fails the first; fixing a listed one fails the
+ * second, so the list cannot rot into a permanent excuse. Locale parity is already exact, so that
+ * half is asserted as an equality.
  *
  * Only statically written keys are covered. `t(\`a.${b}\`)` cannot be resolved by reading source,
  * and there is no attempt to pretend otherwise.
@@ -64,22 +65,6 @@ const MISSING_FROM_BOTH = [
   'userProfile.overview',
   'userProfile.security',
   'userProfile.securityActions'
-]
-
-/** Keys defined in en-US but not zh-CN, so a Chinese user sees English. Tracked by #503. */
-const ENGLISH_ONLY = [
-  'settings.intelligence.addBinding',
-  'settings.intelligence.addFirstModel',
-  'settings.intelligence.dragToReorder',
-  'settings.intelligence.modelOrder',
-  'settings.intelligence.modelSelection',
-  'settings.intelligence.noModelsConfigured',
-  'settings.intelligence.providerSelection',
-  'settings.intelligence.removeBinding',
-  'settings.settingAISDK.promptVariablesLabel',
-  'settings.settingAISDK.promptVariablesPlaceholder',
-  'settings.settingAISDK.userMessageLabel',
-  'settings.settingAISDK.userMessagePlaceholder'
 ]
 
 function loadLocale(name: string): Record<string, unknown> {
@@ -152,11 +137,10 @@ describe('translation coverage', () => {
     expect(missing).toEqual([...MISSING_FROM_BOTH].sort())
   })
 
-  it('introduces no key that only one locale has', () => {
-    const asymmetric = [...enUS].filter((key) => !zhCN.has(key)).sort()
-
-    expect(asymmetric).toEqual([...ENGLISH_ONLY].sort())
-    // The other direction is already clean and must stay that way.
+  it('keeps the two locales on exactly the same key set', () => {
+    // #503 closed the last gap here, so this is an equality rather than a ratchet: any key added to
+    // one file must be added to the other, in either direction.
+    expect([...enUS].filter((key) => !zhCN.has(key))).toEqual([])
     expect([...zhCN].filter((key) => !enUS.has(key))).toEqual([])
   })
 })


### PR DESCRIPTION
Closes #503.

The asymmetry is real, but it is **not** untranslated UI — and the count is **12, not 8**.

## None of the twelve is reachable

No `t()` call references any of them. Checked against all 46 dynamic key templates in the renderer too: every dynamic `settings.intelligence.*` use is under `localSkills.*`, and there is no dynamic `settings.settingAISDK.*` at all. So no user, in either language, has ever seen these strings — which means adding Chinese for them would have restored the count without changing anything a user sees.

They are leftovers of two separate moves:

- The **4 `settings.settingAISDK.*`** entries are exact duplicates of `settings.intelligence.*` keys that exist in **both** locales and are the ones actually rendered (`CapabilityTestInput.vue:116`). They were left behind by 0541eeae2 — which was itself the commit that fixed this namespace, #985.
- The **8 `settings.intelligence.*`** capability-binding labels (`addBinding`, `modelOrder`, `dragToReorder`, …) arrived with a November 2025 UI refactor and were never referenced.

## So the fix is deletion

Both files now hold an identical **4533** keys, and the guard added in #1408 tightens from a ratchet to an equality in both directions: any key added to one file must be added to the other.

## One trap worth recording

The four duplicated labels exist **verbatim** under `settings.intelligence` — same key names, same English values. A value-based deletion pass silently removed the live copies as well, which would have broken the capability-test panel in both languages. The deletion is done by JSON path instead, and the diff is exactly 12 lines in the two intended blocks.

## Verification

`translation-coverage.test.ts`, 4 passed. Mutation-tested: putting a single dead key back into en-US alone fails the parity case. The live `settings.intelligence.promptVariablesLabel` is asserted still present. ESLint clean.