### PR TITLE
fix(intelligence): clean up when the run.start post throws

### DIFF
--- a/apps/core-app/src/main/modules/ai/pi-agent-runtime-host.test.ts
+++ b/apps/core-app/src/main/modules/ai/pi-agent-runtime-host.test.ts
@@ -205,6 +205,45 @@ describe('piAgentRuntimeHost protocol boundary', () => {
     vi.useRealTimers()
   })
 
+  it('run.start 投递失败时不留下 run id,重试不再报 already active', async () => {
+    const host = new PiAgentRuntimeHost()
+    const payload = startPayload()
+
+    // The child goes away between the availability check and the post, or the payload is not
+    // structured-cloneable. Either way postMessage throws.
+    hostMocks.child.postMessage.mockImplementationOnce(() => {
+      throw new Error('child is gone')
+    })
+
+    await expect(host.execute(payload)).rejects.toThrow(/child is gone/)
+
+    // Before #767 the map still held the id, so this second attempt failed with
+    // 'Run <id> is already active' instead of reaching the runtime at all.
+    const retry = host.execute(payload)
+    await settleAsyncWork()
+
+    expect(hostMocks.child.postMessage).toHaveBeenCalledWith({
+      type: 'run.start',
+      payload,
+      protocolVersion: PI_RUNTIME_PROTOCOL_VERSION
+    })
+    await completeRun(payload, retry)
+  })
+
+  it('投递失败也不会留下一个稍后触发的运行定时器', async () => {
+    const host = new PiAgentRuntimeHost()
+    const payload = startPayload()
+    await host.start()
+
+    const before = vi.getTimerCount()
+    hostMocks.child.postMessage.mockImplementationOnce(() => {
+      throw new Error('child is gone')
+    })
+    await expect(host.execute(payload)).rejects.toThrow(/child is gone/)
+
+    expect(vi.getTimerCount()).toBe(before)
+  })
+
   it('preserves run and model request IDs while relaying host-owned model responses', async () => {
     const payload = startPayload()
     const host = new PiAgentRuntimeHost()

--- a/apps/core-app/src/main/modules/ai/pi-agent-runtime-host.ts
+++ b/apps/core-app/src/main/modules/ai/pi-agent-runtime-host.ts
@@ -395,7 +395,18 @@ export class PiAgentRuntimeHost {
         reject,
         timeout
       })
-      this.post({ type: 'run.start', payload })
+      try {
+        this.post({ type: 'run.start', payload })
+      } catch (error) {
+        // The entry and its timer are registered before the post so an immediate reply can find
+        // them. post() throws when the child has gone away between the check above and here,
+        // and postMessage throws on a payload that is not structured-cloneable. Rejecting alone
+        // left the run id wedged -- every retry hit 'already active' -- and the timer still
+        // fired later into settleRun on a promise that had already rejected (#767).
+        clearTimeout(timeout)
+        this.activeRuns.delete(payload.run.id)
+        reject(error instanceof Error ? error : new Error(String(error)))
+      }
     })
   }
 


### PR DESCRIPTION
Closes #767.

`execute()` registers the `activeRuns` entry and its timeout, then posts `run.start` from inside the promise executor. `post()` throws when the child has gone away between the availability check and the post, and `postMessage` throws on a payload that is not structured-cloneable.

The throw rejected the promise but left both behind:

- the run id stayed in `activeRuns`, so **every retry failed with `Run <id> is already active`**
- the timer fired later into `settleRun` on a promise that had already rejected

The post is now wrapped: clear the timer, drop the entry, reject.

The entry is still registered **before** the post rather than after — a reply can arrive before the post call returns and needs to find it.

### Verification

Two tests. Reverting to a bare `reject` fails **both**: the retry hits *already active*, and `vi.getTimerCount()` stays raised. The other eleven pass in both states, so the pair targets this path rather than the run lifecycle around it.

Worth recording: a first draft of the retry test hand-wrote the `run.completed` message and **hung** — the real shape nests `runId` under `payload`. It now uses the suite's own `completeRun` and `settleAsyncWork` helpers rather than a second, wrong copy of the protocol.

Lint and `tsc --noEmit -p tsconfig.node.json --composite false` exit 0. **13/13.**
