### PR TITLE
fix(transport): refuse invokes from a nested frame [#692]

### DIFF
--- a/packages/utils/__tests__/transport/subframe-sender.test.ts
+++ b/packages/utils/__tests__/transport/subframe-sender.test.ts
@@ -1,0 +1,59 @@
+import type { IpcMainInvokeEvent } from 'electron'
+import { describe, expect, it } from 'vitest'
+import { isSubframeSender } from '../../transport/sdk/main-transport'
+
+/**
+ * A nested frame must not reach a privileged invoke handler (#692).
+ *
+ * Every transport event opens a global `ipcMain.handle` channel, and the handler puts `event.sender`
+ * into context without ever asking where the invoke came from. The channel-core path resolves
+ * identity through `resolvePluginRegistrationByWebContents`; the invoke path had no equivalent, so
+ * any frame that could name an event reached main directly.
+ *
+ * This closes the narrow half: a frame nested inside another document is refused. It does not
+ * establish *which* window a top-level frame belongs to — that needs a trusted-sender registry and
+ * is still open on the issue.
+ */
+
+const frame = (parent: unknown): Pick<IpcMainInvokeEvent, 'senderFrame'> =>
+  ({ senderFrame: { parent } } as unknown as Pick<IpcMainInvokeEvent, 'senderFrame'>)
+
+describe('isSubframeSender', () => {
+  it('refuses a frame that has a parent', () => {
+    expect(isSubframeSender(frame({}))).toBe(true)
+  })
+
+  it('accepts a top-level frame', () => {
+    // Positive control: a guard that refused everything would satisfy the case above and break the
+    // entire transport, which is the failure mode worth catching here.
+    expect(isSubframeSender(frame(null))).toBe(false)
+  })
+
+  it('accepts a frame that has already been destroyed', () => {
+    // senderFrame is null after the frame goes away — a race on window close, not an attack. The
+    // handler sees a dead sender anyway, so refusing here would only turn a benign race into a
+    // silently dropped call.
+    expect(isSubframeSender({ senderFrame: null } as never)).toBe(false)
+    expect(isSubframeSender({} as never)).toBe(false)
+  })
+})
+
+describe('the invoke path applies it', () => {
+  it('guards before dispatching to handlers', async () => {
+    // Asserted against the source rather than by booting Electron: the order matters, since a check
+    // placed after the handler lookup would still run the handler.
+    const { readFileSync } = await import('node:fs')
+    const path = await import('node:path')
+    const source = readFileSync(
+      path.resolve(__dirname, '../../transport/sdk/main-transport.ts'),
+      'utf8'
+    )
+
+    const guard = source.indexOf('if (isSubframeSender(event))')
+    const lookup = source.indexOf('const active = invokeHandlers.get(eventName)')
+
+    expect(guard).toBeGreaterThan(-1)
+    expect(lookup).toBeGreaterThan(-1)
+    expect(guard).toBeLessThan(lookup)
+  })
+})

--- a/packages/utils/transport/sdk/main-transport.ts
+++ b/packages/utils/transport/sdk/main-transport.ts
@@ -96,6 +96,18 @@ type LocalHandler = (
 ) => unknown | Promise<unknown>;
 const localHandlers = new Map<string, Set<LocalHandler>>();
 
+/**
+ * Whether an invoke arrived from a frame nested inside another document.
+ *
+ * `senderFrame` is null once the frame has been destroyed — a race on window close rather than an
+ * attack — so that case is left to the handler, which sees a dead sender anyway. Only a frame that
+ * has a parent is refused.
+ */
+export function isSubframeSender(event: Pick<IpcMainInvokeEvent, 'senderFrame'>): boolean {
+  const frame = event.senderFrame;
+  return Boolean(frame && frame.parent);
+}
+
 function registerInvokeHandler<TReq, TRes>(
   eventName: string,
   handler: InvokeHandler<TReq, TRes>,
@@ -106,6 +118,19 @@ function registerInvokeHandler<TReq, TRes>(
     invokeHandlers.set(eventName, handlers);
 
     ipcMain.handle(eventName, async (event, payload) => {
+      // Subframes cannot invoke. Every transport event opens a global ipcMain.handle channel, so a
+      // frame that can name one reaches a privileged main-process handler directly, skipping the
+      // identity resolution the channel-core path performs (#692). Nothing legitimate invokes from
+      // a subframe: the renderer has no <iframe>, and plugin surfaces are separate WebContents
+      // whose own main frame is top-level. So this costs nothing today and closes the case where a
+      // plugin surface later embeds remote content.
+      //
+      // Not a full answer to #692 — it does not establish *which* window a top-level frame belongs
+      // to. That needs a trusted-sender registry, tracked on the issue.
+      if (isSubframeSender(event)) {
+        return undefined;
+      }
+
       const active = invokeHandlers.get(eventName);
       if (!active || active.size === 0) {
         return undefined;


### PR DESCRIPTION
Partial fix for #692 — deliberately narrow, and I would rather say what it does not cover than close the issue.

## Confirmed

`event.senderFrame` is validated nowhere. Control for that absence: `event.sender` *is* used twice in the same file, so the query does find what exists. The channel-core path resolves identity via `resolvePluginRegistrationByWebContents`; the invoke path had no equivalent constraint.

## What this closes

A frame with a parent cannot invoke. Nothing legitimate does: the renderer contains no `<iframe>` (verified, with `<video>`/`<img>` as a control), and plugin surfaces are separate `WebContents` whose own main frame is top-level. So the guard costs nothing today and closes the case where a plugin surface later embeds remote content.

A **destroyed** frame (`senderFrame === null`) is not refused. That is a race on window close, not an attack, and the handler sees a dead sender regardless — refusing there would convert a benign race into a silently dropped call. There is a test for that specifically.

## What it does not close

It does not establish *which* window a top-level frame belongs to. Any top-level `WebContents` in the process can still invoke, which is the larger half of the issue and needs a trusted-sender registry — main window, CoreBox windows, and plugin surfaces each with a declared capability set. That is a design change, not a check, so it stays open.

## Verification

`packages/utils`: **148 files, 1143 passed**. The new suite covers the subframe case, the top-level case (positive control — a guard that refused everything would satisfy the first assertion and break the entire transport), and both destroyed-frame shapes. One test asserts the guard runs **before** the handler lookup, since a check placed after it would still run the handler.

`typecheck:node` = 6, unchanged. ESLint clean.