### PR TITLE
fix(security): stop tfile bypassing the page CSP and drop the stream scheme

### DIFF
--- a/apps/core-app/src/main/csp-bypass.contract.test.ts
+++ b/apps/core-app/src/main/csp-bypass.contract.test.ts
@@ -1,0 +1,61 @@
+/**
+ * `tfile:` used to be registered with `bypassCSP: true`, which exempts everything loaded through
+ * it from the page policy -- so it stayed an open hole no matter how the renderer CSP was
+ * tightened. `stream:` carried the same privilege with no `protocol.handle` anywhere, which is
+ * privilege granted to nothing (#785).
+ *
+ * The capability tfile: actually needs is granted by the policy instead, so this pins both
+ * halves together: no bypass, and the directives that replace it are still present. Asserting
+ * only "no bypassCSP" would pass just as well on a build where tfile: had silently stopped
+ * loading.
+ */
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const MAIN_INDEX = readFileSync(path.join(__dirname, 'index.ts'), 'utf8')
+const PROTOCOL_HANDLER = readFileSync(path.join(__dirname, 'service/protocol-handler.ts'), 'utf8')
+const RENDERER_HTML = readFileSync(path.join(__dirname, '../renderer/index.html'), 'utf8')
+
+function cspDirective(name: string): string {
+  const csp = /content-security-policy"[^>]*content="([^"]*)"/is.exec(RENDERER_HTML)?.[1]
+  if (!csp) throw new Error('No Content-Security-Policy meta found in renderer/index.html')
+  const directive = csp
+    .split(';')
+    .map((entry) => entry.trim())
+    .find((entry) => entry.startsWith(`${name} `))
+  if (!directive) throw new Error(`CSP has no ${name} directive`)
+  return directive
+}
+
+describe('privileged schemes do not bypass the page CSP', () => {
+  /** The privileges object only -- prose around it may legitimately mention the flag. */
+  function privilegedSchemeBlock(source: string): string {
+    const block = /registerSchemesAsPrivileged\(\[([\s\S]*?)\]\)/.exec(source)?.[1]
+    if (!block) return ''
+    return block
+  }
+
+  it('tfile 不再带 bypassCSP', () => {
+    const block = privilegedSchemeBlock(MAIN_INDEX)
+    expect(block).toContain("scheme: 'tfile'")
+    expect(block).not.toContain('bypassCSP')
+  })
+
+  it('tfile: 仍然被 CSP 显式允许(否则上一条会掩盖功能损坏)', () => {
+    for (const directive of ['default-src', 'img-src', 'media-src', 'connect-src']) {
+      expect(cspDirective(directive)).toContain('tfile:')
+    }
+  })
+
+  it('stream scheme 的特权注册已删除', () => {
+    expect(PROTOCOL_HANDLER).not.toContain("scheme: 'stream'")
+    expect(privilegedSchemeBlock(PROTOCOL_HANDLER)).toBe('')
+  })
+
+  it('删除是安全的:stream 从来没有 protocol.handle', () => {
+    // Positive control for the absence check: atom is handled here, so the scan can see handlers.
+    expect(PROTOCOL_HANDLER).toContain("protocol.handle('atom'")
+    expect(PROTOCOL_HANDLER).not.toContain("protocol.handle('stream'")
+  })
+})

--- a/apps/core-app/src/main/index.ts
+++ b/apps/core-app/src/main/index.ts
@@ -62,6 +62,10 @@ import './polyfills'
 process.env.WS_NO_UTF_8_VALIDATE = 'true'
 process.env.WS_NO_BUFFER_UTIL = 'true'
 
+// No bypassCSP: renderer/index.html already names `tfile:` in default-src, connect-src,
+// img-src and media-src, so the capability is granted by the policy rather than exempted from
+// it. Keeping the bypass left tfile: as an open hole that survives any future CSP tightening
+// (#785).
 protocol.registerSchemesAsPrivileged([
   {
     scheme: 'tfile',
@@ -70,7 +74,6 @@ protocol.registerSchemesAsPrivileged([
       secure: true,
       supportFetchAPI: true,
       stream: true,
-      bypassCSP: true,
       corsEnabled: true
     }
   }

--- a/apps/core-app/src/main/service/protocol-handler.ts
+++ b/apps/core-app/src/main/service/protocol-handler.ts
@@ -2,8 +2,6 @@ import { protocol } from 'electron'
 import { TalexEvents, touchEventBus } from '../core/eventbus/touch-event'
 import { createLogger } from '../utils/logger'
 
-protocol.registerSchemesAsPrivileged([{ scheme: 'stream', privileges: { bypassCSP: true } }])
-
 const protocolLog = createLogger('ProtocolHandler')
 
 touchEventBus.on(TalexEvents.APP_READY, () => {


### PR DESCRIPTION
Closes #785.

`tfile:` was registered privileged with `bypassCSP`, so everything loaded through it was exempt from the page policy — an open hole that would survive any future tightening of the renderer CSP. The privilege is unnecessary: `renderer/index.html` **already** names `tfile:` in `default-src`, `connect-src`, `img-src` and `media-src`, so the capability is granted by the policy rather than exempted from it.

`stream:` carried the same bypass with **no `protocol.handle` anywhere**. The only handles in the tree are `atom` (a 410 responder) and `tfile` — which is the positive control for that absence check: the scan can see handlers, so not finding one for `stream` means something. Registration deleted.

### What would break — checked, since bypassCSP only matters where a page has a CSP

| page | CSP | uses tfile: ? |
|---|---|---|
| `renderer/index.html` | lists `tfile:` in all four directives | yes — unaffected |
| `image-translate-pin-window.ts` | strict `default-src 'none'; img-src data:` | **no** — images are `data:` URLs, file never mentions tfile |
| plugin HTML | none sets a CSP | nothing to bypass |

### Four tests, and the pairing is the point

"No `bypassCSP`" on its own would pass just as well on a build where `tfile:` had **silently stopped loading**. So the CSP directives are pinned alongside it.

Each mutation fails exactly one test:

| mutation | failing test |
|---|---|
| restore the tfile bypass | `tfile 不再带 bypassCSP` |
| restore the stream registration | `stream scheme 的特权注册已删除` |
| remove `tfile:` from index.html's `img-src` | `tfile: 仍然被 CSP 显式允许` |

One correction on the way: the first assertion originally scanned the whole of `index.ts` and failed against my own explanatory comment, which mentions the flag. It now reads only the `registerSchemesAsPrivileged` block.

Verified with the pre-commit hook's own steps: `sync:core-pkg` is a no-op, lint-staged's exact command for these paths exits 0 silent, `tsc -p tsconfig.node.json` reports nothing for any of the three files.
