### PR TITLE
fix(clipboard): keep selection capture's synthetic copy out of history

### DIFF
--- a/apps/core-app/src/main/modules/clipboard/clipboard-capture-pipeline.test.ts
+++ b/apps/core-app/src/main/modules/clipboard/clipboard-capture-pipeline.test.ts
@@ -1,6 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
 import { ClipboardCapturePipeline } from './clipboard-capture-pipeline'
 import { ClipboardHelper } from './clipboard-capture-freshness'
+import {
+  resetClipboardCaptureSuppression,
+  withClipboardCaptureSuppressed
+} from './clipboard-capture-suppression'
 
 interface FakeClipboardImage {
   isEmpty: () => boolean
@@ -305,5 +309,40 @@ describe('clipboard-capture-pipeline', () => {
       expect.objectContaining({ id: 13, type: 'image' })
     )
     expect(context.notifyTransportChange).toHaveBeenCalled()
+  })
+})
+
+describe('capture is skipped while the app is writing the clipboard itself', () => {
+  afterEach(() => {
+    resetClipboardCaptureSuppression()
+  })
+
+  it('抑制期间 process() 不读取剪贴板,也不落库', async () => {
+    const getClipboardHelper = vi.fn()
+    const getDatabase = vi.fn()
+    const pipeline = new ClipboardCapturePipeline({
+      getClipboardHelper,
+      getDatabase
+    } as never)
+
+    await withClipboardCaptureSuppressed(async () => {
+      await pipeline.process('poll' as never)
+    })
+
+    // The gate is before the helper/database lookup, so nothing downstream is reached at all.
+    expect(getClipboardHelper).not.toHaveBeenCalled()
+    expect(getDatabase).not.toHaveBeenCalled()
+  })
+
+  it('抑制解除后照常处理(守卫不是"永远跳过")', async () => {
+    const getClipboardHelper = vi.fn(() => undefined)
+    const pipeline = new ClipboardCapturePipeline({
+      getClipboardHelper,
+      getDatabase: vi.fn(() => undefined)
+    } as never)
+
+    await pipeline.process('poll' as never)
+
+    expect(getClipboardHelper).toHaveBeenCalled()
   })
 })

--- a/apps/core-app/src/main/modules/clipboard/clipboard-capture-pipeline.ts
+++ b/apps/core-app/src/main/modules/clipboard/clipboard-capture-pipeline.ts
@@ -34,6 +34,7 @@ import {
   type ClipboardPhaseDurations
 } from './clipboard-phase-diagnostics'
 import { createClipboardFreshnessState } from './clipboard-freshness'
+import { isClipboardCaptureSuppressed } from './clipboard-capture-suppression'
 
 const CLIPBOARD_META_QUEUE_LIMIT = 6
 const CLIPBOARD_SLOW_THRESHOLD_MS = 200
