### PR TITLE
fix(automation): follow POSIX cron for the two day fields

### DIFF
--- a/apps/core-app/src/main/modules/ai/ai-automation-scheduler.test.ts
+++ b/apps/core-app/src/main/modules/ai/ai-automation-scheduler.test.ts
@@ -128,6 +128,46 @@ describe('aiAutomationScheduler', () => {
     expect(schedulerStoreMocks.saveAutomation).not.toHaveBeenCalled()
   })
 
+  it('接受 7 作为周日的标准写法', async () => {
+    const sunday = new Date(2026, 0, 4, 9, 0, 0) // 2026-01-04 is a Sunday
+    const monday = new Date(2026, 0, 5, 9, 0, 0)
+
+    expect(cronMatches('0 9 * * 7', sunday)).toBe(true)
+    expect(cronMatches('0 9 * * 7', monday)).toBe(false)
+    // 0 keeps working: 7 is an alias, not a replacement.
+    expect(cronMatches('0 9 * * 0', sunday)).toBe(true)
+
+    const scheduler = new AiAutomationScheduler()
+    scheduler.setExecutor(vi.fn(async () => completedOrchestratorRun()))
+    await expect(
+      scheduler.save(automation({ trigger: { type: 'cron', expression: '0 9 * * 7' } }))
+    ).resolves.toBeDefined()
+  })
+
+  it('两个日期字段都受限时取并集,而不是交集', async () => {
+    // '0 9 1 * 1' = the 1st, and every Monday.
+    const firstOfMonth = new Date(2026, 3, 1, 9, 0, 0) // 2026-04-01, a Wednesday
+    const anyMonday = new Date(2026, 3, 6, 9, 0, 0) // 2026-04-06, a Monday
+    const plainTuesday = new Date(2026, 3, 7, 9, 0, 0)
+
+    expect(cronMatches('0 9 1 * 1', firstOfMonth)).toBe(true)
+    expect(cronMatches('0 9 1 * 1', anyMonday)).toBe(true)
+    expect(cronMatches('0 9 1 * 1', plainTuesday)).toBe(false)
+  })
+
+  it('只有一个日期字段受限时仍然是交集', async () => {
+    const monday = new Date(2026, 3, 6, 9, 0, 0)
+    const tuesday = new Date(2026, 3, 7, 9, 0, 0)
+
+    // day-of-month is '*', so day-of-week alone decides.
+    expect(cronMatches('0 9 * * 1', monday)).toBe(true)
+    expect(cronMatches('0 9 * * 1', tuesday)).toBe(false)
+
+    // day-of-week is '*', so day-of-month alone decides.
+    expect(cronMatches('0 9 6 * *', monday)).toBe(true)
+    expect(cronMatches('0 9 6 * *', tuesday)).toBe(false)
+  })
+
   it('persists a manual run as pending approval and does not execute it until approved', async () => {
     const definition = automation()
     schedulerStoreMocks.state.definitions.set(definition.id, definition)

--- a/apps/core-app/src/main/modules/ai/ai-automation-scheduler.ts
+++ b/apps/core-app/src/main/modules/ai/ai-automation-scheduler.ts
@@ -96,19 +96,44 @@ function isValidCronExpression(expression: string): boolean {
     isValidCronField(fields[1]!, 0, 23) &&
     isValidCronField(fields[2]!, 1, 31) &&
     isValidCronField(fields[3]!, 1, 12) &&
-    isValidCronField(fields[4]!, 0, 6)
+    isValidCronField(fields[4]!, 0, 7)
   )
+}
+
+/**
+ * Cron spells Sunday as both 0 and 7; Date.getDay() only ever reports 0, so a schedule written
+ * `0 9 * * 7` matched nothing before (#772).
+ */
+function matchesDayOfWeek(day: number, expression: string): boolean {
+  if (matchesCronField(day, expression, 0, 7)) return true
+  return day === 0 && matchesCronField(7, expression, 0, 7)
 }
 
 export function cronMatches(expression: string, date: Date): boolean {
   const fields = expression.trim().split(/\s+/)
   if (fields.length !== 5) return false
+
+  const dayOfMonthExpression = fields[2]!
+  const dayOfWeekExpression = fields[4]!
+
+  /*
+   * POSIX unions the two day fields when both are restricted: `0 9 1 * 1` means "the 1st, and
+   * every Monday", not "Mondays that happen to fall on the 1st" -- which is roughly once a year
+   * instead of about five times a month. Only a literal `*` counts as unrestricted, matching
+   * Vixie cron, so `1-31` is still a restriction.
+   */
+  const dayOfMonthMatches = matchesCronField(date.getDate(), dayOfMonthExpression, 1, 31)
+  const dayOfWeekMatches = matchesDayOfWeek(date.getDay(), dayOfWeekExpression)
+  const dayMatches =
+    dayOfMonthExpression === '*' || dayOfWeekExpression === '*'
+      ? dayOfMonthMatches && dayOfWeekMatches
+      : dayOfMonthMatches || dayOfWeekMatches
+
   return (
     matchesCronField(date.getMinutes(), fields[0]!, 0, 59) &&
     matchesCronField(date.getHours(), fields[1]!, 0, 23) &&
-    matchesCronField(date.getDate(), fields[2]!, 1, 31) &&
     matchesCronField(date.getMonth() + 1, fields[3]!, 1, 12) &&
-    matchesCronField(date.getDay(), fields[4]!, 0, 6)
+    dayMatches
   )
 }
 


### PR DESCRIPTION
Closes #772.

Two deviations from POSIX cron, both user-visible:

**Sunday as `7`.** Day-of-week was validated against `0-6`, so `0 9 * * 7` — a standard spelling — was rejected at `save()` with *"must contain five valid fields"*. `7` is now accepted and treated as Sunday, since `Date.getDay()` only ever reports `0`.

**The two day fields were ANDed.** POSIX unions them when both are restricted, so `0 9 1 * 1` means *"the 1st, and every Monday"* — not *"Mondays that fall on the 1st"*, which fires roughly once a year instead of about five times a month. Only a literal `*` counts as unrestricted (what Vixie cron does), so `1-31` is still a restriction.

### Three tests, each mutation-checked separately

| mutation | result |
|---|---|
| `0-6` validation, no `7` alias | only **接受 7 作为周日的标准写法** fails |
| union back to intersection | only **两个日期字段都受限时取并集** fails |

Each mutation hits exactly one test, so the two halves of the fix are independently pinned.

The third test — one day field restricted, the other `*` — passes in **all three** states. It is the control: the union must not swallow the ordinary case where a single day field decides.

### The pre-existing test was checked, not assumed

`ai-automation-scheduler.test.ts` already asserts on `*/15 9-17 1-31 1-12 1-5` against a Monday the 5th. `1-31` matches day 5 under either rule, so union semantics do not change that expectation — verified rather than hoped. **9/9** pass.

Lint clean under core-app's own config.
