### PR TITLE
fix(conversation): make the replace-all save transactional

### DIFF
--- a/apps/core-app/src/main/modules/conversation/conversation-store.transaction.test.ts
+++ b/apps/core-app/src/main/modules/conversation/conversation-store.transaction.test.ts
@@ -63,8 +63,8 @@ describe('saveConversation rolls back a failed replace-all', () => {
       id: 'thread-1',
       title: 'first',
       messages: [
-        { id: 'm1', role: 'user', content: 'hello', status: 'complete', seq: 0, createdAt: 1 },
-        { id: 'm2', role: 'assistant', content: 'hi', status: 'complete', seq: 1, createdAt: 2 }
+        { id: 'm1', role: 'user', content: 'hello', status: 'complete', createdAt: 1 },
+        { id: 'm2', role: 'assistant', content: 'hi', status: 'complete', createdAt: 2 }
       ]
     })
 
@@ -78,8 +78,8 @@ describe('saveConversation rolls back a failed replace-all', () => {
       id: 'thread-1',
       title: 'first',
       messages: [
-        { id: 'm1', role: 'user', content: 'hello', status: 'complete', seq: 0, createdAt: 1 },
-        { id: 'm2', role: 'assistant', content: 'hi', status: 'complete', seq: 1, createdAt: 2 }
+        { id: 'm1', role: 'user', content: 'hello', status: 'complete', createdAt: 1 },
+        { id: 'm2', role: 'assistant', content: 'hi', status: 'complete', createdAt: 2 }
       ]
     })
 
@@ -90,8 +90,8 @@ describe('saveConversation rolls back a failed replace-all', () => {
         id: 'thread-1',
         title: 'second',
         messages: [
-          { id: 'dup', role: 'user', content: 'a', status: 'complete', seq: 0, createdAt: 3 },
-          { id: 'dup', role: 'assistant', content: 'b', status: 'complete', seq: 1, createdAt: 4 }
+          { id: 'dup', role: 'user', content: 'a', status: 'complete', createdAt: 3 },
+          { id: 'dup', role: 'assistant', content: 'b', status: 'complete', createdAt: 4 }
         ]
       })
     ).rejects.toThrow()

--- a/apps/core-app/src/main/modules/conversation/conversation-store.transaction.test.ts
+++ b/apps/core-app/src/main/modules/conversation/conversation-store.transaction.test.ts
@@ -1,0 +1,101 @@
+/**
+ * saveConversation is a replace-all: it DELETEs every message row for a thread and then INSERTs
+ * the new set (#763). scheduleDbWrite serialises that unit against other writers but gives it no
+ * rollback boundary, so before the fix a failing insert left the thread row present and every
+ * message gone -- the UI kept showing the thread from memory and it opened empty on next launch.
+ *
+ * These run against a real libsql database with the shipped migrations applied, because the
+ * property under test is rollback. A mocked `db` could only prove that `transaction()` was called,
+ * not that the delete actually came back.
+ */
+import { createClient } from '@libsql/client'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { drizzle } from 'drizzle-orm/libsql'
+import { migrate } from 'drizzle-orm/libsql/migrator'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const migrationsFolder = resolve(testDir, '../../../../resources/db/migrations')
+
+let db: ReturnType<typeof drizzle>
+let tempDir: string
+
+vi.mock('../database', () => ({
+  databaseModule: {
+    getDb: () => db
+  }
+}))
+
+// The scheduler only serialises; running the task inline keeps these tests about the write itself.
+vi.mock('../../db/db-write', () => ({
+  scheduleDbWrite: (_name: string, task: () => Promise<unknown>) => task()
+}))
+
+async function loadStore(): Promise<typeof import('./conversation-store')> {
+  return import('./conversation-store')
+}
+
+async function storedMessageIds(conversationId: string): Promise<string[]> {
+  const { getConversation } = await loadStore()
+  const thread = await getConversation(conversationId)
+  return (thread?.messages ?? []).map((message) => message.id)
+}
+
+describe('saveConversation rolls back a failed replace-all', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'conversation-store-'))
+    const client = createClient({ url: `file:${join(tempDir, 'test.db')}` })
+    db = drizzle(client)
+    await migrate(db, { migrationsFolder })
+  })
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('保存两条消息后能读回两条', async () => {
+    const { saveConversation } = await loadStore()
+
+    await saveConversation({
+      id: 'thread-1',
+      title: 'first',
+      messages: [
+        { id: 'm1', role: 'user', content: 'hello', status: 'complete', seq: 0, createdAt: 1 },
+        { id: 'm2', role: 'assistant', content: 'hi', status: 'complete', seq: 1, createdAt: 2 }
+      ]
+    })
+
+    expect(await storedMessageIds('thread-1')).toEqual(['m1', 'm2'])
+  })
+
+  it('重复消息 id 导致插入失败时,原有消息必须还在', async () => {
+    const { saveConversation } = await loadStore()
+
+    await saveConversation({
+      id: 'thread-1',
+      title: 'first',
+      messages: [
+        { id: 'm1', role: 'user', content: 'hello', status: 'complete', seq: 0, createdAt: 1 },
+        { id: 'm2', role: 'assistant', content: 'hi', status: 'complete', seq: 1, createdAt: 2 }
+      ]
+    })
+
+    // A retried stream that reuses an id: the DELETE succeeds, the multi-row INSERT aborts on the
+    // primary-key conflict. Without a transaction the thread is left with zero messages.
+    await expect(
+      saveConversation({
+        id: 'thread-1',
+        title: 'second',
+        messages: [
+          { id: 'dup', role: 'user', content: 'a', status: 'complete', seq: 0, createdAt: 3 },
+          { id: 'dup', role: 'assistant', content: 'b', status: 'complete', seq: 1, createdAt: 4 }
+        ]
+      })
+    ).rejects.toThrow()
+
+    expect(await storedMessageIds('thread-1')).toEqual(['m1', 'm2'])
+  })
+})

