### PR TITLE
fix(intelligence): stop teardown booting the runtime it is shutting down

### DIFF
--- a/apps/core-app/src/main/modules/ai/intelligence-destroy-runtime.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-destroy-runtime.test.ts
@@ -1,0 +1,72 @@
+/**
+ * onDestroy awaited waitForAgentRuntime(), which starts the runtime when none exists. On a module
+ * whose onInit failed before startAgentRuntime(), teardown therefore registered builtin tools and
+ * agents and awaited the orchestrator and agent manager -- booting the thing it was about to shut
+ * down, and stalling quit for as long as that took (#765).
+ *
+ * The lazy start itself is deliberate: agent.run, workflow.execute and the agent channels all
+ * reach the runtime through waitForAgentRuntime and need it created on demand. So the fix belongs
+ * in onDestroy, and these tests pin both halves - teardown must not start one, and the request
+ * path must still get one.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import './intelligence-test-harness'
+
+import { IntelligenceModule } from './intelligence-module'
+
+interface RuntimeInternals {
+  agentRuntimePromise: Promise<void> | null
+  startAgentRuntime: () => void
+  waitForAgentRuntime: () => Promise<void>
+  onDestroy: () => Promise<void>
+}
+
+function createModule(): RuntimeInternals {
+  return new IntelligenceModule() as unknown as RuntimeInternals
+}
+
+describe('intelligence teardown does not boot the runtime', () => {
+  it('onInit 失败后销毁模块,不会启动 agent runtime', async () => {
+    const module = createModule()
+    const startSpy = vi.spyOn(module, 'startAgentRuntime')
+
+    // Never started: this is the state after an onInit that threw before startAgentRuntime().
+    expect(module.agentRuntimePromise).toBeNull()
+
+    await module.onDestroy()
+
+    expect(startSpy).not.toHaveBeenCalled()
+    expect(module.agentRuntimePromise).toBeNull()
+  })
+
+  it('已经启动过的 runtime 仍会在销毁时被等待', async () => {
+    const module = createModule()
+    let settled = false
+    module.agentRuntimePromise = Promise.resolve().then(() => {
+      settled = true
+    })
+
+    await module.onDestroy()
+
+    expect(settled).toBe(true)
+  })
+
+  it('销毁不会吞掉一个失败的 runtime promise', async () => {
+    const module = createModule()
+    module.agentRuntimePromise = Promise.reject(new Error('runtime failed'))
+
+    // The rejection is logged, not rethrown: teardown must continue to the rest of its cleanup.
+    await expect(module.onDestroy()).resolves.toBeUndefined()
+  })
+
+  it('请求路径仍然按需启动 runtime(守卫不能改成"从不启动")', async () => {
+    const module = createModule()
+    const startSpy = vi.spyOn(module, 'startAgentRuntime').mockImplementation(() => {
+      module.agentRuntimePromise = Promise.resolve()
+    })
+
+    await module.waitForAgentRuntime()
+
+    expect(startSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/core-app/src/main/modules/ai/intelligence-module.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-module.ts
@@ -676,10 +676,17 @@ export class IntelligenceModule extends BaseModule<TalexEvents> {
 
   async onDestroy(): Promise<void> {
     intelligenceLog.info('Destroying Intelligence module')
-    try {
-      await this.waitForAgentRuntime()
-    } catch (error) {
-      intelligenceLog.warn('Intelligence agent runtime was not ready during destroy', { error })
+    // Only wait for a runtime that was actually started. waitForAgentRuntime() starts one on
+    // demand -- which is what the request paths at agent.run, workflow.execute and the agent
+    // channels rely on -- but at teardown that means registering builtin tools and agents and
+    // awaiting the orchestrator and agent manager just to shut them down again, stalling quit
+    // for as long as initialization takes (#765).
+    if (this.agentRuntimePromise) {
+      try {
+        await this.agentRuntimePromise
+      } catch (error) {
+        intelligenceLog.warn('Intelligence agent runtime was not ready during destroy', { error })
+      }
     }
     if (this.agentChannelsCleanup) {
       this.agentChannelsCleanup()


### PR DESCRIPTION
Closes #765.

`onDestroy` awaited `waitForAgentRuntime()`, which **starts** a runtime when none exists. On a module whose `onInit` threw before `startAgentRuntime` — a failing `initializeProviderCredentialLifecycle`, say — teardown registered builtin tools and agents and awaited the orchestrator and agent manager, booting the thing it was about to shut down and stalling quit for as long as that took.

### Why not the suggested fix

The issue proposes making `waitForAgentRuntime` return early when the promise is null. **That breaks the callers.** There are four call sites and three are request paths:

| line | caller |
|---|---|
| 680 | `onDestroy` — the one that wants the new behaviour |
| 739 | `waitForRuntime` handed to the agent channels |
| 1266 | `agent.run` / `workflow.execute` capability invocation |
| 2208 | workflow run handler |

The lazy start is the feature for those three. So `onDestroy` awaits `this.agentRuntimePromise` directly and skips when there is none; `waitForAgentRuntime` is untouched.

### Four tests, and the fourth is the point

| mutation | fails |
|---|---|
| revert `onDestroy` | the never-started-runtime test |
| **apply the audit's version instead** | the request-path test |

That fourth test exists precisely so a fix written as *"never start"* is caught rather than shipped. It passes in both the current and the reverted state, so it is a control rather than a mirror of the change.

The other two cover what teardown must keep doing: awaiting a runtime that **was** started, and logging rather than rethrowing when that promise rejects.

Lint, and `tsc --noEmit -p tsconfig.node.json --composite false` — CI's exact command — both exit 0.
