### PR TITLE
fix(audit): let a usage-stats failure roll its transaction back

### DIFF
--- a/apps/core-app/src/main/modules/ai/intelligence-audit-logger.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-audit-logger.ts
@@ -525,7 +525,15 @@ export class IntelligenceAuditLogger {
             }
           })
       } catch (error) {
+        // Logged and then rethrown. These upserts share a transaction with the audit-log insert
+        // precisely so the rows and the counters they aggregate cannot disagree; swallowing the
+        // error let the transaction commit with the audit rows written and the counters not
+        // advanced, and quota checks read those counters (#780).
+        //
+        // flushBatch already handles the throw: it logs, requeues the batch through
+        // requeueAfterRetention and returns false, so nothing is lost and the retry backs off.
         this.logUsageStatsError(`${callerId}:${period}`, error)
+        throw error
       }
     }
   }

--- a/apps/core-app/src/main/modules/ai/intelligence-usage-stats-consistency.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-usage-stats-consistency.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The usage-stats upserts share a transaction with the audit-log insert precisely so the rows and
+ * the counters that aggregate them cannot disagree. Each bucket's upsert was wrapped in its own
+ * try/catch that swallowed the error, so the transaction committed with the audit rows written
+ * and the counters not advanced - and quota checks read those counters (#780).
+ */
+import type { IntelligenceAuditLogEntry } from './intelligence-audit-logger'
+import { describe, expect, it, vi } from 'vitest'
+import './intelligence-test-harness'
+
+import { IntelligenceAuditLogger } from './intelligence-audit-logger'
+
+interface LoggerInternals {
+  updateUsageStats: (
+    tx: { insert: (table: unknown) => unknown },
+    logs: IntelligenceAuditLogEntry[]
+  ) => Promise<void>
+}
+
+function entry(traceId: string): IntelligenceAuditLogEntry {
+  return {
+    traceId,
+    timestamp: Date.parse('2026-02-01T10:00:00.000Z'),
+    capabilityId: 'text.chat',
+    provider: 'test-provider',
+    model: 'test-model',
+    caller: 'plugin:acme:beta',
+    usage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+    estimatedCost: 0.1,
+    latency: 120,
+    success: true
+  }
+}
+
+/** An insert chain whose final onConflictDoUpdate either resolves or rejects. */
+function insertChain(onFinish: () => Promise<unknown>): unknown {
+  const chain = {
+    values: () => chain,
+    onConflictDoUpdate: () => onFinish()
+  }
+  return chain
+}
+
+describe('usage-stats failures roll the audit transaction back', () => {
+  it('某个 bucket 的 upsert 失败时抛出,而不是让事务照常提交', async () => {
+    const logger = new IntelligenceAuditLogger() as unknown as LoggerInternals
+    const tx = {
+      insert: () =>
+        insertChain(async () => {
+          throw new Error('usage stats write failed')
+        })
+    }
+
+    await expect(logger.updateUsageStats(tx, [entry('a')])).rejects.toThrow(
+      /usage stats write failed/
+    )
+  })
+
+  it('全部成功时正常返回(不是"永远抛出")', async () => {
+    const logger = new IntelligenceAuditLogger() as unknown as LoggerInternals
+    const upsert = vi.fn(async () => undefined)
+    const tx = { insert: () => insertChain(upsert) }
+
+    await expect(logger.updateUsageStats(tx, [entry('a')])).resolves.toBeUndefined()
+    expect(upsert).toHaveBeenCalled()
+  })
+
+  it('第一个 bucket 失败即中止,不会带着不一致的计数器继续写后面的', async () => {
+    const logger = new IntelligenceAuditLogger() as unknown as LoggerInternals
+    let upsertCount = 0
+    const tx = {
+      insert: () =>
+        insertChain(async () => {
+          upsertCount += 1
+          throw new Error('usage stats write failed')
+        })
+    }
+
+    // Two callers produce separate buckets; the throw must stop after the first.
+    await expect(
+      logger.updateUsageStats(tx, [entry('a'), { ...entry('b'), caller: 'plugin:acme:gamma' }])
+    ).rejects.toThrow()
+
+    expect(upsertCount).toBe(1)
+  })
+})


### PR DESCRIPTION
Closes #780.

`updateUsageStats` runs inside the **same transaction** as the audit-log insert — which is the whole point: the rows and the counters that aggregate them cannot be allowed to disagree. Each bucket's upsert was wrapped in a `try/catch` that logged and **swallowed**, so the transaction committed with the audit rows written and the counters not advanced.

Quota checks read those counters, so the drift is not cosmetic — it makes a caller look cheaper than it was, permanently.

### The fix

The error is still logged, and then **rethrown**. `flushBatch` already handles a throw from here: it logs, requeues the batch through `requeueAfterRetention` and returns `false`, so nothing is lost and — since #779 — the retry backs off instead of hammering.

That is why this is a two-line change rather than a new error path: the correct handling already existed one level up, it just never got the chance to run.

### Three tests

Restoring the swallow fails **two** of them, including the one that pins the abort: a failing first bucket must not be followed by writes for the remaining buckets, since those would land against counters the transaction is about to discard.

The third is the **control** and passes in both states — a fix written as *"always throw"* would fail it.

eslint **0**, tsc **0** with zero TS errors. **3/3**, and the two existing audit logger suites still pass.
