### PR TITLE
fix(channel): gate debug.openDevTools on host caller and unpackaged build

### DIFF
--- a/apps/core-app/src/main/channel/common.test.ts
+++ b/apps/core-app/src/main/channel/common.test.ts
@@ -840,13 +840,15 @@ describe('CommonChannelModule private helpers', () => {
     handler?.(undefined, {})
     expect(openDevTools).toHaveBeenCalledTimes(1)
 
-    // ...but not once the app is packaged.
-    vi.mocked(app).isPackaged = true
+    // ...but not once the app is packaged. Electron types isPackaged read-only, so the mock is
+    // flipped through an explicitly writable view rather than by suppressing the error.
+    const packagedFlag = app as unknown as { isPackaged: boolean }
+    packagedFlag.isPackaged = true
     try {
       handler?.(undefined, {})
       expect(openDevTools).toHaveBeenCalledTimes(1)
     } finally {
-      vi.mocked(app).isPackaged = false
+      packagedFlag.isPackaged = false
     }
   })
 

--- a/apps/core-app/src/main/channel/common.test.ts
+++ b/apps/core-app/src/main/channel/common.test.ts
@@ -799,6 +799,57 @@ describe('CommonChannelModule private helpers', () => {
     expect(shell.openExternal).toHaveBeenCalledWith('https://example.com/docs')
   })
 
+  it('debug.openDevTools 拒绝插件调用,并在打包构建中拒绝一切调用', async () => {
+    const { app } = await import('electron')
+    const openDevTools = vi.fn()
+    const handlers = new Map<string, (payload: unknown, context: unknown) => unknown>()
+    const transport = {
+      on: vi.fn(
+        (
+          event: { toEventName: () => string },
+          handler: (payload: unknown, context: unknown) => unknown
+        ) => {
+          handlers.set(event.toEventName(), handler)
+          return vi.fn()
+        }
+      ),
+      onStream: vi.fn(() => vi.fn()),
+      broadcastToWindow: vi.fn()
+    }
+
+    getTuffTransportMainMock.mockReturnValue(transport as never)
+
+    const module = new CommonChannelModule()
+    await module.onInit({
+      app: {
+        window: { window: {}, openDevTools, onMaximizedChanged: () => () => {} },
+        app: { addListener: vi.fn() }
+      }
+    } as never)
+
+    const handler = handlers.get(AppEvents.debug.openDevTools.toEventName())
+    expect(handler).toBeTypeOf('function')
+
+    // A plugin view must never reach it, packaged or not.
+    expect(() => handler?.(undefined, { plugin: { name: 'third-party' } })).toThrow(
+      'HOST_ONLY_HANDLER'
+    )
+    expect(openDevTools).not.toHaveBeenCalled()
+
+    // The host can still open DevTools during development.
+    handler?.(undefined, {})
+    expect(openDevTools).toHaveBeenCalledTimes(1)
+
+    // ...but not once the app is packaged.
+    vi.mocked(app).isPackaged = true
+    try {
+      handler?.(undefined, {})
+      expect(openDevTools).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.mocked(app).isPackaged = false
+    }
+  })
+
   it('maps each supported desktop wallpaper backend output to a usable path', async () => {
     const handlers = new Map<string, (payload: unknown, context: unknown) => Promise<unknown>>()
     const transport = {

--- a/apps/core-app/src/main/channel/common.ts
+++ b/apps/core-app/src/main/channel/common.ts
@@ -1525,7 +1525,15 @@ export class CommonChannelModule extends BaseModule {
         touchApp.window.window.show()
         touchApp.window.window.focus()
       }),
-      transport.on(AppEvents.debug.openDevTools, (payload) => {
+      transport.on(AppEvents.debug.openDevTools, (payload, context) => {
+        // DevTools runs arbitrary JS in the main renderer and exposes everything it holds, so a
+        // plugin view reaching this handler is a way out of the plugin sandbox (#783).
+        this.assertHostOnly(context, 'debug.openDevTools')
+        // The same intent already exists for Ctrl+R, which touch-app.ts blocks once packaged.
+        if (app.isPackaged) {
+          log.warn('Refused to open DevTools in a packaged build')
+          return
+        }
         const options =
           payload && typeof payload === 'object' ? (payload as OpenDevToolsOptions) : undefined
         touchApp.window.openDevTools(options)


### PR DESCRIPTION
Closes #783.

The handler had neither a caller check nor an `app.isPackaged` guard, so a plugin view could open DevTools on the **main application window** in a released build. DevTools runs arbitrary JS in the main renderer and exposes everything it holds — a clean step out of the plugin sandbox.

Both guards follow conventions already in the tree rather than new ones:

- `assertHostOnly` is what the neighbouring `system.getCwd`, `system.getPackage` and `window.close` handlers use.
- `touch-app.ts` already blocks Ctrl+R once `app.isPackaged`. The intent to withdraw debug affordances in production existed; it just had not reached this handler.

### Verification

One test with three assertions, and the two guards are **independently** pinned — each mutation fails a different one:

| mutation | failure |
|---|---|
| drop `assertHostOnly` | `expected [Function] to throw an error` |
| drop `app.isPackaged` | `expected "spy" to be called 1 times, but got 2 times` |

The middle assertion is the control: a host caller in an unpackaged build must **still** get DevTools, so a guard written as "always refuse" would fail there.

**32/32** after restoring. Lint and typecheck clean for both files.
