### PR TITLE
ref(search): drop the superseded cleanupOldCompletions [#665]

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/query-completion-service.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/query-completion-service.ts
@@ -229,36 +229,6 @@ export class QueryCompletionService {
     }
   }
 
-  /** Remove completion records older than retention period */
-  async cleanupOldCompletions(retentionDays = 90): Promise<number> {
-    const timer = log.time('cleanupOldCompletions')
-    const db = this.dbUtils.getDb()
-
-    try {
-      const expirationDate = new Date()
-      expirationDate.setDate(expirationDate.getDate() - retentionDays)
-
-      await scheduleDbWrite(
-        'query-completions.cleanup',
-        () =>
-          db
-            .delete(schema.queryCompletions)
-            .where(sql`${schema.queryCompletions.lastCompleted} < ${expirationDate}`),
-        { dropPolicy: 'drop', maxQueueWaitMs: 10_000 }
-      )
-
-      timer.end('info')
-      log.info('Cleaned up old completions', {
-        meta: { cutoffDate: expirationDate.toISOString() }
-      })
-
-      return 0
-    } catch (error) {
-      log.error('Failed to cleanup old completions', { error })
-      return 0
-    }
-  }
-
   getStats() {
     return { ...this.stats }
   }


### PR DESCRIPTION
Closes #665. Replaces #1338, which GitHub closed automatically when its base branch (`fix/664-completion-like`, now merged as #1337) was deleted. Same commit, rebased onto the current base.

The issue reports that this method logs success and returns a hard-coded `0` even when the scheduled delete is dropped. Three of its claims do not hold, and the fourth makes fixing the return value pointless:

- **"Unconditionally logs 'Cleaned up old completions'"** — no. A dropped write does not resolve; the scheduler calls `task.reject`, so the `await` throws, the success log is skipped, and control reaches the `catch`, which logs at **error** level. The scheduler additionally logs `Dropping stale task` at warn, so there are two signals, not none.
- **"Retention past 90 days silently never happens"** — no. `privacy/owners/search-retention-owner.ts` prunes `query_completions` by `last_completed` and is registered in `privacy-module.ts`.
- **The method is dead.** Zero callers anywhere, including inside its own file.

So it is deleted rather than having its return contract polished.

## Verification

Re-confirmed the caller scan on the current base before merging: only the definition matches. The original PR's own note is worth preserving — its first positive control (`getSuggestions`) returned zero not because the scan was broken but because its only caller lives in the same file, which the `grep -v` filter had excluded; it was re-run with a symbol that genuinely has external callers before concluding.

`query-completion-service.test.ts`: 5 passed.