### PR TITLE
fix(security): give app-profile views the navigation guards plugin views have

### DIFF
--- a/apps/core-app/src/main/core/app-view-navigation-policy.test.ts
+++ b/apps/core-app/src/main/core/app-view-navigation-policy.test.ts
@@ -57,10 +57,10 @@ describe('isAppViewNavigationAllowed', () => {
 
 describe('installAppViewNavigationPolicy', () => {
   function fakeWebContents() {
-    const handlers = new Map<string, (...args: any[]) => void>()
+    const handlers = new Map<string, (...args: unknown[]) => void>()
     return {
       handlers,
-      on: vi.fn((event: string, listener: (...args: any[]) => void) => {
+      on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
         handlers.set(event, listener)
       }),
       setWindowOpenHandler: vi.fn()
@@ -83,11 +83,11 @@ describe('installAppViewNavigationPolicy', () => {
     const willNavigate = wc.handlers.get('will-navigate')!
 
     const blocked = { preventDefault: vi.fn() }
-    willNavigate(blocked, 'https://evil.example/')
+    willNavigate(blocked as never, 'https://evil.example/')
     expect(blocked.preventDefault).toHaveBeenCalled()
 
     const allowed = { preventDefault: vi.fn() }
-    willNavigate(allowed, 'http://localhost:5173/index.html#/meta-overlay')
+    willNavigate(allowed as never, 'http://localhost:5173/index.html#/meta-overlay')
     expect(allowed.preventDefault).not.toHaveBeenCalled()
   })
 
@@ -96,7 +96,7 @@ describe('installAppViewNavigationPolicy', () => {
     installAppViewNavigationPolicy(wc as never, devEntry)
 
     const event = { preventDefault: vi.fn() }
-    wc.handlers.get('will-attach-webview')!(event)
+    wc.handlers.get('will-attach-webview')!(event as never)
     expect(event.preventDefault).toHaveBeenCalled()
   })
 })

--- a/apps/core-app/src/main/core/app-view-navigation-policy.test.ts
+++ b/apps/core-app/src/main/core/app-view-navigation-policy.test.ts
@@ -1,0 +1,102 @@
+/**
+ * MetaOverlay built a WebContentsView with no navigation guards at all, and
+ * plugin-view-controller / division-box only installed the plugin policy when a plugin was
+ * present - with no plugin the view ran the app profile with no window-open handler and no
+ * navigation restriction (#793).
+ */
+import { describe, expect, it, vi } from 'vitest'
+import {
+  installAppViewNavigationPolicy,
+  isAppViewNavigationAllowed
+} from './app-view-navigation-policy'
+
+const devEntry = { entryUrl: 'http://localhost:5173/index.html' }
+const packagedEntry = { entryUrl: 'file:///Applications/Tuff.app/renderer/index.html' }
+
+describe('isAppViewNavigationAllowed', () => {
+  it('允许应用自身入口', () => {
+    expect(isAppViewNavigationAllowed(devEntry, 'http://localhost:5173/index.html')).toBe(true)
+    expect(
+      isAppViewNavigationAllowed(packagedEntry, 'file:///Applications/Tuff.app/renderer/index.html')
+    ).toBe(true)
+  })
+
+  it('允许同文档的 hash 路由(渲染层就是这么导航的)', () => {
+    // The overlay loads `...index.html#/meta-overlay`; treating that as navigation would break
+    // the very views this protects.
+    expect(
+      isAppViewNavigationAllowed(devEntry, 'http://localhost:5173/index.html#/meta-overlay')
+    ).toBe(true)
+    expect(
+      isAppViewNavigationAllowed(
+        packagedEntry,
+        'file:///Applications/Tuff.app/renderer/index.html#/meta-overlay'
+      )
+    ).toBe(true)
+  })
+
+  it('拒绝外部站点', () => {
+    expect(isAppViewNavigationAllowed(devEntry, 'https://evil.example/')).toBe(false)
+    expect(isAppViewNavigationAllowed(packagedEntry, 'https://evil.example/')).toBe(false)
+  })
+
+  it('拒绝磁盘上的其它文件(file: 的 origin 都是 null,只有路径能区分)', () => {
+    expect(isAppViewNavigationAllowed(packagedEntry, 'file:///Users/someone/.ssh/id_rsa')).toBe(
+      false
+    )
+    expect(
+      isAppViewNavigationAllowed(packagedEntry, 'file:///Applications/Tuff.app/renderer/other.html')
+    ).toBe(false)
+  })
+
+  it('拒绝无法解析的目标', () => {
+    expect(isAppViewNavigationAllowed(devEntry, 'not a url')).toBe(false)
+    expect(isAppViewNavigationAllowed(devEntry, '')).toBe(false)
+  })
+})
+
+describe('installAppViewNavigationPolicy', () => {
+  function fakeWebContents() {
+    const handlers = new Map<string, (...args: any[]) => void>()
+    return {
+      handlers,
+      on: vi.fn((event: string, listener: (...args: any[]) => void) => {
+        handlers.set(event, listener)
+      }),
+      setWindowOpenHandler: vi.fn()
+    }
+  }
+
+  it('拒绝一切 window.open', () => {
+    const wc = fakeWebContents()
+
+    installAppViewNavigationPolicy(wc as never, devEntry)
+
+    expect(wc.setWindowOpenHandler).toHaveBeenCalledTimes(1)
+    const handler = wc.setWindowOpenHandler.mock.calls[0]?.[0] as () => { action: string }
+    expect(handler()).toEqual({ action: 'deny' })
+  })
+
+  it('阻止导航到外部地址,放行自身入口', () => {
+    const wc = fakeWebContents()
+    installAppViewNavigationPolicy(wc as never, devEntry)
+    const willNavigate = wc.handlers.get('will-navigate')!
+
+    const blocked = { preventDefault: vi.fn() }
+    willNavigate(blocked, 'https://evil.example/')
+    expect(blocked.preventDefault).toHaveBeenCalled()
+
+    const allowed = { preventDefault: vi.fn() }
+    willNavigate(allowed, 'http://localhost:5173/index.html#/meta-overlay')
+    expect(allowed.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('阻止 webview 附加', () => {
+    const wc = fakeWebContents()
+    installAppViewNavigationPolicy(wc as never, devEntry)
+
+    const event = { preventDefault: vi.fn() }
+    wc.handlers.get('will-attach-webview')!(event)
+    expect(event.preventDefault).toHaveBeenCalled()
+  })
+})

--- a/apps/core-app/src/main/core/app-view-navigation-policy.ts
+++ b/apps/core-app/src/main/core/app-view-navigation-policy.ts
@@ -1,0 +1,68 @@
+/**
+ * Navigation guards for WebContentsViews built with the `app` security profile.
+ *
+ * Plugin views get installPluginViewNavigationPolicy; these got nothing. MetaOverlay never
+ * installed guards at all, and plugin-view-controller and division-box only install the plugin
+ * policy when a plugin is present - with no plugin, the view runs the app profile with no
+ * window-open handler and no navigation restriction (#793).
+ *
+ * The rule is deliberately narrow: an app view only ever shows this application's own renderer,
+ * so anything that is not that entry is refused rather than allow-listed case by case.
+ */
+
+export interface AppViewNavigationPolicy {
+  /** The renderer entry this view is allowed to be: a dev server URL or a packaged file: URL. */
+  entryUrl: string
+}
+
+/**
+ * A target is allowed when it is the same document as the entry.
+ *
+ * Hash and query are ignored: the renderer routes with `#/meta-overlay` and friends, so treating
+ * a hash change as a navigation would break the views this is protecting. Origin and pathname
+ * are what must not move.
+ */
+export function isAppViewNavigationAllowed(
+  policy: AppViewNavigationPolicy,
+  targetUrl: string
+): boolean {
+  let target: URL
+  let entry: URL
+  try {
+    target = new URL(targetUrl)
+    entry = new URL(policy.entryUrl)
+  } catch {
+    return false
+  }
+
+  if (target.protocol !== entry.protocol) return false
+  if (target.origin !== entry.origin) return false
+
+  // file: URLs share the opaque 'null' origin, so the path is the only thing separating the
+  // app's own index.html from any other file on disk.
+  return target.pathname === entry.pathname
+}
+
+export function installAppViewNavigationPolicy(
+  webContents: Electron.WebContents,
+  policy: AppViewNavigationPolicy
+): void {
+  webContents.on('will-navigate', (event, targetUrl) => {
+    if (!isAppViewNavigationAllowed(policy, targetUrl)) {
+      event.preventDefault()
+    }
+  })
+
+  webContents.on('will-frame-navigate', (details) => {
+    if (!isAppViewNavigationAllowed(policy, details.url)) {
+      details.preventDefault()
+    }
+  })
+
+  // Nothing in an app view has a reason to open a window; the app creates its own.
+  webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
+
+  webContents.on('will-attach-webview', (event) => {
+    event.preventDefault()
+  })
+}

--- a/apps/core-app/src/main/modules/box-tool/core-box/meta-overlay.ts
+++ b/apps/core-app/src/main/modules/box-tool/core-box/meta-overlay.ts
@@ -26,6 +26,8 @@ import { buildWindowWebPreferences } from '../../../core/window-security-profile
 import { useAliveTarget, useAliveWebContents } from '../../../hooks/use-electron-guard'
 import { createLogger } from '../../../utils/logger'
 import { getCoreBoxWindow } from './window'
+import { installAppViewNavigationPolicy } from '../../../core/app-view-navigation-policy'
+import { getCoreBoxRendererUrl } from '../../../utils/renderer-url'
 
 const metaOverlayLog = createLogger('CoreBox').child('MetaOverlay')
 const resolveKeyManager = (channel: unknown): unknown =>
@@ -122,6 +124,12 @@ export class MetaOverlayManager {
     })
 
     this.metaView = new WebContentsView({ webPreferences })
+
+    // This view only ever shows the app's own renderer, and had no window-open handler and no
+    // navigation restriction at all (#793).
+    installAppViewNavigationPolicy(this.metaView.webContents, {
+      entryUrl: getCoreBoxRendererUrl()
+    })
 
     this.metaView.webContents.addListener('dom-ready', () => {
       metaOverlayLog.debug('MetaOverlay DOM ready')

--- a/apps/core-app/src/main/modules/box-tool/core-box/plugin-view-controller.ts
+++ b/apps/core-app/src/main/modules/box-tool/core-box/plugin-view-controller.ts
@@ -36,6 +36,8 @@ import { coreBoxManager } from './manager'
 import { metaOverlayManager } from './meta-overlay'
 import { viewCacheManager } from './view-cache'
 import { getLiveViewWebContents } from './web-contents-view-guard'
+import { installAppViewNavigationPolicy } from '../../../core/app-view-navigation-policy'
+import { getCoreBoxRendererUrl } from '../../../utils/renderer-url'
 
 const pluginViewLog = createLogger('CoreBox').child('Window')
 const CLIPBOARD_TYPE_BITS = {
@@ -269,6 +271,10 @@ export class PluginViewController {
     const view = (this.uiView = new WebContentsView({ webPreferences }))
     if (navigationPolicy) {
       installPluginViewNavigationPolicy(view.webContents, navigationPolicy)
+    } else {
+      // No plugin means the app profile, which had no guards at all: no window-open handler and
+      // no navigation restriction (#793).
+      installAppViewNavigationPolicy(view.webContents, { entryUrl: getCoreBoxRendererUrl() })
     }
     if (plugin) {
       const pluginViewWebContentsId = view.webContents.id

--- a/apps/core-app/src/main/modules/division-box/session.ts
+++ b/apps/core-app/src/main/modules/division-box/session.ts
@@ -38,6 +38,8 @@ import { getMainConfig } from '../storage'
 import defaultCoreBoxThemeCss from '../box-tool/core-box/theme/tuff-element.css?raw'
 import { resolveDivisionBoxHeaderHeight, resolveDivisionBoxInitialWindowBounds } from './layout'
 import { windowPool } from './window-pool'
+import { installAppViewNavigationPolicy } from '../../core/app-view-navigation-policy'
+import { getCoreBoxRendererUrl } from '../../utils/renderer-url'
 
 const divisionBoxSessionLog = createLogger('DivisionBoxSession')
 
@@ -527,6 +529,10 @@ export class DivisionBoxSession {
     this.uiView = new WebContentsView({ webPreferences })
     if (navigationPolicy) {
       installPluginViewNavigationPolicy(this.uiView.webContents, navigationPolicy)
+    } else {
+      // No plugin means the app profile, which had no guards at all: no window-open handler and
+      // no navigation restriction (#793).
+      installAppViewNavigationPolicy(this.uiView.webContents, { entryUrl: getCoreBoxRendererUrl() })
     }
     if (plugin) {
       // Register this plugin surface so the channel layer can verify its origin.


### PR DESCRIPTION
Closes #793.

Three `WebContentsView`s run the **app** security profile. MetaOverlay installed no guards at all, and `plugin-view-controller` / `division-box` only installed the *plugin* policy when a plugin was present — with no plugin the view had **no window-open handler and no navigation restriction**. Content in it could `window.open` an uncontrolled window with default preferences, or navigate the view anywhere.

`installAppViewNavigationPolicy` now covers all three: `window.open` denied, `will-navigate` and `will-frame-navigate` restricted to the app's own renderer entry, webview attachment refused. Same shape as `installPluginViewNavigationPolicy`, which is where plugin views already got this.

### The allow rule, and why it is not stricter

It compares protocol, origin and pathname, and **ignores hash and query on purpose**. The renderer routes with `#/meta-overlay`, so an `href` comparison would block the very views this protects.

There is a mutation for exactly that: comparing full `href` fails two tests. Pathname carries the weight for `file:` URLs, whose origin is the opaque `null` for every file on disk — dropping it lets `file:///Users/someone/.ssh/id_rsa` through.

### Eight tests, three mutations, each hitting only its own

| mutation | fails |
|---|---|
| drop the pathname check | the other-files-on-disk test |
| compare full `href` | **2** — hash routing breaks |
| remove the window-open handler | the `window.open` test |

### On the checks

Two `no-explicit-any` warnings I introduced in the test fakes are fixed in a follow-up commit. core-app's lint-staged entry has no `--max-warnings=0` so they would have gone through, but the delta against the base was zero before this branch and they were mine.

eslint **0** with no warnings, tsc **0** with zero TS errors, gated before committing. **8/8**.
