### PR TITLE
fix(quit): never let the before-quit tail leave the app unquittable

### DIFF
--- a/apps/core-app/src/main/core/before-quit-finalize.test.ts
+++ b/apps/core-app/src/main/core/before-quit-finalize.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The before-quit handler calls event.preventDefault() unconditionally, so anything that throws
+ * before app.quit() leaves the app unquittable - every later attempt is prevented too and the
+ * user has to force-kill it. broadcastBeforeQuit resolves the channel and builds a transport,
+ * both of which can be in a bad state at shutdown, and it sat outside any try/catch (#796).
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { finalizeBeforeQuit } from './before-quit-finalize'
+
+function options(overrides: Partial<Parameters<typeof finalizeBeforeQuit>[0]> = {}) {
+  return {
+    broadcast: vi.fn(),
+    shouldDelegateToDevManager: vi.fn(() => false),
+    delegateToDevManager: vi.fn(),
+    quit: vi.fn(),
+    logError: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('the before-quit tail always ends in a quit', () => {
+  it('正常路径:广播之后退出', () => {
+    const opts = options()
+
+    expect(finalizeBeforeQuit(opts).delegated).toBe(false)
+
+    expect(opts.broadcast).toHaveBeenCalled()
+    expect(opts.quit).toHaveBeenCalledTimes(1)
+  })
+
+  it('广播抛错时仍然退出,而不是把应用变成关不掉', () => {
+    const opts = options({
+      broadcast: vi.fn(() => {
+        throw new Error('transport is gone')
+      })
+    })
+
+    expect(() => finalizeBeforeQuit(opts)).not.toThrow()
+
+    expect(opts.quit).toHaveBeenCalledTimes(1)
+    expect(opts.logError).toHaveBeenCalledWith(
+      expect.stringContaining('broadcast failed'),
+      expect.any(Error)
+    )
+  })
+
+  it('开发模式下交给 DevProcessManager,并且不自己退出', () => {
+    const opts = options({ shouldDelegateToDevManager: vi.fn(() => true) })
+
+    expect(finalizeBeforeQuit(opts).delegated).toBe(true)
+
+    expect(opts.delegateToDevManager).toHaveBeenCalledTimes(1)
+    // The control: quitting here as well would cut the dev manager's shutdown short.
+    expect(opts.quit).not.toHaveBeenCalled()
+  })
+
+  it('委派本身抛错时,回退为直接退出', () => {
+    const opts = options({
+      shouldDelegateToDevManager: vi.fn(() => true),
+      delegateToDevManager: vi.fn(() => {
+        throw new Error('dev manager unavailable')
+      })
+    })
+
+    expect(finalizeBeforeQuit(opts).delegated).toBe(false)
+
+    // Nobody else is going to quit for us if delegation failed.
+    expect(opts.quit).toHaveBeenCalledTimes(1)
+  })
+
+  it('判断是否委派的那个回调抛错时,也不会卡住退出', () => {
+    const opts = options({
+      shouldDelegateToDevManager: vi.fn(() => {
+        throw new Error('cannot read packaged state')
+      })
+    })
+
+    expect(() => finalizeBeforeQuit(opts)).not.toThrow()
+
+    expect(opts.quit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/core-app/src/main/core/before-quit-finalize.ts
+++ b/apps/core-app/src/main/core/before-quit-finalize.ts
@@ -1,0 +1,54 @@
+/**
+ * The tail of the before-quit flow: broadcast, then either hand off to the dev shutdown manager
+ * or quit.
+ *
+ * Extracted because the handler in precore.ts calls event.preventDefault() unconditionally, so
+ * anything that throws before app.quit() leaves the app unquittable - every later attempt is
+ * prevented too, and the user has to force-kill it. broadcastBeforeQuit resolves the channel and
+ * builds a transport, both of which can be in a bad state at shutdown, and it sat outside any
+ * try/catch (#796).
+ *
+ * Nothing here may throw past its own step. The contract is simply: this function always ends in
+ * a quit or an explicit delegation, whatever the callbacks do.
+ */
+export interface BeforeQuitFinalizeOptions {
+  broadcast: () => void
+  shouldDelegateToDevManager: () => boolean
+  delegateToDevManager: () => void
+  quit: () => void
+  logError: (message: string, error: unknown) => void
+}
+
+export interface BeforeQuitFinalizeResult {
+  /** True when the dev shutdown manager took over and this flow must not call quit. */
+  delegated: boolean
+}
+
+export function finalizeBeforeQuit(options: BeforeQuitFinalizeOptions): BeforeQuitFinalizeResult {
+  try {
+    options.broadcast()
+  } catch (error) {
+    // A renderer that never hears about the quit is a far smaller problem than an app that
+    // cannot be closed.
+    options.logError('before-quit broadcast failed, continuing shutdown', error)
+  }
+
+  let delegated = false
+  try {
+    if (options.shouldDelegateToDevManager()) {
+      options.delegateToDevManager()
+      delegated = true
+    }
+  } catch (error) {
+    // Delegation failing means nobody else is going to quit for us, so fall through and do it.
+    options.logError('dev shutdown delegation failed, quitting directly', error)
+    delegated = false
+  }
+
+  if (delegated) {
+    return { delegated: true }
+  }
+
+  options.quit()
+  return { delegated: false }
+}

--- a/apps/core-app/src/main/core/precore.ts
+++ b/apps/core-app/src/main/core/precore.ts
@@ -28,6 +28,7 @@ import { getCurrentTouchApp } from './main-runtime-state'
 import { runWithBeforeQuitTimeout } from './before-quit-guard'
 import { ensureUserNormalQuitIntent, getQuitIntent, setQuitIntent } from './quit-intent'
 import { setupSingleInstanceGuard } from './single-instance-guard'
+import { finalizeBeforeQuit } from './before-quit-finalize'
 
 const resolveKeyManager = (channel: unknown): unknown =>
   (channel as { keyManager?: unknown } | null | undefined)?.keyManager ?? channel
@@ -361,18 +362,27 @@ app.on('before-quit', (event) => {
     } catch (error) {
       mainLog.error('before-quit handlers failed, continue shutdown', { error })
     }
-    broadcastBeforeQuit()
     mainLog.info('App quit requested')
 
-    // Development mode: let DevProcessManager orchestrate shutdown steps.
-    if (!app.isPackaged && !devProcessManager.isShuttingDownProcess()) {
-      mainLog.debug('Development mode: delegating quit to DevProcessManager')
-      devProcessManager.triggerGracefulShutdown()
+    const finalized = finalizeBeforeQuit({
+      broadcast: broadcastBeforeQuit,
+      // Development mode: let DevProcessManager orchestrate shutdown steps.
+      shouldDelegateToDevManager: () =>
+        !app.isPackaged && !devProcessManager.isShuttingDownProcess(),
+      delegateToDevManager: () => {
+        mainLog.debug('Development mode: delegating quit to DevProcessManager')
+        devProcessManager.triggerGracefulShutdown()
+      },
+      quit: () => {
+        beforeQuitFlowDone = true
+        app.quit()
+      },
+      logError: (message, error) => mainLog.error(message, { error })
+    })
+
+    if (finalized.delegated) {
       return
     }
-
-    beforeQuitFlowDone = true
-    app.quit()
   })()
     .catch((error) => {
       mainLog.error('before-quit cleanup flow failed', { error })


### PR DESCRIPTION
Closes #796.

The handler calls `event.preventDefault()` unconditionally, so anything that throws before `app.quit()` is fatal in the worst way: `beforeQuitFlowDone` stays `false`, the outer `.catch` swallows the error, and **every later quit attempt is prevented too**. The user has to force-kill the app.

`broadcastBeforeQuit` sat outside any try/catch — and it resolves the channel and builds a transport, both plausibly in a bad state at shutdown, which is exactly when this runs.

### The tail is now `finalizeBeforeQuit`

Broadcast, then either delegate to the dev shutdown manager or quit, with **each step contained** so a throw cannot skip the quit. Delegation failing falls through to quitting directly — if the dev manager did not take over, nobody else is going to.

Extracted rather than fixed in place because `precore.ts` runs its guards, its handlers and its filesystem setup at module scope. Importing it to test this would boot most of the main process, which is why #790 had to settle for source assertions. This is a real unit instead.

### Five tests, two mutations

| mutation | fails |
|---|---|
| broadcast back outside the try | the broadcast-throws test |
| delegation failure marked as delegated | two — both quit paths |

The dev-delegation test is the **control** and passes in every state: when the dev manager *does* take over, this flow must not also call `quit`, or it would cut that shutdown short. A fix written as "always quit" would fail it.

### Not added

The backstop `app.exit()` timer the issue also suggests. Forcing an exit on a timer can kill a legitimately slow shutdown, and with the quit no longer skippable it guards a case that now needs a different failure to reach — worth its own decision rather than bundling it here.

eslint **0**, tsc **0** with zero TS errors, gated before committing. **5/5**.
