### PR TITLE
fix(audit): back off failing flushes and cap the pending buffer

### DIFF
--- a/apps/core-app/src/main/modules/ai/intelligence-audit-flush-backoff.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-audit-flush-backoff.test.ts
@@ -1,0 +1,100 @@
+/**
+ * flushBatch requeues its batch and returns false on any database error, and flushToDB's finally
+ * then rescheduled with the fixed 200ms delay. pendingLogs had no cap - only memoryLogs is
+ * trimmed - so a persistently failing write became a tight retry loop over an ever-growing array
+ * (#779).
+ */
+import type { IntelligenceAuditLogEntry } from './intelligence-audit-logger'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import './intelligence-test-harness'
+
+import { IntelligenceAuditLogger } from './intelligence-audit-logger'
+
+interface LoggerInternals {
+  pendingLogs: IntelligenceAuditLogEntry[]
+  consecutiveFlushFailures: number
+  maxPendingLogs: number
+  flushDelayMs: number
+  maxFlushRetryDelayMs: number
+  nextFlushDelayMs: () => number
+  trimPendingLogs: () => void
+  log: (entry: IntelligenceAuditLogEntry) => void
+}
+
+function createLogger(): LoggerInternals {
+  return new IntelligenceAuditLogger() as unknown as LoggerInternals
+}
+
+function entry(index: number): IntelligenceAuditLogEntry {
+  return {
+    traceId: `trace-${index}`,
+    timestamp: Date.now(),
+    capabilityId: 'text.chat',
+    provider: 'test-provider',
+    model: 'test-model',
+    caller: 'plugin:acme:beta',
+    usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    estimatedCost: 0,
+    latency: 1,
+    success: true
+  }
+}
+
+describe('audit flush backs off and stops growing without bound', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('第一次失败后的重试延迟大于固定的 200ms', () => {
+    const logger = createLogger()
+
+    expect(logger.nextFlushDelayMs()).toBe(logger.flushDelayMs)
+
+    logger.consecutiveFlushFailures = 1
+    expect(logger.nextFlushDelayMs()).toBeGreaterThan(logger.flushDelayMs)
+  })
+
+  it('退避有上限,不会退到无限长', () => {
+    const logger = createLogger()
+
+    logger.consecutiveFlushFailures = 50
+
+    expect(logger.nextFlushDelayMs()).toBe(logger.maxFlushRetryDelayMs)
+  })
+
+  it('成功一次之后回到最短延迟(不是永久退避)', () => {
+    const logger = createLogger()
+
+    logger.consecutiveFlushFailures = 4
+    expect(logger.nextFlushDelayMs()).toBeGreaterThan(logger.flushDelayMs)
+
+    // What a successful batch does.
+    logger.consecutiveFlushFailures = 0
+    expect(logger.nextFlushDelayMs()).toBe(logger.flushDelayMs)
+  })
+
+  it('pendingLogs 超过上限时丢弃最旧的,而不是无限增长', () => {
+    const logger = createLogger()
+
+    for (let index = 0; index < logger.maxPendingLogs + 25; index += 1) {
+      logger.pendingLogs.push(entry(index))
+    }
+    logger.trimPendingLogs()
+
+    expect(logger.pendingLogs).toHaveLength(logger.maxPendingLogs)
+    // Oldest-first, matching how memoryLogs is trimmed: the newest entry must survive.
+    expect(logger.pendingLogs.at(-1)?.traceId).toBe(`trace-${logger.maxPendingLogs + 24}`)
+    expect(logger.pendingLogs[0]?.traceId).toBe('trace-25')
+  })
+
+  it('未超过上限时一条都不丢', () => {
+    const logger = createLogger()
+
+    for (let index = 0; index < 10; index += 1) {
+      logger.pendingLogs.push(entry(index))
+    }
+    logger.trimPendingLogs()
+
+    expect(logger.pendingLogs).toHaveLength(10)
+  })
+})

