### PR TITLE
fix(selection): bound the macOS direct-selection probe

### DIFF
--- a/apps/core-app/src/main/modules/system/selection-capture.test.ts
+++ b/apps/core-app/src/main/modules/system/selection-capture.test.ts
@@ -104,7 +104,19 @@ describe('selectionCaptureService.capture', () => {
       limitations: ['Direct AX selection is available.'],
       capturedAt: CAPTURED_AT
     })
-    expect(mocks.execFileAsync).toHaveBeenCalledWith('osascript', expect.any(Array))
+    // The probe must be bounded: the frontmost app answers Apple events on its main thread, so a
+    // beachball or a TCC sheet blocks it and captureSelection() never returns (#771).
+    expect(mocks.execFileAsync).toHaveBeenCalledWith(
+      'osascript',
+      expect.any(Array),
+      expect.objectContaining({ timeout: expect.any(Number) })
+    )
+    const [, , probeOptions] = mocks.execFileAsync.mock.calls[0] as [
+      string,
+      string[],
+      { timeout?: number }
+    ]
+    expect(probeOptions.timeout).toBeGreaterThan(0)
     expect(mocks.sendPlatformShortcut).not.toHaveBeenCalled()
     expect(mocks.availableFormats).not.toHaveBeenCalled()
   })

--- a/apps/core-app/src/main/modules/system/selection-capture.ts
+++ b/apps/core-app/src/main/modules/system/selection-capture.ts
@@ -15,6 +15,16 @@ const selectionCaptureLog = createLogger('SelectionCapture')
 const execFileAsync = promisify(execFile)
 const COPY_COMMAND_TIMEOUT_MS = 900
 const COPY_RESULT_POLL_DELAY_MS = 120
+/**
+ * Bound on the direct-selection AppleScript probe.
+ *
+ * The frontmost app answers Apple events on its main thread, so a beachball or an open TCC
+ * consent sheet blocks the query indefinitely. Without this the probe hung captureSelection()
+ * itself, and the transport handler awaiting it never replied - the caller saw a request that
+ * never returned instead of the 'failed' result this function is built to produce (#771).
+ * Matched to the copy shortcut's budget: both are "ask the foreground app something".
+ */
+const DIRECT_SELECTION_PROBE_TIMEOUT_MS = 900
 
 interface ClipboardSnapshot {
   items: Array<{
@@ -67,7 +77,9 @@ async function captureMacSelectionTextDirectly(): Promise<string | null> {
       '  end tell',
       'end tell'
     ].join('\n')
-    const { stdout } = await execFileAsync('osascript', ['-e', script])
+    const { stdout } = await execFileAsync('osascript', ['-e', script], {
+      timeout: DIRECT_SELECTION_PROBE_TIMEOUT_MS
+    })
     const selectedText = typeof stdout === 'string' ? stdout.trim() : ''
     return selectedText || null
   } catch {


### PR DESCRIPTION
Closes #771.

`captureMacSelectionTextDirectly` ran `osascript` unbounded while the **very next step of the same function** wraps the copy shortcut in `withTimeout`. The module's intent that every step be bounded was already explicit; this one call just missed it.

The frontmost app answers Apple events on its main thread, so a beachball or an open TCC consent sheet blocks the probe. `captureSelection` then never resolved and the transport handler awaiting it never replied — the caller saw a request that **hangs** rather than the `failed` / `unsupported` result the function is built to return.

900ms matches the copy shortcut's budget: both are the same kind of operation — ask the foreground app something and expect an answer.

### The contract went into the assertion that already covered this path

Rather than adding a new test. That assertion was:

```ts
expect(mocks.execFileAsync).toHaveBeenCalledWith('osascript', expect.any(Array))
```

which matches the call **exactly**, so adding the options argument broke it — a useful signal that the existing test was the right place. It now requires a positive numeric timeout, and removing the option fails it.

Same defect as #770 in `active-app.ts`, fixed separately because the files and the constants differ.

eslint **0**, tsc **0** with zero TS errors, **7/7**.
