### PR TITLE
fix(notification): keep the replacement toast tracked when the old one closes

### DIFF
--- a/apps/core-app/src/main/modules/notification.system-replace.test.ts
+++ b/apps/core-app/src/main/modules/notification.system-replace.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Replacing a system notification reuses its id: the old toast is closed and the new one is
+ * registered under the same key. The OS delivers the old toast's 'close' after that, and the
+ * handler used to delete by id alone -- untracking the replacement, so a later dismiss found
+ * nothing and silently left the toast on screen (#775).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { FakeNotification } = vi.hoisted(() => {
+  class FakeNotification {
+    static instances: FakeNotification[] = []
+    static isSupported = (): boolean => true
+
+    readonly handlers = new Map<string, (...args: unknown[]) => void>()
+    closeCalls = 0
+    showCalls = 0
+
+    constructor(public readonly options: Record<string, unknown>) {
+      FakeNotification.instances.push(this)
+    }
+
+    on(event: string, handler: (...args: unknown[]) => void): this {
+      this.handlers.set(event, handler)
+      return this
+    }
+
+    show(): void {
+      this.showCalls += 1
+    }
+
+    close(): void {
+      this.closeCalls += 1
+    }
+
+    /** The OS delivering 'close' — deliberately separate from close() so timing is explicit. */
+    emitClose(): void {
+      this.handlers.get('close')?.()
+    }
+  }
+
+  return { FakeNotification }
+})
+
+vi.mock('electron', () => ({
+  Notification: FakeNotification
+}))
+
+vi.mock('../core/runtime-accessor', () => ({
+  resolveMainRuntime: () => ({ transport: null })
+}))
+
+import { NotificationModule } from './notification'
+
+interface SystemNotificationInternals {
+  showSystemNotification: (request: { id: string; title: string; message: string }) => void
+  dismissSystemNotification: (id: string) => void
+  systemRequests: Map<string, unknown>
+}
+
+function createModule(): SystemNotificationInternals {
+  return new NotificationModule() as unknown as SystemNotificationInternals
+}
+
+describe('system notification replacement keeps the newest toast tracked', () => {
+  beforeEach(() => {
+    FakeNotification.instances = []
+  })
+
+  it('旧通知的 close 事件不能把替换它的新通知解除跟踪', () => {
+    const module = createModule()
+
+    module.showSystemNotification({ id: 'progress', title: 'Sync', message: '10%' })
+    module.showSystemNotification({ id: 'progress', title: 'Sync', message: '80%' })
+
+    const [first, second] = FakeNotification.instances
+    expect(FakeNotification.instances).toHaveLength(2)
+    expect(first!.closeCalls).toBe(1) // replaced
+
+    // The OS now delivers the first toast's close, after the second已 taken the id.
+    first!.emitClose()
+
+    module.dismissSystemNotification('progress')
+    expect(second!.closeCalls).toBe(1)
+  })
+
+  it('通知自己的 close 事件仍然会解除跟踪(守卫不是"永不删除")', () => {
+    const module = createModule()
+
+    module.showSystemNotification({ id: 'solo', title: 'Done', message: 'ok' })
+    const [only] = FakeNotification.instances
+    expect(module.systemRequests.has('solo')).toBe(true)
+
+    only!.emitClose()
+
+    expect(module.systemRequests.has('solo')).toBe(false)
+  })
+})

--- a/apps/core-app/src/main/modules/notification.ts
+++ b/apps/core-app/src/main/modules/notification.ts
@@ -485,12 +485,19 @@ export class NotificationModule extends BaseModule {
     })
 
     notification.on('close', () => {
+      // Replacing a notification reuses its id: dismissSystemNotification closes the old toast
+      // and the new one registers under the same key, so the OS can deliver the old toast's
+      // 'close' after that (#775). Deleting by id alone untracked the replacement, leaving it on
+      // screen with no way to dismiss it programmatically.
+      if (this.systemNotifications.get(id) !== notification) return
       this.systemNotifications.delete(id)
       this.systemRequests.delete(id)
     })
 
-    notification.show()
+    // Registered before show() so a synchronous 'close' during show cannot leave a closed
+    // notification tracked forever.
     this.systemNotifications.set(id, notification)
+    notification.show()
   }
 
   private dismissSystemNotification(id: string): void {


### PR DESCRIPTION
Closes #775.

`showSystemNotification` closes any existing notification with the same id and then registers the replacement under that id. The old notification's `close` arrives from the OS **after** that and deleted the map entries by id — untracking the toast that had just taken the key. A later dismiss for that id then found nothing and silently no-opped, leaving the toast on screen with no way to close it programmatically.

The close handler now only clears entries that still belong to the notification that emitted it.

Registration also moved ahead of `show()`, so a `close` delivered synchronously during show cannot leave a closed notification tracked forever. That window existed before this change too.

### Verification

Two tests against a fake `Notification` whose OS `close` is emitted **explicitly**, so the ordering is the thing under test rather than a timing accident.

Removing only the guard fails the race test — the replacement is untracked, so dismiss never closes it:

```
× 旧通知的 close 事件不能把替换它的新通知解除跟踪
  → expected +0 to be 1
✓ 通知自己的 close 事件仍然会解除跟踪
```

The second test passes in **both** states by design: a notification's own close must still untrack it, so a guard written as "never delete" would fail there.

### Deliberately not changed

`systemRequests` is populated *before* the `Notification.isSupported()` check, so on an unsupported platform the entry survives until an explicit dismiss. The issue frames this as a second leak; reading the call sites, it looks deliberate — three of them read `systemRequests` to merge update patches, to run the permission check, and to resolve which channel an id belongs to. All three still need to work when the OS cannot show a toast, and `dismissSystemNotification` does delete the entry.

Lint clean under core-app's own config.