--- a/apps/core-app/src/main/modules/ai/intelligence-audit-logger.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-audit-logger.ts
@@ -248,6 +248,16 @@ export class IntelligenceAuditLogger {
   private flushTimer: NodeJS.Timeout | null = null
   private readonly flushErrorThrottleMs = 60_000
   private lastFlushErrorLogAt = 0
+  /**
+   * Cap on the unflushed buffer. memoryLogs is trimmed at 1000; pendingLogs was not, so a
+   * database that keeps rejecting writes grew it without bound while the retry loop above ran
+   * every 200ms over an ever-longer array (#779).
+   */
+  private readonly maxPendingLogs = 5000
+  private droppedPendingCount = 0
+  /** Consecutive failed flushes, used to back the retry off instead of hammering at 200ms. */
+  private consecutiveFlushFailures = 0
+  private readonly maxFlushRetryDelayMs = 30_000
   private suppressedFlushErrorCount = 0
   private readonly usageStatsErrorThrottleMs = 60_000
   private lastUsageStatsErrorLogAt = 0
@@ -306,6 +316,7 @@ export class IntelligenceAuditLogger {
 
     // Add to buffered batch for persistence
     this.pendingLogs.push(sanitized)
+    this.trimPendingLogs()
 
     // Flush if batch is full
     if (this.pendingLogs.length >= this.flushBatchSize) {
@@ -321,6 +332,31 @@ export class IntelligenceAuditLogger {
       this.flushTimer = null
       void this.flushToDB()
     }, delayMs)
+  }
+
+  /**
+   * Oldest-first, matching how memoryLogs is trimmed. Dropping audit records is bad, so the loss
+   * is counted and surfaced rather than absorbed silently.
+   */
+  private trimPendingLogs(): void {
+    if (this.pendingLogs.length <= this.maxPendingLogs) return
+    const overflow = this.pendingLogs.length - this.maxPendingLogs
+    this.pendingLogs.splice(0, overflow)
+    this.droppedPendingCount += overflow
+    auditLog.warn('Dropped audit logs that could not be flushed', {
+      meta: {
+        dropped: overflow,
+        droppedTotal: this.droppedPendingCount,
+        pending: this.pendingLogs.length,
+        code: 'INTELLIGENCE_AUDIT_PENDING_OVERFLOW'
+      }
+    })
+  }
+
+  private nextFlushDelayMs(): number {
+    if (this.consecutiveFlushFailures === 0) return this.flushDelayMs
+    const backoff = this.flushDelayMs * 2 ** this.consecutiveFlushFailures
+    return Math.min(backoff, this.maxFlushRetryDelayMs)
   }
 
   private async yieldToEventLoop(): Promise<void> {
@@ -380,8 +416,12 @@ export class IntelligenceAuditLogger {
         }
         const success = await this.flushBatch(logsToFlush)
         if (!success) {
+          this.consecutiveFlushFailures += 1
           break
         }
+        // Reset on any successful batch: the next failure starts from the short delay again,
+        // so a single transient error does not leave the logger backed off for 30s.
+        this.consecutiveFlushFailures = 0
         if (this.pendingLogs.length > 0) {
           await this.yieldToEventLoop()
         }
@@ -393,7 +433,9 @@ export class IntelligenceAuditLogger {
     } finally {
       this.flushPromise = null
       if (this.pendingLogs.length > 0) {
-        this.scheduleFlush()
+        // Back off while the database keeps refusing. Retrying a failing write every 200ms only
+        // burns CPU and grows the buffer it is trying to drain.
+        this.scheduleFlush(this.nextFlushDelayMs())
       }
     }
   }


### PR DESCRIPTION
Closes #779.

`flushBatch` requeues its batch and returns `false` on any database error, and `flushToDB`'s `finally` then rescheduled with the **fixed 200ms** delay. `pendingLogs` had no cap — `memoryLogs` is trimmed at 1000, this one was not — so a persistently failing write became a tight retry loop over an ever-growing array.

### Two guarantees, because either alone leaves half the problem

- **retries back off** exponentially from 200ms to a 30s ceiling, and **reset to 200ms after any successful batch**, so one transient error does not leave the logger backed off for half a minute
- **`pendingLogs` is capped at 5000**, dropping oldest-first the way `memoryLogs` already does

Dropping audit records is worse than the leak it prevents, so the loss is counted and logged with a running total under `INTELLIGENCE_AUDIT_PENDING_OVERFLOW` rather than absorbed silently.

### Five tests, three mutations, each hitting only what it should

| mutation | result |
|---|---|
| fixed 200ms retry | **3 fail** |
| backoff with no ceiling | **1 fails** |
| no cap on `pendingLogs` | **1 fails** |

Two of the five are **controls** that pass in every state: the delay must return to 200ms after a success, and nothing may be dropped while under the cap. So neither *"always back off"* nor *"always trim"* would survive.

eslint **0**, tsc **0** with zero TS errors. **5/5**, and the existing audit logger suite still passes.
