### PR TITLE
ci: make lint-staged fail on warnings in core-app too [#721]

### DIFF
--- a/apps/core-app/src/main/db/db-write-scheduler.test.ts
+++ b/apps/core-app/src/main/db/db-write-scheduler.test.ts
@@ -387,7 +387,6 @@ describe('DbWriteScheduler scheduler-native busy retry', () => {
     expect(result).toBe(42)
     expect(order).toEqual(['outer:start', 'inner', 'outer:end'])
   })
-
 })
 
 // Phase 3 lane split: the pre-split test asserting "lane is accepted but

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-index-writer.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-index-writer.test.ts
@@ -141,7 +141,9 @@ describe('SearchIndexWriter worker init failure', () => {
     // search-index.db. The rejection must flow to the initialize() caller
     // exactly once, flag the writer unavailable, and make every later write
     // fail fast — never silently reopen another database file.
-    const initError = new Error('SQLITE_ERROR: table keyword_mappings has no column named provider_id')
+    const initError = new Error(
+      'SQLITE_ERROR: table keyword_mappings has no column named provider_id'
+    )
     const client = {
       init: vi.fn<(dbPath: string) => Promise<void>>(async () => {
         throw initError
@@ -154,9 +156,9 @@ describe('SearchIndexWriter worker init failure', () => {
     await expect(writer.initialize('/tmp/search-index.db')).rejects.toBe(initError)
     expect(writer.getStatus().readiness).toBe('failed')
 
-    await expect(writer.indexItems('file-provider', [indexedItem('file:/tmp/one.txt')])).rejects.toBe(
-      initError
-    )
+    await expect(
+      writer.indexItems('file-provider', [indexedItem('file:/tmp/one.txt')])
+    ).rejects.toBe(initError)
     expect(client.init).toHaveBeenCalledTimes(1)
     expect(client.applyProviderItems).not.toHaveBeenCalled()
 

--- a/apps/core-app/src/main/modules/database/index.search-schema.test.ts
+++ b/apps/core-app/src/main/modules/database/index.search-schema.test.ts
@@ -191,74 +191,66 @@ describe('initSearchDatabase schema parity with the primary fixups', () => {
     await rm(dir, { recursive: true, force: true })
   })
 
-  it(
-    'creates search-index.db with provider_id and source-scoped scan_progress',
-    async () => {
-      const module = new DatabaseModule()
-      const internals = moduleInternals(module)
+  it('creates search-index.db with provider_id and source-scoped scan_progress', async () => {
+    const module = new DatabaseModule()
+    const internals = moduleInternals(module)
 
-      await internals.initSearchDatabase(dir)
+    await internals.initSearchDatabase(dir)
 
-      expect(internals.searchInitialized).toBe(true)
-      expect(internals.searchDbPath).toBe(join(dir, 'search-index.db'))
-      const searchClient = internals.searchClient
-      expect(searchClient).not.toBeNull()
-      try {
-        expect(await hasProviderIdColumn(searchClient!)).toBe(true)
-        expect(await readScanProgressPrimaryKey(searchClient!)).toEqual(['source_id', 'path'])
-        // Regression: the statement that killed the V1 worker init must work
-        // against the fresh search file.
-        await expect(searchClient!.execute(V1_FAILING_INDEX_DDL)).resolves.toBeDefined()
-        // Perf-index parity: embeddings are split-routed, so the search file
-        // needs the same (source_type, source_id) index the primary gets from
-        // ensureSearchPerformanceIndexes().
-        const perfIndex = await searchClient!.execute(
-          "SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_embeddings_source' LIMIT 1"
-        )
-        expect(perfIndex.rows).toHaveLength(1)
-      } finally {
-        searchClient?.close()
-      }
-    },
-    60_000
-  )
+    expect(internals.searchInitialized).toBe(true)
+    expect(internals.searchDbPath).toBe(join(dir, 'search-index.db'))
+    const searchClient = internals.searchClient
+    expect(searchClient).not.toBeNull()
+    try {
+      expect(await hasProviderIdColumn(searchClient!)).toBe(true)
+      expect(await readScanProgressPrimaryKey(searchClient!)).toEqual(['source_id', 'path'])
+      // Regression: the statement that killed the V1 worker init must work
+      // against the fresh search file.
+      await expect(searchClient!.execute(V1_FAILING_INDEX_DDL)).resolves.toBeDefined()
+      // Perf-index parity: embeddings are split-routed, so the search file
+      // needs the same (source_type, source_id) index the primary gets from
+      // ensureSearchPerformanceIndexes().
+      const perfIndex = await searchClient!.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_embeddings_source' LIMIT 1"
+      )
+      expect(perfIndex.rows).toHaveLength(1)
+    } finally {
+      searchClient?.close()
+    }
+  }, 60_000)
 
-  it(
-    'fails search init closed and falls back when the scan_progress fixup is blocked',
-    async () => {
-      // Pre-migrate the search file, then poison scan_progress with a blank
-      // path row so the source-scope plan reports 'blocked'.
-      const searchDbPath = join(dir, 'search-index.db')
-      const seedClient = createClient({ url: `file:${searchDbPath}` })
-      const testDir = dirname(fileURLToPath(import.meta.url))
-      const migrationsFolder = resolve(testDir, '../../../../resources/db/migrations')
-      await migrate(drizzle(seedClient), { migrationsFolder })
-      await seedClient.execute("INSERT INTO scan_progress (path, last_scanned) VALUES ('', 1)")
-      seedClient.close()
+  it('fails search init closed and falls back when the scan_progress fixup is blocked', async () => {
+    // Pre-migrate the search file, then poison scan_progress with a blank
+    // path row so the source-scope plan reports 'blocked'.
+    const searchDbPath = join(dir, 'search-index.db')
+    const seedClient = createClient({ url: `file:${searchDbPath}` })
+    const testDir = dirname(fileURLToPath(import.meta.url))
+    const migrationsFolder = resolve(testDir, '../../../../resources/db/migrations')
+    await migrate(drizzle(seedClient), { migrationsFolder })
+    await seedClient.execute("INSERT INTO scan_progress (path, last_scanned) VALUES ('', 1)")
+    seedClient.close()
 
-      const module = new DatabaseModule()
-      const internals = moduleInternals(module)
+    const module = new DatabaseModule()
+    const internals = moduleInternals(module)
 
-      await internals.initSearchDatabase(dir)
+    await internals.initSearchDatabase(dir)
 
-      // Fixup failure must follow the existing fallback: no split, primary
-      // topology preserved (this is exactly the flag-off behavior).
-      expect(internals.searchInitialized).toBe(false)
-      expect(internals.searchClient).toBeNull()
-      expect(internals.searchDbPath).toBe('')
-      expect(dbLogMock.warn).toHaveBeenCalledWith(
-        'scan_progress source-scope migration blocked on search database',
-        expect.objectContaining({
-          meta: expect.objectContaining({
-            blockers: expect.arrayContaining(['scan_progress blank path rows'])
-          })
+    // Fixup failure must follow the existing fallback: no split, primary
+    // topology preserved (this is exactly the flag-off behavior).
+    expect(internals.searchInitialized).toBe(false)
+    expect(internals.searchClient).toBeNull()
+    expect(internals.searchDbPath).toBe('')
+    expect(dbLogMock.warn).toHaveBeenCalledWith(
+      'scan_progress source-scope migration blocked on search database',
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          blockers: expect.arrayContaining(['scan_progress blank path rows'])
         })
-      )
-      expect(dbLogMock.warn).toHaveBeenCalledWith(
-        'Search index database initialization failed; falling back to primary DB',
-        expect.objectContaining({ error: expect.anything() })
-      )
-    },
-    60_000
-  )
+      })
+    )
+    expect(dbLogMock.warn).toHaveBeenCalledWith(
+      'Search index database initialization failed; falling back to primary DB',
+      expect.objectContaining({ error: expect.anything() })
+    )
+  }, 60_000)
 })

--- a/apps/core-app/src/main/modules/sentry/telemetry-upload-stats-store.test.ts
+++ b/apps/core-app/src/main/modules/sentry/telemetry-upload-stats-store.test.ts
@@ -6,7 +6,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import * as schema from '../../db/schema'
-import { sanitizeTelemetryFailureCode, TelemetryUploadStatsStore } from './telemetry-upload-stats-store'
+import {
+  sanitizeTelemetryFailureCode,
+  TelemetryUploadStatsStore
+} from './telemetry-upload-stats-store'
 
 let clients: Client[] = []
 let directory: string | undefined

--- a/apps/core-app/src/main/modules/tool-gateway/gateway-server.test.ts
+++ b/apps/core-app/src/main/modules/tool-gateway/gateway-server.test.ts
@@ -80,11 +80,24 @@ function call(
   })
 }
 
