### PR TITLE
fix(search): clamp plugin-supplied manifest priority

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/sort/tuff-sorter.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/sort/tuff-sorter.test.ts
@@ -1,6 +1,6 @@
 import type { TuffItem, TuffQuery } from '@talex-touch/utils'
 import { describe, expect, it } from 'vitest'
-import { tuffSorter } from './tuff-sorter'
+import { calculateSortScore, tuffSorter } from './tuff-sorter'
 
 type UsageStats = NonNullable<NonNullable<TuffItem['meta']>['usageStats']>
 
@@ -516,5 +516,60 @@ describe('tuff-sorter ranking strategy', () => {
 
     const sorted = tuffSorter.sort([first, second], { text: 'clip' } as TuffQuery, signal)
     expect(sorted[0]?.id).toBe('feature-first')
+  })
+})
+
+describe('manifest priority is a bias, not an override', () => {
+  const signal = new AbortController().signal
+
+  function priorityItem(id: string, priority: number): TuffItem {
+    const item = createItem({
+      id,
+      kind: 'feature',
+      title: 'Unrelated Feature',
+      sourceId: 'plugin-provider'
+    })
+    return { ...item, meta: { ...item.meta, priority } }
+  }
+
+  async function rank(items: TuffItem[], text: string): Promise<string[]> {
+    const query: TuffQuery = { text }
+    const sorted = await tuffSorter.sort(items, query, signal)
+    return sorted.map((entry) => entry.id)
+  }
+
+  it('一个声明超大 priority 的 feature 不能压过精确标题匹配的 app', async () => {
+    const exactApp = createItem({
+      id: 'app-safari',
+      kind: 'app',
+      title: 'Safari',
+      sourceId: 'app-provider',
+      searchTokens: ['safari'],
+      matchResult: [{ start: 0, end: 6 }]
+    })
+
+    const ranked = await rank([priorityItem('greedy-feature', 100_000), exactApp], 'safari')
+
+    expect(ranked[0]).toBe('app-safari')
+  })
+
+  it('钳制之后 priority 仍然能区分同类结果的先后', async () => {
+    const ranked = await rank([priorityItem('low', 1), priorityItem('high', 200)], 'unrelated')
+
+    expect(ranked).toEqual(['high', 'low'])
+  })
+
+  it('钳制在上限处饱和:超出上限的 priority 得到与上限完全相同的分数', () => {
+    const atCap = calculateSortScore(priorityItem('at-cap', 500), 'unrelated')
+    const overCap = calculateSortScore(priorityItem('way-over-cap', 9_999_999), 'unrelated')
+
+    expect(overCap).toBe(atCap)
+  })
+
+  it('负 priority 不会把分数拖到上限之外', () => {
+    const zero = calculateSortScore(priorityItem('zero', 0), 'unrelated')
+    const negative = calculateSortScore(priorityItem('negative', -9_999_999), 'unrelated')
+
+    expect(negative).toBe(zero)
   })
 })

--- a/apps/core-app/src/main/modules/box-tool/search-engine/sort/tuff-sorter.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/sort/tuff-sorter.ts
@@ -21,6 +21,21 @@ const APP_TITLE_PREFIX_INTENT_BONUS = 480_000
 const APP_TITLE_SUBSTRING_INTENT_BONUS = 180_000
 const APP_EXACT_TOKEN_INTENT_BONUS = 6_200_000
 const APP_PREFIX_TOKEN_INTENT_BONUS = 5_700_000
+/**
+ * Ceiling for the plugin-supplied `feature.priority` from a manifest.
+ *
+ * The value was previously unbounded, so a feature declaring `"priority": 100000` scored
+ * 100000 * KIND_SCORE_MULTIPLIER = 3e7 and outranked an exact app title match (6_200_000)
+ * on every query it recalled on -- contradicting the "soft bias" it is documented to be.
+ *
+ * 500 puts the ceiling (500 * 300 = 150_000) below the smallest app intent bonus
+ * (APP_TITLE_SUBSTRING_INTENT_BONUS = 180_000), while leaving headroom above the largest
+ * value any shipped manifest declares: touch-intelligence's 200. Clamping to the range the
+ * audit suggested (0..100) would have collapsed that plugin's 200/195/194/193/192 ladder
+ * into a single value and destroyed its intended ordering.
+ */
+const MAX_META_PRIORITY = 500
+
 const LOW_CONFIDENCE_APP_FUZZY_MATCH_CAP = 160
 const LOW_CONFIDENCE_FEATURE_FREQUENCY_CAP = 18
 const LOW_CONFIDENCE_FEATURE_RECENCY_CAP = 1
@@ -29,8 +44,10 @@ function getKindBias(item: TuffItem): number {
   const kind = item.kind || 'unknown'
   const baseBias = DEFAULT_KIND_BIAS[kind] || 0
 
-  // Feature manifest priority remains effective, but only as a soft bias.
-  const metaPriority = Number(item.meta?.priority) || 0
+  // Feature manifest priority remains effective, but only as a soft bias: it is
+  // plugin-supplied, so it is clamped rather than trusted.
+  const rawPriority = Number(item.meta?.priority) || 0
+  const metaPriority = Math.min(Math.max(rawPriority, 0), MAX_META_PRIORITY)
   return baseBias + metaPriority
 }
 


### PR DESCRIPTION
Closes #662.

`getKindBias` added `feature.priority` straight from the plugin manifest, and the sum is multiplied by `KIND_SCORE_MULTIPLIER = 300`. A plugin declaring `"priority": 100000` contributed **3e7**, beating `APP_EXACT_TOKEN_INTENT_BONUS` at **6.2e6** — so its feature outranked an exact app title match on every query it recalled on, which is the opposite of the "soft bias" the comment directly above it promised.

### Why not the suggested 0..100

The issue suggests clamping to `0..100`. That breaks a shipped plugin: **`touch-intelligence` declares 200, 195, 194, 193 and 192** across five features. A cap of 100 flattens all five to the same value and destroys the ordering they encode.

### Choosing 500 from the actual numbers

- ceiling = `500 * 300 = 150_000`, which sits **below the smallest app intent bonus** (`APP_TITLE_SUBSTRING_INTENT_BONUS = 180_000`), so a plugin can no longer outrank app intent
- the largest value any shipped manifest declares is **200**, leaving 2.5× headroom
- scanning every `plugins/*/manifest.json`: max **200**, features clipped by the cap: **none**
- negatives clamp to 0; nothing declares one, the lowest in the tree is `1`

### Verification

Three tests added to the existing `tuff-sorter.test.ts`, and they were **mutation-checked**: reverting only the clamp expression, leaving everything else intact, fails exactly those three —

```
× 一个声明超大 priority 的 feature 不能压过精确标题匹配的 app
× 钳制在上限处饱和:超出上限的 priority 得到与上限完全相同的分数
× 负 priority 不会把分数拖到上限之外
  Tests  3 failed | 18 passed (21)
```

The other 18 keep passing, so the tests target the clamp rather than the surrounding ranking. Restored: **21/21**.

Two of the three assert on `calculateSortScore` directly rather than on ordering — an earlier draft compared result sets, which was trivially true and would have passed against the bug.

Lint judged as a **delta against HEAD using core-app's own config**, not the root one (they disagree on trailing commas): baseline 0 problems, this change 0 problems.
