### PR TITLE
test(update): pin the four throws that are the only update integrity check

### DIFF
--- a/apps/core-app/src/main/modules/update/update-system.test.ts
+++ b/apps/core-app/src/main/modules/update/update-system.test.ts
@@ -201,6 +201,77 @@ describe('UpdateSystem install handoff preparation', () => {
     )
   })
 
+  /*
+   * electron-builder.yml sets `verifyUpdateCodeSignature: false`, so Windows performs no
+   * publisher check on a downloaded package (#787). Until a code-signing certificate exists,
+   * these four throws in resolveVerifiedInstallTask are the entire integrity story for an
+   * update, and only two of them were pinned: the happy path and a checksum mismatch. The
+   * three below are the ones that decide whether a missing or forged signature stops an
+   * install or merely gets logged.
+   */
+  it('缺少校验和时拒绝安装,而不是跳过校验', async () => {
+    const downloadCenter = createDownloadCenterMock()
+    downloadCenter.task.status = DownloadStatus.COMPLETED
+    downloadCenter.task.metadata.checksum = ''
+    const updateSystem = new UpdateSystem(downloadCenter as never, {
+      storageRoot: '/tmp/tuff-test'
+    })
+
+    await expect(updateSystem.prepareInstallHandoff('task-1')).rejects.toThrow(
+      /checksum is required but missing/i
+    )
+  })
+
+  it('缺少签名 URL 时拒绝安装', async () => {
+    const chunks = [Buffer.from('trusted-'), Buffer.from('package')]
+    const checksum = crypto.createHash('sha256').update(Buffer.concat(chunks)).digest('hex')
+    const downloadCenter = createDownloadCenterMock()
+    downloadCenter.task.status = DownloadStatus.COMPLETED
+    downloadCenter.task.metadata.checksum = checksum
+    downloadCenter.task.metadata.signatureUrl = ''
+    createReadStreamMock.mockReturnValue(
+      (async function* () {
+        yield* chunks
+      })()
+    )
+    const updateSystem = new UpdateSystem(downloadCenter as never, {
+      storageRoot: '/tmp/tuff-test'
+    })
+
+    await expect(updateSystem.prepareInstallHandoff('task-1')).rejects.toThrow(
+      /signature is required but missing/i
+    )
+  })
+
+  it('签名验证失败时抛错,而不是记一条日志继续', async () => {
+    const chunks = [Buffer.from('trusted-'), Buffer.from('package')]
+    const checksum = crypto.createHash('sha256').update(Buffer.concat(chunks)).digest('hex')
+    const downloadCenter = createDownloadCenterMock()
+    downloadCenter.task.status = DownloadStatus.COMPLETED
+    downloadCenter.task.metadata.checksum = checksum
+    createReadStreamMock.mockReturnValue(
+      (async function* () {
+        yield* chunks
+      })()
+    )
+    const updateSystem = new UpdateSystem(downloadCenter as never, {
+      storageRoot: '/tmp/tuff-test'
+    })
+    // The module-level SignatureVerifier mock always returns valid; override this instance.
+    ;(
+      updateSystem as unknown as {
+        signatureVerifier: { verifyFileSignatureWithCache: () => Promise<unknown> }
+      }
+    ).signatureVerifier.verifyFileSignatureWithCache = vi.fn(async () => ({
+      valid: false,
+      reason: 'signature mismatch'
+    }))
+
+    await expect(updateSystem.prepareInstallHandoff('task-1')).rejects.toThrow(
+      /signature verification failed/i
+    )
+  })
+
   it('returns rollback compatibility when the installed version exactly matches the manifest target', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     const updateSystem = new UpdateSystem(createDownloadCenterMock() as never, {


### PR DESCRIPTION
Closes #787.

The issue asks for two things. One cannot be done yet; the other is confirmed and now guarded.

### Removing `verifyUpdateCodeSignature: false` would be worse than the bug today

The `win:` block has **no signing configuration at all** — no `certificateFile`, no `publisherName` — and both `CSC_LINK` references in `build-and-release.yml` are gated on `matrix.os == 'macos-latest'`. Windows NSIS installers are unsigned.

Flipping the flag to its default would make electron-updater reject **every** Windows update. The issue's own wording ("once a Windows code-signing certificate is available") is right, and that prerequisite does not exist in this repo yet.

### The in-house check does hard-fail — confirmed

`resolveVerifiedInstallTask` throws on all four of: missing checksum, checksum mismatch, missing `signatureUrl`, invalid signature. Nothing warns and continues.

### But only two of the four were pinned

The happy path and the checksum mismatch had tests. **The three that decide whether a missing or forged signature stops an install had no coverage at all** — which is the shape that matters most while the OS-level check is off. A future refactor could have softened any of them silently.

Now covered, and each mutation reproduces exactly the failure mode the issue names — turning the `throw` into a warn-and-continue:

| mutation | result |
|---|---|
| checksum-required → warn | 1 failed \| 7 passed |
| signature-required → warn | 1 failed \| 7 passed |
| invalid-signature → warn | 1 failed \| 7 passed |

Three for three, one test each. **8/8** restored.

Test-only change; no production behaviour is altered.

### A measurement error worth recording

My first attempt to measure this coverage grepped for the literal error strings and reported the *renderer-override* path as uncovered too — which is false; its test asserts with a regex. The positive control caught it. The numbers above come from the call sites instead.
