### PR TITLE
fix(transport): let a rehydrated error keep the time it was raised

### DIFF
--- a/apps/nexus/content/docs/dev/api/transport-internals.en.mdc
+++ b/apps/nexus/content/docs/dev/api/transport-internals.en.mdc
@@ -436,7 +436,8 @@ code: |
 
     static fromJSON(obj) {
       return new TuffTransportError(obj.code, obj.message, {
-        eventName: obj.eventName
+        eventName: obj.eventName,
+        timestamp: obj.timestamp
       })
     }
   }

--- a/apps/nexus/content/docs/dev/api/transport-internals.zh.mdc
+++ b/apps/nexus/content/docs/dev/api/transport-internals.zh.mdc
@@ -436,7 +436,8 @@ code: |
 
     static fromJSON(obj) {
       return new TuffTransportError(obj.code, obj.message, {
-        eventName: obj.eventName
+        eventName: obj.eventName,
+        timestamp: obj.timestamp
       })
     }
   }

--- a/packages/utils/__tests__/transport-error-roundtrip.test.ts
+++ b/packages/utils/__tests__/transport-error-roundtrip.test.ts
@@ -1,0 +1,84 @@
+/**
+ * toJSON serialised `timestamp` and fromJSON threw it away - the constructor overwrote it with
+ * Date.now() at rehydration time (#873). A renderer correlating an IPC-transported error against
+ * a main-process log line read the deserialisation moment, so the two never lined up, and the
+ * pair did not round-trip despite being named as if it did.
+ *
+ * The timestamp now arrives through a constructor option rather than a post-hoc write, so the
+ * field stays `readonly` and untrusted input still cannot install a non-number: fromJSON's cast
+ * is a lie whenever the payload came off the wire, and the constructor is where that is caught.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { TuffTransportError, TuffTransportErrorCode } from '../transport/errors'
+
+const FAILURE_TIME = Date.parse('2026-02-01T10:00:00.000Z')
+const REHYDRATION_TIME = Date.parse('2026-02-01T10:05:00.000Z')
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+/** Serialises an error stamped at FAILURE_TIME, then rehydrates it five minutes later. */
+function roundTrip(mutate: (payload: Record<string, unknown>) => void = () => {}): {
+  original: TuffTransportError
+  restored: TuffTransportError
+} {
+  vi.useFakeTimers()
+  vi.setSystemTime(FAILURE_TIME)
+  const original = new TuffTransportError(
+    TuffTransportErrorCode.INVALID_PLUGIN_KEY,
+    'plugin key rejected',
+    { eventName: 'storage:get', pluginName: 'com.acme.demo' },
+  )
+  const payload = original.toJSON()
+
+  vi.setSystemTime(REHYDRATION_TIME)
+  mutate(payload)
+  return { original, restored: TuffTransportError.fromJSON(payload) }
+}
+
+describe('TuffTransportError round-trips through toJSON/fromJSON', () => {
+  it('还原出来的 timestamp 是故障发生的时刻,不是反序列化的时刻', () => {
+    const { original, restored } = roundTrip()
+
+    expect(restored.timestamp).toBe(FAILURE_TIME)
+    expect(restored.timestamp).toBe(original.timestamp)
+    expect(restored.timestamp).not.toBe(REHYDRATION_TIME)
+  })
+
+  it('其余字段一并还原(否则上一条会掩盖 fromJSON 整体损坏)', () => {
+    const { restored } = roundTrip()
+
+    expect(restored).toMatchObject({
+      code: TuffTransportErrorCode.INVALID_PLUGIN_KEY,
+      message: 'plugin key rejected',
+      eventName: 'storage:get',
+      pluginName: 'com.acme.demo',
+    })
+    expect(restored).toBeInstanceOf(TuffTransportError)
+  })
+
+  it('新建的错误仍然打当前时间,而不是"永远用传入值"', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(REHYDRATION_TIME)
+
+    expect(new TuffTransportError(TuffTransportErrorCode.INTERNAL_ERROR, 'fresh').timestamp).toBe(
+      REHYDRATION_TIME,
+    )
+  })
+
+  it.each([
+    ['缺失', undefined],
+    ['字符串', '2026-02-01T10:00:00.000Z'],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['null', null],
+  ])('payload 的 timestamp 是%s时,退回当前时间而不是原样吞下', (_label, value) => {
+    const { restored } = roundTrip((payload) => {
+      payload.timestamp = value
+    })
+
+    expect(restored.timestamp).toBe(REHYDRATION_TIME)
+  })
+})

--- a/packages/utils/transport/errors.ts
+++ b/packages/utils/transport/errors.ts
@@ -141,6 +141,8 @@ export class TuffTransportError extends Error {
       eventName?: string
       pluginName?: string
       cause?: Error
+      /** When the failure happened. Defaults to now; supplied by fromJSON to keep the round-trip lossless. */
+      timestamp?: number
     },
   ) {
     super(message)
@@ -156,7 +158,10 @@ export class TuffTransportError extends Error {
         writable: true,
       })
     }
-    this.timestamp = Date.now()
+    this.timestamp =
+      typeof options?.timestamp === 'number' && Number.isFinite(options.timestamp)
+        ? options.timestamp
+        : Date.now()
 
     // Maintain proper stack trace in V8 environments
     if (Error.captureStackTrace) {
@@ -194,6 +199,7 @@ export class TuffTransportError extends Error {
       {
         eventName: obj.eventName as string | undefined,
         pluginName: obj.pluginName as string | undefined,
+        timestamp: obj.timestamp as number | undefined,
       },
     )
     if (obj.stack && typeof obj.stack === 'string') {


### PR DESCRIPTION
Closes #873.

`toJSON` serialises `timestamp`; `fromJSON` restored `stack` but not it, and the constructor overwrote the field with `Date.now()`. A renderer correlating an IPC-transported error against a main-process log line read the **deserialisation** moment, so the two never lined up — and the pair did not round-trip despite being named as if it did.

### Why a constructor option instead of `error.timestamp = obj.timestamp`

`timestamp` is `readonly`, so the direct write needs a cast — and the cast is the actual hazard here. `fromJSON`'s `obj.timestamp as number` is a **lie** for anything that came off the wire: the payload is `Record<string, unknown>`, and a string or `NaN` would be installed into a field the whole codebase reads as a number.

Routing it through the constructor puts validation where the untrusted value enters, and keeps `readonly` meaning what it says:

```ts
this.timestamp =
  typeof options?.timestamp === 'number' && Number.isFinite(options.timestamp)
    ? options.timestamp
    : Date.now()
```

### Eight tests, four mutations

| mutation | fails |
|---|---|
| revert the whole fix | the round-trip test |
| `fromJSON` stops passing it (option kept) | the round-trip test |
| **over-correct**: `options?.timestamp ?? Date.now()` | **3** — string / `NaN` / `Infinity` |
| **over-correct**: always the payload, never now | **7** |

The third is the one that matters. The naive fix passes the headline round-trip assertion and still installs a string into a `readonly number` — it is the version I would have shipped without the fallback cases.

### Scope

No caller in the repo uses `fromJSON`; it is SDK surface. The `transport-internals` doc (en + zh) showed a `fromJSON` sketch dropping the same field — updated, since leaving it would have made the docs contradict the code this PR changes.

utils suite **156 files / 1188 passed**, eslint **0** at `--max-warnings=0`, `check:mdc-fences` **0**.
