### PR TITLE
fix(startup): stop a duplicate instance bootstrapping before its quit lands

### DIFF
--- a/apps/core-app/src/main/core/duplicate-instance-bootstrap.test.ts
+++ b/apps/core-app/src/main/core/duplicate-instance-bootstrap.test.ts
@@ -1,0 +1,58 @@
+/**
+ * A second launch calls app.quit() before Electron is ready. That quit does not land
+ * immediately -- precore's before-quit handler used to preventDefault unconditionally and run an
+ * async shutdown with a timeout -- so whenReady still fired and the duplicate began loading
+ * modules, including the database. Two processes opening the same libsql file is the failure
+ * this guards (#790).
+ *
+ * Three sites have to agree for that to be closed, and each one is load-bearing on its own:
+ * precore must keep the guard's return value, index.ts must check it before bootstrapping, and
+ * before-quit must let a duplicate exit instead of holding it open.
+ *
+ * These are source assertions, in the style of the sibling quit-paths.test.ts. precore.ts runs
+ * its guard, its handlers and its filesystem setup at module scope, so importing it to observe
+ * the behaviour would boot most of the main process; the sites are pinned instead of the
+ * runtime. The guard function's own return value is covered behaviourally in
+ * single-instance-guard.test.ts.
+ */
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PRECORE = readFileSync(path.join(__dirname, 'precore.ts'), 'utf8')
+const MAIN_INDEX = readFileSync(path.join(__dirname, '../index.ts'), 'utf8')
+
+describe('a duplicate instance must not bootstrap', () => {
+  it('precore 保留 setupSingleInstanceGuard 的返回值', () => {
+    // Positive control: the call itself must still be there, or the rest proves nothing.
+    expect(PRECORE).toContain('setupSingleInstanceGuard({')
+    expect(PRECORE).toMatch(/const\s+hasSingleInstanceLock\s*=\s*setupSingleInstanceGuard\(/)
+    expect(PRECORE).toMatch(/export function isDuplicateInstance\(\)/)
+  })
+
+  it('whenReady 在做任何事之前先检查它', () => {
+    const body = /app\.whenReady\(\)\.then\(async \(\) => \{([\s\S]*?)\n\}\)/.exec(MAIN_INDEX)?.[1]
+    expect(body, 'whenReady callback not found in index.ts').toBeTruthy()
+
+    const guardAt = body!.indexOf('isDuplicateInstance()')
+    expect(guardAt, 'whenReady does not check isDuplicateInstance').toBeGreaterThanOrEqual(0)
+
+    // Anything that touches modules or the database must come after the guard.
+    const bootstrapAt = body!.indexOf('enforceDevReleaseStartupConstraint')
+    expect(bootstrapAt).toBeGreaterThan(guardAt)
+  })
+
+  it('before-quit 让重复实例直接退出,而不是 preventDefault 后走关停流程', () => {
+    const handler = /app\.on\('before-quit', \(event\) => \{([\s\S]*?)\n\}\)/.exec(PRECORE)?.[1]
+    expect(handler, 'before-quit handler not found in precore.ts').toBeTruthy()
+
+    const exemptionAt = handler!.indexOf("intent.kind === 'duplicate-instance'")
+    expect(exemptionAt, 'before-quit does not exempt a duplicate instance').toBeGreaterThanOrEqual(
+      0
+    )
+
+    // The exemption is only worth anything if it precedes the preventDefault it is avoiding.
+    const preventAt = handler!.indexOf('event.preventDefault()')
+    expect(preventAt).toBeGreaterThan(exemptionAt)
+  })
+})

--- a/apps/core-app/src/main/core/precore.ts
+++ b/apps/core-app/src/main/core/precore.ts
@@ -217,7 +217,7 @@ if (process.platform === 'win32' && release().startsWith('6.1')) app.disableHard
 if (process.platform === 'win32') app.setAppUserModelId(app.getName())
 
 const startupBenchmarkMode = parseBooleanEnv(process.env.TUFF_STARTUP_BENCHMARK_ONCE)
-setupSingleInstanceGuard({
+const hasSingleInstanceLock = setupSingleInstanceGuard({
   app,
   startupBenchmarkMode,
   emitSecondaryLaunch: (eventName, payload) => touchEventBus.emit(eventName, payload),
@@ -230,6 +230,18 @@ setupSingleInstanceGuard({
     warn: (message, options) => mainLog.warn(message, options)
   }
 })
+
+/**
+ * True in a second launch, whose app.quit() was issued before Electron was ready.
+ *
+ * The quit does not take effect immediately -- the before-quit handler below used to
+ * preventDefault unconditionally and run an async shutdown -- so whenReady still fired and the
+ * duplicate began loading modules, including the database. Two processes opening the same libsql
+ * file is the failure this guards (#790).
+ */
+export function isDuplicateInstance(): boolean {
+  return !hasSingleInstanceLock
+}
 
 void app.whenReady().then(() => {
   // Installed here rather than in a module: modules load after this, and some of
@@ -311,6 +323,13 @@ app.on('before-quit', (event) => {
   const intent = ensureUserNormalQuitIntent('electron-before-quit')
   markAppQuitting('before-quit')
   if (beforeQuitFlowDone) {
+    return
+  }
+
+  // A duplicate instance has loaded no modules and holds no resources, so there is nothing for
+  // the shutdown flow to flush. Delaying its quit is what let it reach whenReady in the first
+  // place, so it is allowed to exit immediately.
+  if (intent.kind === 'duplicate-instance') {
     return
   }
 

--- a/apps/core-app/src/main/index.ts
+++ b/apps/core-app/src/main/index.ts
@@ -10,7 +10,7 @@ import { resolveThemeModeFromStyle } from '../shared/theme/theme-mode'
 import { commonChannelModule } from './channel/common'
 import { genTouchApp } from './core'
 import { AllModulesLoadedEvent, TalexEvents, touchEventBus } from './core/eventbus/touch-event'
-import { innerRootPath } from './core/precore'
+import { innerRootPath, isDuplicateInstance } from './core/precore'
 import { setQuitIntent } from './core/quit-intent'
 import { loadStartupModules } from './core/startup-module-loader'
 import { enforceDevReleaseStartupConstraint } from './core/startup-version-guard'
@@ -225,6 +225,13 @@ try {
 }
 
 app.whenReady().then(async () => {
+  // A duplicate launch already called app.quit(); bootstrapping here would open the database a
+  // second time before that quit lands (#790).
+  if (isDuplicateInstance()) {
+    mainLog.info('Duplicate instance detected, skipping bootstrap')
+    return
+  }
+
   const canContinue = await enforceDevReleaseStartupConstraint()
   if (!canContinue) return
 


### PR DESCRIPTION
Closes #790.

Filed at **low confidence** — "the exact interleaving depends on Electron's internal ready timing and I did not run it". The mechanism checks out on the code, so here is what was verified before changing anything.

### The premise

- `setupSingleInstanceGuard` returns `false` for a duplicate, and `precore.ts` **discarded** that value.
- `index.ts`'s `whenReady` callback had **no** corresponding check.
- `precore`'s `before-quit` handler called `preventDefault()` **unconditionally** and ran an async shutdown with an 8s timeout.

So the guard's `app.quit()` preempted nothing: the duplicate stayed alive long enough for `whenReady` to fire and start loading modules, including the database. Two processes opening the same libsql file is the risk.

### The part the audit could not confirm

The quit-intent plumbing does carry the signal end to end. `ensureUserNormalQuitIntent` returns the **existing** intent rather than replacing it, and `duplicate-instance` sits at the top priority tier (3, alongside `system-shutdown`), so the intent set by `onDuplicateInstance` survives into `before-quit` — which is exactly what made the unconditional `preventDefault` apply to it, and what now lets it be exempted precisely.

### Three sites, each load-bearing alone

| site | change |
|---|---|
| `precore.ts` | keeps the guard's result, exports `isDuplicateInstance()` |
| `index.ts` | `whenReady` returns before touching anything else |
| `precore.ts` before-quit | a duplicate exits immediately — it has loaded no modules and has nothing to flush |

### How it is pinned, and why that way

Source assertions, in the style of the sibling `quit-paths.test.ts`. `precore.ts` runs its guard, its handlers and its filesystem setup at **module scope**, so importing it to observe the behaviour would boot most of the main process.

The assertions check **ordering**, not just presence: the `whenReady` check must precede the bootstrap call, and the before-quit exemption must precede the `preventDefault` it avoids. Each of the three mutations fails exactly one test. The guard function's own return value stays covered behaviourally by `single-instance-guard.test.ts`.

**Not verified:** the race itself. Reproducing it needs two real Electron processes and depends on internal ready timing — the same reason the audit could not confirm it.
