### PR TITLE
docs(build): stop verifyNativeModules claiming it checked the Electron ABI

### DIFF
--- a/apps/core-app/scripts/build-target.js
+++ b/apps/core-app/scripts/build-target.js
@@ -134,6 +134,16 @@ function resolveBuilderBin() {
   return binPath
 }
 
+// Presence check only. It stands in for electron-builder's install-app-deps on the macOS
+// legs, which set SKIP_INSTALL_APP_DEPS=true, and that substitution is sound because every
+// @talex-touch/tuff-native addon is N-API (node-addon-api): `nm -u` shows napi_ imports and
+// no v8/node symbols, so a Node-targeted build is ABI-compatible with Electron. CI says the
+// same thing out loud - the Windows rebuild step is named "for Node.js".
+//
+// Not covered: tuff_native_screenshot.node, which screenshot-protocol.js loads on every
+// platform. It is deliberately left out because that loader degrades gracefully
+// (`binding-unavailable`) rather than throwing, so requiring it here would turn a soft
+// capability loss into a hard build failure.
 function verifyNativeModules(strict, target) {
   const releaseDir = path.join(
     projectRoot,
@@ -160,7 +170,7 @@ function verifyNativeModules(strict, target) {
 
   const message =
     `Required native modules missing from ${releaseDir}: ${missingModuleNames.join(', ')}. ` +
-    'Please ensure @talex-touch/tuff-native was rebuilt for the Electron target.'
+    'Run `pnpm --filter @talex-touch/tuff-native rebuild` to produce them.'
 
   if (strict || target === 'win') {
     throw new Error(message)


### PR DESCRIPTION
Closes #743.

The issue is filed as *plausible*, so the first job was deciding whether the failure scenario is real. **It is not, for this dependency set.**

### The refutation

The scenario requires a native module built for Node to ship unrebuilt and throw at `require()` inside the signed macOS app. `nm -u` on all three addons:

| module | `napi_` imports | v8/node symbols |
|---|---|---|
| `tuff_native_ocr` | 47 | 0 |
| `tuff_native_everything` | 29 | 0 |
| `tuff_native_screenshot` | 43 | 0 |

They are pure N-API (`node-addon-api ^7.1.1`, `NAPI_CPP_EXCEPTIONS` in `binding.gyp`). N-API is ABI-stable across Node and Electron, so a Node-targeted build is exactly what should ship — `install-app-deps`' rebuild is not something the macOS legs are missing.

CI already states this: the Windows step is named **"Rebuild Everything native addon for Node.js"**.

The other native module in the tree, `talex-mica-electron`, ships prebuilt `.node` files for Windows only, on the leg where `install-app-deps` does run.

### What was actually wrong

The part of the issue that holds up is the error string. `verifyNativeModules` calls only `fs.existsSync`, yet told the reader to *"ensure @talex-touch/tuff-native was rebuilt for the Electron target"* — a guarantee it never checked. That message is now what it can honestly say, plus a comment recording why the substitution for `install-app-deps` is sound.

I did not add an ABI probe: it would need `nm`/`dumpbin` per platform to assert a property that N-API makes true by construction.

### Recorded, deliberately not changed

`tuff_native_screenshot.node` is loaded on every platform by `screenshot-protocol.js` but is missing from `requiredModuleNames`. Adding it would turn that loader's graceful `binding-unavailable` degradation into a hard build failure — a policy call, not a gap to close quietly. It is written into the comment so the next reader sees it.

### Verification

Behaviour is unchanged: one string and a comment, `node --check` clean.

**Not verified:** the new message at runtime. Reaching it needs a missing `.node` partway through a full electron-vite build, and the function is not exported, so there is no cheap way to trigger it.

One scan on the way here was broken and worth flagging: `find apps/core-app/node_modules -name '*.node'` returned nothing, which reads as "no other native modules". `find` does not follow symlinks and every workspace package there is one. The real answer came from scanning `packages/` directly.
