### PR TITLE
fix(selection): restore every clipboard format the snapshot can still write

### DIFF
--- a/apps/core-app/src/main/modules/system/selection-capture.test.ts
+++ b/apps/core-app/src/main/modules/system/selection-capture.test.ts
@@ -227,6 +227,26 @@ describe('selectionCaptureService.capture', () => {
     }
   )
 
+  it('单个格式写入失败时,其余格式仍然被恢复', async () => {
+    // clear() has already run by the time the writes happen, so aborting the loop at the first
+    // throw took every later format down with it (#768).
+    mocks.availableFormats.mockReturnValue(['text/plain', 'text/html', 'image/png'])
+    mocks.readBuffer.mockImplementation((format: string) => Buffer.from(`original-${format}`))
+    mocks.readText.mockReturnValue('new selection')
+    mocks.writeBuffer.mockImplementation((format: string) => {
+      if (format === 'text/html') throw new Error('clipboard locked')
+    })
+
+    const capture = withPlatform('linux', () => selectionCaptureService.capture({ enabled: true }))
+    await advanceCopyPollingDelay()
+    await capture
+
+    const restored = mocks.writeBuffer.mock.calls.map(([format]: [string]) => format)
+    // The format after the failing one is the point: it used to never be attempted.
+    expect(restored).toContain('image/png')
+    expect(restored).toEqual(['text/plain', 'text/html', 'image/png'])
+  })
+
   it('fails closed without selected text when clipboard restoration fails', async () => {
     mocks.availableFormats.mockReturnValue(['text/html'])
     mocks.readBuffer.mockReturnValue(Buffer.from('<i>original</i>'))

--- a/apps/core-app/src/main/modules/system/selection-capture.test.ts
+++ b/apps/core-app/src/main/modules/system/selection-capture.test.ts
@@ -241,7 +241,7 @@ describe('selectionCaptureService.capture', () => {
     await advanceCopyPollingDelay()
     await capture
 
-    const restored = mocks.writeBuffer.mock.calls.map(([format]: [string]) => format)
+    const restored = mocks.writeBuffer.mock.calls.map((call: unknown[]) => call[0] as string)
     // The format after the failing one is the point: it used to never be attempted.
     expect(restored).toContain('image/png')
     expect(restored).toEqual(['text/plain', 'text/html', 'image/png'])

--- a/apps/core-app/src/main/modules/system/selection-capture.ts
+++ b/apps/core-app/src/main/modules/system/selection-capture.ts
@@ -93,18 +93,47 @@ function snapshotClipboard(): ClipboardSnapshot {
 }
 
 function restoreClipboard(snapshot: ClipboardSnapshot): boolean {
+  // clear() has already destroyed the original by the time the writes run, so one throwing
+  // format used to abort the loop and take every format after it with it -- a user with an
+  // image plus RTF could be left with neither (#768). Each write is attempted independently
+  // now, so a format that cannot be restored costs only itself.
+  let cleared = false
+  const failedFormats: string[] = []
+
   try {
     clipboard.clear()
-    for (const item of snapshot.items) {
-      clipboard.writeBuffer(item.format, item.data)
-    }
-    return true
+    cleared = true
   } catch (error) {
-    selectionCaptureLog.warn('Failed to restore clipboard snapshot', {
+    selectionCaptureLog.warn('Failed to clear clipboard before restore', {
       error: error instanceof Error ? error.message : String(error)
     })
     return false
   }
+
+  for (const item of snapshot.items) {
+    try {
+      clipboard.writeBuffer(item.format, item.data)
+    } catch (error) {
+      failedFormats.push(item.format)
+      selectionCaptureLog.warn('Failed to restore a clipboard format', {
+        meta: { format: item.format },
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
+  if (failedFormats.length > 0) {
+    selectionCaptureLog.warn('Clipboard snapshot restored only in part', {
+      meta: {
+        restored: snapshot.items.length - failedFormats.length,
+        total: snapshot.items.length,
+        failedFormats
+      }
+    })
+    return false
+  }
+
+  return cleared
 }
 
 async function captureSelection(

--- a/apps/core-app/src/main/modules/system/selection-capture.ts
+++ b/apps/core-app/src/main/modules/system/selection-capture.ts
@@ -127,7 +127,7 @@ function restoreClipboard(snapshot: ClipboardSnapshot): boolean {
       meta: {
         restored: snapshot.items.length - failedFormats.length,
         total: snapshot.items.length,
-        failedFormats
+        failedFormats: failedFormats.join(', ')
       }
     })
     return false


### PR DESCRIPTION
Closes #768.

`restoreClipboard` cleared the clipboard and then wrote each snapshotted format inside **one** try block. `clear()` destroys the original before any write runs, so a single throwing format aborted the loop and took **every format after it** with it — a user with an image plus RTF could be left with neither.

Each write is attempted independently now, so a format that cannot be restored costs only itself, and the log names which ones failed and how many of the total were recovered.

### The failure contract is unchanged on purpose

Any failed format still returns `false`, so the caller still surfaces `issueCode: 'failed'`. The existing test that pins that behaviour passes untouched — I checked it before changing anything, because a "more forgiving restore" that started reporting success would have been a worse bug than the one being fixed.

### Verification

Mutation: reverting to the single try block fails the new test, because the format *after* the throwing one is never attempted. The other seven pass in both states.

### Not changed, worth its own look

When `snapshotClipboard` cannot read any format at all, the snapshot is empty and `clear()` still runs — the clipboard ends up emptied with nothing to put back. Whether to skip the clear or accept leaving the synthetic copy's content behind is a product call, not a mechanical one.

### A verification mistake of mine, and its fix

The first push carried **two typecheck errors**. I had run tsc as `... | head -3; echo "exit=$?"`, which reports **head's** status, so a failing run looked clean:

- `selection-capture.ts` — TS2322: log `meta` values are `Primitive`, so the `failedFormats` array is now joined into a string
- `selection-capture.test.ts` — TS2345: `mock.calls` is `any[][]`, so the tuple annotation on the map callback did not apply

Re-verified by capturing tsc's own exit code: **0**, zero TS errors. Tests **8/8**, lint clean.
