### PR TITLE
fix(security): close the CSP directives that fell through to default-src [#689]

### DIFF
--- a/apps/core-app/src/renderer/index.html
+++ b/apps/core-app/src/renderer/index.html
@@ -18,6 +18,12 @@
       what the renderer actually reaches at runtime (user-configured AI provider origins,
       the Vite dev server and its websocket) that a static reading cannot produce; tracked
       on the issue rather than guessed at here.
+
+      object-src, frame-src and worker-src are set because they were falling through to
+      `default-src *` while nothing uses them: the renderer contains no <object>, <embed> or
+      <iframe>, and no `new Worker`. worker-src keeps 'self' blob: rather than 'none' because a
+      dependency may create one at runtime — that still excludes remote origins, which is the
+      part that mattered (#689).
     -->
     <meta
       http-equiv="Content-Security-Policy"
@@ -30,6 +36,9 @@
     style-src * 'unsafe-inline' blob: data:;
     style-src-elem * 'unsafe-inline' blob: data:;
     media-src * blob: data: tfile:;
+    object-src 'none';
+    frame-src 'none';
+    worker-src 'self' blob:;
   "
     />
 

--- a/packages/utils/__tests__/renderer-csp.test.ts
+++ b/packages/utils/__tests__/renderer-csp.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The renderer CSP is the only barrier between injected content and `system.executeCommand` (#689).
+ *
+ * The renderer holds the contextBridge `ipcRenderer`, so anything that reaches its DOM and executes
+ * — markdown, plugin-supplied rich text, an AI response — reaches local code execution. #913
+ * already removed the wildcard and `'unsafe-inline'` from `script-src`, which was the severe half.
+ *
+ * What this pins is that they do not come back, and that the directives nothing uses stay closed
+ * rather than falling through to `default-src *`.
+ *
+ * `'unsafe-eval'` is asserted as *present* on purpose. The plugin widget runtime executes widget
+ * code through `new Function`, so removing it would delete plugin widgets rather than harden
+ * anything — a test that demanded its absence would be demanding a product change.
+ *
+ * Lives in packages/utils because `ci / CI - utils` is blocking, while `App suites (core-app)` is
+ * continue-on-error and reports success however the suite does.
+ */
+
+const INDEX_HTML = readFileSync(
+  path.resolve(__dirname, '../../../apps/core-app/src/renderer/index.html'),
+  'utf8'
+)
+
+const csp = (() => {
+  const match = /http-equiv="Content-Security-Policy"\s*\n?\s*content="([\s\S]*?)"/.exec(INDEX_HTML)
+  return (match?.[1] ?? '').replace(/\s+/g, ' ').trim()
+})()
+
+function directive(name: string): string | undefined {
+  return csp
+    .split(';')
+    .map((part) => part.trim())
+    .find((part) => part === name || part.startsWith(`${name} `))
+}
+
+describe('renderer Content-Security-Policy', () => {
+  it('is present and parsed', () => {
+    // Positive control: every assertion below passes vacuously against an empty policy, which is
+    // exactly what a changed attribute shape would produce.
+    expect(csp.length).toBeGreaterThan(80)
+    expect(directive('script-src')).toBeDefined()
+  })
+
+  it('keeps script-src free of a wildcard and of unsafe-inline', () => {
+    // The regression #913 fixed: either of these lets a javascript: URL or an inline handler that
+    // survives the markdown sanitiser run inside the privileged renderer.
+    const scriptSrc = directive('script-src')!
+
+    expect(scriptSrc).not.toMatch(/(^|\s)\*/)
+    expect(scriptSrc).not.toContain('unsafe-inline')
+    expect(scriptSrc).toContain("'self'")
+  })
+
+  it("still allows 'unsafe-eval', which the widget runtime needs", () => {
+    // Stated as a requirement rather than left implicit: widget-registry.ts runs widget code through
+    // `new Function`. Dropping this is a product change, not a hardening.
+    expect(directive('script-src')).toContain("'unsafe-eval'")
+  })
+
+  it('closes the directives nothing uses instead of letting them fall through', () => {
+    // Without these three, `default-src *` governs them — and the renderer has no <object>,
+    // <embed>, <iframe> or `new Worker` to justify that.
+    expect(directive('object-src')).toBe("object-src 'none'")
+    expect(directive('frame-src')).toBe("frame-src 'none'")
+    expect(directive('worker-src')).toBe("worker-src 'self' blob:")
+  })
+
+  it('records that default-src and connect-src are still open', () => {
+    // Not an endorsement — an acknowledgement. Narrowing connect-src needs the set of origins the
+    // renderer actually reaches, and users configure arbitrary AI provider base URLs, so it cannot
+    // be derived by reading the source. If someone does narrow it, this test should be updated
+    // rather than deleted, so the change is deliberate.
+    expect(directive('connect-src')).toContain('*')
+    expect(directive('default-src')).toContain('*')
+  })
+})


### PR DESCRIPTION
Partial fix for #689 — the severe half is already done, and I would rather say what is left than close it as if it were complete.

## Already fixed

`script-src` no longer carries a wildcard or `'unsafe-inline'`. #913 did that, and it was the part that mattered: those are what let a `javascript:` URL or an inline handler surviving the markdown sanitiser execute inside the renderer that holds the contextBridge `ipcRenderer`.

Current: `script-src 'self' 'unsafe-eval' blob: data:`.

## What this PR closes

`object-src`, `frame-src` and `worker-src` were unset, so `default-src *` governed them — while nothing in the renderer uses any of them. Verified before restricting: no `<object>`, no `<embed>`, no `<iframe>`, no `new Worker` (control: `<video>` and `<img>` *are* found by the same queries).

- `object-src 'none'`
- `frame-src 'none'`
- `worker-src 'self' blob:` — a value rather than `'none'`, because a dependency may create a worker at runtime; excluding remote origins is the point.

## What stays open, and why

`default-src *` and `connect-src *`. Narrowing `connect-src` needs the set of origins the renderer actually reaches at runtime, and **users configure arbitrary AI provider base URLs** — that set cannot be derived by reading the source, so guessing it would break user-configured providers. The issue's suggestion of `connect-src 'self'` plus known backends does not survive that.

Delivering the policy as a header via `onHeadersReceived` instead of a meta tag is also still open; that is the part that would cover worker contexts.

## One assertion that looks backwards

The test asserts `'unsafe-eval'` is **present**. The plugin widget runtime executes widget code through `new Function` in `widget-registry.ts`, so removing it deletes plugin widgets rather than hardening anything. Stating it as a requirement keeps the next person from "fixing" it.

## Verification

5 passed, mutation-tested both ways: restoring `script-src *` with `'unsafe-inline'` fails one case, and dropping `object-src` fails another. The suite carries a positive control, since an unparsed policy satisfies every assertion vacuously. ESLint clean.

Placed in `packages/utils` because `ci / CI - utils` is blocking and `App suites (core-app)` is `continue-on-error`.