### PR TITLE
chore(deps): remove catalog entries that name versions the repo does not use

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,20 +41,17 @@ catalog:
   '@langchain/openai': ^0.4.9
   '@sentry/nuxt': ^10.64.0
   '@sidebase/nuxt-auth': ^0.9.4
-  ai-elements-vue: ^1.5.0
   better-sqlite3: ^12.11.1
   echarts: ^6.1.0
   fighting-design: 0.25.1
   gsap: ^3.15.0
-  jsqr: ^1.4.0
   jszip: ^3.10.1
-  markdown-it: ^14.3.0
+  markdown-it: 14.1.0
   marked: ^17.0.6
   mermaid: ^11.16.0
   next-auth: ~4.24.15
   ogl: ^1.0.11
   openapi-typescript: ^7.13.0
-  qrcode: ^1.5.4
   sass: ^1.101.0
   simplex-noise: ^4.0.3
   theme-colors: ^0.1.0


### PR DESCRIPTION
Closes #599.

### Re-measured rather than trusting the list

The audit counted 15 dead entries. Scanning all 34 workspace `package.json` files for `"<name>": "catalog:"`: **29 root-catalog entries, 13 unreferenced.** The scan was checked in both directions — referenced entries (`@floating-ui/vue`, `@langchain/langgraph`, `@langchain/openai`, …) do show up as referenced — so the dead count is a real result, not a broken grep.

Several of the audit's specific examples have gone stale: `@langchain/langgraph` and `@langchain/openai` are now referenced through the catalog, `next-auth` agrees at `~4.24.15` across all four places, and `nodemailer` is no longer in the catalog at all.

### "Unreferenced" and "wrong" are not the same thing

Splitting the 13 by the harm they actually do:

| count | situation | action |
|---|---|---|
| **9** | catalog version matches every consumer exactly | **kept** — harmless, and exactly what `catalog:` adoption should point at |
| **1** | `markdown-it`: catalog `^14.3.0`, root devDependency pinned `14.1.0`, lockfile resolves `14.1.0` | **corrected to `14.1.0`** |
| **3** | `ai-elements-vue`, `jsqr`, `qrcode` declared by nobody anywhere | **removed** |

`markdown-it` was the only entry left that gives a wrong answer to "what version does this repo use?" — and it is the dangerous shape the issue describes, since adopting `catalog:` there would have *upgraded* the dependency.

Deleting all 13 would have been the literal suggestion, but it would also delete the nine correct migration targets — including the `next-auth` entry I argued for keeping in #749.

### Verification

Editing these cannot disturb resolution, and that is checked rather than assumed: none of the four edited names appear in the lockfile's `default` catalog, while referenced entries do. One file changed; `pnpm-lock.yaml` untouched.

Re-running the measurement after the change:

- entries with no consumer at all: **0**
- unreferenced entries that disagree with their consumers: **0**
- unreferenced but accurate: **10**, left as migration targets

**Not verified:** no `pnpm install` was run — pnpm cannot execute in this environment. The claim rests on the lockfile's own catalog contents, which is why the absence check was given a positive control.
