### PR TITLE
fix(security): stop accepting a self-declared plugin identity [#698]

### DIFF
--- a/apps/core-app/src/main/core/channel-caller-identity.test.ts
+++ b/apps/core-app/src/main/core/channel-caller-identity.test.ts
@@ -63,7 +63,16 @@ describe('resolveChannelCallerIdentity', () => {
     expect(result.pluginIdentity).toBeUndefined()
   })
 
-  it('routes an unregistered valid-key holder as unverified plugin', () => {
+  it('gives an unregistered sender no plugin name, however valid its key', () => {
+    // Previously this returned { pluginName: 'plugin-a' } and was called "unverified plugin" —
+    // pluginIdentity stayed empty, so main-transport's strict check still rejected. But the name
+    // alone routes the message onto the PLUGIN channel and lands in `data.plugin`, which is what
+    // storage namespacing, quota accounting and permission lookups read. "Unverified" was the
+    // wrong frame: a name nobody can verify is an impersonation, not a weaker credential (#698).
+    //
+    // Nothing legitimate lands here. Both production registration sites register the webContents
+    // immediately after creating it and before loading content, so a real plugin surface is never
+    // unregistered while it can still send.
     const result = resolveChannelCallerIdentity({
       senderId: 74,
       senderDestroyed: false,
@@ -71,7 +80,19 @@ describe('resolveChannelCallerIdentity', () => {
       resolveIdentity: () => activation(2)
     })
 
-    expect(result).toEqual({ pluginName: 'plugin-a' })
+    expect(result).toEqual({})
+  })
+
+  it('still refuses an unregistered sender whose key resolves to nothing', () => {
+    // Control for the case above: it must fail closed for the same reason, not for a different one.
+    const result = resolveChannelCallerIdentity({
+      senderId: 76,
+      senderDestroyed: false,
+      declaredKey: 'unknown-key',
+      resolveIdentity: () => undefined
+    })
+
+    expect(result).toEqual({})
   })
 
   it('does not let a stolen key replace the registered plugin identity', () => {

--- a/apps/core-app/src/main/core/channel-caller-identity.ts
+++ b/apps/core-app/src/main/core/channel-caller-identity.ts
@@ -45,9 +45,15 @@ export function resolveChannelCallerIdentity(
     return { pluginName: registration.name, pluginIdentity: current }
   }
 
-  if (!input.declaredKey) {
-    return {}
-  }
-  const declaredIdentity = input.resolveIdentity(input.declaredKey)
-  return declaredIdentity ? { pluginName: declaredIdentity.name } : {}
+  // No registration means no plugin identity, whatever the message claims. The key travelling in
+  // the payload used to be accepted here as an identity source, so any webContents holding a plugin
+  // key impersonated that plugin on the PLUGIN channel — pluginIdentity stayed empty, so the strict
+  // check in main-transport rejected, but every handler reading only `data.plugin` was fooled:
+  // storage namespacing, quota accounting, permission lookups (#698).
+  //
+  // Safe to drop because both production registration sites — plugin-view-controller and
+  // plugin-window-transport-service — register the webContents immediately after creating it and
+  // before loading any content, so a real plugin surface is never unregistered while it can send.
+  // declaredKey survives above purely as a consistency check that rejects on mismatch.
+  return {}
 }


### PR DESCRIPTION
Closes #698. Takes the suggested direction exactly: identity comes only from the registry, and `declaredKey` is a consistency check that rejects on mismatch — never an identity source.

## The framing was the bug

The fallback left `pluginIdentity` empty, so `main-transport`'s strict check still rejected, and the existing test called the result an *"unverified plugin"*. But the **name alone** routes the message onto the PLUGIN channel (`channel-core.ts:227`) and lands in `data.plugin`, which is what storage namespacing, quota accounting and permission lookups read. A name nobody can verify is an impersonation, not a weaker credential.

That test asserted the old behaviour, so it is updated rather than deleted — with the reasoning written down, and a companion control that an unresolvable key fails closed for the *same* reason rather than a different one.

## Checked the callers before removing it

The question that decides whether this is safe is whether any legitimate sender can be unregistered while it can still send. Both production registration sites say no:

- `plugin-view-controller.ts:275` — registers immediately after `new WebContentsView`, before `addChildView` and before any navigation.
- `plugin-window-transport-service.ts:135` — registers immediately after taking `win.window.webContents`, before `loadFile`.

Both unregister only on `destroyed`. So there is no window in which a real plugin surface sends without a registration.

## Verification

`channel-caller-identity.test.ts`: 8 passed, including the five existing fail-closed cases which are untouched. Mutation-tested — restoring the fallback fails the new case. `typecheck:node` = 6, unchanged. ESLint clean.