### PR TITLE
build(tuffex): guarantee dist exists before publish

### DIFF
--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -45,6 +45,7 @@
     }
   },
   "scripts": {
+    "prepublishOnly": "pnpm run build",
     "build": "node ./node_modules/gulp/bin/gulp.js -f packages/script/build/index.ts",
     "build:vite": "vite build",
     "dev": "vite build --watch",


### PR DESCRIPTION
`@talex-touch/tuffex` is public, ships `files: ["dist"]`, and points `main`, `module` and `types` at `dist/lib` and `dist/es` — **with no `prepublishOnly`**. Nothing made the build run, so `npm publish` from a clean tree would have produced a package that cannot resolve for any consumer.

### This is what fails CI on #1272

That PR adds exactly this rule to `validate-publish-manifests`: an entry pointing into a directory absent from the tree requires a `prepublishOnly` script. It fixed `tuff-cli` and `tuff-core` and **missed tuffex**.

The miss is invisible locally — a developer who has built tuffex has `dist` on disk, so the check passes. CI checks out clean. `.gitignore:46` covers `dist/`, and `git ls-files packages/tuffex/dist` returns **zero** tracked files, so the entries are genuinely absent there. That also explains why #1272 failed in CI with `'fail' !== 'pass'` while the same test passed on my machine.

### Enumerating every publishable workspace package whose entry points into `dist/` with no `prepublishOnly`

| state | flagged |
|---|---|
| this base | `packages/tuffex` |
| with #1272 alone | `packages/tuffex` |
| **with #1272 and this change** | **none** |

`pnpm run build` matches what `tuff-cli` and `tuff-core` use, and is tuffex's own existing build script.

Merging this alongside #1272 clears that PR's CI failure and closes a real publish hazard for tuffex.