### PR TITLE
feat(startup): make an optional module's failure visible to the user

### DIFF
--- a/apps/core-app/src/main/index.ts
+++ b/apps/core-app/src/main/index.ts
@@ -57,6 +57,7 @@ import { pluginLogModule } from './service/plugin-log.service'
 
 import { loggerManager, mainLog } from './utils/logger'
 import './polyfills'
+import { getAnalyticsMessageStore } from './modules/analytics/message-store'
 
 // 设置环境变量禁用 ws 模块的可选依赖
 process.env.WS_NO_UTF_8_VALIDATE = 'true'
@@ -170,6 +171,30 @@ applyLoggerConfig({ diagnostics: { verboseLogs: false } })
 
 // Permission module instance
 const permissionModule = new PermissionModule()
+
+/**
+ * An optional module that fails is a feature the user silently does not have. Only logging it
+ * means nobody outside a log file ever learns, which is why widening the optional tier needs
+ * this first: trading "the app refuses to start" for "the feature is quietly missing" is not an
+ * improvement unless the absence is visible (#789).
+ */
+function reportOptionalModuleFailure(tier: 'foreground' | 'deferred', moduleName: string): void {
+  mainLog.warn(`Optional ${tier} module failed to load, continue startup`, {
+    meta: { module: moduleName }
+  })
+  try {
+    getAnalyticsMessageStore().add({
+      source: 'system',
+      severity: 'warn',
+      title: 'A feature failed to start',
+      message: `${moduleName} did not load. The app started without it.`,
+      meta: { module: moduleName, tier }
+    })
+  } catch (error) {
+    // Reporting must never be the thing that stops startup.
+    mainLog.warn('Failed to record optional module failure', { error })
+  }
+}
 
 const foregroundModulesToLoad = [
   databaseModule,
@@ -307,9 +332,7 @@ app.whenReady().then(async () => {
       },
       optionalModules: optionalModulesToLoad,
       onOptionalModuleLoadFailed: async (_moduleCtor, metric) => {
-        mainLog.warn('Optional foreground module failed to load, continue startup', {
-          meta: { module: metric.name }
-        })
+        reportOptionalModuleFailure('foreground', metric.name)
       },
       onLoaded: handleModuleLoaded
     })) as ModuleLoadMetric[]
@@ -369,9 +392,7 @@ app.whenReady().then(async () => {
           },
           optionalModules: optionalModulesToLoad,
           onOptionalModuleLoadFailed: async (_moduleCtor, metric) => {
-            mainLog.warn('Optional deferred module failed to load, continue startup', {
-              meta: { module: metric.name }
-            })
+            reportOptionalModuleFailure('deferred', metric.name)
           },
           onLoaded: handleModuleLoaded
         })) as ModuleLoadMetric[]

--- a/apps/core-app/src/main/optional-module-visibility.test.ts
+++ b/apps/core-app/src/main/optional-module-visibility.test.ts
@@ -1,0 +1,39 @@
+/**
+ * 35 of 38 foreground modules are mandatory, so any one of them failing to init quits the app -
+ * a peripheral feature's blast radius equals total unavailability (#789).
+ *
+ * Widening the optional tier is the fix, but it needs this first: an optional module that fails
+ * only produced a mainLog.warn, so moving modules into that tier would have traded "the app
+ * refuses to start" for "the feature is quietly missing", which is not obviously better.
+ *
+ * Source assertions: index.ts is the app entry point and boots Electron on import.
+ */
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const INDEX = readFileSync(path.join(__dirname, 'index.ts'), 'utf8')
+
+describe('an optional module failing is visible, not just logged', () => {
+  it('两个 optional 失败回调都走同一个上报函数', () => {
+    // Positive control: both callbacks must still exist, or the assertions below prove nothing.
+    const callbacks = INDEX.match(/onOptionalModuleLoadFailed/g) ?? []
+    expect(callbacks).toHaveLength(2)
+
+    const reports = INDEX.match(/reportOptionalModuleFailure\(/g) ?? []
+    // One definition plus both call sites.
+    expect(reports.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('上报进入 analytics message store,而不是只写日志', () => {
+    expect(INDEX).toContain('getAnalyticsMessageStore().add(')
+    expect(INDEX).toMatch(/reportOptionalModuleFailure[\s\S]{0,600}?getAnalyticsMessageStore/)
+  })
+
+  it('上报自身失败不会中断启动', () => {
+    // The report is a nicety; startup is not. It must not be able to throw past itself.
+    expect(INDEX).toMatch(
+      /getAnalyticsMessageStore\(\)\.add\([\s\S]{0,400}?\}\)\s*\n\s*\} catch \(error\) \{/
+    )
+  })
+})


### PR DESCRIPTION
Groundwork for #789 — **not** the whole of it, and deliberately so.

35 of 38 foreground modules are mandatory, so voice, terminal, download, sync or screenshot failing to init quits the launcher. The blast radius of a peripheral feature equals total unavailability, for an app whose core job is search.

### Why the suggested fix could not be applied as written

The issue says to widen the optional tier so those failures "degrade and surface through the existing analytics message store". **They do not surface there.** An optional module failing produced a single `mainLog.warn` and nothing else.

Moving six modules into that tier today would have traded *"the app refuses to start"* for *"the feature is quietly missing with no indication anywhere the user looks"* — which is not obviously an improvement, and is much harder to diagnose.

### What this does

Both optional-failure callbacks now report through the analytics message store as a warn-level system message naming the module, and the report is wrapped so it can never be the thing that stops startup.

### What this deliberately does not do

Decide **which** modules belong in the optional tier. That is a product judgement about acceptable degradation: `buildVerificationModule` failing may well be something you want fatal, and `updateServiceModule` is arguable in both directions. It is not mine to make from the module list alone — the issue stays open for it.

### Verification

Three source assertions, since `index.ts` boots Electron on import.

| mutation | fails |
|---|---|
| back to log-only | **2** |
| remove the try/catch around the report | **1** |

eslint **0**, tsc **0** with zero TS errors, gated before committing. **3/3**.
