### PR TITLE
fix(intelligence): insert command arguments literally

### DIFF
--- a/apps/core-app/src/main/modules/ai/ai-imported-config-runtime.test.ts
+++ b/apps/core-app/src/main/modules/ai/ai-imported-config-runtime.test.ts
@@ -243,6 +243,52 @@ describe('AiImportedConfigRuntime scoped imports', () => {
     )
   })
 
+  it("参数里的 $& / $' / $1 按字面插入,不被当成替换模式", async () => {
+    importedConfigMocks.items.push(
+      importedItem({
+        id: 'command-echo',
+        kind: 'command',
+        name: 'echo',
+        alias: 'echo',
+        contentRef: 'command-echo-content'
+      })
+    )
+    importedConfigMocks.content.set('command-echo-content', 'ARGS=[$ARGUMENTS]; TAIL')
+    const runtime = new AiImportedConfigRuntime()
+
+    // $& would expand to the matched '$ARGUMENTS', $' to everything after it.
+    const prompt = await runtime.buildSystemPrompt(
+      profile(),
+      '/workspace/release',
+      "/echo\tfix the $& and $' handler"
+    )
+
+    expect(prompt).toContain("ARGS=[fix the $& and $' handler]; TAIL")
+  })
+
+  it('用户参数里的 $1 不会被位置替换二次改写', async () => {
+    importedConfigMocks.items.push(
+      importedItem({
+        id: 'command-pos',
+        kind: 'command',
+        name: 'pos',
+        alias: 'pos',
+        contentRef: 'command-pos-content'
+      })
+    )
+    importedConfigMocks.content.set('command-pos-content', 'ARGS=[$ARGUMENTS]; FIRST=[$1]')
+    const runtime = new AiImportedConfigRuntime()
+
+    const prompt = await runtime.buildSystemPrompt(
+      profile(),
+      '/workspace/release',
+      '/pos\tkeep $1 literal'
+    )
+
+    // The template's own $1 still expands to the first token; the one the user typed does not.
+    expect(prompt).toContain('ARGS=[keep $1 literal]; FIRST=[keep]')
+  })
+
   it('rejects a skill read outside its workspace while allowing reads inside that workspace', async () => {
     importedConfigMocks.items.push(
       importedItem({

--- a/apps/core-app/src/main/modules/ai/ai-imported-config-runtime.ts
+++ b/apps/core-app/src/main/modules/ai/ai-imported-config-runtime.ts
@@ -48,9 +48,20 @@ function expandCommand(content: string, args: string): string {
   const values = Array.from(args.matchAll(/"([^"]*)"|'([^']*)'|(\S+)/g)).map(
     (match) => match[1] ?? match[2] ?? match[3] ?? ''
   )
-  return content
-    .replace(/\$ARGUMENTS\b/g, args)
-    .replace(/\$(\d)\b/g, (_, index: string) => values[Number(index) - 1] ?? '')
+  /*
+   * One pass, and every substitution goes through a replacer function.
+   *
+   * Passing `args` as a replacement string let String.replace interpret it as a pattern, so a
+   * user typing `/mycommand fix the $& handler` had `$&` expand to the matched text and `$'` to
+   * the rest of the command body (#773). A replacer function never does that.
+   *
+   * Single pass because two passes rescan text that was just inserted: `$1` typed by the user
+   * landed in the content and was then substituted by the positional pass, mangling it the same
+   * way. `$1` in the command template still expands -- that is what it is for.
+   */
+  return content.replace(/\$ARGUMENTS\b|\$(\d)\b/g, (_match, index?: string) =>
+    index === undefined ? args : (values[Number(index) - 1] ?? '')
+  )
 }
 
 function ruleApplies(item: AiImportedConfigItem, objective: string, cwd: string): boolean {


### PR DESCRIPTION
Closes #773.

`expandCommand` passed the user's argument text to `String.replace` as the **replacement string**, so `replace` interpreted it as a pattern. Typing `/mycommand fix the $& handler` sent the model something the user never wrote.

The mutation shows it exactly. Restoring the old expression turns

```
ARGS=[fix the $& and $' handler]; TAIL
```

into

```
ARGS=[fix the $ARGUMENTS and ]; TAIL] handler]; TAIL
```

`$&` became the matched text, `$'` became the rest of the template.

### One pass, not the suggested `() => args`

The issue suggests `.replace(/\$ARGUMENTS\b/g, () => args)`, which fixes the reported case but leaves a second one in the same expression: two passes rescan text that was just inserted, so a `$1` the user typed landed in the content and was then substituted by the **positional** pass — mangled the same way, one line later.

A single pass over `/\$ARGUMENTS\b|\$(\d)\b/g` with a replacer function closes both. A `$1` in the command *template* still expands, which is what it is for, and that is pinned by its own test.

### Verification

Both new tests fail under the mutation. The twelve existing tests pass in **both** states — including `expands command arguments only for an explicit slash invocation without changing quoted token values`, which already covered quoted tokens and `$1`/`$2` in the template. **14/14** after the fix.

Worth recording: a first draft wrote the objective as a `String.raw` template, which put a **real tab character** into the source where no reader would see it — the command-argument regex requires a tab separator, so the test only worked by accident of how it was generated. The tests now use ordinary strings with an explicit `\t`.

Lint clean under core-app's own config.
