### PR TITLE
fix(preload): skip the loading post instead of broadcasting it to '*'

### DIFF
--- a/apps/core-app/src/preload/index.ts
+++ b/apps/core-app/src/preload/index.ts
@@ -9,6 +9,7 @@ import { AppEvents, installTransportPortHandoff } from '@talex-touch/utils/trans
 import appLogoSvgRaw from '../../public/logo.svg?raw'
 import { contextBridge, ipcRenderer } from 'electron'
 import { RAW_MAIN_PROCESS_CHANNEL, RAW_PLUGIN_PROCESS_CHANNEL } from '../shared/ipc/raw-channel'
+import { resolvePreloadTargetOrigin } from './preload-target-origin'
 
 interface StartupHandshakePayload {
   rendererStartTime: number
@@ -103,12 +104,11 @@ const api: CoreAppPreloadAPI = {
    * Update loading overlay from renderer when needed.
    */
   sendPreloadEvent(event: LoadingEvent) {
-    const targetOrigin =
-      window.location.origin !== 'null'
-        ? window.location.origin
-        : window.location.protocol === 'file:'
-          ? 'file://'
-          : '*'
+    const targetOrigin = resolvePreloadTargetOrigin(window.location)
+    if (!targetOrigin) {
+      console.warn('[preload] Skipped a loading event: the page origin could not be determined')
+      return
+    }
     window.postMessage({ channel: PRELOAD_LOADING_CHANNEL, data: event }, targetOrigin)
   },
   async getStartupContext() {

--- a/apps/core-app/src/preload/preload-target-origin.test.ts
+++ b/apps/core-app/src/preload/preload-target-origin.test.ts
@@ -1,0 +1,34 @@
+/**
+ * sendPreloadEvent used to fall back to '*', delivering the loading-state payload to any
+ * cross-origin frame embedded in the page (#798).
+ */
+import { describe, expect, it } from 'vitest'
+import { resolvePreloadTargetOrigin } from './preload-target-origin'
+
+describe('resolvePreloadTargetOrigin', () => {
+  it('返回真实来源', () => {
+    expect(resolvePreloadTargetOrigin({ origin: 'https://app.example', protocol: 'https:' })).toBe(
+      'https://app.example'
+    )
+  })
+
+  it('file: 页面得到 file:// 而不是通配符', () => {
+    expect(resolvePreloadTargetOrigin({ origin: 'null', protocol: 'file:' })).toBe('file://')
+  })
+
+  it('无法确定来源时返回 null,由调用方跳过投递', () => {
+    expect(resolvePreloadTargetOrigin({ origin: 'null', protocol: 'https:' })).toBeNull()
+    expect(resolvePreloadTargetOrigin({ protocol: 'about:' })).toBeNull()
+    expect(resolvePreloadTargetOrigin({})).toBeNull()
+  })
+
+  it('永远不会返回 *', () => {
+    for (const location of [
+      { origin: 'null', protocol: 'https:' },
+      { origin: '', protocol: 'data:' },
+      {}
+    ]) {
+      expect(resolvePreloadTargetOrigin(location)).not.toBe('*')
+    }
+  })
+})

--- a/apps/core-app/src/preload/preload-target-origin.ts
+++ b/apps/core-app/src/preload/preload-target-origin.ts
@@ -1,0 +1,18 @@
+/**
+ * postMessage targetOrigin for the preload's loading-state channel.
+ *
+ * `'*'` delivers the payload to any cross-origin frame embedded in the page. The data is low
+ * value, but the wildcard is exposure nobody asked for, so an origin that cannot be pinned down
+ * means the post is skipped rather than broadcast (#798).
+ *
+ * An opaque origin serialises as the string 'null', which postMessage cannot use; file: pages
+ * have a usable 'file://' instead.
+ */
+export function resolvePreloadTargetOrigin(location: {
+  origin?: string
+  protocol?: string
+}): string | null {
+  if (location.origin && location.origin !== 'null') return location.origin
+  if (location.protocol === 'file:') return 'file://'
+  return null
+}

--- a/packages/utils/transport/port-handoff.ts
+++ b/packages/utils/transport/port-handoff.ts
@@ -17,10 +17,13 @@ type TransportPortHandoffWindow = Pick<
  * script running in the page satisfies, so an injected script could take the port
  * and keep it for the lifetime of the page (#694).
  *
- * Mirrors the rule already used by sendPreloadEvent in the app preload: an opaque
- * origin serialises as the string 'null', for which postMessage has no usable
- * specific value — file: pages get 'file://' and anything else falls back to '*',
- * which is no worse than today for those cases and correct for every real origin.
+ * An opaque origin serialises as the string 'null', for which postMessage has no usable
+ * specific value — file: pages get 'file://' and anything else falls back to '*'.
+ *
+ * The app preload used to share this rule, but sendPreloadEvent now skips the post instead of
+ * broadcasting it (#798). This one still widens to '*' because the two are not comparable: the
+ * preload drops a loading-state payload, while dropping here would leave the transport with no
+ * port and no session at all. Narrowing it is its own change, with its own fallback to design.
  */
 function resolveHandoffTargetOrigin(targetWindow: TransportPortHandoffWindow): string {
   const location = targetWindow.location


### PR DESCRIPTION
Closes #798.

`sendPreloadEvent` fell back to a wildcard `targetOrigin` when the page origin could not be determined, delivering the loading-state payload to any cross-origin frame embedded in the page. The payload is low value; the wildcard is exposure nobody asked for.

The rule moved into `resolvePreloadTargetOrigin`, which returns `null` for an origin it cannot pin down, and the caller skips the post with a warning. Extracted rather than fixed in place because it was an expression inside an object literal in a preload that runs `contextBridge` at import — there was no way to assert on it otherwise.

### A comment this change made false

`port-handoff.ts` said its own resolver *"mirrors the rule already used by sendPreloadEvent"*. That stopped being true, so the comment was corrected.

**That wildcard is still there, deliberately.** The two are not comparable: the preload drops a loading-state payload, while dropping in the handoff would leave the transport with **no port and no session at all**. Narrowing it needs a fallback designed for that case, which is its own change — the issue calls it "the more serious wildcard" and it is right.

Worth flagging plainly: #694 fixed the *reachability* of that resolver, not the wildcard itself. Anyone reading this issue as "the transport one is already handled" would be wrong.

### Verification

Four tests. Restoring the `'*'` fallback fails **two** of them — including the one that exists purely to say the function must never return it. The other three would all pass against a resolver that widened only in the unreachable case, which is why that test is there.

Two packages are touched, so both lint-staged entries were run as written: core-app's **without** `--max-warnings`, `packages/utils`' **with** it. Both exit 0 silent; `sync:core-pkg` is a no-op; `tsc -p tsconfig.node.json` reports nothing for the preload files.
