### PR TITLE
fix(plugin): make dev-plugin install host-only and development-only

### DIFF
--- a/apps/core-app/src/main/modules/addon-opener.dev-install-guard.test.ts
+++ b/apps/core-app/src/main/modules/addon-opener.dev-install-guard.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The dev-install handler installs a plugin from a caller-supplied path, registering it with its
+ * own permissions. With only a non-empty check in front of it, a plugin view could point it at a
+ * directory it had staged elsewhere on disk and get a second, attacker-authored plugin installed
+ * -- lateral movement out of its own sandbox (#791).
+ *
+ * `app` inside onInit is the runtime's app, not the module-level electron import, so isPackaged
+ * is injected through the runtime stub rather than mocked globally.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const installDevPluginFromPathMock = vi.hoisted(() => vi.fn(async () => ({ status: 'success' })))
+const transportMock = vi.hoisted(() => ({
+  handlers: new Map<string, (payload: unknown, context?: unknown) => unknown>(),
+  on: vi.fn()
+}))
+
+// The import graph reaches temp-file.service, plugin-module and sentry-service, all of which
+// touch electron at module scope. This harness is the repo's own answer to that.
+import './ai/intelligence-test-harness'
+
+vi.mock('../modules/plugin/dev-plugin-installer', () => ({
+  installDevPluginFromPath: installDevPluginFromPathMock
+}))
+
+vi.mock('@talex-touch/utils/transport/main', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@talex-touch/utils/transport/main')>()
+  return {
+    ...actual,
+    getTuffTransportMain: () => ({
+      on: (event: { toEventName: () => string }, handler: (p: unknown, c?: unknown) => unknown) => {
+        transportMock.handlers.set(event.toEventName(), handler)
+        return vi.fn()
+      }
+    })
+  }
+})
+
+import { OpenerEvents } from '@talex-touch/utils/transport/events'
+import { AddonOpenerModule } from './addon-opener'
+
+type DevInstallHandler = (
+  payload: { path?: string; forceUpdate?: boolean },
+  context?: { plugin?: { name: string } }
+) => Promise<{ status: string; error?: string }>
+
+function captureDevInstallHandler(isPackaged: boolean): DevInstallHandler {
+  transportMock.handlers.clear()
+  const module = new AddonOpenerModule()
+  module.onInit({
+    app: {
+      app: {
+        isPackaged,
+        on: vi.fn(),
+        setAsDefaultProtocolClient: vi.fn(),
+        isDefaultProtocolClient: vi.fn(() => true),
+        removeAsDefaultProtocolClient: vi.fn(),
+        getPath: vi.fn(() => '/tmp/tuff-test')
+      },
+      window: { window: { isDestroyed: () => true, on: vi.fn() } },
+      channel: {}
+    },
+    file: { dirPath: '/tmp' }
+  } as never)
+
+  const handler = transportMock.handlers.get(OpenerEvents.install.dev.toEventName())
+  if (!handler) throw new Error('dev install handler was not registered')
+  return handler as DevInstallHandler
+}
+
+describe('dev plugin install is host-only and development-only', () => {
+  beforeEach(() => {
+    installDevPluginFromPathMock.mockClear()
+  })
+
+  it('插件调用被拒绝,且安装器根本不会被调用', async () => {
+    const handler = captureDevInstallHandler(false)
+
+    await expect(
+      handler({ path: '/tmp/staged-plugin' }, { plugin: { name: 'third-party' } })
+    ).resolves.toMatchObject({ status: 'error', error: 'HOST_ONLY' })
+    expect(installDevPluginFromPathMock).not.toHaveBeenCalled()
+  })
+
+  it('打包构建中一律拒绝', async () => {
+    const handler = captureDevInstallHandler(true)
+
+    await expect(handler({ path: '/tmp/staged-plugin' }, {})).resolves.toMatchObject({
+      status: 'error',
+      error: 'DEV_ONLY'
+    })
+    expect(installDevPluginFromPathMock).not.toHaveBeenCalled()
+  })
+
+  it('开发构建里的宿主调用仍然可以安装(否则上面两条会掩盖功能损坏)', async () => {
+    const handler = captureDevInstallHandler(false)
+
+    await handler({ path: '/tmp/my-plugin', forceUpdate: true }, {})
+
+    expect(installDevPluginFromPathMock).toHaveBeenCalledWith('/tmp/my-plugin', {
+      forceUpdate: true
+    })
+  })
+})

