### PR TITLE
fix(security): route the last two windows through the webPreferences builder

### DIFF
--- a/apps/core-app/src/main/core/window-security-profile.contract.test.ts
+++ b/apps/core-app/src/main/core/window-security-profile.contract.test.ts
@@ -1,0 +1,103 @@
+/**
+ * buildWindowWebPreferences is only worth anything as the *single* entry point: it strips caller
+ * overrides of the managed keys, so any window that skips it is outside the policy. Two sites
+ * hand-wrote their own set and omitted webSecurity/nodeIntegrationInSubFrames/webviewTag (#794).
+ *
+ * Nothing was broken at the time - Electron's own defaults happened to match the three omissions.
+ * The defect is drift: the next flag added to SECURITY_BASE would silently miss those windows.
+ * That makes the invariant a property of the *source*, not of any one window's runtime options,
+ * and it has to generalise - a per-site assertion would say nothing about the third site someone
+ * adds next month.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const MAIN_ROOT = path.join(__dirname, '..')
+
+/** Keys buildWindowWebPreferences owns. Writing any of them by hand is the thing under test. */
+const MANAGED_KEYS = [
+  'webSecurity',
+  'nodeIntegration',
+  'nodeIntegrationInSubFrames',
+  'contextIsolation',
+  'sandbox',
+  'webviewTag'
+]
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((name) => {
+    const full = path.join(dir, name)
+    if (statSync(full).isDirectory()) return sourceFiles(full)
+    if (!name.endsWith('.ts') || name.includes('.test.')) return []
+    return [full]
+  })
+}
+
+/**
+ * Returns the managed keys written inline under a `webPreferences:` object literal. The builder
+ * form is `webPreferences: buildWindowWebPreferences(...)`, which has no literal to scan.
+ */
+function handRolledManagedKeys(source: string): string[] {
+  const found = new Set<string>()
+  const literal = /webPreferences:\s*\{([\s\S]*?)\}/g
+  let match = literal.exec(source)
+  while (match) {
+    const body = match[1] ?? ''
+    for (const key of MANAGED_KEYS) {
+      if (new RegExp(`\\b${key}\\s*:`).test(body)) found.add(key)
+    }
+    match = literal.exec(source)
+  }
+  return [...found]
+}
+
+describe('every main-process window goes through the central builder', () => {
+  it('检测器确实能认出手写的 webPreferences(缺这条,下面的空结果什么都不证明)', () => {
+    const fixture = `new BrowserWindow({
+      webPreferences: {
+        sandbox: true,
+        contextIsolation: true,
+        nodeIntegration: false
+      }
+    })`
+
+    expect(handRolledManagedKeys(fixture).sort()).toEqual([
+      'contextIsolation',
+      'nodeIntegration',
+      'sandbox'
+    ])
+  })
+
+  it('检测器不会把 builder 调用误报成手写', () => {
+    expect(handRolledManagedKeys(`webPreferences: buildWindowWebPreferences('app')`)).toEqual([])
+  })
+
+  it('src/main 下没有任何一处手写受管安全项', () => {
+    const offenders = sourceFiles(MAIN_ROOT)
+      .map((file) => ({ file, keys: handRolledManagedKeys(readFileSync(file, 'utf8')) }))
+      .filter((entry) => entry.keys.length > 0)
+      .map((entry) => `${path.relative(MAIN_ROOT, entry.file)} (${entry.keys.join(', ')})`)
+
+    expect(offenders).toEqual([])
+  })
+
+  it('扫描确实覆盖到了那两个文件(否则「零违规」可能只是没扫到)', () => {
+    const scanned = sourceFiles(MAIN_ROOT).map((file) => path.relative(MAIN_ROOT, file))
+
+    expect(scanned).toContain(path.join('modules', 'quick-ops', 'quick-ops-session-manager.ts'))
+    expect(scanned).toContain(
+      path.join('modules', 'box-tool', 'core-box', 'image-translate-pin-window.ts')
+    )
+  })
+
+  it('两处仍然在建窗口,而不是把 webPreferences 整个删掉了事', () => {
+    for (const relative of [
+      path.join('modules', 'quick-ops', 'quick-ops-session-manager.ts'),
+      path.join('modules', 'box-tool', 'core-box', 'image-translate-pin-window.ts')
+    ]) {
+      const source = readFileSync(path.join(MAIN_ROOT, relative), 'utf8')
+      expect(source).toContain(`webPreferences: buildWindowWebPreferences('app')`)
+    }
+  })
+})

