### PR TITLE
fix(shortcut): stop one malformed record unregistering every shortcut

### DIFF
--- a/apps/core-app/src/main/modules/global-shortcon.test.ts
+++ b/apps/core-app/src/main/modules/global-shortcon.test.ts
@@ -186,6 +186,74 @@ afterEach(() => {
   mainStorageMocks.saveConfig.mockReset()
 })
 
+describe('ShortcutModule survives a malformed shortcut record', () => {
+  /**
+   * Shortcut.meta is typed as required, but this module guards it with `?.` in a dozen places
+   * because older schemas and partial writes produce records without one (#776). The
+   * classification loop then wrote through the guarded value and threw -- after
+   * globalShortcut.unregisterAll() had already run, so nothing was re-registered.
+   *
+   * Two separate properties, because either half of the fix alone makes a single
+   * "does everything still register" assertion pass: normalising meta stops the throw, and the
+   * try/catch hides it. They are asserted independently so each mutation is detectable.
+   */
+  function seedTrigger(module: ShortcutModuleHarness, storage: InMemoryShortcutStorage): void {
+    module.registerMainTrigger('core.test.trigger', ShortcutTriggerKind.MOUSE_RIGHT_LONG_PRESS, {
+      enabled: true,
+      onStateChange: vi.fn(),
+      owner: 'test'
+    })
+    storage.addShortcut({
+      id: 'core.test.trigger',
+      accelerator: ShortcutTriggerKind.MOUSE_RIGHT_LONG_PRESS,
+      type: ShortcutType.TRIGGER
+    } as unknown as Shortcut)
+  }
+
+  it('缺少 meta 的记录会被补齐,而不是被判为无效', () => {
+    const { module, storage } = createModule()
+    seedTrigger(module, storage)
+
+    module.reregisterAllShortcuts?.()
+
+    const stored = storage.getShortcutById('core.test.trigger')
+    expect(stored?.meta).toBeDefined()
+    expect(stored?.meta?.triggerKind).toBe(ShortcutTriggerKind.MOUSE_RIGHT_LONG_PRESS)
+    expect(module.shortcutStatusMap?.get('core.test.trigger')?.state).toBe('active')
+
+    module.onDestroy()
+  })
+
+  it('单条记录抛错不会让其它快捷键失去注册', () => {
+    const { module } = createModule()
+
+    // Both must be registered through registerMainShortcut, otherwise the classification loop
+    // skips them at the mainCallbackRegistry check and never reaches the fault.
+    module.registerMainShortcut('core.test.main', 'CommandOrControl+Shift+K', vi.fn())
+    module.registerMainShortcut('core.test.broken', 'CommandOrControl+Shift+J', vi.fn())
+
+    // A per-record fault, standing in for anything the classification loop can hit on one
+    // shortcut. Injected after registration so setup does not trip over it.
+    const internals = module as unknown as {
+      normalizeAccelerator: (accelerator: string) => string | null
+    }
+    const originalNormalize = internals.normalizeAccelerator.bind(module)
+    internals.normalizeAccelerator = (accelerator: string): string | null => {
+      if (accelerator === 'CommandOrControl+Shift+J') throw new Error('malformed record')
+      return originalNormalize(accelerator)
+    }
+
+    electronMocks.register.mockClear()
+    expect(() => module.reregisterAllShortcuts?.()).not.toThrow()
+    expect(electronMocks.register).toHaveBeenCalledWith(
+      'CommandOrControl+Shift+K',
+      expect.any(Function)
+    )
+
+    module.onDestroy()
+  })
+})
+
 describe('ShortcutModule retired shortcut migration', () => {
   it('removes retired IDs before the initial global registration pass', () => {
     const timestamp = Date.now()

--- a/apps/core-app/src/main/modules/global-shortcon.ts
+++ b/apps/core-app/src/main/modules/global-shortcon.ts
@@ -1,5 +1,8 @@
 import type { MaybePromise, ModuleInitContext, ModuleKey } from '@talex-touch/utils'
-import type { Shortcut } from '@talex-touch/utils/common/storage/entity/shortcut-settings'
+import type {
+  Shortcut,
+  ShortcutMeta
+} from '@talex-touch/utils/common/storage/entity/shortcut-settings'
 import process from 'node:process'
 import {
   ShortcutTriggerKind,
@@ -296,7 +299,7 @@ export class ShortcutModule extends BaseModule {
       }
       if (typeof options?.enabled === 'boolean' && meta?.enabled === undefined) {
         this.storage!.updateShortcutEnabled(id, options.enabled)
-        existingShortcut.meta.enabled = options.enabled
+        this.ensureShortcutMeta(existingShortcut).enabled = options.enabled
         updated = true
       }
       if (updated) {
@@ -444,6 +447,25 @@ export class ShortcutModule extends BaseModule {
   }
 
   /**
+   * `Shortcut.meta` is typed as required, but this file guards it with `?.` in a dozen places
+   * because records written by an older schema, a hand-edited store or a partial write reach us
+   * without one. Writing through the guarded value then threw, and since reregisterAllShortcuts
+   * starts with globalShortcut.unregisterAll(), that TypeError took every shortcut down with it
+   * -- including the CoreBox trigger -- until the app restarted (#776).
+   */
+  private ensureShortcutMeta(shortcut: Shortcut): ShortcutMeta {
+    if (!shortcut.meta) {
+      const now = Date.now()
+      shortcut.meta = {
+        creationTime: now,
+        modificationTime: now,
+        author: SYSTEM_SHORTCUT_AUTHOR
+      }
+    }
+    return shortcut.meta
+  }
+
+  /**
    * Core function: unregisters everything and re-registers from storage.
    */
   private reregisterAllShortcuts(): void {
@@ -460,66 +482,74 @@ export class ShortcutModule extends BaseModule {
     const statusMap = new Map<string, ShortcutStatus>()
 
     for (const shortcut of allShortcuts) {
-      if (shortcut.meta?.enabled === false) {
-        statusMap.set(shortcut.id, { state: 'disabled', reason: 'disabled' })
-        continue
-      }
-      if (shortcut.type === ShortcutType.TRIGGER) {
-        if (!mainTriggerRegistry.has(shortcut.id)) {
+      // One malformed record must not abort classification: the loop runs after
+      // unregisterAll(), so throwing here leaves every shortcut unregistered.
+      try {
+        if (shortcut.meta?.enabled === false) {
+          statusMap.set(shortcut.id, { state: 'disabled', reason: 'disabled' })
+          continue
+        }
+        if (shortcut.type === ShortcutType.TRIGGER) {
+          if (!mainTriggerRegistry.has(shortcut.id)) {
+            statusMap.set(shortcut.id, { state: 'unavailable', reason: 'runtime-missing' })
+            continue
+          }
+          const triggerKind =
+            typeof shortcut.meta?.triggerKind === 'string' &&
+            shortcut.meta.triggerKind.trim().length > 0
+              ? shortcut.meta.triggerKind
+              : shortcut.accelerator
+
+          if (!triggerKind) {
+            statusMap.set(shortcut.id, { state: 'unavailable', reason: 'invalid' })
+            shortconLog.error(`Invalid trigger kind for shortcut ${shortcut.id}`)
+            continue
+          }
+
+          if (shortcut.accelerator !== triggerKind) {
+            this.storage!.updateShortcutAccelerator(shortcut.id, triggerKind)
+            shortcut.accelerator = triggerKind
+          }
+          if (shortcut.meta?.triggerKind !== triggerKind) {
+            const meta = this.ensureShortcutMeta(shortcut)
+            meta.triggerKind = triggerKind
+            meta.modificationTime = Date.now()
+            this.persistShortcutMeta()
+          }
+
+          statusMap.set(shortcut.id, { state: 'active' })
+          continue
+        }
+
+        if (shortcut.type === ShortcutType.MAIN && !mainCallbackRegistry.has(shortcut.id)) {
           statusMap.set(shortcut.id, { state: 'unavailable', reason: 'runtime-missing' })
           continue
         }
-        const triggerKind =
-          typeof shortcut.meta?.triggerKind === 'string' &&
-          shortcut.meta.triggerKind.trim().length > 0
-            ? shortcut.meta.triggerKind
-            : shortcut.accelerator
 
-        if (!triggerKind) {
+        const normalizedAccelerator = this.normalizeAccelerator(shortcut.accelerator)
+        if (!normalizedAccelerator) {
           statusMap.set(shortcut.id, { state: 'unavailable', reason: 'invalid' })
-          shortconLog.error(`Invalid trigger kind for shortcut ${shortcut.id}`)
+          shortconLog.error(
+            `Invalid accelerator for shortcut ${shortcut.id}: ${shortcut.accelerator}`
+          )
           continue
         }
 
-        if (shortcut.accelerator !== triggerKind) {
-          this.storage!.updateShortcutAccelerator(shortcut.id, triggerKind)
-          shortcut.accelerator = triggerKind
-        }
-        if (shortcut.meta?.triggerKind !== triggerKind) {
-          shortcut.meta.triggerKind = triggerKind
-          shortcut.meta.modificationTime = Date.now()
-          this.persistShortcutMeta()
+        if (normalizedAccelerator !== shortcut.accelerator) {
+          this.storage!.updateShortcutAccelerator(shortcut.id, normalizedAccelerator)
+          shortcut.accelerator = normalizedAccelerator
         }
 
-        statusMap.set(shortcut.id, { state: 'active' })
-        continue
-      }
-
-      if (shortcut.type === ShortcutType.MAIN && !mainCallbackRegistry.has(shortcut.id)) {
-        statusMap.set(shortcut.id, { state: 'unavailable', reason: 'runtime-missing' })
-        continue
-      }
-
-      const normalizedAccelerator = this.normalizeAccelerator(shortcut.accelerator)
-      if (!normalizedAccelerator) {
+        normalizedMap.set(shortcut.id, normalizedAccelerator)
+        const group = groupedByAccelerator.get(normalizedAccelerator)
+        if (group) {
+          group.push(shortcut)
+        } else {
+          groupedByAccelerator.set(normalizedAccelerator, [shortcut])
+        }
+      } catch (error) {
         statusMap.set(shortcut.id, { state: 'unavailable', reason: 'invalid' })
-        shortconLog.error(
-          `Invalid accelerator for shortcut ${shortcut.id}: ${shortcut.accelerator}`
-        )
-        continue
-      }
-
-      if (normalizedAccelerator !== shortcut.accelerator) {
-        this.storage!.updateShortcutAccelerator(shortcut.id, normalizedAccelerator)
-        shortcut.accelerator = normalizedAccelerator
-      }
-
-      normalizedMap.set(shortcut.id, normalizedAccelerator)
-      const group = groupedByAccelerator.get(normalizedAccelerator)
-      if (group) {
-        group.push(shortcut)
-      } else {
-        groupedByAccelerator.set(normalizedAccelerator, [shortcut])
+        shortconLog.error(`Failed to classify shortcut ${shortcut.id}`, { error })
       }
     }
 


### PR DESCRIPTION
Closes #776.

`reregisterAllShortcuts` starts with `globalShortcut.unregisterAll()`, then classifies each shortcut in a loop with no error handling. That loop read `shortcut.meta` with optional chaining and immediately assigned through it, so a record persisted without `meta` threw *"Cannot set properties of undefined"* — and **every** global shortcut, including the CoreBox trigger, stayed unregistered until the app restarted.

`Shortcut.meta` is typed as **required**, which is why the compiler never caught this; the file's dozen `meta?.` guards are the honest description of what actually arrives at runtime. Both write sites (the reregister loop and `registerMainShortcut`) now normalise through `ensureShortcutMeta`, and the classification loop handles per-record faults.

### Two properties, asserted separately — and why that matters

A single "does everything still register" test passes with **either half alone**: normalising stops the throw, and the try/catch hides it. That is not hypothetical — the first version of this test was exactly that shape, and **both mutations passed against it**. It would have shipped as a test that proved nothing.

Split apart, each mutation is detected:

| mutation | failing test |
|---|---|
| remove the meta normalisation | `缺少 meta 的记录会被补齐,而不是被判为无效` |
| remove the try/catch | `单条记录抛错不会让其它快捷键失去注册` |

Two further corrections were needed before the second test could fail for the right reason:

- The fault is injected on `normalizeAccelerator`, not on storage. `storage.updateShortcutAccelerator` only runs when an accelerator actually changes shape, so an earlier attempt injected there and the mutation passed because the throw was never reached.
- The broken record must be registered through `registerMainShortcut`, or the loop skips it at the `mainCallbackRegistry` check before reaching the fault at all.

**9/9** after restoring. Typecheck and lint clean for both files.
