### PR TITLE
fix(modules): stop reporting "not loaded" as "failed to load"

### DIFF
--- a/apps/core-app/src/main/core/module-manager.test.ts
+++ b/apps/core-app/src/main/core/module-manager.test.ts
@@ -28,6 +28,67 @@ const createManager = () => {
   return new ModuleManager(app, channel, { modulesRoot })
 }
 
+describe('loadModule distinguishes not-loading from failing', () => {
+  /**
+   * loadModule returned false for three different things: already loaded, skipped by an env
+   * flag, and an actual lifecycle failure. loadStartupModules throws on any false for a required
+   * module and index.ts turns that into app.quit(), so the first module to declare an env flag
+   * would have quit the app on every machine where that variable was unset (#788).
+   */
+  class TrivialModule extends BaseModule {
+    static key: ModuleKey = Symbol.for('LoadOutcomeTrivial')
+    name: ModuleKey = TrivialModule.key
+    constructor() {
+      super(TrivialModule.key, { create: false })
+    }
+    onInit(): void {}
+    onDestroy(): void {}
+  }
+
+  class EnvGatedModule extends BaseModule {
+    static key: ModuleKey = Symbol.for('LoadOutcomeEnvGated')
+    name: ModuleKey = EnvGatedModule.key
+    constructor() {
+      super(EnvGatedModule.key, { create: false }, ['TUFF_DEFINITELY_UNSET_FLAG'])
+    }
+    onInit(): void {}
+    onDestroy(): void {}
+  }
+
+  class FailingModule extends BaseModule {
+    static key: ModuleKey = Symbol.for('LoadOutcomeFailing')
+    name: ModuleKey = FailingModule.key
+    constructor() {
+      super(FailingModule.key, { create: false })
+    }
+    onInit(): void {
+      throw new Error('init exploded')
+    }
+    onDestroy(): void {}
+  }
+
+  it('已经加载过时返回 true(与它自己的文档契约一致)', async () => {
+    const manager = createManager()
+
+    await expect(manager.loadModule(new TrivialModule())).resolves.toBe(true)
+    // Second call: the module is already in the map.
+    await expect(manager.loadModule(new TrivialModule())).resolves.toBe(true)
+  })
+
+  it('被 env flag 跳过时返回 true,而不是让启动器判定为致命', async () => {
+    const manager = createManager()
+    delete process.env.TUFF_DEFINITELY_UNSET_FLAG
+
+    await expect(manager.loadModule(new EnvGatedModule())).resolves.toBe(true)
+  })
+
+  it('生命周期真的失败时仍然返回 false', async () => {
+    const manager = createManager()
+
+    await expect(manager.loadModule(new FailingModule())).resolves.toBe(false)
+  })
+})
+
 describe('ModuleManager lifecycle isolation', () => {
   it('rolls back on created failure', async () => {
     const manager = createManager()

--- a/apps/core-app/src/main/core/module-manager.ts
+++ b/apps/core-app/src/main/core/module-manager.ts
@@ -295,13 +295,17 @@ export class ModuleManager implements TalexTouch.IModuleManager<TalexEvents> {
   /**
    * Overload signature: Loads a module by its instance.
    * @param module - The module instance to load.
-   * @returns A Promise that resolves to `true` if the module was successfully loaded (or already loaded), otherwise `false`.
+   * @returns A Promise that resolves to `true` when the module is usable - freshly loaded,
+   * already loaded, or deliberately skipped by an env flag - and `false` only when a lifecycle
+   * phase actually failed.
    */
   public loadModule<T extends TalexTouch.IModule<TalexEvents>>(module: T): Promise<boolean>
   /**
    * Overload signature: Loads a module by its constructor.
    * @param module - The module constructor to load.
-   * @returns A Promise that resolves to `true` if the module was successfully loaded (or already loaded), otherwise `false`.
+   * @returns A Promise that resolves to `true` when the module is usable - freshly loaded,
+   * already loaded, or deliberately skipped by an env flag - and `false` only when a lifecycle
+   * phase actually failed.
    */
   public loadModule<T extends TalexTouch.IModule<TalexEvents>>(
     module: ModuleCtor<T, TalexEvents>
@@ -356,7 +360,10 @@ export class ModuleManager implements TalexTouch.IModuleManager<TalexEvents> {
 
     const key = instance.name
     if (this.modules.has(key)) {
-      return false
+      // Already loaded is not a failure - and the documented contract above already said so
+      // while this returned false. loadStartupModules cannot tell the reasons apart and treats
+      // any false on a required module as fatal, so it quit the app (#788).
+      return true
     }
 
     const moduleName = key.description ?? key.toString()
@@ -368,7 +375,10 @@ export class ModuleManager implements TalexTouch.IModuleManager<TalexEvents> {
           envFlags: envFlags.join(', ')
         }
       })
-      return false
+      // Deliberately not loaded, which is the point of declaring env flags. Returning false here
+      // meant the first module to declare one would quit the app on every machine where that
+      // variable is unset.
+      return true
     }
 
     moduleLog.info('Loading module', {


### PR DESCRIPTION
Closes #788.

`loadModule` returned `false` for three different things: the module was **already loaded**, it was **skipped by an env flag**, or a lifecycle phase **actually failed**. `loadStartupModules` cannot tell them apart and throws on any `false` for a required module, which `index.ts` turns into `app.quit()`.

The already-loaded case also **contradicted the method's own JSDoc**, which already promised `true` *"if the module was successfully loaded (or already loaded)"*.

Both non-failures now return `true`, and the two JSDoc blocks describe all three outcomes. A real lifecycle failure still returns `false`.

### The env case is the one that mattered

No module declares `env` today, but `isModuleEnvEnabled` exists to be used. The first developer to add `env: ['TUFF_SOMETHING']` would have shipped an app that **quits at startup on every machine where that variable is unset** — reported as a generic *"Required module failed to load"* naming the module but not the reason.

### Callers checked before changing the contract

`index.ts` feeds the result straight to the startup loader; `core-box/index.ts` ignores it. Nothing depended on `false` meaning "already loaded".

### Three tests, each mutation hitting only its own

| mutation | fails |
|---|---|
| already-loaded returns `false` again | the already-loaded test |
| env-skipped returns `false` again | the env test |

The third is the **control** and passes in every state — a module whose `onInit` throws must still report `false`, so *"always return true"* is caught rather than shipped.

eslint **0**, tsc **0** with zero TS errors, gated before committing. **12/12** here; the `startup-module-loader` suite is untouched and still passes **5/5**.
