### PR TITLE
fix(download): merge chunks through a temp file and rename into place

### DIFF
--- a/apps/core-app/src/main/modules/download/chunk-manager.ts
+++ b/apps/core-app/src/main/modules/download/chunk-manager.ts
@@ -50,24 +50,39 @@ export class ChunkManager {
   // 合并切片文件
   async mergeChunks(task: DownloadTask, chunks: ChunkInfo[]): Promise<void> {
     const outputPath = path.join(task.destination, task.filename)
+    // Merged into a sibling temp file and renamed into place, rather than opened at the real
+    // filename with 'w'. Truncating the destination first meant a crash or an incomplete chunk
+    // left a truncated file under the real name - and unlike the single-stream path, nothing
+    // removed it (#781). A rename within the same directory is atomic, so the destination either
+    // holds the previous file or the complete new one, never a partial merge.
+    const tempOutputPath = `${outputPath}.${task.id}.part`
 
     // 确保输出目录存在
     await fs.mkdir(path.dirname(outputPath), { recursive: true })
 
-    // 按顺序合并切片
-    const writeStream = await fs.open(outputPath, 'w')
-
     try {
-      for (const chunk of chunks) {
-        if (chunk.status === ChunkStatus.COMPLETED) {
-          const chunkData = await fs.readFile(chunk.filePath)
-          await writeStream.write(chunkData)
-        } else {
-          throw new Error(`Chunk ${chunk.index} is not completed`)
+      // 按顺序合并切片
+      const writeStream = await fs.open(tempOutputPath, 'w')
+
+      try {
+        for (const chunk of chunks) {
+          if (chunk.status === ChunkStatus.COMPLETED) {
+            const chunkData = await fs.readFile(chunk.filePath)
+            await writeStream.write(chunkData)
+          } else {
+            throw new Error(`Chunk ${chunk.index} is not completed`)
+          }
         }
+      } finally {
+        await writeStream.close()
       }
-    } finally {
-      await writeStream.close()
+
+      await fs.rename(tempOutputPath, outputPath)
+    } catch (error) {
+      // The destination was never touched; drop the partial merge rather than leaving it beside
+      // the file it failed to replace.
+      await fs.rm(tempOutputPath, { force: true }).catch(() => {})
+      throw error
     }
 
     // 清理临时切片文件和任务临时目录

--- a/apps/core-app/src/main/modules/download/chunk-merge-atomicity.test.ts
+++ b/apps/core-app/src/main/modules/download/chunk-merge-atomicity.test.ts
@@ -1,0 +1,99 @@
+/**
+ * mergeChunks opened the final output path with 'w' and wrote each chunk into it, so a failure
+ * partway through left a truncated file under the real filename - and unlike the single-stream
+ * path, nothing removed it (#781).
+ *
+ * These run against a real temp directory: the property under test is what is on disk after a
+ * failed merge, which a mocked fs cannot show.
+ */
+import { ChunkStatus } from '@talex-touch/utils'
+import type { ChunkInfo, DownloadTask } from '@talex-touch/utils'
+import fs from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { ChunkManager } from './chunk-manager'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(async (dir) => await fs.rm(dir, { recursive: true, force: true }))
+  )
+})
+
+async function createWorkspace(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'chunk-merge-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+function task(destination: string): DownloadTask {
+  return { id: 'task-1', destination, filename: 'payload.bin' } as unknown as DownloadTask
+}
+
+async function chunk(dir: string, index: number, body: string, status: ChunkStatus) {
+  const filePath = path.join(dir, `chunk-${index}`)
+  await fs.writeFile(filePath, body)
+  return { index, filePath, status, size: body.length } as unknown as ChunkInfo
+}
+
+describe('chunk merge does not damage the destination', () => {
+  it('合并成功后目标文件是完整拼接结果', async () => {
+    const dir = await createWorkspace()
+    const manager = new ChunkManager(dir)
+    const chunks = [
+      await chunk(dir, 0, 'hello-', ChunkStatus.COMPLETED),
+      await chunk(dir, 1, 'world', ChunkStatus.COMPLETED)
+    ]
+
+    await manager.mergeChunks(task(dir), chunks)
+
+    expect(await fs.readFile(path.join(dir, 'payload.bin'), 'utf8')).toBe('hello-world')
+  })
+
+  it('某个切片未完成时,已存在的目标文件保持不变', async () => {
+    const dir = await createWorkspace()
+    const destination = path.join(dir, 'payload.bin')
+    await fs.writeFile(destination, 'previous-good-download')
+    const manager = new ChunkManager(dir)
+    const chunks = [
+      await chunk(dir, 0, 'partial-', ChunkStatus.COMPLETED),
+      await chunk(dir, 1, 'never-written', ChunkStatus.PENDING)
+    ]
+
+    await expect(manager.mergeChunks(task(dir), chunks)).rejects.toThrow(/not completed/i)
+
+    // Before the fix this read 'partial-' - the destination had been truncated and half-written.
+    expect(await fs.readFile(destination, 'utf8')).toBe('previous-good-download')
+  })
+
+  it('失败后不留下 .part 残file', async () => {
+    const dir = await createWorkspace()
+    const manager = new ChunkManager(dir)
+    const chunks = [
+      await chunk(dir, 0, 'partial-', ChunkStatus.COMPLETED),
+      await chunk(dir, 1, 'never-written', ChunkStatus.PENDING)
+    ]
+
+    await expect(manager.mergeChunks(task(dir), chunks)).rejects.toThrow()
+
+    const leftovers = (await fs.readdir(dir)).filter((name) => name.endsWith('.part'))
+    expect(leftovers).toEqual([])
+  })
+
+  it('目标文件此前不存在且合并失败时,不会凭空造出一个截断文件', async () => {
+    const dir = await createWorkspace()
+    const manager = new ChunkManager(dir)
+    const chunks = [
+      await chunk(dir, 0, 'partial-', ChunkStatus.COMPLETED),
+      await chunk(dir, 1, 'never-written', ChunkStatus.PENDING)
+    ]
+
+    await expect(manager.mergeChunks(task(dir), chunks)).rejects.toThrow()
+
+    expect(existsSync(path.join(dir, 'payload.bin'))).toBe(false)
+  })
+})

--- a/apps/core-app/src/main/modules/download/chunk-merge-atomicity.test.ts
+++ b/apps/core-app/src/main/modules/download/chunk-merge-atomicity.test.ts
@@ -43,7 +43,7 @@ async function chunk(dir: string, index: number, body: string, status: ChunkStat
 describe('chunk merge does not damage the destination', () => {
   it('合并成功后目标文件是完整拼接结果', async () => {
     const dir = await createWorkspace()
-    const manager = new ChunkManager(dir)
+    const manager = new ChunkManager(undefined, dir)
     const chunks = [
       await chunk(dir, 0, 'hello-', ChunkStatus.COMPLETED),
       await chunk(dir, 1, 'world', ChunkStatus.COMPLETED)
@@ -58,7 +58,7 @@ describe('chunk merge does not damage the destination', () => {
     const dir = await createWorkspace()
     const destination = path.join(dir, 'payload.bin')
     await fs.writeFile(destination, 'previous-good-download')
-    const manager = new ChunkManager(dir)
+    const manager = new ChunkManager(undefined, dir)
     const chunks = [
       await chunk(dir, 0, 'partial-', ChunkStatus.COMPLETED),
       await chunk(dir, 1, 'never-written', ChunkStatus.PENDING)
@@ -70,9 +70,9 @@ describe('chunk merge does not damage the destination', () => {
     expect(await fs.readFile(destination, 'utf8')).toBe('previous-good-download')
   })
 
-  it('失败后不留下 .part 残file', async () => {
+  it('失败后不留下 .part 残留文件', async () => {
     const dir = await createWorkspace()
-    const manager = new ChunkManager(dir)
+    const manager = new ChunkManager(undefined, dir)
     const chunks = [
       await chunk(dir, 0, 'partial-', ChunkStatus.COMPLETED),
       await chunk(dir, 1, 'never-written', ChunkStatus.PENDING)
@@ -86,7 +86,7 @@ describe('chunk merge does not damage the destination', () => {
 
   it('目标文件此前不存在且合并失败时,不会凭空造出一个截断文件', async () => {
     const dir = await createWorkspace()
-    const manager = new ChunkManager(dir)
+    const manager = new ChunkManager(undefined, dir)
     const chunks = [
       await chunk(dir, 0, 'partial-', ChunkStatus.COMPLETED),
       await chunk(dir, 1, 'never-written', ChunkStatus.PENDING)


### PR DESCRIPTION
Closes #781.

`mergeChunks` opened the final output path with `'w'` and wrote each chunk into it, so an incomplete chunk or a crash partway through left a **truncated file under the real filename** — and unlike the single-stream path, nothing removed it. A failed re-download destroyed the copy the user already had.

The merge now goes to a sibling `.part` file and renames into place. Rename within a directory is atomic, so the destination holds either the previous file or the complete new one, never a partial merge. On failure the temp file is removed and the destination is left untouched.

### Tested against a real filesystem

The property under test is *what is on disk after a failed merge*, which a mocked `fs` cannot show. Each test gets its own temp directory.

Two of the four fail when the merge writes straight to the destination again — the pre-existing file is clobbered, and a truncated file appears where there was none. The other two pass in both states (a successful merge still produces the full concatenation; no `.part` file is left behind), so a fix that simply stopped writing would be caught.

### Observed, not changed

`download-worker.ts`'s single-stream path also opens the destination with `'w'`, though it *does* unlink on failure. That leaves the same "a failed re-download destroys the previous file" gap — different file, different fix, worth its own issue rather than a silent edit here.

### A mistake in the first push

The four tests constructed `ChunkManager(dir)`, but the signature is `(chunkSize?: number, baseTempDir?: string)` — the directory landed in `chunkSize`. Four TS2345 errors, which I pushed because I printed tsc's exit code and then committed **without gating on it**.

They passed anyway, for the wrong reason: `mergeChunks` never reads `chunkSize`, and `baseTempDir` stayed `undefined` so cleanup fell back to `<destination>/.tmp/<id>`. Fixed in the follow-up commit; tsc now exits **0** with zero errors, checked before the commit ran.

eslint **0**. **4/4**.
