### PR TITLE
docs: stop calling the search-index split flag a default-off gate [#633]

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,12 +39,12 @@
 来源：[`docs/plan-prd/TODO.md`](docs/plan-prd/TODO.md)
 
 1. **关闭已验证的 release 和 runtime blocker** — OTA、macOS release-evidence、application-icon acceptance
-2. **完成搜索和跨平台修复** — Windows Everything productionization、search-index split write-path migration（flag 默认 off）
+2. **完成搜索和跨平台修复** — Windows Everything productionization、search-index split write-path migration（flag 自 `cd39bdbf6` / 2026-08-05 起默认 **on**）
 3. **继续其余独立活跃任务** — 按 Trellis task-local PRD 定义的实现顺序
 
 ### 安全门禁（不可绕过）
 
-- `DB_SEARCH_SPLIT_ENABLED` 默认 **off**，开启前必须有 flag-on app run evidence
+- `DB_SEARCH_SPLIT_ENABLED` 自 `cd39bdbf6`（2026-08-05）起默认 **on**，2d.3 write-path 迁移与之同批落地；`TUFF_DB_SEARCH_SPLIT_ENABLED=0` 是回退到共享文件拓扑的应急开关，不是安全默认值
 - 不把 local mock/dry-run/preflight/focused test 写成生产完成
 - SQLite 是本地 SoT；JSON 只允许作为密文同步载荷
 
@@ -68,7 +68,7 @@
 | └ [optimize-clipboard-plugin](.trellis/tasks/07-27-optimize-clipboard-plugin/prd.md) | P1 | planning |
 | [search-crossplatform-audit](.trellis/tasks/07-13-search-crossplatform-audit/prd.md) | P2 | 🔄 审计父任务 [1/3] |
 | ├ [windows-everything-productionization](.trellis/tasks/07-17-windows-everything-productionization/prd.md) | P1 | 🔴 backend gate passed，packaged UI manifest 开放 |
-| └ [migrate-search-index-split-write-paths](.trellis/tasks/07-28-migrate-search-index-split-write-paths/prd.md) | P1 | 🔴 flag 默认 off，等待全部 writer 迁移 |
+| └ [migrate-search-index-split-write-paths](.trellis/tasks/07-28-migrate-search-index-split-write-paths/prd.md) | P1 | flag 默认 on（`cd39bdbf6`），剩余 writer 归属待收口 |
 | [unify-ota-update-flow](.trellis/tasks/07-17-unify-ota-update-flow/prd.md) | P2 | 🔄 OTA lifecycle 落地 [4/6]；host acceptance 开放 |
 | ├ [ota-one-click-background-update](.trellis/tasks/07-22-ota-one-click-background-update/prd.md) | P2 | 🔄 in_progress |
 | └ [bilingual-whats-changed](.trellis/tasks/07-27-bilingual-whats-changed/prd.md) | P2 | 🔄 in_progress |
@@ -160,7 +160,7 @@ talex-touch/
 
 | 类别 | 风险 | 状态 |
 |------|------|------|
-| **数据安全** | `DB_SEARCH_SPLIT_ENABLED` flag-off 前开启会导致 silent data loss | 🔴 默认 off，待 evidence |
+| **数据安全** | `DB_SEARCH_SPLIT_ENABLED` 半迁移状态会导致 silent data loss | 默认 on 自 `cd39bdbf6`；该失效态随 2d.3 写路径迁移一并消失 |
 | **搜索** | B1 语义搜索接而未用 | ✅ 已修（延迟召回二段推送）；余 1 项派生 carve-out 开放 |
 | **搜索** | B2 completion 加权被 sorter 绕过 | ✅ 已修（46 相关用例通过） |
 | **跨平台** | R1 Rust screenshot 模块未接入构建 | 🟠 已审计，开放 |

--- a/docs/engineering/reports/maintenance-audit-2026-08-05.md
+++ b/docs/engineering/reports/maintenance-audit-2026-08-05.md
@@ -12,6 +12,7 @@
 ## 数据库、发布与跨平台门禁
 
 - **搜索索引分库仍可静默丢数据** — `DB_SEARCH_SPLIT_ENABLED` / `TUFF_DB_SEARCH_SPLIT_ENABLED` 默认关闭，但环境变量仍可启用半迁移模式：剩余 provider/embedding 写入 `database.db`，读取改走 `search-index.db`。应完成每个 writer 的 worker 归属和 flag-on 应用证据，或在完成前硬禁用运行时开关；不得维持可公开激活的半迁移模式。跟踪：[#331](https://github.com/talex-touch/tuff/issues/331)。
+  > **2026-08-10 更正：** 这条在写下当天就已过时。`cd39bdbf6`（2026-08-05）把该 flag 改为默认 **on**，2d.3 write-path 迁移与之同批落地，本条描述的半迁移失效态不再存在；`TUFF_DB_SEARCH_SPLIT_ENABLED=0` 现在是回退到共享文件拓扑的应急开关。原文保留，因为这是当日的审计记录（#633）。
 - **SQLite writer ownership 分散** — scheduler、retry、worker、admission 与 observer 的职责尚未收敛，新的写路径可绕过策略。完成 #331 后需建立 owner map、显式窄 bypass 与真实锁竞争/恢复测试。跟踪：[#351](https://github.com/talex-touch/tuff/issues/351)。
 - **大目录扫描/对账可 OOM** — worker、client 与 reconciliation 同时物化完整集合；百万级根目录可同时保留约三份数据。需采用有界背压批次，并对 worker/client/reconciliation 峰值、取消和关机释放建立验收。跟踪：[#480](https://github.com/talex-touch/tuff/issues/480)。
 - **macOS 架构发布策略未决** — 需明确 arm64-only，或交付完整 x64/Universal 的签名、公证、清单、下载选择和真机矩阵；不支持的架构必须显式失败，不能下发不兼容资产。跟踪：[#311](https://github.com/talex-touch/tuff/issues/311)。

--- a/packages/utils/__tests__/split-flag-docs.test.ts
+++ b/packages/utils/__tests__/split-flag-docs.test.ts
@@ -1,0 +1,109 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * No doc may claim the search-index split flag defaults off (#633).
+ *
+ * `DB_SEARCH_SPLIT_ENABLED` flipped to on in cd39bdbf6 on 2026-08-05, together with the 2d.3
+ * write-path migration that removed the half-migrated failure mode the flag used to guard. Four
+ * ROADMAP claims and one audit report still described it as a default-off safety gate.
+ *
+ * Both directions of that mistake cost something. An engineer verifying the gate before a release
+ * reads "defaults off", ships without checking, and the split topology has been live for every user
+ * the whole time. Someone reproducing a bug in the shared-file topology assumes no env var is
+ * needed and cannot reproduce it.
+ *
+ * This lives in packages/utils on purpose: `ci / CI - utils` is a blocking check, whereas
+ * `App suites (core-app)` is continue-on-error and reports success whatever the suite does.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const FLAG = 'TUFF_DB_SEARCH_SPLIT_ENABLED'
+
+/** Phrases that assert the flag is off by default, in either language. */
+const DEFAULT_OFF_CLAIMS = [
+  /默认\s*\*?\*?off/i,
+  /默认关闭/,
+  /defaults?\s+\*?\*?off/i,
+  /default[- ]off/i
+]
+
+const SEARCH_DIRS = ['docs', '.trellis/spec']
+
+/**
+ * `docs/engineering/reports/` holds dated maintenance audits. Each records what was true on its own
+ * date, and the flag genuinely did default off before 2026-08-05, so rewriting them would falsify
+ * the record rather than correct it. They are excluded here and reconciled by hand — the reports
+ * dated after the flip repeated the stale finding, which is noted on #633.
+ */
+const SKIP = new Set(['node_modules', 'dist', '.git', 'archive', 'reports'])
+
+function markdownFiles(dir: string): string[] {
+  let entries: string[]
+  try {
+    entries = readdirSync(dir)
+  }
+  catch {
+    return []
+  }
+  const found: string[] = []
+  for (const entry of entries) {
+    if (SKIP.has(entry)) continue
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) found.push(...markdownFiles(full))
+    else if (entry.endsWith('.md')) found.push(full)
+  }
+  return found
+}
+
+const docs = [path.join(REPO_ROOT, 'ROADMAP.md'), ...SEARCH_DIRS.flatMap(
+  (dir) => markdownFiles(path.join(REPO_ROOT, dir))
+)]
+
+/** Paragraph-ish window around a flag mention, so a nearby unrelated sentence is not blamed. */
+function claimsNearFlag(source: string): string[] {
+  const found: string[] = []
+  for (const block of source.split(/\n{2,}/)) {
+    if (!block.includes(FLAG) && !block.includes('DB_SEARCH_SPLIT_ENABLED')) continue
+    if (/更正|correction/i.test(block)) continue
+    if (DEFAULT_OFF_CLAIMS.some((pattern) => pattern.test(block))) found.push(block.slice(0, 120))
+  }
+  return found
+}
+
+describe('search-index split flag', () => {
+  it('is on by default in the code', () => {
+    // Positive control, and the fact everything below is measured against. If the default ever goes
+    // back to false, this fails first and the doc rule below stops applying.
+    const flags = readFileSync(
+      path.join(REPO_ROOT, 'apps/core-app/src/main/db/runtime-flags.ts'),
+      'utf8'
+    )
+
+    expect(flags).toContain(`parseEnvBoolean('${FLAG}', true)`)
+  })
+
+  it('scans a plausible set of documents', () => {
+    // Second control: the rule below is vacuous against an empty file list, which is what a wrong
+    // root produces.
+    expect(docs.length).toBeGreaterThan(20)
+    expect(docs.some((file) => file.endsWith('ROADMAP.md'))).toBe(true)
+  })
+
+  it('is described somewhere, so the scan has something to check', () => {
+    const mentioning = docs.filter((file) => readFileSync(file, 'utf8').includes(FLAG)
+      || readFileSync(file, 'utf8').includes('DB_SEARCH_SPLIT_ENABLED'))
+
+    expect(mentioning.length).toBeGreaterThan(0)
+  })
+
+  it('is not called default-off by any document', () => {
+    const offenders = docs.flatMap((file) => {
+      const claims = claimsNearFlag(readFileSync(file, 'utf8'))
+      return claims.map((claim) => `${path.relative(REPO_ROOT, file)}: ${claim}`)
+    })
+
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #633.

`cd39bdbf6` (2026-08-05) flipped `TUFF_DB_SEARCH_SPLIT_ENABLED` to **on**, together with the 2d.3 write-path migration that removed the half-migrated failure mode the flag guarded. Verified in `runtime-flags.ts:26`: `parseEnvBoolean('TUFF_DB_SEARCH_SPLIT_ENABLED', true)`.

## What was actually stale

**`docs/plan-prd/TODO.md:13` — the location this issue names — is already correct.** It now reads *"defaults **on** since `cd39bdbf6`"*. What is still wrong is four claims in `ROADMAP.md`, one of them under 非协商安全门禁, and one in a dated audit report.

Corrected all four ROADMAP claims to state the default, the commit and the date, and that `=0` is an emergency revert rather than the safe default.

## The dated audit report gets a note, not an edit

`maintenance-audit-2026-08-05.md` records what the audit found that day. Rewriting it would falsify the record, so it carries a dated correction and keeps the original finding. The same reasoning excludes `docs/engineering/reports/` from the guard — the reports from 07-30 through 08-04 were **true when written**.

Worth flagging separately: the reports dated **08-06, 08-07 and 08-08** repeat the same default-off finding, three days after it stopped being true. That is the audit process copying a stale finding forward, which is a different problem from this issue and not something I would fix by editing dated files.

## Verification

`split-flag-docs.test.ts`, 4 passed. It asserts the code default first — so if the flag ever goes back to `false`, that control fails before the doc rule is applied — then that no living doc paragraph mentioning the flag also claims default-off, in either language. Two further controls guard the scan itself: a plausible file count, and at least one document that actually mentions the flag.

Placed in `packages/utils` deliberately: `ci / CI - utils` is blocking, whereas `App suites (core-app)` is `continue-on-error` and reports success however the suite does — so a guard put there could not fail this.

Mutation-tested: restoring the previous ROADMAP fails the rule. ESLint clean.

Note it touches `ROADMAP.md`, as does #1319 — whichever lands second needs a re-check.