### PR TITLE
fix(channel): drop unparseable IPC messages instead of crashing main

### DIFF
--- a/apps/core-app/src/main/core/channel-core.malformed-payload.test.ts
+++ b/apps/core-app/src/main/core/channel-core.malformed-payload.test.ts
@@ -1,0 +1,64 @@
+/**
+ * `ipcMain.on` listeners run inside an EventEmitter, so a throw from one becomes an uncaught
+ * main-process exception. The only uncaughtException handler in the tree lives in
+ * dev-process-manager, which returns early when app.isPackaged -- so in a released build any
+ * renderer or plugin view could end the app with
+ * `ipcRenderer.send('@main-process-message', 'x')` (#784).
+ *
+ * The payloads here are the ones from that report, driven through the real __handle_main.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+// The import chain reaches talex-mica-electron, @sentry/electron and precore, all of which
+// touch Electron at module scope. This harness is the repo's own answer to that; using it keeps
+// one set of mocks rather than a parallel copy that can drift.
+import '../modules/ai/intelligence-test-harness'
+
+import { genTouchChannel } from './channel-core'
+
+interface HandleMainCapable {
+  __handle_main: (event: unknown, arg: unknown) => unknown
+}
+
+function fakeSenderEvent(): { event: Record<string, unknown>; returnValues: unknown[] } {
+  const returnValues: unknown[] = []
+  const event = {
+    sender: { id: 1, isDestroyed: () => false, send: vi.fn() },
+    set returnValue(value: unknown) {
+      returnValues.push(value)
+    },
+    get returnValue(): unknown {
+      return returnValues[returnValues.length - 1]
+    }
+  }
+  return { event, returnValues }
+}
+
+describe('channel-core drops unparseable IPC payloads instead of crashing main', () => {
+  // TouchChannel is not exported, so the singleton is built through genTouchChannel with a
+  // stand-in app: only the ipcMain wiring matters for these payloads.
+  const channel = genTouchChannel({
+    window: { window: {} },
+    app: { on: vi.fn() }
+  } as never) as unknown as HandleMainCapable
+
+  it.each([
+    { name: 'a bare string', payload: 'x' },
+    { name: 'a number', payload: 42 },
+    { name: 'null', payload: null },
+    { name: 'an object with no header', payload: { name: 'some:event' } },
+    { name: 'an object whose header is a string', payload: { name: 'e', header: 'nope' } }
+  ])('$name 不会把异常抛出监听器', ({ payload }) => {
+    const { event } = fakeSenderEvent()
+
+    expect(() => channel.__handle_main(event, payload)).not.toThrow()
+  })
+
+  it('丢弃畸形消息时会给同步调用方一个 returnValue,避免其永久阻塞', () => {
+    const { event, returnValues } = fakeSenderEvent()
+
+    channel.__handle_main(event, 'x')
+
+    expect(returnValues).toEqual([null])
+  })
+})

--- a/apps/core-app/src/main/core/channel-core.ts
+++ b/apps/core-app/src/main/core/channel-core.ts
@@ -252,7 +252,25 @@ class TouchChannel {
   }
 
   __handle_main(e: Electron.IpcMainEvent, arg: unknown) {
-    const rawData = this.__parse_raw_data(e, arg)
+    // ipcMain.on listeners run inside an EventEmitter, so anything thrown here becomes an
+    // uncaught main-process exception -- and the only uncaughtException handler in the tree
+    // (dev-process-manager) returns early when app.isPackaged. Before this guard, any renderer
+    // or plugin view could end the app with `ipcRenderer.send('@main-process-message', 'x')`
+    // (#784).
+    let rawData: RawStandardChannelData
+    try {
+      rawData = this.__parse_raw_data(e, arg)
+    } catch (error) {
+      channelLog.error('[Channel] Dropped an unparseable message', { error })
+      // A sendSync caller would otherwise block waiting for a value nobody sets. Guarded the
+      // same way as the returnValue assignment further down, which can throw on a gone sender.
+      try {
+        e.returnValue = null
+      } catch {
+        // The sender is already gone; there is nothing to unblock.
+      }
+      return
+    }
 
     if (rawData.header.status === 'reply' && rawData.sync) {
       const { id } = rawData.sync


### PR DESCRIPTION
Closes #784.

`__parse_raw_data` throws when a payload has no header object, and `__handle_main` called it with **no try/catch**. `ipcMain.on` listeners run inside an EventEmitter, so that throw became an uncaught main-process exception — and the tree's only `uncaughtException` handler lives in `dev-process-manager`, which returns early when `app.isPackaged`.

Both halves of the premise check out:

```
$ grep -rn "process.on('uncaughtException'" apps/core-app/src
apps/core-app/src/main/utils/dev-process-manager.ts:50   ← inside init(), after `if (app.isPackaged) return`
```

`precore.ts:41` registers `unhandledRejection` but not `uncaughtException`. So in a released build, `ipcRenderer.send('@main-process-message', 'x')` from any renderer or plugin view ended the app.

The parse is now guarded: log and drop. A `null` returnValue is also set so a `sendSync` caller is not left waiting for a value nobody assigns — wrapped the same way as the `returnValue` assignment further down, which can throw on a sender that has gone away.

### Verification

Six tests drive the **real** `__handle_main` with the payload from the report and four neighbours (`42`, `null`, an object with no header, an object whose header is a string). All six fail with the guard removed — five throw `Invalid message!` out of the listener, and the returnValue one is never set. **6/6** restored.

### Deliberately not done

The issue also asks for a production `uncaughtException` handler in `precore.ts`. That is a policy call, not part of this hole: swallowing uncaught exceptions app-wide changes crash semantics everywhere and can mask real faults. It belongs in its own change with its own decision.

### On the checks

Verified with the pre-commit hook's own steps rather than through the hook: `sync:core-pkg` is a no-op (all five synced fields already match root), and lint-staged's exact command for these paths — `eslint --cache --fix --no-warn-ignored` under `apps/core-app`'s config — exits 0 silent. `tsc -p tsconfig.node.json` reports nothing for either file.
