### PR TITLE
fix(intelligence): release the session stream when its renderer goes away

### DIFF
--- a/apps/core-app/src/main/modules/ai/intelligence-module.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-module.ts
@@ -2261,7 +2261,6 @@ export class IntelligenceModule extends BaseModule<TalexEvents> {
         let closed = false
         let doneSent = false
         let keepaliveTimer: ReturnType<typeof setInterval> | null = null
-        let cancelWatcher: ReturnType<typeof setInterval> | null = null
         let unsubscribe: () => void = () => {}
 
         const sendStreamEvent = (event: IntelligenceAgentStreamEvent): boolean => {
@@ -2284,16 +2283,44 @@ export class IntelligenceModule extends BaseModule<TalexEvents> {
             clearInterval(keepaliveTimer)
             keepaliveTimer = null
           }
-          if (cancelWatcher) {
-            clearInterval(cancelWatcher)
-            cancelWatcher = null
-          }
           unsubscribe()
           try {
             streamContext.end()
           } catch {
             // Ignore stream close failures on disconnected clients.
           }
+        }
+
+        /**
+         * Resolves when this stream should stop: the client cancelled, or its renderer went away.
+         *
+         * The renderer half matters because handleCancel only runs on an explicit cancel message
+         * (#764). A reloaded, closed or crashed window never sends one, so the previous 250ms
+         * poll on isCancelled() never resolved and the keepalive timer, the poll itself and the
+         * trace subscription stayed live for the rest of the process -- one more set per reload.
+         *
+         * The poll is gone because it was only ever observing the same state as `signal`:
+         * handleCancel sets `cancelled` and calls `abortController.abort()` together, and
+         * `signal` is that controller's.
+         */
+        const waitForStreamRelease = (): Promise<void> => {
+          const sender = streamContext.sender
+          if (streamContext.isCancelled() || !sender || sender.isDestroyed()) {
+            return Promise.resolve()
+          }
+
+          return new Promise<void>((resolve) => {
+            const release = (): void => {
+              streamContext.signal.removeEventListener('abort', release)
+              sender.off('destroyed', release)
+              sender.off('render-process-gone', release)
+              resolve()
+            }
+
+            streamContext.signal.addEventListener('abort', release)
+            sender.once('destroyed', release)
+            sender.once('render-process-gone', release)
+          })
         }
 
         const replayTrace = async () => {
@@ -2402,14 +2429,7 @@ export class IntelligenceModule extends BaseModule<TalexEvents> {
             })
           }, INTELLIGENCE_STREAM_KEEPALIVE_MS)
 
