### PR TITLE
fix(core): stop capping every renderer's heap at 512MB

### DIFF
--- a/apps/core-app/src/main/core/precore.ts
+++ b/apps/core-app/src/main/core/precore.ts
@@ -193,8 +193,15 @@ log4js.configure({
 
 mainLog.success('Talex Touch bootstrap started')
 
-// Increase renderer process V8 heap limit (main process uses NODE_OPTIONS)
-const v8JsFlags = ['--max-old-space-size=512']
+// V8 flags handed to every child process, renderers and utility processes included.
+//
+// This list used to carry `--max-old-space-size=512` under a comment claiming it raised the
+// limit. On 64-bit platforms V8's default old-space is already far above that, so the flag
+// lowered the ceiling for every renderer instead - which is the opposite of what the commit
+// that added it set out to do, and touch-window.ts already reports RENDER_PROCESS_OOM (#795).
+// Nothing is set now, so renderers get V8's default. Per-process budgets that are deliberate,
+// like the plugin runtime's, are set at their own spawn sites.
+const v8JsFlags: string[] = []
 
 // Opt-in escape hatch for the macOS 26/27 (Tahoe) V8 JIT-page crash
 // (electron/electron#51351): `--jitless` removes the executable MAP_JIT pages
@@ -205,7 +212,9 @@ if (parseBooleanEnv(process.env.TUFF_V8_JITLESS)) {
   mainLog.warn('V8 JIT disabled via TUFF_V8_JITLESS (slower JS; Tahoe crash workaround)')
 }
 
-app.commandLine.appendSwitch('js-flags', v8JsFlags.join(' '))
+if (v8JsFlags.length > 0) {
+  app.commandLine.appendSwitch('js-flags', v8JsFlags.join(' '))
+}
 
 // Disable GPU Acceleration for Windows 7 (NT 6.1).
 // The platform guard is load-bearing: os.release() returns the kernel version on

--- a/apps/core-app/src/main/core/v8-flags.contract.test.ts
+++ b/apps/core-app/src/main/core/v8-flags.contract.test.ts
@@ -1,0 +1,34 @@
+/**
+ * `--max-old-space-size=512` sat in the renderer js-flags under a comment claiming it raised the
+ * heap limit. On 64-bit platforms V8's default old-space is far above 512MB, so it lowered the
+ * ceiling for every renderer instead - the opposite of what the commit adding it described, and
+ * touch-window.ts already reports RENDER_PROCESS_OOM (#795).
+ *
+ * Source assertions, in the style of the sibling quit-paths.test.ts: precore.ts runs its guards,
+ * its handlers and its filesystem setup at module scope, so importing it to read the flag list
+ * would boot most of the main process.
+ */
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PRECORE = readFileSync(path.join(__dirname, 'precore.ts'), 'utf8')
+
+describe('global V8 flags do not cap the renderer heap', () => {
+  it('不再给所有子进程设 --max-old-space-size', () => {
+    // Positive control: the flag list must still be there, or the absence below proves nothing.
+    expect(PRECORE).toContain('const v8JsFlags')
+
+    expect(PRECORE).not.toMatch(/v8JsFlags\s*=\s*\[[^\]]*max-old-space-size/)
+  })
+
+  it('--jitless 逃生开关仍然保留', () => {
+    // Removing the cap must not take the Tahoe crash workaround with it.
+    expect(PRECORE).toContain('TUFF_V8_JITLESS')
+    expect(PRECORE).toContain("v8JsFlags.push('--jitless')")
+  })
+
+  it('空列表时不会附加一个空的 js-flags 开关', () => {
+    expect(PRECORE).toMatch(/if \(v8JsFlags\.length > 0\) \{\s*\n\s*app\.commandLine\.appendSwitch/)
+  })
+})


### PR DESCRIPTION
Closes #795.

The js-flags list carried `--max-old-space-size=512` under a comment saying it **increased** the limit. On 64-bit platforms V8's default old-space is already far above that, so the flag **lowered** the ceiling for every renderer and utility process instead.

### Was 512 deliberate? No — and the evidence is unambiguous

The issue asks that first, so it was checked before anything changed. The commit that added it, `cd8c4b995`, describes it as:

> Increased V8 heap limit for both main and renderer processes to improve memory handling.

and in the same commit set `NODE_OPTIONS='--max-old-space-size=512'` in the dev script. The same mistake, made with the opposite intent, in both places. `touch-window.ts` already reports `RENDER_PROCESS_OOM` — which is what hitting this ceiling looks like from the outside.

### Removed rather than raised

The intent was *not to constrain*, and V8's default already expresses that without inventing a figure. Deliberate per-process budgets — the plugin runtime's 96/128MB — stay at their own spawn sites where they are explicit and visible.

`appendSwitch` is now guarded so an empty list does not pass an empty `js-flags` string, and the `--jitless` escape hatch still populates it.

### Verification

Three source assertions, in the style of the sibling `quit-paths.test.ts` — `precore.ts` runs its guards and filesystem setup at module scope, so importing it to read the list would boot most of the main process.

| mutation | fails |
|---|---|
| restore the cap | the no-cap test |
| drop the empty-list guard | the empty-switch test |
| remove `--jitless` along with the cap | the escape-hatch test |

That third one matters: the hatch shares the same array, and a careless removal takes it along.

### Not changed

The dev script's `NODE_OPTIONS='--max-old-space-size=512'` in `apps/core-app/package.json`. Same error, same commit — but it only affects `pnpm dev`, and changing a developer's heap budget is a call for whoever relies on it.

eslint **0**, tsc **0** with zero TS errors, gated before committing. **3/3**.
