### PR TITLE
fix(clipboard): write file formats after the wholesale clipboard write

### DIFF
--- a/apps/core-app/src/main/modules/clipboard.ts
+++ b/apps/core-app/src/main/modules/clipboard.ts
@@ -1278,10 +1278,12 @@ export class ClipboardModule extends BaseModule {
         .map((filePath) => pathToFileURL(filePath).toString())
         .join('\n')
       const buffer = Buffer.from(fileUrlContent, 'utf8')
+      // Same ordering rule as clipboard-autopaste-automation: clipboard.write() replaces
+      // everything, so the file formats have to be written after it, not before (#782).
+      clipboard.write({ text: resolvedPaths[0] ?? '' })
       for (const format of ['public.file-url', 'public.file-url-multiple', 'text/uri-list']) {
         clipboard.writeBuffer(format, buffer)
       }
-      clipboard.write({ text: resolvedPaths[0] ?? '' })
       this.clipboardHelper?.primeFiles(resolvedPaths)
       this.lastSuccessfulClipboardScanAt = Date.now()
       return

--- a/apps/core-app/src/main/modules/clipboard/clipboard-autopaste-automation.test.ts
+++ b/apps/core-app/src/main/modules/clipboard/clipboard-autopaste-automation.test.ts
@@ -186,6 +186,36 @@ describe('clipboard-autopaste-automation', () => {
     expect(mocks.sendPlatformShortcut).not.toHaveBeenCalled()
   })
 
+  it('文件格式写在 clipboard.write() 之后,否则会被它整体清掉', async () => {
+    // clipboard.write() replaces the whole clipboard. Writing the file URL formats before it
+    // discarded all three, so a paste into Finder or Explorer produced a plain string instead of
+    // the files (#782).
+    const fileItem: IClipboardItem = {
+      id: 2,
+      type: 'files',
+      content: JSON.stringify(['/tmp/a.txt', '/tmp/b.txt']),
+      rawContent: ''
+    }
+    const options = createOptions({ getItemById: vi.fn(async () => fileItem) })
+    const automation = new ClipboardAutopasteAutomation(options)
+
+    await automation.handleApplyRequest({ id: 2, autoPaste: false }, createContext())
+
+    expect(mocks.clipboardWrite).toHaveBeenCalled()
+    expect(mocks.clipboardWriteBuffer).toHaveBeenCalled()
+
+    const writeOrder = mocks.clipboardWrite.mock.invocationCallOrder[0]
+    const bufferOrders = mocks.clipboardWriteBuffer.mock.invocationCallOrder
+
+    // Every file format must land after the wholesale write, or it does not survive.
+    for (const order of bufferOrders) {
+      expect(order).toBeGreaterThan(writeOrder)
+    }
+    expect(
+      mocks.clipboardWriteBuffer.mock.calls.map((call: unknown[]) => call[0] as string)
+    ).toEqual(['public.file-url', 'public.file-url-multiple', 'text/uri-list'])
+  })
+
   it('returns explicit failures for unavailable database and missing item', async () => {
     const noDb = new ClipboardAutopasteAutomation(createOptions({ hasDatabase: () => false }))
     await expect(noDb.handleApplyRequest({ id: 1 }, createContext())).resolves.toEqual({

--- a/apps/core-app/src/main/modules/clipboard/clipboard-autopaste-automation.ts
+++ b/apps/core-app/src/main/modules/clipboard/clipboard-autopaste-automation.ts
@@ -277,6 +277,12 @@ export class ClipboardAutopasteAutomation {
       .join('\n')
     const buffer = Buffer.from(fileUrlContent, 'utf8')
 
+    // Text first, then the file formats on top. clipboard.write() replaces the whole clipboard,
+    // so writing the file URLs before it discarded all three and a paste into Finder or Explorer
+    // got a plain string instead of the files (#782). writeBuffer sets one format without
+    // clearing the others, so this order keeps both.
+    clipboard.write({ text: resolvedPaths[0] ?? '' })
+
     try {
       for (const format of ['public.file-url', 'public.file-url-multiple', 'text/uri-list']) {
         clipboard.writeBuffer(format, buffer)
@@ -284,8 +290,6 @@ export class ClipboardAutopasteAutomation {
     } catch (error) {
       this.options.logWarn('Failed to populate file clipboard formats', { error })
     }
-
-    clipboard.write({ text: resolvedPaths[0] ?? '' })
     this.options.primeFiles?.(resolvedPaths)
     this.options.onWrite?.()
   }


### PR DESCRIPTION
Closes #782.

Both file-apply paths wrote the three file-URL pasteboard formats with `writeBuffer` and **then** called `clipboard.write({ text })`. Electron's `write()` replaces the whole clipboard, so all three were discarded — a paste into Finder or Explorer produced a plain string instead of the files.

The order is swapped in both places: `write()` first, then `writeBuffer` on top. `writeBuffer` sets one format without clearing the others, so text and files both survive.

### Fixed in both sites

`clipboard.ts` as well as `clipboard-autopaste-automation.ts`. The issue names both, and fixing only the tested one would have made the suite green while the bug stayed reachable through the other entry point.

### The test asserts ordering, not final state

The mock cannot model `write()` replacing what came before, so asserting on a "final clipboard" would prove nothing. It uses `invocationCallOrder`: every `writeBuffer` call must land after the `write()` call, and the three formats are pinned by name. Putting the old order back fails it.

### On the checks

Two type errors in the first draft of that test — a `'file'` item type where the union is `'files'`, and a tuple annotation on a `mock.calls` map callback — were caught by **gating the commit on tsc's exit code** rather than printing it. That is exactly the check I got wrong on #781, where I read the failing code and committed anyway.

Noted while running: this suite already logs an unhandled rejection about a missing `"session"` export on the electron mock. It occurs once on the base too, so it is pre-existing and not from this change.

eslint **0**, tsc **0** with zero TS errors. **5/5**.