-          await new Promise<void>((resolve) => {
-            cancelWatcher = setInterval(() => {
-              if (!streamContext.isCancelled()) {
-                return
-              }
-              resolve()
-            }, 250)
-          })
+          await waitForStreamRelease()
 
           await pauseOnDisconnect()
           if (!doneSent) {

--- a/apps/core-app/src/main/modules/ai/intelligence-session-stream-release.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-session-stream-release.test.ts
@@ -1,0 +1,171 @@
+/**
+ * The session subscribe stream used to park on a 250ms poll of isCancelled(), and that flag is
+ * only set by an explicit cancel message from the renderer (#764). A reloaded, closed or crashed
+ * window never sends one, so the keepalive interval, the poll itself and the trace subscription
+ * stayed live for the rest of the process -- one more set per reload.
+ *
+ * These assert on timer count rather than on a "did it resolve" boolean: a stream that resolves
+ * but leaves its interval armed is exactly the bug.
+ */
+import type { HandlerContext } from '@talex-touch/utils/transport/main'
+import type { StreamContext } from '@talex-touch/utils/transport/types'
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import './intelligence-test-harness'
+
+const runtimeMocks = vi.hoisted(() => ({
+  getSessionHistory: vi.fn(),
+  queryTrace: vi.fn(),
+  pauseSession: vi.fn(),
+  getSessionState: vi.fn(),
+  subscribeSessionTrace: vi.fn()
+}))
+
+vi.mock('./tuff-intelligence-runtime', () => ({
+  tuffIntelligenceRuntime: runtimeMocks
+}))
+
+vi.mock('../permission/channel-guard', () => ({
+  withPermission: vi.fn(
+    (
+      _options: unknown,
+      handler: (payload: unknown, context: HandlerContext) => Promise<void> | void
+    ) => handler
+  )
+}))
+
+vi.mock('../sentry/sentry-service', () => {
+  class SentryServiceModule {
+    isTelemetryEnabled = vi.fn(() => false)
+    isEnabled = vi.fn(() => false)
+    queueNexusTelemetry = vi.fn()
+  }
+
+  const service = new SentryServiceModule()
+  return {
+    SentryServiceModule,
+    getSentryService: vi.fn(() => service),
+    setSentryServiceInstance: vi.fn()
+  }
+})
+
+import { IntelligenceModule } from './intelligence-module'
+
+type SessionStreamHandler = (payload: unknown, context: StreamContext<unknown>) => Promise<void>
+
+interface TransportCapture {
+  on: (event: { toEventName: () => string }, handler: unknown) => void
+  onStream: (event: { toEventName: () => string }, handler: SessionStreamHandler) => void
+}
+
+interface OrchestrationChannelRegistrar {
+  registerOrchestrationStreamChannels: () => void
+  transport: TransportCapture | null
+}
+
+function captureSubscribeHandler(): SessionStreamHandler {
+  const streamHandlers = new Map<string, SessionStreamHandler>()
+  const module = new IntelligenceModule() as unknown as OrchestrationChannelRegistrar
+  module.transport = {
+    on: vi.fn(),
+    onStream: (event, handler) => streamHandlers.set(event.toEventName(), handler)
+  }
+  module.registerOrchestrationStreamChannels()
+
+  const handler = streamHandlers.get('intelligence:agent:session:subscribe')
+  if (!handler) {
+    throw new Error('Intelligence session subscribe handler was not registered')
+  }
+  return handler
+}
+
+/** Stands in for the renderer's WebContents: only lifecycle events matter here. */
+class FakeSender extends EventEmitter {
+  private destroyed = false
+
+  isDestroyed(): boolean {
+    return this.destroyed
+  }
+
+  destroy(): void {
+    this.destroyed = true
+    this.emit('destroyed')
+  }
+}
+
+function createStreamContext(sender: FakeSender): {
+  context: StreamContext<unknown>
+  cancel: () => void
+} {
+  const controller = new AbortController()
+  let cancelled = false
+  const context = {
+    emit: vi.fn(),
+    error: vi.fn(),
+    end: vi.fn(),
+    isCancelled: () => cancelled,
+    signal: controller.signal,
+    streamId: 'stream-1',
+    sender: sender as unknown as StreamContext<unknown>['sender']
+  } as unknown as StreamContext<unknown>
+
+  return {
+    context,
+    cancel: () => {
+      cancelled = true
+      controller.abort()
+    }
+  }
+}
+
+describe('intelligence session stream releases with its renderer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    runtimeMocks.subscribeSessionTrace.mockReturnValue(vi.fn())
+    // Not running, so pauseOnDisconnect does not try to pause.
+    runtimeMocks.getSessionState.mockResolvedValue({ status: 'completed' })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('渲染进程销毁后,流上的定时器必须全部清掉', async () => {
+    const handler = captureSubscribeHandler()
+    const sender = new FakeSender()
+    const { context } = createStreamContext(sender)
+
+    const pending = handler({ sessionId: 'session-1' }, context)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+    sender.destroy()
+    // 300ms so a 250ms poll would have had its chance to tick: this must fail because the poll
+    // never observes a destroyed sender, not because timers were not advanced.
+    await vi.advanceTimersByTimeAsync(300)
+    await pending
+
+    expect(vi.getTimerCount()).toBe(0)
+    expect(runtimeMocks.subscribeSessionTrace.mock.results[0]?.value).toHaveBeenCalled()
+  })
+
+  it('显式取消仍然结束流(没有被 sender 钩子取代)', async () => {
+    const handler = captureSubscribeHandler()
+    const sender = new FakeSender()
+    const { context, cancel } = createStreamContext(sender)
+
+    const pending = handler({ sessionId: 'session-1' }, context)
+    await vi.advanceTimersByTimeAsync(0)
+
+    cancel()
+    // Same 300ms budget. This case worked before the change too, so it is the control: it must
+    // keep passing when the fix is reverted.
+    await vi.advanceTimersByTimeAsync(300)
+    await pending
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})


### PR DESCRIPTION
Closes #764.

The subscribe handler parked on a 250ms poll of `streamContext.isCancelled()`. That flag is only set by an explicit cancel message, so a reloaded, closed or crashed window never released the stream: the 10s keepalive interval, the poll itself and the trace subscription stayed live for the rest of the process — **one more set per reload** — and `onDestroy` never touched them either.

The wait is now on the `AbortSignal` the stream context already exposes, plus `destroyed` and `render-process-gone` on its `sender`. Both listeners are removed when either path fires, so a long-lived sender does not accumulate handlers across streams.

### Dropping the poll is checked, not assumed

`handleCancel` in `packages/utils/transport/sdk/stream/server-runtime.ts` sets `cancelled` **and** calls `abortController.abort()` in the same breath, and the `signal` the context exposes is that controller's:

```ts
state.cancelled = true;
state.abortController.abort();
```

So the poll was only ever observing state the signal already carries. Removing it cannot lose a cancellation.

### Two tests, and the mutation is the interesting part

They assert on `vi.getTimerCount()` rather than on "did it resolve" — a stream that resolves while leaving its interval armed is precisely the bug.

Restoring the poll:

```
× 渲染进程销毁后,流上的定时器必须全部清掉   (times out)
✓ 显式取消仍然结束流
```

The cancel case **still passes**, which is the control: the tests track this specific leak rather than any change to the stream.

Worth recording: an earlier draft advanced fake timers by 0ms, and under mutation *both* tests failed — the cancel one only because the 250ms interval never got a chance to tick. That looked like a stronger result and was a worse test. The budget is now 300ms so the restored poll gets its tick, and the control is real.

### Typecheck

No errors in `intelligence-module.ts`. `tsconfig.node.json` reports one pre-existing `TS6307` in `telemetry-sanitizer.canary.test.ts`, a file this change does not touch.