--- a/apps/core-app/src/main/modules/addon-opener.ts
+++ b/apps/core-app/src/main/modules/addon-opener.ts
@@ -10,6 +10,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { OpenerEvents } from '@talex-touch/utils/transport/events'
+import type { HandlerContext } from '@talex-touch/utils/transport/main'
 import { getTuffTransportMain } from '@talex-touch/utils/transport/main'
 import { APP_SCHEMA } from '../config/default'
 import { installDevPluginFromPath } from '../modules/plugin/dev-plugin-installer'
@@ -267,7 +268,26 @@ export class AddonOpenerModule extends BaseModule {
 
     this.transportDisposers.push(transport.on(OpenerEvents.install.request, installPluginHandler))
 
-    const installDevPluginHandler = async (payload: PluginDevInstallRequest) => {
+    const installDevPluginHandler = async (
+      payload: PluginDevInstallRequest,
+      context?: HandlerContext
+    ) => {
+      // Installing from a caller-supplied path registers a new plugin with its own permissions.
+      // A plugin view could point this at a directory it had staged elsewhere on disk and get a
+      // second, attacker-authored plugin installed -- lateral movement out of its own sandbox
+      // (#791). It is a development affordance, so it is closed in both directions: not from a
+      // plugin, and not in a packaged build at all.
+      if (context?.plugin) {
+        addonOpenerLog.warn('Blocked dev plugin install requested by a plugin', {
+          meta: { plugin: context.plugin.name }
+        })
+        return { status: 'error', error: 'HOST_ONLY' }
+      }
+      if (app.isPackaged) {
+        addonOpenerLog.warn('Blocked dev plugin install in a packaged build')
+        return { status: 'error', error: 'DEV_ONLY' }
+      }
+
       const sourcePath = payload?.path
       if (!sourcePath) {
         return { status: 'error', error: 'INVALID_PATH' }


### PR DESCRIPTION
Closes #791.

The dev-install handler installed from a caller-supplied path behind nothing but a non-empty check. Installing registers a **new plugin with its own permissions**, so a plugin view could point it at a directory staged elsewhere on disk — via the temp-file API, for instance — and get a second, attacker-authored plugin installed. Lateral movement out of one plugin's sandbox, live in release builds.

It is a development affordance, so it is now closed in both directions: **not from a plugin, and not in a packaged build at all**. `app.isPackaged` is the idiom this file already uses, a few dozen lines up, for the protocol-client registration.

Worth knowing when reading the diff: `app` inside `onInit` is the **runtime's** app (`const app = touchApp.app`), not the module-level electron import — so the packaged check follows whatever the runtime supplies, which is also how the test injects it.

### Three tests, each guard independently pinned

| mutation | result |
|---|---|
| drop the host-only check | only the plugin-caller test fails |
| drop the `isPackaged` check | only the packaged test fails |

The third test is the **control**: a host caller in a development build must still reach `installDevPluginFromPath` with its path and `forceUpdate` intact, so a guard written as "always refuse" would fail there.

Both refusal tests assert the installer was **never called**, not merely that an error came back — a handler that returned an error after installing would pass the weaker check.

### Deliberately not done

Constraining the path to a directory chosen through `dialog.showOpenDialog`, which the issue also suggests. With the handler now unreachable from plugins and absent from packaged builds, that would only add protection against a compromised *host* renderer in a dev build — and it changes how developers load a local plugin. That is a workflow decision.

Verified with the pre-commit hook's own steps: `sync:core-pkg` is a no-op, lint-staged's exact command exits 0 silent, `tsc -p tsconfig.node.json` reports nothing for either file.
