### PR TITLE
fix(mcp): do not cache a session whose transport closed during connect

### DIFF
--- a/apps/core-app/src/main/modules/ai/intelligence-mcp-registry.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-mcp-registry.test.ts
@@ -145,6 +145,32 @@ describe('IntelligenceMcpRegistry session lifecycle', () => {
     expect(registryMocks.clients[0].callTool).toHaveBeenCalledTimes(2)
   })
 
+  it('连接期间收到 close 时不缓存该会话,下一次调用重新连接', async () => {
+    // onclose is installed before the await, but the session object only exists after it. A
+    // close landing in that window used to hit `session === null`, do nothing, and let the
+    // freshly built object be returned and cached with closed: false (#777).
+    const connection = deferred<void>()
+    registryMocks.connectResults.push(connection.promise)
+    const registry = new IntelligenceMcpRegistry()
+    registries.push(registry)
+    registry.registerProfile(stdioProfile())
+
+    const call = registry.callTool('mcp-profile', 'status', {})
+    await Promise.resolve()
+
+    // The transport dies while connect() is still pending.
+    registryMocks.clients[0].onclose?.()
+    connection.resolve()
+
+    await expect(call).rejects.toThrow(/closed during connect/i)
+
+    // The dead session must not have been cached: a second call has to build a new client.
+    const second = registry.callTool('mcp-profile', 'status', {})
+    await Promise.resolve()
+    expect(registryMocks.clients).toHaveLength(2)
+    await expect(second).resolves.toBe('tool result')
+  })
+
   it('closes a stale connecting generation and retries against the replacement profile', async () => {
     const firstConnection = deferred<void>()
     registryMocks.connectResults.push(firstConnection.promise)

--- a/apps/core-app/src/main/modules/ai/intelligence-mcp-registry.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-mcp-registry.ts
@@ -306,15 +306,29 @@ export class IntelligenceMcpRegistry {
           })
 
     let session: ConnectedMcpSession | null = null
+    // A close can arrive while connect() is still awaiting, before there is a session object to
+    // mark. Recording it is what stops the object built below from being returned and cached
+    // with closed: false, leaving the registry serving a dead transport (#777).
+    let closedBeforeSessionExisted = false
     client.onerror = (error) => {
       mcpLog.warn(`MCP profile ${profile.id} transport error`, { error })
     }
     client.onclose = () => {
-      if (session) this.removeSession(profile.id, session)
+      if (session) {
+        this.removeSession(profile.id, session)
+      } else {
+        closedBeforeSessionExisted = true
+      }
       mcpLog.info(`MCP profile ${profile.id} disconnected`)
     }
 
     await client.connect(transport)
+    if (closedBeforeSessionExisted) {
+      // Nothing to remove -- this session was never added to this.sessions. connectProfile
+      // propagates the throw and clears its pending entry in the finally, so the next caller
+      // starts a fresh connect rather than awaiting a dead one.
+      throw new Error(`MCP profile ${profile.id} closed during connect`)
+    }
     session = {
       client,
       transport,


### PR DESCRIPTION
Closes #777.

`openSession` installs `client.onclose` **before** awaiting `connect`, but the handler reads a `session` variable that is only assigned **after** that await. A close landing in that window found `session === null`, did nothing, and the object built afterwards was returned and cached with `closed: false` — the registry then served a dead transport until something else noticed.

The close is recorded instead, and `connect` throws when it happened.

Nothing needs removing: this session was never added to `this.sessions`. `connectProfile` propagates the throw and clears its pending entry in the `finally`, so the next caller starts a fresh connect rather than awaiting a dead one — which the test checks by asserting a **second** client is built.

### Filed as plausible, so it was reproduced rather than argued

The audit marked this *"needs a repro / verification before acting"*. The existing harness could already express it: `connectResults` supplies a deferred connect and the mock client exposes `onclose`, so the close can be fired in exactly that window.

Reverting to the original ordering fails the new test:

```
× 连接期间收到 close 时不缓存该会话,下一次调用重新连接
  Tests  1 failed | 3 passed (4)
```

eslint **0**, tsc **0** with zero TS errors, **4/4** plus the smoke suite.