--- a/apps/core-app/src/main/modules/conversation/conversation-store.ts
+++ b/apps/core-app/src/main/modules/conversation/conversation-store.ts
@@ -105,33 +105,39 @@ export async function saveConversation(input: SaveConversationInput): Promise<St
   // One scheduled unit: the delete and the re-insert must not be separated by another writer, or a
   // concurrent read would see the thread with its messages already gone.
   await scheduleDbWrite('conversation.save', async () => {
-    if (existing) {
-      await db
-        .update(conversations)
-        .set({ title: input.title, updatedAt: now })
-        .where(eq(conversations.id, input.id))
-    } else {
-      await db
-        .insert(conversations)
-        .values({ id: input.id, title: input.title, createdAt: now, updatedAt: now })
-    }
+    // Transactional because this is a replace-all: the DELETE below removes every message row
+    // before the INSERT puts them back. Without a rollback boundary a failing insert -- a
+    // duplicate message id from a retried stream, a full disk, a SQLITE_BUSY that outlives the
+    // retry budget -- leaves the thread row present and permanently empty.
+    await db.transaction(async (tx) => {
+      if (existing) {
+        await tx
+          .update(conversations)
+          .set({ title: input.title, updatedAt: now })
+          .where(eq(conversations.id, input.id))
+      } else {
+        await tx
+          .insert(conversations)
+          .values({ id: input.id, title: input.title, createdAt: now, updatedAt: now })
+      }
 
-    await db.delete(conversationMessages).where(eq(conversationMessages.conversationId, input.id))
+      await tx.delete(conversationMessages).where(eq(conversationMessages.conversationId, input.id))
 
-    if (input.messages.length > 0) {
-      await db.insert(conversationMessages).values(
-        input.messages.map((message, index) => ({
-          id: message.id,
-          conversationId: input.id,
-          role: message.role,
-          content: message.content,
-          status: message.status,
-          meta: message.meta ? JSON.stringify(message.meta) : null,
-          seq: index,
-          createdAt: message.createdAt ?? now
-        }))
-      )
-    }
+      if (input.messages.length > 0) {
+        await tx.insert(conversationMessages).values(
+          input.messages.map((message, index) => ({
+            id: message.id,
+            conversationId: input.id,
+            role: message.role,
+            content: message.content,
+            status: message.status,
+            meta: message.meta ? JSON.stringify(message.meta) : null,
+            seq: index,
+            createdAt: message.createdAt ?? now
+          }))
+        )
+      }
+    })
   })
 
   return {


### PR DESCRIPTION
Closes #763.

`saveConversation` is a replace-all: it deletes every message row for a thread and re-inserts the new set. `scheduleDbWrite` serialises that unit against other writers — which is what the comment above it is about — but gives it **no rollback boundary**. A failing insert left the thread row present and every message gone: the UI kept showing the thread from memory, and it opened empty on the next launch.

The delete and both inserts now run inside `db.transaction()`, matching how `catalog-repository` and `update-attempt-repository` already wrap multi-statement writes.

### Tested against a real database, not a mock

The property under test is **rollback**. A mocked `db` could only prove `transaction()` was called — it could not show that the delete came back. So the test runs against a real libsql database with the shipped migrations from `resources/db/migrations` applied, following the harness `recommendation-exposure-schema.test.ts` already uses.

The failure is driven exactly the way the issue says it happens in practice — a retried stream reusing a message id, so the multi-row insert aborts on the primary-key conflict — rather than through an injected error. The test fails for the reason it is named for.

### The mutation is the point

Reverting **only** the transaction boundary, leaving the same statements in the same order on the same connection:

```
✓ 保存两条消息后能读回两条
× 重复消息 id 导致插入失败时,原有消息必须还在
  → expected [] to deeply equal [ 'm1', 'm2' ]
```

`[]` — every message gone, which is precisely the data loss described. Restored: **2/2**.

Lint clean on both files under core-app's own config.