--- a/apps/core-app/src/main/modules/box-tool/core-box/image-translate-pin-window.ts
+++ b/apps/core-app/src/main/modules/box-tool/core-box/image-translate-pin-window.ts
@@ -3,6 +3,7 @@ import { Buffer } from 'node:buffer'
 import { platform } from 'node:process'
 import { clipboard, Menu, nativeImage, screen } from 'electron'
 import { TouchWindow } from '../../../core/touch-window'
+import { buildWindowWebPreferences } from '../../../core/window-security-profile'
 
 export interface ImageTranslatePinWindowPayload {
   translatedImageBase64: string
@@ -387,11 +388,7 @@ export async function openImageTranslatePinWindow(
     frame: true,
     title: 'Image Translation',
     alwaysOnTop: true,
-    webPreferences: {
-      contextIsolation: true,
-      nodeIntegration: false,
-      sandbox: true
-    }
+    webPreferences: buildWindowWebPreferences('app')
   })
 
   touchWindow.window.setAlwaysOnTop(true, 'floating')

--- a/apps/core-app/src/main/modules/quick-ops/quick-ops-session-manager.ts
+++ b/apps/core-app/src/main/modules/quick-ops/quick-ops-session-manager.ts
@@ -2,6 +2,7 @@ import type { BrowserWindow as ElectronBrowserWindow, Rectangle } from 'electron
 import type { NotificationRequest } from '@talex-touch/utils/transport/events/types'
 import { BrowserWindow, powerSaveBlocker, screen } from 'electron'
 import { getLogger } from '@talex-touch/utils/common/logger'
+import { buildWindowWebPreferences } from '../../core/window-security-profile'
 import { notificationModule } from '../notification'
 
 export type QuickOpsSessionKind =
@@ -674,11 +675,7 @@ function createScreenCleanWindow(
     minimizable: false,
     maximizable: false,
     backgroundColor: palette.windowBackground,
-    webPreferences: {
-      sandbox: true,
-      contextIsolation: true,
-      nodeIntegration: false
-    }
+    webPreferences: buildWindowWebPreferences('app')
   })
 
   window.setAlwaysOnTop(true, 'screen-saver')


### PR DESCRIPTION
Closes #794.

`buildWindowWebPreferences` is worth something only as the **single** entry point — it strips caller overrides of the managed keys, so a window that skips it is outside the policy. Two sites hand-wrote `{sandbox, contextIsolation, nodeIntegration}` and omitted `webSecurity`, `nodeIntegrationInSubFrames` and `webviewTag`:

- `quick-ops-session-manager.ts:677` — the screen-clean overlay
- `image-translate-pin-window.ts:390` — the image-translation pin window

`TouchWindow` passes `webPreferences` straight through, so nothing compensated downstream. Both now call `buildWindowWebPreferences('app')`; every other window in `src/main` already did.

### Nothing is broken today, and that is the point

Electron's own defaults match all three omissions, so this changes no runtime behaviour. The defect is **drift** — the next flag added to `SECURITY_BASE` would silently miss these two windows, and both load `data:` URLs with interpolated content, so they are exactly the ones that need the baseline.

### Why a source contract instead of two per-window assertions

The failure mode is *the third site someone adds next month*. A test pinning these two windows' options would say nothing about it. The invariant is a property of the source — "no managed key is written by hand anywhere in `src/main`" — so that is what the test asserts, and it generalises.

### Five tests, four mutations

| mutation | fails |
|---|---|
| revert quick-ops only | no-hand-rolled, still-uses-builder |
| revert pin window only | no-hand-rolled, still-uses-builder |
| **over-correct**: delete `webPreferences` entirely | still-uses-builder only — no-hand-rolled passes |
| **blind the detector** | the positive control only |

The last two are the ones that matter. The over-correction shows the scan alone would accept a window with *no* preferences at all. Blinding the detector shows the "zero offenders" test passes **vacuously** when the regex matches nothing — which is why the positive control is a test and not a comment.

tsc **0**, eslint **0** with no warnings, **10/10** (5 new + the builder's existing 5).
