### PR TITLE
fix(quota): make per-minute limits bind against a burst

### DIFF
--- a/apps/core-app/src/main/modules/ai/intelligence-quota-burst.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-quota-burst.test.ts
@@ -1,0 +1,97 @@
+/**
+ * checkQuota compared the configured limits against a usage snapshot that is (a) built from
+ * intelligence_audit_logs, so it only reflects requests already flushed, and (b) cached for 10
+ * seconds with nothing invalidating it - clearCache had no production caller. A caller with
+ * requestsPerMinute: 10 could fire hundreds of calls in two seconds and every one would read the
+ * same stale zero (#778).
+ *
+ * These drive the real checkQuota with the database pinned at zero usage, which is exactly the
+ * state that used to admit an unbounded burst.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import './intelligence-test-harness'
+
+import { IntelligenceQuotaManager } from './intelligence-quota-manager'
+
+interface QuotaInternals {
+  getDb: () => unknown
+  getQuota: (callerId: string, callerType?: string) => Promise<unknown>
+  checkQuota: (
+    callerId: string,
+    callerType?: 'plugin' | 'user' | 'system',
+    estimatedTokens?: number
+  ) => Promise<{ allowed: boolean; reason?: string }>
+  clearCache: () => void
+}
+
+/** A database that always reports zero usage - the pre-flush state during a burst. */
+function zeroUsageDb(): unknown {
+  const rows: unknown[] = []
+  const chain = {
+    from: () => chain,
+    where: () => chain,
+    limit: () => Promise.resolve(rows),
+    then: (resolve: (value: unknown[]) => unknown) => resolve(rows)
+  }
+  return { select: () => chain }
+}
+
+function createManager(requestsPerMinute: number | undefined): QuotaInternals {
+  const manager = new IntelligenceQuotaManager() as unknown as QuotaInternals
+  manager.getDb = () => zeroUsageDb()
+  manager.getQuota = async () => ({
+    callerId: 'plugin-a',
+    callerType: 'plugin',
+    enabled: true,
+    requestsPerMinute
+  })
+  return manager
+}
+
+describe('quota binds during a burst the database has not caught up with', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-01T00:00:00.000Z'))
+  })
+
+  it('每分钟 3 次的限额:第 4 次被拒,而不是全部放行', async () => {
+    const manager = createManager(3)
+
+    const verdicts: boolean[] = []
+    for (let index = 0; index < 5; index += 1) {
+      verdicts.push((await manager.checkQuota('plugin-a', 'plugin')).allowed)
+    }
+
+    expect(verdicts).toEqual([true, true, true, false, false])
+  })
+
+  it('拒绝理由是每分钟速率限制', async () => {
+    const manager = createManager(1)
+
+    await manager.checkQuota('plugin-a', 'plugin')
+    const second = await manager.checkQuota('plugin-a', 'plugin')
+
+    expect(second.allowed).toBe(false)
+    expect(second.reason).toMatch(/requests per minute/i)
+  })
+
+  it('一分钟窗口滑过之后重新放行(不是永久拒绝)', async () => {
+    const manager = createManager(2)
+
+    expect((await manager.checkQuota('plugin-a', 'plugin')).allowed).toBe(true)
+    expect((await manager.checkQuota('plugin-a', 'plugin')).allowed).toBe(true)
+    expect((await manager.checkQuota('plugin-a', 'plugin')).allowed).toBe(false)
+
+    vi.setSystemTime(new Date('2026-02-01T00:01:01.000Z'))
+
+    expect((await manager.checkQuota('plugin-a', 'plugin')).allowed).toBe(true)
+  })
+
+  it('没有配置每分钟限额时不受影响', async () => {
+    const manager = createManager(undefined)
+
+    for (let index = 0; index < 20; index += 1) {
+      expect((await manager.checkQuota('plugin-a', 'plugin')).allowed).toBe(true)
+    }
+  })
+})

