### PR TITLE
fix(plugin): enforce the 10MB plugin storage quota against the directory

### DIFF
--- a/apps/core-app/src/main/modules/plugin/plugin.test.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin.test.ts
@@ -3569,3 +3569,68 @@ describe('touchPlugin.enable', () => {
     })
   })
 })
+
+describe('savePluginFile enforces the per-plugin storage quota', () => {
+  const tempRoots: string[] = []
+
+  afterEach(() => {
+    for (const root of tempRoots.splice(0)) {
+      fse.removeSync(root)
+    }
+  })
+
+  function createPlugin(name: string): TouchPlugin {
+    const rootPath = fse.mkdtempSync(path.join(os.tmpdir(), 'plugin-quota-'))
+    tempRoots.push(rootPath)
+    return new TouchPlugin(
+      name,
+      { type: 'class', value: 'i-ri-test-tube-line' },
+      '1.0.0',
+      'desc',
+      '',
+      { enable: false, address: '' },
+      '/tmp',
+      {},
+      { skipDataInit: true, runtime: { rootPath, mainWindowId: 1 } }
+    )
+  }
+
+  /** A payload whose JSON encoding is at least `bytes` long. */
+  function payloadOfSize(bytes: number): { blob: string } {
+    return { blob: 'x'.repeat(bytes) }
+  }
+
+  it('单个文件仍然可以写到接近上限', () => {
+    const plugin = createPlugin('quota-single')
+
+    expect(
+      plugin.savePluginFile('a.json', payloadOfSize(4 * 1024 * 1024), { broadcast: false })
+    ).toEqual({
+      success: true
+    })
+  })
+
+  it('多个各自合规的文件累计超出 10MB 时必须被拒绝', () => {
+    const plugin = createPlugin('quota-total')
+    const fourMb = payloadOfSize(4 * 1024 * 1024)
+
+    expect(plugin.savePluginFile('a.json', fourMb, { broadcast: false }).success).toBe(true)
+    expect(plugin.savePluginFile('b.json', fourMb, { broadcast: false }).success).toBe(true)
+
+    // Third 4MB file: each payload passes the per-file check, the directory total does not.
+    const third = plugin.savePluginFile('c.json', fourMb, { broadcast: false })
+    expect(third.success).toBe(false)
+    expect(third.error).toContain('Storage quota exceeded')
+
+    expect(fse.existsSync(path.join(plugin.getConfigPath(), 'c.json'))).toBe(false)
+  })
+
+  it('覆写已存在的文件不会把旧内容重复计入', () => {
+    const plugin = createPlugin('quota-replace')
+    const sixMb = payloadOfSize(6 * 1024 * 1024)
+
+    expect(plugin.savePluginFile('a.json', sixMb, { broadcast: false }).success).toBe(true)
+    // Replacing 6MB with 6MB stays at 6MB; counting the old copy too would wrongly reject.
+    expect(plugin.savePluginFile('a.json', sixMb, { broadcast: false }).success).toBe(true)
+  })
+})

