### PR TITLE
refactor(nexus): share the runtime-server policy between the processes [#522]

### DIFF
--- a/apps/core-app/src/main/modules/nexus/runtime-base.ts
+++ b/apps/core-app/src/main/modules/nexus/runtime-base.ts
@@ -1,6 +1,7 @@
 import type { AppSetting } from '@talex-touch/utils/common/storage/entity/app-settings'
 import { StorageList } from '@talex-touch/utils'
 import {
+  migrateTuffNexusRuntimeServer,
   NEXUS_BASE_URL,
   type TuffNexusRuntimeServer,
   resolveTuffNexusBaseUrl
@@ -12,18 +13,11 @@ type LegacyDevSettings = AppSetting['dev'] & {
   runtimeServer?: TuffNexusRuntimeServer
 }
 
-function normalizeRuntimeServer(value: unknown): TuffNexusRuntimeServer {
-  return value === 'local' ? 'local' : 'production'
-}
-
 export function ensureRuntimeServerSettings(appSettings: AppSetting): TuffNexusRuntimeServer {
   const dev = (appSettings.dev ?? {}) as LegacyDevSettings
-  const current = dev.runtimeServer
-  const next = current ?? dev.authServer ?? 'production'
-  dev.runtimeServer = normalizeRuntimeServer(next)
-  delete dev.authServer
+  const runtimeServer = migrateTuffNexusRuntimeServer(dev)
   appSettings.dev = dev
-  return dev.runtimeServer
+  return runtimeServer
 }
 
 export function getRuntimeServerMode(): TuffNexusRuntimeServer {

--- a/apps/core-app/src/renderer/src/modules/nexus/runtime-base.ts
+++ b/apps/core-app/src/renderer/src/modules/nexus/runtime-base.ts
@@ -1,5 +1,6 @@
 import type { AppSetting } from '@talex-touch/utils/common/storage/entity/app-settings'
 import {
+  migrateTuffNexusRuntimeServer,
   NEXUS_BASE_URL,
   type TuffNexusRuntimeServer,
   resolveTuffNexusBaseUrl
@@ -9,10 +10,6 @@ import { appSetting } from '~/modules/storage/app-storage'
 type LegacyDevSettings = AppSetting['dev'] & {
   authServer?: TuffNexusRuntimeServer
   runtimeServer?: TuffNexusRuntimeServer
-}
-
-function normalizeRuntimeServer(value: unknown): TuffNexusRuntimeServer {
-  return value === 'local' ? 'local' : 'production'
 }
 
 export function ensureRuntimeServerSettings(): TuffNexusRuntimeServer {
@@ -25,12 +22,9 @@ export function ensureRuntimeServerSettings(): TuffNexusRuntimeServer {
   }
 
   const dev = appSetting.dev as LegacyDevSettings
-  const current = dev.runtimeServer
-  const next = current ?? dev.authServer ?? 'production'
-  dev.runtimeServer = normalizeRuntimeServer(next)
-  delete dev.authServer
+  const runtimeServer = migrateTuffNexusRuntimeServer(dev)
   appSetting.dev = dev
-  return dev.runtimeServer
+  return runtimeServer
 }
 
 export function getRuntimeServerMode(): TuffNexusRuntimeServer {

--- a/packages/utils/__tests__/nexus-runtime-server.test.ts
+++ b/packages/utils/__tests__/nexus-runtime-server.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  migrateTuffNexusRuntimeServer,
+  normalizeTuffNexusRuntimeServer
+} from '../env'
+
+/**
+ * Both processes must decide the Nexus backend the same way (#522).
+ *
+ * The policy — resolve `runtimeServer`, fall back to the legacy `authServer`, coerce anything
+ * unrecognised to production, then drop the legacy key — was written twice, once in
+ * `main/modules/nexus/runtime-base.ts` and once in the renderer's. The copies had already drifted
+ * in signature and function set, and a drift in the *policy* would mean the two halves of one
+ * application talking to different backends: the renderer showing account state from production
+ * while main sends intelligence requests to a local server, or the reverse.
+ *
+ * Only the policy is shared. How each side obtains and persists `dev` is genuinely different — main
+ * reads the config file and writes it back when it changed, the renderer mutates a reactive object
+ * — and stays where it is.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+
+describe('normalizeTuffNexusRuntimeServer', () => {
+  it('accepts only an explicit local', () => {
+    expect(normalizeTuffNexusRuntimeServer('local')).toBe('local')
+  })
+
+  it('coerces everything else to production', () => {
+    // Settings come off disk, so the input is whatever an earlier version or a hand edit left.
+    for (const value of ['production', 'LOCAL', 'staging', '', null, undefined, 0, {}, []]) {
+      expect(normalizeTuffNexusRuntimeServer(value)).toBe('production')
+    }
+  })
+})
+
+describe('migrateTuffNexusRuntimeServer', () => {
+  it('promotes the legacy authServer when runtimeServer is absent', () => {
+    const dev: Record<string, unknown> = { authServer: 'local' }
+
+    expect(migrateTuffNexusRuntimeServer(dev)).toBe('local')
+    expect(dev.runtimeServer).toBe('local')
+    expect('authServer' in dev).toBe(false)
+  })
+
+  it('prefers runtimeServer when both are present', () => {
+    const dev: Record<string, unknown> = { runtimeServer: 'production', authServer: 'local' }
+
+    expect(migrateTuffNexusRuntimeServer(dev)).toBe('production')
+    expect('authServer' in dev).toBe(false)
+  })
+
+  it('defaults an empty dev block to production', () => {
+    const dev: Record<string, unknown> = {}
+
+    expect(migrateTuffNexusRuntimeServer(dev)).toBe('production')
+    expect(dev.runtimeServer).toBe('production')
+  })
+
+  it('normalises a value that is already stored', () => {
+    // The stored value is not trusted either — it was written by whichever version ran last.
+    const dev: Record<string, unknown> = { runtimeServer: 'staging' }
+
+    expect(migrateTuffNexusRuntimeServer(dev)).toBe('production')
+  })
+
+  it('writes the migration back in place, which is what completes it', () => {
+    // Main persists `dev` only when it changed, so the mutation is the migration; a pure function
+    // returning a value would leave authServer on disk forever.
+    const dev: Record<string, unknown> = { authServer: 'local', autoCloseDev: true }
+    migrateTuffNexusRuntimeServer(dev)
+
+    expect(dev).toEqual({ runtimeServer: 'local', autoCloseDev: true })
+  })
+})
+
+describe('neither process keeps its own copy', () => {
+  const sources = ['apps/core-app/src/main/modules/nexus/runtime-base.ts',
+    'apps/core-app/src/renderer/src/modules/nexus/runtime-base.ts']
+    .map((file) => ({ file, source: readFileSync(path.join(REPO_ROOT, file), 'utf8') }))
+
+  it('reads both files', () => {
+    // Positive control: the absence checks below are satisfied by an unreadable path.
+    expect(sources).toHaveLength(2)
+    for (const { source } of sources) expect(source).toContain('getRuntimeNexusBaseUrl')
+  })
+
+  it('calls the shared migration instead of restating it', () => {
+    for (const { file, source } of sources) {
+      expect(source, file).toContain('migrateTuffNexusRuntimeServer(dev)')
+      expect(source, file).not.toContain("value === 'local' ? 'local' : 'production'")
+      expect(source, file).not.toContain('dev.authServer')
+    }
+  })
+})

--- a/packages/utils/env/index.ts
+++ b/packages/utils/env/index.ts
@@ -185,3 +185,39 @@ export function getTelemetryApiBase(): string {
 export function getTpexApiBase(): string {
   return resolveTuffNexusBaseUrl()
 }
+
+/**
+ * The `dev` block of app settings, as it exists on disk rather than as declared.
+ *
+ * `authServer` is the name this setting shipped under before it also selected the runtime backend
+ * for non-auth calls. Installations from that era still hold it, so every reader has to migrate.
+ */
+export interface TuffNexusRuntimeServerSettings {
+  authServer?: TuffNexusRuntimeServer
+  runtimeServer?: TuffNexusRuntimeServer
+}
+
+/** Unknown values become 'production'; only an explicit 'local' opts out. */
+export function normalizeTuffNexusRuntimeServer(value: unknown): TuffNexusRuntimeServer {
+  return value === 'local' ? 'local' : 'production'
+}
+
+/**
+ * Resolves the runtime backend and migrates the legacy key in place.
+ *
+ * Shared because both processes make this decision independently — main from the config file,
+ * renderer from the reactive settings object — and a disagreement means the two halves of one app
+ * talk to different backends. Only the policy is shared; how each side obtains and persists `dev`
+ * is genuinely different and stays where it is.
+ *
+ * Mutates: `runtimeServer` is written back normalized and `authServer` is dropped, so a caller that
+ * persists `dev` afterwards completes the migration.
+ */
+export function migrateTuffNexusRuntimeServer(
+  dev: TuffNexusRuntimeServerSettings
+): TuffNexusRuntimeServer {
+  const next = dev.runtimeServer ?? dev.authServer ?? 'production'
+  dev.runtimeServer = normalizeTuffNexusRuntimeServer(next)
+  delete dev.authServer
+  return dev.runtimeServer
+}


### PR DESCRIPTION
Closes #522.

Confirmed — the same rule (resolve `runtimeServer`, fall back to the legacy `authServer`, coerce anything unrecognised to `production`, drop the legacy key) was implemented once in `main/modules/nexus/runtime-base.ts` and once in the renderer's, with different signatures and different function sets.

## Why it matters more than the duplication suggests

If the *policy* halves drift, the two parts of one application talk to **different backends** — the renderer showing account state from production while main sends intelligence requests to a local server, or the reverse. Nothing reports that; it looks like stale data.

## What moved and what did not

`migrateTuffNexusRuntimeServer` and `normalizeTuffNexusRuntimeServer` now live in `@talex-touch/utils/env`, beside `TuffNexusRuntimeServer` and `resolveTuffNexusBaseUrl` which they already depend on.

What stays: how each side obtains and persists `dev`. Main reads the config file and writes it back **only when it changed**; the renderer mutates a reactive object and also exposes `setRuntimeServerMode`. Those differences are genuine, not drift.

One detail the shared function has to keep: it **mutates in place**. Main persists only on change, so a pure function returning a value would leave `authServer` on disk forever and re-run the migration on every start. There is a test for exactly that.

## Verification

`packages/utils`: 142 files, 1111 passed. The new suite covers both precedence orders, nine unrecognised values coerced to production, the empty-`dev` default, and the in-place mutation — plus a guard that neither process file restates the rule, with a positive control so an unreadable path cannot pass it silently.

Mutation-tested: inlining the old logic back into the main copy fails the guard. `typecheck:node` = 6, unchanged. ESLint clean.