+/**
+ * The gateway's JSON body as a test reads it.
+ *
+ * `JSON.parse` returns `any`, and the assertions reach fields the helper cannot know about, so this
+ * keeps indexing ergonomic without spreading `any` — an unknown key is `unknown`, which still has
+ * to be narrowed before it is used as anything.
+ */
+interface GatewayJson {
+  [key: string]: unknown
+  isError?: boolean
+  output?: string
+}
+
 async function invoke(
   gateway: ToolGatewayHandle,
   body: unknown,
   token = gateway.token
-): Promise<{ status: number; json: any }> {
+): Promise<{ status: number; json: GatewayJson }> {
   const response = await call(gateway.url, { token, body })
   return {
     status: response.status,

--- a/apps/core-app/src/main/service/failed-files-cleanup-task.test.ts
+++ b/apps/core-app/src/main/service/failed-files-cleanup-task.test.ts
@@ -72,7 +72,10 @@ describe('failed-files-cleanup-task split routing', () => {
   })
 
   it('split on: forwards ONE compiled delete through the worker writer', async () => {
-    const compiled = { sql: 'DELETE FROM file_index_progress WHERE file_id IN (?, ?, ?)', params: [11, 12, 13] }
+    const compiled = {
+      sql: 'DELETE FROM file_index_progress WHERE file_id IN (?, ?, ?)',
+      params: [11, 12, 13]
+    }
     const read = createReadDbMock({ rows: failedRows, compiled })
     const primary = createPrimaryDbMock()
     const execSearchIndexWrite = vi.fn(async () => [])

--- a/apps/core-app/src/main/service/failed-files-cleanup-task.ts
+++ b/apps/core-app/src/main/service/failed-files-cleanup-task.ts
@@ -59,7 +59,10 @@ export class FailedFilesCleanupTask implements BackgroundTask {
   private readonly deps: FailedFilesCleanupTaskDeps
   private options: FailedFilesCleanupTaskOptions
 
-  constructor(deps: FailedFilesCleanupTaskDeps, options: Partial<FailedFilesCleanupTaskOptions> = {}) {
+  constructor(
+    deps: FailedFilesCleanupTaskDeps,
+    options: Partial<FailedFilesCleanupTaskOptions> = {}
+  ) {
     this.deps = deps
     this.options = {
       maxRetryAge: 24 * 60 * 60 * 1000, // 24小时

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
   },
   "lint-staged": {
     "apps/core-app/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}": [
-      "pnpm -C \"apps/core-app\" exec eslint --cache --fix --no-warn-ignored"
+      "pnpm -C \"apps/core-app\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored"
     ],
     "apps/nexus/**/*.{js,jsx,ts,tsx,vue,mjs,cjs,cts,mts}": [
       "pnpm -C \"apps/nexus\" exec eslint --cache --fix --max-warnings=0 --no-warn-ignored"

--- a/packages/utils/__tests__/lint-staged-warning-parity.test.ts
+++ b/packages/utils/__tests__/lint-staged-warning-parity.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Every lint-staged entry must fail on warnings, not just most of them (#721).
+ *
+ * Twenty of the twenty-one entries passed `--max-warnings=0`; `apps/core-app` did not. So the same
+ * warning blocked a commit in `packages/utils` and passed silently in the largest package in the
+ * repo — the one where a slipped warning has the most places to hide.
+ *
+ * A gate that applies to 20 of 21 paths is worse than no gate, because it reads as one.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const manifest = JSON.parse(readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8')) as {
+  'lint-staged': Record<string, string | string[]>
+}
+
+const entries = Object.entries(manifest['lint-staged'])
+
+describe('lint-staged', () => {
+  it('covers the packages it claims to', () => {
+    // Positive control: the parity rule below is vacuous against an empty or misread config.
+    expect(entries.length).toBeGreaterThan(15)
+    expect(entries.some(([glob]) => glob.startsWith('apps/core-app/'))).toBe(true)
+  })
+
+  it('fails on warnings in every package, with no exception', () => {
+    const missing = entries
+      .filter(([, commands]) => {
+        const list = Array.isArray(commands) ? commands : [commands]
+        return list.some((command) => command.includes('eslint'))
+          && !list.some((command) => command.includes('--max-warnings=0'))
+      })
+      .map(([glob]) => glob)
+
+    expect(missing).toEqual([])
+  })
+
+  it('runs eslint for every entry it defines', () => {
+    // Guards the rule above against being satisfied by deleting the entry instead of fixing it.
+    const withoutEslint = entries
+      .filter(([, commands]) => {
+        const list = Array.isArray(commands) ? commands : [commands]
+        return !list.some((command) => command.includes('eslint'))
+      })
+      .map(([glob]) => glob)
+
+    expect(withoutEslint).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #721.

Confirmed: **20 of 21** lint-staged entries pass `--max-warnings=0`; `apps/core-app` is the only one that does not. So the same warning blocks a commit in `packages/utils` and passes silently in the largest package in the repo.

## The flag alone would have broken commits

Measured before changing anything — `apps/core-app` currently has **0 errors and 63 warnings across 7 files**:

| rule | count |
|---|---|
| `prettier/prettier` | 62 |
| `@typescript-eslint/no-explicit-any` | 1 |

All 62 prettier warnings are autofixable, and 56 of them live in one file. Cleared first, so the flag lands on a clean package rather than blocking the next commit that touches any of those seven files.

## The one that needed a decision

`gateway-server.test.ts` had `json: any` on a helper returning `JSON.parse`'s result, which 17 call sites index by arbitrary field. Rather than silence it — a disable comment to satisfy `--max-warnings=0` hollows out the gate this PR is trying to restore — it is typed as an index signature of `unknown` with the two known fields named. Indexing stays ergonomic, an unknown key is `unknown` and still has to be narrowed, and `any` stops spreading.

## Verification

`apps/core-app` eslint: **0 errors, 0 warnings**. The three touched suites pass (26 tests), `gateway-server.test.ts` passes (22), `typecheck:node` unchanged.

`lint-staged-warning-parity.test.ts` in `packages/utils` (so `ci / CI - utils` enforces it): 3 passed. It also asserts every entry still *runs* eslint, so the parity rule cannot be satisfied by deleting an entry instead of fixing it. Mutation-tested: restoring the old `package.json` fails it.