### PR TITLE
fix(i18n): translate the account dialog's five hardcoded section names [#491]

### DIFF
--- a/apps/core-app/src/renderer/src/components/base/TuffUserInfo.vue
+++ b/apps/core-app/src/renderer/src/components/base/TuffUserInfo.vue
@@ -225,7 +225,7 @@ watch(profileVisible, (visible) => {
           borderless
         >
           <TxTabItem name="overview" activation>
-            <template #name>{{ t('userProfile.overview', '概览') }}</template>
+            <template #name>{{ t('userProfile.overview') }}</template>
             <div class="UserProfile">
               <div class="UserProfile-TopCard">
                 <div class="UserProfile-TopIdentity">
@@ -397,23 +397,23 @@ watch(profileVisible, (visible) => {
             </div>
           </TxTabItem>
           <TxTabItem name="security">
-            <template #name>{{ t('userProfile.security', '安全与登录') }}</template>
+            <template #name>{{ t('userProfile.security') }}</template>
             <div class="UserProfileTabContent">
               <div class="UserProfile-SectionTitle">
-                {{ t('userProfile.securityActions', '登录与安全选项') }}
+                {{ t('userProfile.securityActions') }}
               </div>
               <div class="UserProfile-Actions">
                 <TxButton variant="flat" size="sm" @click="handleLoginMethods">
                   {{ t('userProfile.openEmailSettings', 'Manage email') }}
                 </TxButton>
                 <TxButton variant="flat" size="sm" @click="openSyncSecurity">
-                  {{ t('settingUser.syncSecurity', '同步安全') }}
+                  {{ t('settingUser.syncSecurity') }}
                 </TxButton>
                 <TxButton variant="flat" size="sm" @click="openDeviceManagement">
                   {{ t('userProfile.devices', 'Devices') }}
                 </TxButton>
                 <TxButton variant="flat" size="sm" @click="requestStepUp">
-                  {{ t('settingUser.stepUp', '二次验证') }}
+                  {{ t('settingUser.stepUp') }}
                 </TxButton>
               </div>
             </div>

--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -562,6 +562,8 @@
     }
   },
   "settingUser": {
+    "syncSecurity": "Sync security",
+    "stepUp": "Step-up verification",
     "groupTitle": "Account",
     "groupDesc": "Manage your account information and login status.",
     "logout": "Logout",
@@ -684,6 +686,9 @@
     "billingNoticeTitle": "Billing notice"
   },
   "userProfile": {
+    "overview": "Overview",
+    "security": "Security & sign-in",
+    "securityActions": "Sign-in and security options",
     "title": "Account",
     "unknownName": "User",
     "unknownEmail": "No email",

--- a/apps/core-app/src/renderer/src/modules/lang/translation-coverage.test.ts
+++ b/apps/core-app/src/renderer/src/modules/lang/translation-coverage.test.ts
@@ -56,14 +56,9 @@ const MISSING_FROM_BOTH = [
   'settingMessages.title',
   'settingMessages.unread',
   'settingMessages.unreadTag',
-  'settingUser.stepUp',
-  'settingUser.syncSecurity',
   'store.official',
   'system.unknownError',
-  'systemPermission.requiredPermission',
-  'userProfile.overview',
-  'userProfile.security',
-  'userProfile.securityActions'
+  'systemPermission.requiredPermission'
 ]
 
 /** Keys defined in en-US but not zh-CN, so a Chinese user sees English. Tracked by #503. */

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -562,6 +562,8 @@
     }
   },
   "settingUser": {
+    "syncSecurity": "同步安全",
+    "stepUp": "二次验证",
     "groupTitle": "账户",
     "groupDesc": "管理您的账户信息和登录状态。",
     "logout": "登出",
@@ -684,6 +686,9 @@
     "billingNoticeTitle": "计费提示"
   },
   "userProfile": {
+    "overview": "概览",
+    "security": "安全与登录",
+    "securityActions": "登录与安全选项",
     "title": "账户",
     "unknownName": "用户",
     "unknownEmail": "暂无邮箱",


### PR DESCRIPTION
Closes #491.

Confirmed — all five `t(key, default)` calls in `TuffUserInfo.vue` pass Chinese literals as the default message, and none of the keys exists in either locale, so the Chinese is what renders in **every** locale.

| key | en-US | zh-CN |
|---|---|---|
| `userProfile.overview` | Overview | 概览 |
| `userProfile.security` | Security & sign-in | 安全与登录 |
| `userProfile.securityActions` | Sign-in and security options | 登录与安全选项 |
| `settingUser.syncSecurity` | Sync security | 同步安全 |
| `settingUser.stepUp` | Step-up verification | 二次验证 |

The Chinese values are the literals themselves — the author's own wording; the English is new.

## The literal defaults are also removed

For the reason the issue itself gives: *"the fallback masks the missing key"*. That is exactly why this survived — a defaulted `t()` looks fine in review and renders wrong only in the other locale. Without a default, an absent key renders as the key: ugly, but self-announcing, and now caught by the ratchet before it ships.

## Verification

`translation-coverage.test.ts`, 4 passed, with the inventory of unresolvable keys down from 33 to **28**. Mutation-tested: renaming one of the five call sites to a nonexistent key fails the ratchet. ESLint clean.

Note this touches `translation-coverage.test.ts`, as does #1411 — whichever lands second needs its inventory line re-checked.