--- a/apps/core-app/src/main/modules/ai/intelligence-quota-manager.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-quota-manager.ts
@@ -51,6 +51,16 @@ export class IntelligenceQuotaManager {
   private quotaCache = new Map<string, QuotaConfig>()
   private usageCache = new Map<string, { usage: CurrentUsage; timestamp: number }>()
   private readonly usageCacheTTL = 10000 // 10 seconds
+  /**
+   * Timestamps of requests this manager has admitted, per caller.
+   *
+   * The cached snapshot is built from intelligence_audit_logs, so it only ever reflects
+   * requests already flushed to the database - and it is reused for 10s on top of that. A
+   * caller with requestsPerMinute: 10 could therefore fire hundreds of calls in two seconds and
+   * every one of them would read the same stale zero (#778). Admissions are counted here the
+   * moment they are granted, so a burst binds against the limit immediately.
+   */
+  private admissions = new Map<string, number[]>()
 
   private getDb() {
     return databaseModule.getDb()
@@ -278,7 +288,17 @@ export class IntelligenceQuotaManager {
       return { allowed: false, reason: 'Quota is disabled for this caller' }
     }
 
-    const usage = await this.getCurrentUsage(callerId, callerType)
+    const snapshot = await this.getCurrentUsage(callerId, callerType)
+    // Whichever is higher: the database has the truth once rows are flushed, the ledger has it
+    // during a burst. Taking the max rather than the sum keeps a request from being counted
+    // twice as its audit row lands.
+    const usage: CurrentUsage = {
+      ...snapshot,
+      requestsThisMinute: Math.max(
+        snapshot.requestsThisMinute,
+        this.countRecentAdmissions(callerId, callerType)
+      )
+    }
 
     // Check requests per minute
     if (quota.requestsPerMinute && usage.requestsThisMinute >= quota.requestsPerMinute) {
@@ -352,6 +372,11 @@ export class IntelligenceQuotaManager {
       }
     }
 
+    // Counted at admission, not when the audit row lands, so the next check in the same burst
+    // sees this request. The unlimited early-return above is deliberately not counted: there is
+    // no limit for it to bind against.
+    this.recordAdmission(callerId, callerType)
+
     // Calculate remaining
     return {
       allowed: true,
@@ -388,7 +413,38 @@ export class IntelligenceQuotaManager {
   /**
    * Clear quota cache
    */
+  private admissionKey(callerId: string, callerType: 'plugin' | 'user' | 'system'): string {
+    return `${callerType}:${callerId}`
+  }
+
+  /** Admissions inside the trailing minute, pruning anything older as it goes. */
+  private countRecentAdmissions(
+    callerId: string,
+    callerType: 'plugin' | 'user' | 'system',
+    now: number = Date.now()
+  ): number {
+    const key = this.admissionKey(callerId, callerType)
+    const recent = (this.admissions.get(key) ?? []).filter((at) => now - at < 60 * 1000)
+    if (recent.length === 0) {
+      this.admissions.delete(key)
+      return 0
+    }
+    this.admissions.set(key, recent)
+    return recent.length
+  }
+
+  private recordAdmission(
+    callerId: string,
+    callerType: 'plugin' | 'user' | 'system',
+    now: number = Date.now()
+  ): void {
+    const key = this.admissionKey(callerId, callerType)
+    this.countRecentAdmissions(callerId, callerType, now)
+    this.admissions.set(key, [...(this.admissions.get(key) ?? []), now])
+  }
+
   clearCache(): void {
+    this.admissions.clear()
     this.quotaCache.clear()
     this.usageCache.clear()
   }


### PR DESCRIPTION
Closes #778.

`checkQuota` compared the configured limits against a usage snapshot that is built from `intelligence_audit_logs` — so it only ever reflects requests **already flushed** — and then cached for 10 seconds with nothing invalidating it. `clearCache` had **no caller anywhere in the tree**, verified against a control showing the manager's eight other methods do have callers.

A caller with `requestsPerMinute: 10` could fire hundreds of calls in two seconds and every one read the same stale zero. `intelligence-sdk` gates the real invoke on that result, so the limit never bound.

### The fix

Admissions are counted in memory the moment they are granted, and the per-minute check takes the **max** of that count and the database snapshot.

Max rather than sum, so a request is not counted twice as its audit row lands: the database is authoritative once flushed, the ledger is authoritative during a burst.

Entries older than the trailing minute are pruned on every read, so the window **slides** instead of denying forever. The unlimited early return is deliberately not counted — there is no limit for it to bind against — and the ledger is cleared by `clearCache` along with the snapshot cache.

### Four tests against a database pinned at zero usage

That is the exact state which used to admit an unbounded burst.

| mutation | result |
|---|---|
| drop the ledger overlay | **3 fail** — the burst is admitted again |
| never prune the window | **1 fails** — the caller is denied forever |

The *"no `requestsPerMinute` configured"* test passes in every state, so a fix that started denying unlimited callers would be caught rather than shipped.

eslint **0**, tsc **0** with zero TS errors. **4/4**, and the existing quota boundary suite still passes **7/7**.
