### PR TITLE
fix(active-app): bound the macOS osascript lookup

### DIFF
--- a/apps/core-app/src/main/modules/system/active-app.test.ts
+++ b/apps/core-app/src/main/modules/system/active-app.test.ts
@@ -306,6 +306,44 @@ ConvertTo-Json -Compress`),
     })
   })
 
+  it('macOS osascript 带超时,卡住的调用不会永久占住 in-flight 去重', async () => {
+    // AppleScript's frontmost-process query blocks while the foreground app is beachballing or a
+    // TCC prompt is up. Without a timeout the promise never settles, macosResolveInFlight is
+    // never cleared, and every later lookup returns that same pending promise (#770).
+    withOSAdapterMock.mockImplementation(
+      async (options: Record<string, () => Promise<unknown>>) => {
+        return await options.darwin()
+      }
+    )
+
+    // Captured, not asserted inside the mock: the production code catches command failures, so
+    // an expect() that throws in there is swallowed and the test passes on the bug.
+    let observedOptions: { timeout?: number } | undefined
+    execFilePromiseMock.mockImplementationOnce(
+      async (_file: string, _args: string[], opts?: { timeout?: number }) => {
+        observedOptions = opts
+        throw Object.assign(new Error('osascript timed out'), { killed: true, signal: 'SIGTERM' })
+      }
+    )
+
+    await expect(
+      activeAppService.getActiveApp({ forceRefresh: true, includeIcon: false })
+    ).resolves.toBeNull()
+
+    // A hung osascript can only be escaped by a timeout, so the option itself is the contract.
+    expect(observedOptions?.timeout).toBeGreaterThan(0)
+
+    // A second lookup must actually run again rather than await the first, dead promise.
+    execFilePromiseMock.mockImplementationOnce(async () => ({
+      stdout: 'Safari||com.apple.Safari||321||Start Page\n',
+      stderr: ''
+    }))
+
+    await expect(
+      activeAppService.getActiveApp({ forceRefresh: true, includeIcon: false })
+    ).resolves.toMatchObject({ displayName: 'Safari', processId: 321 })
+  })
+
   it('returns null when platform command output is malformed', async () => {
     withOSAdapterMock.mockImplementation(
       async (options: Record<string, () => Promise<unknown>>) => {

--- a/apps/core-app/src/main/modules/system/active-app.ts
+++ b/apps/core-app/src/main/modules/system/active-app.ts
@@ -226,7 +226,14 @@ tell application "System Events"
   return appName & "||" & appID & "||" & (appPID as text) & "||" & winTitle
 end tell`
 
-      const { stdout } = await execFileAsync('osascript', ['-e', script])
+      // The only command in this file that used to run unbounded. AppleScript's
+      // 'first application process whose frontmost is true' blocks while the frontmost app is
+      // beachballing or a TCC prompt is up, and resolveActiveWindowMacOS dedupes callers onto
+      // macosResolveInFlight - so one hung call left that field set for the rest of the session
+      // and every later lookup returned the same promise that never settles (#770).
+      const { stdout } = await execFileAsync('osascript', ['-e', script], {
+        timeout: ACTIVE_APP_COMMAND_TIMEOUT_MS
+      })
       const parts = stdout.trim().split('||')
       const appName = parts[0] ?? ''
       const bundleId = parts[1] || null


### PR DESCRIPTION
Closes #770.

The macOS `osascript` call was the **only** command in the file running unbounded — the Windows PowerShell call, three `xdotool` calls and the `ps` call all pass `ACTIVE_APP_COMMAND_TIMEOUT_MS`.

AppleScript's *"first application process whose frontmost is true"* blocks while the frontmost app is beachballing or a TCC prompt is up. `resolveActiveWindowMacOS` dedupes callers onto `macosResolveInFlight`, so a single hung call left that field set and **every later lookup returned the same promise that never settles** — active-app resolution, and anything downstream of it such as clipboard source attribution, stayed dead for the rest of the session.

All six `execFileAsync` calls in the file are now bounded.

### The test asserts the option, not elapsed time

A hung child can only be escaped by a timeout, so the option itself is the contract. The test also checks that a **second** lookup runs again rather than awaiting the first, dead promise.

### A test that passed against the bug, and how it was caught

My first version asserted inside the mock:

```ts
execFilePromiseMock.mockImplementationOnce(async (_f, _a, opts) => {
  expect(opts?.timeout).toBeGreaterThan(0)   // ← swallowed
  throw ...
})
```

The production code catches command failures, so the `expect()` that throws in there was treated as a failed command and the test **passed with the timeout removed**. The mutation is what exposed it. The options are captured and asserted outside the mock now, and dropping the timeout fails the test.

eslint **0**, tsc **0** with zero TS errors, **11/11**.
