### PR TITLE
fix(intelligence): bound how long the Pi runtime may take to report ready

### DIFF
--- a/apps/core-app/src/main/modules/ai/pi-agent-runtime-host.test.ts
+++ b/apps/core-app/src/main/modules/ai/pi-agent-runtime-host.test.ts
@@ -713,4 +713,31 @@ describe('piAgentRuntimeHost protocol boundary', () => {
     await settleAsyncWork()
     await completeRun(payload, execution)
   })
+
+  it('worker 迟迟不 ready 时,start() 有界失败并杀掉子进程', async () => {
+    // A worker that spawns but never posts runtime.ready: the process is alive so no 'exit'
+    // fires, and execute() awaits start() before arming its own run timeout, so before #766
+    // this promise stayed pending forever.
+    hostMocks.fork.mockImplementationOnce(() => hostMocks.child)
+
+    const host = new PiAgentRuntimeHost()
+    const started = host.start()
+    const assertion = expect(started).rejects.toThrow(/not ready within/i)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await assertion
+
+    expect(hostMocks.child.kill).toHaveBeenCalled()
+  })
+
+  it('正常 ready 的 worker 不会被这个定时器杀掉', async () => {
+    // The control: a fix written as "always kill after 30s" would fail here.
+    const host = new PiAgentRuntimeHost()
+
+    await expect(host.start()).resolves.toBeUndefined()
+
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    expect(hostMocks.child.kill).not.toHaveBeenCalled()
+  })
 })

--- a/apps/core-app/src/main/modules/ai/pi-agent-runtime-host.ts
+++ b/apps/core-app/src/main/modules/ai/pi-agent-runtime-host.ts
@@ -83,6 +83,15 @@ const SENSITIVE_TOOL_OUTPUT_KEY =
   /token|api.?key|secret|password|credential|authorization|cookie|authref/i
 const MAX_SERIALIZED_TOOL_OUTPUT_CHARS = 64 * 1024
 
+/**
+ * How long the forked worker gets to post `runtime.ready`.
+ *
+ * Generous next to what readiness actually costs (module load and a single message) and far
+ * below the run timeout, which defaults to ten minutes -- the point is that a stuck worker
+ * surfaces as an error in seconds rather than as a request that never returns.
+ */
+const READY_TIMEOUT_MS = 30_000
+
 function canonicalToolInput(value: unknown): unknown {
   if (value === null || typeof value !== 'object') return value
   if (Array.isArray(value)) return value.map(canonicalToolInput)
@@ -301,6 +310,7 @@ export class PiAgentRuntimeHost {
   private readyPromise: Promise<void> | null = null
   private readyResolve: (() => void) | null = null
   private readyReject: ((error: Error) => void) | null = null
+  private readyTimeout: ReturnType<typeof setTimeout> | null = null
   private readonly activeRuns = new Map<string, ActiveRunContext>()
   private readonly onEvent?: PiAgentRuntimeHostOptions['onEvent']
   private readonly loadToolCallResult?: PiAgentRuntimeHostOptions['loadToolCallResult']
@@ -324,6 +334,12 @@ export class PiAgentRuntimeHost {
     return this.ready
   }
 
+  private clearReadyTimeout(): void {
+    if (!this.readyTimeout) return
+    clearTimeout(this.readyTimeout)
+    this.readyTimeout = null
+  }
+
   async start(): Promise<void> {
     if (this.child && this.readyPromise) return this.readyPromise
     if (!app.isReady()) throw new Error('Pi runtime can only start after Electron app ready')
@@ -334,6 +350,19 @@ export class PiAgentRuntimeHost {
       this.readyResolve = resolve
       this.readyReject = reject
     })
+    // A worker that spawns but never posts runtime.ready leaves this promise pending forever:
+    // the process is alive so no 'exit' fires, and execute() awaits start() before arming its
+    // own run timeout, so every call hangs with nothing to rescue it (#766). Bounded here, and
+    // the child is killed so the exit path can run its normal cleanup.
+    this.readyTimeout = setTimeout(() => {
+      this.readyTimeout = null
+      const error = new Error(`Pi runtime was not ready within ${READY_TIMEOUT_MS}ms`)
+      runtimeLog.error(error.message, { error })
+      this.readyReject?.(error)
+      this.readyResolve = null
+      this.readyReject = null
+      this.child?.kill()
+    }, READY_TIMEOUT_MS)
     const child = utilityProcess.fork(workerPath, [], {
       cwd: app.getPath('userData'),
       env: createRestrictedEnvironment(),
@@ -438,6 +467,7 @@ export class PiAgentRuntimeHost {
       context.reject(new Error('Pi runtime stopped'))
     }
     this.activeRuns.clear()
+    this.clearReadyTimeout()
     this.child?.kill()
     this.child = null
     this.readyPromise = null
@@ -459,6 +489,7 @@ export class PiAgentRuntimeHost {
       case 'runtime.ready':
         this.ready = true
         this.restartAttempts = 0
+        this.clearReadyTimeout()
         this.readyResolve?.()
         this.readyResolve = null
         this.readyReject = null
@@ -721,6 +752,7 @@ export class PiAgentRuntimeHost {
     const error = new Error(`Pi runtime utility process exited with code ${code}`)
     if (!this.shuttingDown) runtimeLog.error(error.message, { error })
     this.ready = false
+    this.clearReadyTimeout()
     this.readyReject?.(error)
     for (const context of this.activeRuns.values()) {
       clearTimeout(context.timeout)


### PR DESCRIPTION
Closes #766.

`readyPromise` was settled only by a `runtime.ready` message or by the process exiting. A worker that spawns but hangs during module load posts neither — the process is alive so no `exit` fires — and `execute()` awaits `start()` **before** arming its own run timeout, so every call parked on the same pending promise with nothing left to rescue it. The conversation UI showed a request that never completed and never timed out.

`start()` now races a **30s** timer that rejects and kills the child, letting the existing exit path do its normal cleanup. 30s is generous for what readiness actually costs — module load and one message — and far below the run timeout's ten-minute default. The point is that a stuck worker surfaces in seconds instead of never.

### Cleared at all three places readiness settles

The `runtime.ready` message, `handleExit`, and `stop()`. Missing any one of them leaves a timer that later kills a **healthy** worker.

### Two tests, each mutation caught by its own

| mutation | fails |
|---|---|
| remove the timer | the stuck-worker test — it hangs, exactly as the bug does |
| never clear it on ready | the healthy-worker test — the timer kills a runtime that had already reported ready |

The second is the control: a fix written as *"always kill after 30s"* passes the first test and fails this one.

Lint and `tsc --noEmit -p tsconfig.node.json --composite false` both exit 0. **13/13.**
