### PR TITLE
ci: run the quality workflow on the default branch, not only on PRs [#723]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,19 @@ name: CI
 
 on:
   pull_request:
+  # Also on the default branch. Two PRs that each pass independently can break typecheck or a test
+  # in combination — a semantic conflict PR-level CI cannot see — and with no run on the merge
+  # commit the branch stays broken until the next PR, whose failure then looks like its own (#723).
+  push:
+    branches:
+      - main
+      - master
 
 permissions:
   contents: read
 
 concurrency:
+  # github.ref for a push, so a master run is not cancelled by an unrelated PR and vice versa.
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
@@ -16,10 +24,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
-      release_acceptance: ${{ steps.filter_not_allowed.outputs.release_acceptance }}
-      nexus: ${{ steps.filter_not_allowed.outputs.nexus }}
+      # On a push there is no filtering: the default branch gets the full run, which is the point of
+      # validating it at all. paths-filter is also PR-shaped here — it resolves the base through the
+      # API and this job has no checkout, so it cannot diff a push (#723).
+      release_acceptance: ${{ github.event_name == 'push' && 'true' || steps.filter_not_allowed.outputs.release_acceptance }}
+      nexus: ${{ github.event_name == 'push' && 'true' || steps.filter_not_allowed.outputs.nexus }}
     steps:
       - name: Check Not Allowed File Changes
+        if: ${{ github.event_name == 'pull_request' }}
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter_not_allowed
         with:
@@ -37,8 +49,9 @@ jobs:
               - 'packages/tuffex/**'
               - '.github/workflows/ci.yml'
 
+      # A contribution policy, so it only makes sense on the incoming change, not on the branch.
       - name: Fail on foreign lockfile changes
-        if: ${{ steps.filter_not_allowed.outputs.change == 'true' }}
+        if: ${{ github.event_name == 'pull_request' && steps.filter_not_allowed.outputs.change == 'true' }}
         run: |
           echo "Foreign lockfile changes are not accepted in this PR workflow:"
           echo '${{ steps.filter_not_allowed.outputs.change_files }}'

--- a/packages/utils/__tests__/ci-default-branch.test.ts
+++ b/packages/utils/__tests__/ci-default-branch.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The default branch must be validated, not only incoming PRs (#723).
+ *
+ * `ci.yml` carries lint, typecheck, the app suites and the integration suite, and was wired to
+ * `pull_request` alone. Two PRs that each pass independently can break typecheck or a test in
+ * combination — a semantic conflict no PR-level run can see — and with nothing running on the merge
+ * commit the branch stays broken until the next PR, whose failure then reads as its own fault.
+ *
+ * The subtlety this pins is the one that would have made the fix worse than the gap: `job1` uses
+ * `dorny/paths-filter`, which resolves the base through the PR API and has no checkout here, so it
+ * cannot diff a push. Every other job `needs: job1`. Adding the trigger without gating that step
+ * would have left the default branch permanently red instead of unvalidated.
+ */
+
+const WORKFLOW = readFileSync(
+  path.resolve(__dirname, '../../../.github/workflows/ci.yml'),
+  'utf8'
+)
+
+describe('ci.yml triggers', () => {
+  it('is the workflow that carries the quality gates', () => {
+    // Positive control: every assertion below would pass against some other file that happened to
+    // have a push trigger.
+    expect(WORKFLOW).toContain('name: CI')
+    for (const job of ['PR Quality', 'Typecheck (workspace)', 'App suites']) {
+      expect(WORKFLOW).toContain(job)
+    }
+  })
+
+  it('runs on pull requests and on the default branch', () => {
+    expect(WORKFLOW).toMatch(/^on:\n\s+pull_request:/m)
+    expect(WORKFLOW).toMatch(/^ {2}push:\n {4}branches:\n {6}- main\n {6}- master$/m)
+  })
+})
+
+describe('the paths filter stays pull-request shaped', () => {
+  it('does not run on a push', () => {
+    // paths-filter cannot diff a push without a checkout, and job1 has none. Left ungated it fails,
+    // and everything downstream needs: job1.
+    const step = /id: filter_not_allowed[\s\S]{0,200}/.exec(WORKFLOW)?.[0] ?? ''
+    const before = WORKFLOW.slice(0, WORKFLOW.indexOf('id: filter_not_allowed'))
+
+    expect(step).not.toBe('')
+    expect(before).toMatch(/if: \$\{\{ github\.event_name == 'pull_request' \}\}\s*\n\s*uses: dorny\/paths-filter/)
+  })
+
+  it('gives the downstream gates a full run on a push instead of an empty one', () => {
+    // The outputs feed `if:` conditions on the nexus and release-acceptance jobs. Unset, they are
+    // empty strings and those jobs silently skip — which would validate the default branch less
+    // than a PR, the opposite of the point.
+    for (const output of ['release_acceptance', 'nexus']) {
+      expect(WORKFLOW).toMatch(
+        new RegExp(`${output}: \\$\\{\\{ github\\.event_name == 'push' && 'true' \\|\\|`)
+      )
+    }
+  })
+
+  it('keeps the foreign-lockfile check on pull requests only', () => {
+    // A contribution policy. Running it against the branch itself would fail every push that ever
+    // touched one of those files.
+    expect(WORKFLOW).toMatch(
+      /if: \$\{\{ github\.event_name == 'pull_request' && steps\.filter_not_allowed\.outputs\.change == 'true' \}\}/
+    )
+  })
+})


### PR DESCRIPTION
Closes #723.

Confirmed: `ci.yml` is `on: pull_request:` only. It carries `PR Quality`, `Typecheck (workspace)`, both `App suites` and the `Integration suite`, so nothing validates the branch after a merge.

## The part that makes this more than a two-line change

`job1` uses `dorny/paths-filter`, which resolves its base through the **pull-request API** — and this job has no `actions/checkout`, so it cannot diff a push. Every other job in the file is `needs: job1`.

Adding the trigger alone would therefore have left the default branch **permanently red** rather than merely unvalidated, which is worse than the gap being fixed. So:

- the filter step is gated to `pull_request`;
- its two outputs default to `'true'` on a push, so the default branch gets the **full** run including the nexus and release-acceptance gates, rather than skipping them on empty strings;
- the foreign-lockfile check stays PR-only — it is a contribution policy, and running it against the branch would fail every push that ever touched one of those files.

The `concurrency` group already falls back to `github.ref`, which is correct for a push; that is now stated rather than accidental.

## Verification

`ci-default-branch.test.ts`, 5 passed, in `packages/utils` so `ci / CI - utils` actually enforces it. It pins the trigger, that the filter step is PR-gated, that the outputs default to a full run, and that the lockfile check stays PR-only — each being a way the fix could regress into "the branch is red" or "the branch runs less than a PR".

Mutation-tested: restoring the previous `ci.yml` fails 4 of the 5; the survivor is the positive control that this is the file carrying the gates at all. ESLint clean.