--- a/apps/core-app/src/main/modules/plugin/plugin.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin.ts
@@ -3636,6 +3636,45 @@ export class TouchPlugin implements ITouchPlugin {
    * @param content 文件内容
    * @returns 保存结果
    */
+  /**
+   * Size and file count of the config directory as they would be after writing `targetPath`
+   * with `nextBytes`. `targetPath` is excluded from the walk because it is being replaced.
+   *
+   * The 10MB figure getStorageStats reports as `maxSize` is a per-plugin budget, but
+   * savePluginFile only ever compared the single payload against it, so a plugin could write
+   * 100 distinct 9MB files and occupy ~900MB while the stats reported usagePercent in the
+   * thousands (#774). This mirrors assertProjectedQuota in plugin-business-file-storage.
+   *
+   * Scoped to the config directory this API owns. getStorageRoots also covers logs and temp,
+   * and counting those here would let ordinary log growth lock a plugin out of its own storage.
+   */
+  private projectConfigStorage(
+    configPath: string,
+    targetPath: string,
+    nextBytes: number
+  ): { totalBytes: number; fileCount: number } {
+    let totalBytes = nextBytes
+    let fileCount = 1
+
+    const walk = (dirPath: string): void => {
+      for (const name of fse.readdirSync(dirPath)) {
+        const entryPath = path.join(dirPath, name)
+        const entry = fse.lstatSync(entryPath)
+        if (entry.isDirectory()) {
+          walk(entryPath)
+          continue
+        }
+        if (!entry.isFile() || entryPath === targetPath) continue
+        fileCount += 1
+        totalBytes += entry.size
+      }
+    }
+
+    if (fse.existsSync(configPath)) walk(configPath)
+
+    return { totalBytes, fileCount }
+  }
+
   savePluginFile(
     fileName: string,
     content: unknown,
@@ -3652,7 +3691,9 @@ export class TouchPlugin implements ITouchPlugin {
     }
 
     const PLUGIN_CONFIG_MAX_SIZE = 10 * 1024 * 1024 // 10MB
-    if (Buffer.byteLength(configData, 'utf-8') > PLUGIN_CONFIG_MAX_SIZE) {
+    const PLUGIN_CONFIG_MAX_FILES = 1_000
+    const nextBytes = Buffer.byteLength(configData, 'utf-8')
+    if (nextBytes > PLUGIN_CONFIG_MAX_SIZE) {
       return {
         success: false,
         error: `File size exceeds the ${PLUGIN_CONFIG_MAX_SIZE} limit for plugin ${this.name}`
@@ -3660,6 +3701,21 @@ export class TouchPlugin implements ITouchPlugin {
     }
 
     const p = safePath.resolvedPath
+
+    const projected = this.projectConfigStorage(configPath, p, nextBytes)
+    if (
+      projected.totalBytes > PLUGIN_CONFIG_MAX_SIZE ||
+      projected.fileCount > PLUGIN_CONFIG_MAX_FILES
+    ) {
+      return {
+        success: false,
+        error:
+          `Storage quota exceeded for plugin ${this.name}: ` +
+          `${projected.fileCount} file(s), ${projected.totalBytes} bytes would exceed ` +
+          `${PLUGIN_CONFIG_MAX_FILES} files / ${PLUGIN_CONFIG_MAX_SIZE} bytes`
+      }
+    }
+
     fse.ensureDirSync(configPath)
     fse.writeFileSync(p, configData)
 


### PR DESCRIPTION
Closes #774.

`savePluginFile` compared only the single payload against `PLUGIN_CONFIG_MAX_SIZE`, while `getStorageStats` reports that same 10MB as `maxSize` against the **sum** of every file. A plugin driving the storage IPC with 100 distinct 9MB file names passed every check and occupied ~900MB, with `usagePercent` reported in the thousands. The advertised per-plugin quota did not exist.

The write now projects the config directory's total bytes and file count — **excluding the file being replaced** — and rejects anything that would push the plugin over 10MB or 1000 files. This mirrors `assertProjectedQuota` in `plugin-business-file-storage.ts`, which the issue correctly identifies as the sibling that already does this.

### Scoped to the config directory, not `getStorageRoots`

`getStorageRoots()` returns config, runtimeLogs, dataLogs **and temp**. Enforcing the write quota across all of them would let ordinary log growth lock a plugin out of its own storage — trading a disk-usage bug for an availability one. The quota is enforced on the directory this API actually writes.

Side effect worth stating: `getStorageStats` still measures all four roots against the same 10MB, so its `usagePercent` remains a different number from what the writer enforces. Fixing that is a reporting decision (which roots count toward the advertised quota) rather than part of closing the hole.

### Three tests, mutation-checked

Disabling **only** the quota condition while leaving the projection running lets the third 4MB write through:

```
✓ 单个文件仍然可以写到接近上限
× 多个各自合规的文件累计超出 10MB 时必须被拒绝
  → expected true to be false
✓ 覆写已存在的文件不会把旧内容重复计入
```

The other two pass in **both** states by design — they are controls, so a quota implemented as "reject everything" would fail them. The overwrite case also pins the exclusion: counting the old copy would put the projection at 12MB and wrongly reject a legal write.

Restored: **55/55** in `plugin.test.ts`. Lint clean under core-app's own config.
