### PR TITLE
chore(deps): drop the generated conflicts_next-auth catalog

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,5 +99,3 @@ catalogs:
   icons:
     '@iconify-json/carbon': ^1.2.24
     '@iconify-json/twemoji': ^1.2.5
-  conflicts_next-auth_t4_24_15:
-    next-auth: ~4.24.15


### PR DESCRIPTION
Closes #749.

The audit reported two contradictory `next-auth` pins — `~4.21.1` in the main catalog against `~4.24.14` in the generated `conflicts_` catalog. **Both have since moved.** The catalog, the `conflicts_` entry and `apps/nexus/package.json` all say `~4.24.15` today, so nothing contradicts anything.

What survived is a named catalog that duplicates the default one and is referenced by nobody.

### Removing it cannot touch the lockfile — checked, not assumed

`pnpm-workspace.yaml` declared five named catalogs; `pnpm-lock.yaml` carries four:

| catalog | workspace | lockfile |
|---|---|---|
| `build`, `dev`, `frontend`, `icons` | ✅ | ✅ |
| `conflicts_next-auth_t4_24_15` | ✅ | **absent** |

The four that appear in both are the positive control that makes the absence meaningful: the `conflicts_` catalog never reached the lockfile because nothing resolves through it. After the deletion the two lists match exactly and `git diff` touches one file.

### Left alone deliberately

- **The default catalog's `next-auth: ~4.24.15`.** Equally unreferenced, but it is the entry the audit wants consumers to adopt via `catalog:` — deleting it works against that.
- **Pointing `apps/nexus` at `catalog:`.** That changes resolution and needs a lockfile regeneration, which cannot be produced or verified in this environment.

### Not fixed, because it is a real dependency decision

`@sidebase/nuxt-auth@0.9.4` declares `next-auth: ~4.21.1` as a peer while the app runs `4.24.15`, and root `package.json`'s `allowedVersions` silences it. That mismatch is genuine and unresolved — but choosing between upgrading nuxt-auth and pinning next-auth back needs an install and an auth smoke test.

For the record: the `~4.21.1` line in the lockfile is that upstream peer declaration, not a stale pin of ours. I checked before reporting it as drift.

Overlaps #599, which covers the whole dead-catalog surface.
