### PR TITLE
ci: pin the release runner images without renaming the matrix key

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -47,7 +47,7 @@ concurrency:
 jobs:
   build-and-release:
     name: Build and Release Tuff App
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.image }}
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.sync_tag == ''
     permissions:
       contents: read
@@ -62,7 +62,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, macos-latest, ubuntu-latest]
+        # `os` is the logical platform key, not a runner label. Every `matrix.os == ...`
+        # condition below compares against it -- including the macOS signing secrets -- and the
+        # uploaded artifact is named `${{ matrix.os }}-<channel>`, which the collect job looks
+        # up by that exact string. Renaming `os` therefore disables code signing silently.
+        # `image` is the runner that actually executes, pinned so a tag rebuild cannot land on
+        # a different toolchain. Bump `image` deliberately; leave `os` alone.
+        include:
+          - os: windows-2022
+            image: windows-2022
+          - os: macos-latest
+            image: macos-26
+          - os: ubuntu-latest
+            image: ubuntu-24.04
 
     steps:
       - name: Check out git repository


### PR DESCRIPTION
Closes #745.

The signed-release matrix pinned `windows-2022` but left macOS and Linux on `-latest`, so two thirds of the release toolchain could change under a tag rebuild with no commit.

### The suggested pin was already stale

The issue suggests pinning `macos-15`. Reading the last **successful signed release** (v2.4.14-beta.2, 2026-08-03) job log:

```
Operating System: macOS 26.5.2
Image: macos-26-arm64
```

`macos-latest` has already rolled past 15. Pinning to `macos-15` would have moved the build back an Xcode generation rather than freezing it — the rollover the issue warns about has happened, and the fix would have compounded it. `ubuntu-latest` did resolve to `ubuntu-24.04`, so that half of the suggestion was right.

### Why the matrix values were not edited

`matrix.os` is not merely a runner label. **18** `matrix.os == '…'` conditions compare against it, and four of them gate the signing credentials:

```yaml
CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.CSC_LINK || '' }}
CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.CSC_KEY_PASSWORD || '' }}
APPLE_API_KEY_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_API_KEY_ID || '' }}
APPLE_API_ISSUER: ${{ matrix.os == 'macos-latest' && secrets.APPLE_API_ISSUER || '' }}
```

Rename the key and the macOS leg still builds, still reports green, and **ships unsigned**. The uploaded artifact is also named `${{ matrix.os }}-<channel>` and looked up by that exact string in the collect job.

So `os` stays as the logical platform key, and a new `image` carries the pinned runner:

```yaml
include:
  - os: windows-2022
    image: windows-2022
  - os: macos-latest
    image: macos-26
  - os: ubuntu-latest
    image: ubuntu-24.04
```

with `runs-on: ${{ matrix.image }}`. Bumping a runner is now one line and cannot silently disarm signing. A comment above the matrix records why `os` must not be renamed.

### Verification

By parsing the workflow:

- all **18** `matrix.os` comparisons resolve to a matrix entry
- the three recovery-artifact literals are unchanged
- job count and matrix length unchanged

That checker was itself checked: renaming one key in memory makes it report the break, so "all resolve" is a real result rather than a silent pass. `check-action-pins` and `check-workflow-injection` both pass. `macos-26` and `ubuntu-24.04` are both listed as labels in the `actions/runner-images` README (positive control: `ubuntu-24.04` appears there 4 times).

**Not verified:** an actual run of the release workflow.
