### PR TITLE
fix(utils): make three SupportOS members name the OS they carry

### DIFF
--- a/packages/utils/__tests__/support-os-labels.test.ts
+++ b/packages/utils/__tests__/support-os-labels.test.ts
@@ -1,0 +1,54 @@
+/**
+ * SupportOS is the vocabulary a plugin manifest declares its platforms in, published through the
+ * SDK. Three members named one OS version and carried another: WATCHOS_9 and WATCHOS_10 had their
+ * values swapped, and WINDOWS_11 was 'Windows 10 Pro' (#872). A consumer gating on
+ * SupportOS.WATCHOS_10 matched watchOS 9 devices and missed watchOS 10 - inverted, not merely
+ * broken.
+ *
+ * The pin is the general rule rather than three literals, because the bug is a copy-paste slip and
+ * the next one will land on a different member. Every underscore-separated segment of the key must
+ * appear in the value: WINDOWS_11 must say 'Windows' and '11' somewhere, whatever the casing. That
+ * needs no table of how each OS capitalises itself, and it caught exactly these three out of 46.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { SupportOS } from '../base/index'
+
+const MEMBERS = Object.entries(SupportOS) as [string, string][]
+
+describe('SupportOS values match the member they are named for', () => {
+  it('规则本身有效:构造一个错值会被判为违规(缺这条,下面的空结果什么都不证明)', () => {
+    expect(violations([['WATCHOS_10', 'watchOS 9']])).toEqual(['WATCHOS_10 = "watchOS 9"'])
+    expect(violations([['WATCHOS_10', 'watchOS 10']])).toEqual([])
+  })
+
+  it('46 个成员全部自洽', () => {
+    expect(MEMBERS).toHaveLength(46)
+    expect(violations(MEMBERS)).toEqual([])
+  })
+
+  it('被交换的两个 watchOS 成员各自指向自己的版本', () => {
+    expect(SupportOS.WATCHOS_9).toBe('watchOS 9')
+    expect(SupportOS.WATCHOS_10).toBe('watchOS 10')
+  })
+
+  it('WINDOWS_11 不再是 Windows 10 的一个版本', () => {
+    expect(SupportOS.WINDOWS_11).toBe('Windows 11')
+    expect(SupportOS.WINDOWS_11).not.toBe(SupportOS.WINDOWS_10)
+  })
+
+  it('没有两个成员共享同一个值(否则平台门控会把两个 OS 当成一个)', () => {
+    const values = MEMBERS.map(([, value]) => value)
+
+    expect(new Set(values).size).toBe(values.length)
+  })
+})
+
+/** Keys whose value is missing one of the segments the key names, formatted for the failure text. */
+function violations(members: [string, string][]): string[] {
+  return members
+    .filter(([key, value]) =>
+      key.split('_').some((segment) => !value.toLowerCase().includes(segment.toLowerCase()))
+    )
+    .map(([key, value]) => `${key} = ${JSON.stringify(value)}`)
+}

--- a/packages/utils/base/index.ts
+++ b/packages/utils/base/index.ts
@@ -125,7 +125,7 @@ export enum DepartedOS {
 
 export enum SupportOS {
   WINDOWS = 'Windows',
-  WINDOWS_11 = 'Windows 10 Pro',
+  WINDOWS_11 = 'Windows 11',
   WINDOWS_10 = 'Windows 10',
 
   MACOS = 'macOS',
@@ -168,8 +168,8 @@ export enum SupportOS {
   WEB_IPADOS = 'Web iPadOS',
 
   WATCHOS = 'watchOS',
-  WATCHOS_9 = 'watchOS 10',
-  WATCHOS_10 = 'watchOS 9',
+  WATCHOS_9 = 'watchOS 9',
+  WATCHOS_10 = 'watchOS 10',
 
   TVOS = 'tvOS',
   TVOS_17 = 'tvOS 17',


### PR DESCRIPTION
Closes #872.

`SupportOS` is the vocabulary a plugin manifest declares its platforms in, published through the SDK. Three members named one OS version and carried another:

| member | was | now |
|---|---|---|
| `WATCHOS_9` | `'watchOS 10'` | `'watchOS 9'` |
| `WATCHOS_10` | `'watchOS 9'` | `'watchOS 10'` |
| `WINDOWS_11` | `'Windows 10 Pro'` | `'Windows 11'` |

The watchOS pair is **inverted**, not merely wrong: gating on `SupportOS.WATCHOS_10` matched watchOS 9 devices and missed watchOS 10.

### Blast radius: none

No manifest in the repo declares `os`, and nothing compares against these values at runtime — the only `SupportOS` reference outside the enum is the `IPlatformInfo.os` field type.

`OSIcon.vue:18` does test the literal `'Windows 10 Pro'`, which is what made this worth checking before touching the enum. It is unrelated: it receives `os?.version` — a real `os.version()` string, where `'Windows 10 Pro'` is genuinely what a Windows 10 Pro machine reports. Left alone.

### Pinned as a rule, not as three literals

This is a copy-paste slip, and the next one will land on a different member. So the test asserts: **every underscore-separated segment of a key must appear in its value**, case-insensitively. `WINDOWS_11` has to say `Windows` and `11` somewhere.

That needs no table of how each OS capitalises itself (`macOS`, `iPadOS`, `WearOS`, `VisionOS` …) and it flagged **exactly these three out of 46 members** — no collateral, which is why the fix stops here.

### Five tests, four mutations

| mutation | fails |
|---|---|
| restore all three original values | the rule, both literal pins |
| re-swap the watchOS pair only | the rule, the watchOS pin |
| **over-correct**: `WINDOWS_11 = 'Windows 10'` | the rule, the Windows pin, **and uniqueness** |
| **blind the rule** | the positive control only |

The last one is the point of the control: with the filter neutered, "46 members are all consistent" passes **vacuously**.

utils suite **156 files / 1185 passed**, eslint **0** at `--max-warnings=0`.
