### PR TITLE
fix(preload): reject message events this window did not send itself

### DIFF
--- a/apps/core-app/src/preload/index.ts
+++ b/apps/core-app/src/preload/index.ts
@@ -10,6 +10,7 @@ import appLogoSvgRaw from '../../public/logo.svg?raw'
 import { contextBridge, ipcRenderer } from 'electron'
 import { RAW_MAIN_PROCESS_CHANNEL, RAW_PLUGIN_PROCESS_CHANNEL } from '../shared/ipc/raw-channel'
 import { resolvePreloadTargetOrigin } from './preload-target-origin'
+import { isTrustedPreloadMessage } from './trusted-preload-message'
 
 interface StartupHandshakePayload {
   rendererStartTime: number
@@ -684,6 +685,7 @@ function useLoading(options: LoadingOptions) {
   }
 
   const messageListener = (ev: MessageEvent) => {
+    if (!isTrustedPreloadMessage(ev, window)) return
     if (ev.data?.channel !== PRELOAD_LOADING_CHANNEL) return
     const payload = ev.data.data as LoadingEvent | undefined
     if (!payload) return
@@ -779,7 +781,10 @@ domReady().then(() => {
   document.body.classList.add(info.platform)
 })
 
-window.onmessage = (ev) => {
+// addEventListener rather than `window.onmessage =`: the assignment form replaces whatever the
+// page had registered, which is not this preload's call to make (#797).
+window.addEventListener('message', (ev) => {
+  if (!isTrustedPreloadMessage(ev, window)) return
   if (!ev.data) return
   if (ev.data.payload === 'removeLoading') {
     removeLoading()
@@ -788,7 +793,7 @@ window.onmessage = (ev) => {
   if (ev.data.channel === PRELOAD_LOADING_CHANNEL) {
     handleEvent(ev.data.data as LoadingEvent)
   }
-}
+})
 
 window.addEventListener('DOMContentLoaded', () => {
   updateMessage('Renderer initializing modules...')

--- a/apps/core-app/src/preload/trusted-preload-message.test.ts
+++ b/apps/core-app/src/preload/trusted-preload-message.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The preload's loading-overlay sinks dispatched on `ev.data` alone, in the privileged preload
+ * context, so any cross-origin frame embedded in the page could post `{ payload: 'removeLoading' }`
+ * or a crafted channel event and be obeyed (#797).
+ */
+import { describe, expect, it } from 'vitest'
+import { isTrustedPreloadMessage } from './trusted-preload-message'
+
+function selfWindow(origin: string): Window {
+  return { location: { origin } } as unknown as Window
+}
+
+describe('isTrustedPreloadMessage', () => {
+  it('接受本窗口 postMessage 给自己的消息', () => {
+    const self = selfWindow('https://app.example')
+
+    expect(isTrustedPreloadMessage({ source: self, origin: 'https://app.example' }, self)).toBe(
+      true
+    )
+  })
+
+  it('拒绝来自其它窗口的消息,哪怕 origin 相同', () => {
+    const self = selfWindow('https://app.example')
+    const frame = {} as unknown as Window
+
+    // A same-origin iframe is still not this window: source is what cannot be forged.
+    expect(isTrustedPreloadMessage({ source: frame, origin: 'https://app.example' }, self)).toBe(
+      false
+    )
+  })
+
+  it('拒绝跨源来源', () => {
+    const self = selfWindow('https://app.example')
+    const frame = {} as unknown as Window
+
+    expect(isTrustedPreloadMessage({ source: frame, origin: 'https://evil.example' }, self)).toBe(
+      false
+    )
+  })
+
+  it('source 相同但 origin 不符时仍然拒绝', () => {
+    const self = selfWindow('https://app.example')
+
+    expect(isTrustedPreloadMessage({ source: self, origin: 'https://evil.example' }, self)).toBe(
+      false
+    )
+  })
+
+  it('file: 页面不会被自己的 null origin 挡住', () => {
+    // The packaged app loads from file:, whose origin serialises as 'null'. Rejecting on that
+    // would break the real app rather than an attacker.
+    const self = selfWindow('null')
+
+    expect(isTrustedPreloadMessage({ source: self, origin: 'null' }, self)).toBe(true)
+    expect(isTrustedPreloadMessage({ source: self, origin: '' }, self)).toBe(true)
+  })
+
+  it('没有 source 的消息一律拒绝', () => {
+    const self = selfWindow('https://app.example')
+
+    expect(isTrustedPreloadMessage({ source: null, origin: 'https://app.example' }, self)).toBe(
+      false
+    )
+  })
+})

--- a/apps/core-app/src/preload/trusted-preload-message.ts
+++ b/apps/core-app/src/preload/trusted-preload-message.ts
@@ -1,0 +1,26 @@
+/**
+ * Whether a `message` event was posted by this window to itself.
+ *
+ * The preload's loading-overlay sinks dispatched on `ev.data` alone, in the privileged preload
+ * context, so any cross-origin frame embedded in the page could post `{ payload: 'removeLoading' }`
+ * or a crafted channel event and be obeyed (#797).
+ *
+ * `source` is the decisive test: only a message posted by this same window object carries
+ * `source === window`. A frame posting to its parent carries that frame's window instead, whatever
+ * it claims in `data`. Origin is checked too when both sides have a real one - a `file:` page
+ * serialises its origin as the string `'null'`, and rejecting on that would break the packaged
+ * app rather than an attacker.
+ */
+export function isTrustedPreloadMessage(
+  event: Pick<MessageEvent, 'source' | 'origin'>,
+  self: Window | null
+): boolean {
+  if (!self || event.source !== self) return false
+
+  const expected = self.location?.origin
+  const actual = event.origin
+  if (!expected || expected === 'null') return true
+  if (!actual || actual === 'null') return true
+
+  return actual === expected
+}


### PR DESCRIPTION
Closes #797.

Both loading-overlay sinks dispatched on `ev.data` alone, in the **privileged preload context**, so any cross-origin frame embedded in the page could post `{ payload: 'removeLoading' }` or a crafted channel event and be obeyed.

### `source`, not origin, is the decisive test

Legitimate events come from `sendPreloadEvent` calling `window.postMessage` on **this same window**, so `source === window`. A frame posting to its parent carries that frame's window instead — whatever it puts in `data`. Origin is checked as well when both sides have a real one.

**Null origins are accepted deliberately.** The packaged app loads from `file:`, whose origin serialises as the string `'null'`. Rejecting on that would break the real app rather than an attacker — there is nothing to compare against, and `source` has already done the work.

### `window.onmessage =` became `addEventListener`

The assignment form replaces whatever the page had registered, which is not this preload's call to make. The issue is right to flag it.

### Six tests, three mutations, each hitting only its own

| mutation | fails |
|---|---|
| drop the `source` check | **2** — including a message with no source at all |
| drop the origin check | **1** — a same-window claim with a foreign origin |
| reject null origins | **1** — the packaged `file:` case |

That last mutation is the one worth keeping: it is the shape a *stricter-looking* fix would take, and it breaks the shipped app.

eslint **0**, tsc **0** with zero TS errors, gated before committing. **6/6**.