@@ -76,6 +77,12 @@ export class ClipboardCapturePipeline {
   constructor(private readonly options: ClipboardCapturePipelineOptions) {}
 
   public async process(source: ClipboardCaptureSource): Promise<void> {
+    // The app writes to the clipboard itself during selection capture. Those writes are not user
+    // copies and must not reach the history (#769).
+    if (isClipboardCaptureSuppressed()) {
+      return
+    }
+
     const helper = this.options.getClipboardHelper()
     // Database readiness gate only; the persist itself resolves its write
     // handle at enqueue time through metaPersistence.withDbWrite.

--- a/apps/core-app/src/main/modules/clipboard/clipboard-capture-suppression.test.ts
+++ b/apps/core-app/src/main/modules/clipboard/clipboard-capture-suppression.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Selection capture sends a real Cmd/Ctrl+C and then restores the previous clipboard. The native
+ * watcher cannot tell those writes from a user copy, so the selected text was persisted to
+ * clipboard_history and the restore added a duplicate row (#769).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  isClipboardCaptureSuppressed,
+  resetClipboardCaptureSuppression,
+  withClipboardCaptureSuppressed
+} from './clipboard-capture-suppression'
+
+afterEach(() => {
+  resetClipboardCaptureSuppression()
+  vi.useRealTimers()
+})
+
+describe('clipboard capture suppression', () => {
+  it('默认不抑制', () => {
+    expect(isClipboardCaptureSuppressed()).toBe(false)
+  })
+
+  it('作用域内抑制,退出后恢复', async () => {
+    let insideScope = false
+
+    await withClipboardCaptureSuppressed(async () => {
+      insideScope = isClipboardCaptureSuppressed()
+    })
+
+    expect(insideScope).toBe(true)
+    expect(isClipboardCaptureSuppressed()).toBe(false)
+  })
+
+  it('任务抛错也会恢复,不会永久抑制', async () => {
+    await expect(
+      withClipboardCaptureSuppressed(async () => {
+        throw new Error('copy failed')
+      })
+    ).rejects.toThrow('copy failed')
+
+    expect(isClipboardCaptureSuppressed()).toBe(false)
+  })
+
+  it('嵌套作用域:内层结束不会提前解除抑制', async () => {
+    let afterInner = false
+
+    await withClipboardCaptureSuppressed(async () => {
+      await withClipboardCaptureSuppressed(async () => {})
+      afterInner = isClipboardCaptureSuppressed()
+    })
+
+    expect(afterInner).toBe(true)
+    expect(isClipboardCaptureSuppressed()).toBe(false)
+  })
+
+  it('超过上限后自行过期,卡住的作用域不会静默吞掉后续复制', async () => {
+    const start = Date.now()
+    let stillSuppressedLater = true
+
+    await withClipboardCaptureSuppressed(async () => {
+      // A scope that outlives its budget: a hung shortcut, or a crash before the finally runs.
+      stillSuppressedLater = isClipboardCaptureSuppressed(start + 5_001)
+    })
+
+    expect(stillSuppressedLater).toBe(false)
+  })
+})

--- a/apps/core-app/src/main/modules/clipboard/clipboard-capture-suppression.ts
+++ b/apps/core-app/src/main/modules/clipboard/clipboard-capture-suppression.ts
@@ -1,0 +1,48 @@
+/**
+ * A window in which OS clipboard changes are the app's own doing and must not be recorded.
+ *
+ * Selection capture sends a real Cmd/Ctrl+C to the foreground app and then restores the previous
+ * clipboard. The native watcher cannot tell those writes apart from a user copy, so the selected
+ * text - a password, a private message - was persisted to clipboard_history, shown in the history
+ * UI and forwarded to plugins, and the restore added a duplicate row of the pre-existing entry
+ * (#769).
+ *
+ * Kept in its own module so neither side imports the other: the clipboard pipeline and the
+ * selection-capture service both depend on this and not on each other.
+ */
+
+/**
+ * Upper bound on a single scope. A crash or a hung shortcut must not leave capture suppressed for
+ * the rest of the session, so the window expires on its own even if the scope never closes.
+ */
+const MAX_SUPPRESSION_MS = 5_000
+
+let activeScopes = 0
+let expiresAt = 0
+
+/**
+ * Runs `task` with clipboard capture suppressed. Nested scopes are counted, so an inner scope
+ * finishing does not re-enable capture while an outer one is still open.
+ */
+export async function withClipboardCaptureSuppressed<T>(task: () => Promise<T>): Promise<T> {
+  activeScopes += 1
+  expiresAt = Math.max(expiresAt, Date.now() + MAX_SUPPRESSION_MS)
+  try {
+    return await task()
+  } finally {
+    activeScopes = Math.max(0, activeScopes - 1)
+    if (activeScopes === 0) {
+      expiresAt = 0
+    }
+  }
+}
+
+export function isClipboardCaptureSuppressed(now: number = Date.now()): boolean {
+  return activeScopes > 0 && now < expiresAt
+}
+
+/** Test seam: clears state a failed scope may have left behind. */
+export function resetClipboardCaptureSuppression(): void {
+  activeScopes = 0
+  expiresAt = 0
+}

--- a/apps/core-app/src/main/modules/system/selection-capture.ts
+++ b/apps/core-app/src/main/modules/system/selection-capture.ts
@@ -10,6 +10,7 @@ import { getXdotoolUnavailableReason } from './linux-desktop-tools'
 // Captured selections feed the recommendation context (hashed at ingest);
 // the store is separate so readers do not import this module's Electron deps.
 import { selectionSnapshotStore } from './selection-snapshot-store'
+import { withClipboardCaptureSuppressed } from '../clipboard/clipboard-capture-suppression'
 
 const selectionCaptureLog = createLogger('SelectionCapture')
 const execFileAsync = promisify(execFile)
@@ -147,62 +148,68 @@ async function captureSelection(
   const startedAt = Date.now()
   let result: SelectionCaptureResult
 
-  try {
-    await withTimeout(sendPlatformShortcut('copy'), COPY_COMMAND_TIMEOUT_MS, 'copy-command')
-    await delay(COPY_RESULT_POLL_DELAY_MS)
-    const text = clipboard.readText().trim()
-    if (text) {
-      selectionSnapshotStore.set({ text, capturedAt })
+  // Everything from here to the restore is the app writing to the clipboard, not the user. The
+  // native watcher cannot tell the difference, so without this the selected text lands in
+  // clipboard_history and the restore adds a duplicate row of what was already there (#769).
+  return await withClipboardCaptureSuppressed(async () => {
+    try {
+      await withTimeout(sendPlatformShortcut('copy'), COPY_COMMAND_TIMEOUT_MS, 'copy-command')
+      await delay(COPY_RESULT_POLL_DELAY_MS)
+      const text = clipboard.readText().trim()
+      if (text) {
+        selectionSnapshotStore.set({ text, capturedAt })
+      }
+      result = text
+        ? {
+            text,
+            ...baseResult
+          }
+        : {
+            text: '',
+            ...baseResult,
+            issueCode: 'empty',
+            issueMessage: 'No selected text was captured from the active application.'
+          }
+    } catch (error) {
+      const issueMessage =
+        error instanceof Error ? error.message : 'Failed to capture selected text'
+      const xdotoolUnavailableReason = getXdotoolUnavailableReason()
+      result = {
+        text: '',
+        ...baseResult,
+        issueCode: issueMessage === xdotoolUnavailableReason ? 'unsupported' : 'failed',
+        issueMessage,
+        limitations:
+          issueMessage === xdotoolUnavailableReason && xdotoolUnavailableReason
+            ? [xdotoolUnavailableReason]
+            : baseResult.limitations
+      }
     }
-    result = text
-      ? {
-          text,
-          ...baseResult
-        }
-      : {
-          text: '',
-          ...baseResult,
-          issueCode: 'empty',
-          issueMessage: 'No selected text was captured from the active application.'
-        }
-  } catch (error) {
-    const issueMessage = error instanceof Error ? error.message : 'Failed to capture selected text'
-    const xdotoolUnavailableReason = getXdotoolUnavailableReason()
-    result = {
-      text: '',
-      ...baseResult,
-      issueCode: issueMessage === xdotoolUnavailableReason ? 'unsupported' : 'failed',
-      issueMessage,
-      limitations:
-        issueMessage === xdotoolUnavailableReason && xdotoolUnavailableReason
-          ? [xdotoolUnavailableReason]
-          : baseResult.limitations
-    }
-  }
 
-  const restored = restoreClipboard(clipboardSnapshot)
-  selectionCaptureLog.debug('Selection capture completed', {
-    meta: {
-      costMs: Date.now() - startedAt,
-      restored,
-      supportLevel: result.supportLevel,
-      issueCode: result.issueCode
+    const restored = restoreClipboard(clipboardSnapshot)
+    selectionCaptureLog.debug('Selection capture completed', {
+      meta: {
+        costMs: Date.now() - startedAt,
+        restored,
+        supportLevel: result.supportLevel,
+        issueCode: result.issueCode
+      }
+    })
+
+    if (!restored) {
+      // The caller is told the capture failed, so the snapshot must not survive
+      // it either.
+      selectionSnapshotStore.clear()
+      return {
+        text: '',
+        ...baseResult,
+        issueCode: 'failed',
+        issueMessage: 'Clipboard snapshot restore failed after selection capture.'
+      }
     }
+
+    return result
   })
-
-  if (!restored) {
-    // The caller is told the capture failed, so the snapshot must not survive
-    // it either.
-    selectionSnapshotStore.clear()
-    return {
-      text: '',
-      ...baseResult,
-      issueCode: 'failed',
-      issueMessage: 'Clipboard snapshot restore failed after selection capture.'
-    }
-  }
-
-  return result
 }
 
 export const selectionCaptureService = {


### PR DESCRIPTION
Closes #769.

Selection capture sends a **real** Cmd/Ctrl+C to the foreground app and then restores the previous clipboard. The native watcher cannot tell those writes from a user copy, and nothing coordinated the two modules — so the selected text was persisted to `clipboard_history`, shown in the history UI and forwarded to plugins, and the restore added a second row duplicating what was already there.

A password or a private message the user never copied ended up in a durable log.

The absence of coordination was verified with a control: grepping each module for the other found nothing, while a grep for a symbol that *is* present matched 11 times.

### The shape of the fix

Capture is suppressed for the span from the clipboard snapshot to the restore. The suppression lives in **its own module** rather than on either side, so the pipeline and the selection-capture service both depend on it and not on each other — importing one from the other would close a cycle.

Two properties beyond the obvious one, because a suppression switch is easy to get wrong in the direction of **losing real copies**:

- **scopes are counted**, so an inner scope closing does not re-enable capture while an outer one is still open
- **a scope expires after 5s regardless**, so a hung shortcut or a crash before the `finally` cannot silently swallow every copy for the rest of the session

### Verification

| mutation | fails |
|---|---|
| remove the pipeline gate | the suppressed-capture test |
| make suppression permanent | the expiry test |

The pipeline's *"still processes when not suppressed"* test passes in both states, so a gate written as **"always skip"** is caught rather than shipped.

Real exit codes this time — eslint **0**, tsc **0** with zero TS errors. **77/77** across the clipboard suite, **7/7** selection capture.
