### PR TITLE
fix(permission): let PermissionId express the localization permissions

### DIFF
--- a/packages/utils/__tests__/permission-ids-registry-parity.test.ts
+++ b/packages/utils/__tests__/permission-ids-registry-parity.test.ts
@@ -1,0 +1,46 @@
+/**
+ * PERMISSIONS registered i18n.read, lexicon.read and lexicon.register; PermissionIds did not, so
+ * the PermissionId union could not express them. A plugin author writing
+ * `const p: PermissionId = 'lexicon.register'` got a type error for a permission that
+ * permissionRegistry.has() answers true for - forcing a cast, which is the one thing a constant
+ * described as existing 'for type safety' must never require (#871).
+ *
+ * The union is *derived* from PermissionIds - `(typeof PermissionIds)[keyof typeof PermissionIds]` -
+ * so pinning the runtime object against the registry pins the type by construction. There is no
+ * type-level assertion here on purpose: packages/utils has no tsconfig covering __tests__, so one
+ * would never be checked by anything and would only look like coverage.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { PERMISSIONS, PermissionIds, permissionRegistry } from '../permission/registry'
+
+const REGISTERED = PERMISSIONS.map((permission) => permission.id)
+const DECLARED = Object.values(PermissionIds) as string[]
+
+describe('PermissionIds and the permission registry describe the same set', () => {
+  it('注册表里的每一条都能被 PermissionIds 表达', () => {
+    expect(REGISTERED.filter((id) => !DECLARED.includes(id))).toEqual([])
+  })
+
+  it('PermissionIds 里没有注册表不认识的条目(反向漂移同样是 bug)', () => {
+    expect(DECLARED.filter((id) => !permissionRegistry.has(id))).toEqual([])
+  })
+
+  it('三条本地化权限现在有了常量,且注册表确实认识它们', () => {
+    expect(PermissionIds.I18N_READ).toBe('i18n.read')
+    expect(PermissionIds.LEXICON_READ).toBe('lexicon.read')
+    expect(PermissionIds.LEXICON_REGISTER).toBe('lexicon.register')
+
+    // The half that made the gap a defect rather than an omission: runtime already said yes.
+    expect(permissionRegistry.has('lexicon.register')).toBe(true)
+  })
+
+  it('两边条目数相等(挡住"新增权限只加一边"这种漂移)', () => {
+    expect(DECLARED).toHaveLength(REGISTERED.length)
+  })
+
+  it('检查确实在看真实数据:注册表非空,且不认识一个编造的 id', () => {
+    expect(REGISTERED.length).toBeGreaterThan(20)
+    expect(permissionRegistry.has('lexicon.definitely-not-a-permission')).toBe(false)
+  })
+})

--- a/packages/utils/permission/registry.ts
+++ b/packages/utils/permission/registry.ts
@@ -366,6 +366,11 @@ export const PermissionIds = {
 
   // Search
   SEARCH_ROOT_RESULTS: "search.root-results",
+
+  // Localization and Domain Lexicon
+  I18N_READ: "i18n.read",
+  LEXICON_READ: "lexicon.read",
+  LEXICON_REGISTER: "lexicon.register",
 } as const;
 
 export type PermissionId = (typeof PermissionIds)[keyof typeof PermissionIds];


### PR DESCRIPTION
Closes #871.

`PERMISSIONS` registered 27 permissions; `PermissionIds` declared 24. The three missing ones were `i18n.read`, `lexicon.read` and `lexicon.register` — computed, not eyeballed, and the reverse direction was empty.

`PermissionId` is derived as `(typeof PermissionIds)[keyof typeof PermissionIds]`, so a plugin author writing `const p: PermissionId = 'lexicon.register'` got a type error for a permission `permissionRegistry.has()` answers **true** for. That forces a cast — the one thing a constant documented as existing "for type safety" must never require.

### Widening the union is safe here

Checked before touching it: there is no `Record<PermissionId, …>` and no `switch` over the union anywhere in the repo — every consumer takes `string` and goes through `normalizePermissionId`, which is currently the identity function. Nothing can lose exhaustiveness.

### Why not derive the union from `PERMISSIONS` instead

`PERMISSIONS` is annotated `PermissionDefinition[]`, not `as const`, so its `id`s are `string` and carry no literal types to derive from. Making them derivable means restructuring the registry to keep the named constants (`FS_READ` etc.) that callers actually use. Adding the three entries plus a parity test buys the same anti-drift guarantee without that.

### Five tests, four mutations

| mutation | fails |
|---|---|
| drop all three constants | forward direction, the literal pins, count |
| drop only `LEXICON_REGISTER` | same three |
| **over-correct**: add `I18N_WRITE` that is not registered | reverse direction, count |
| **over-correct**: `LEXICON_READ: 'lexicon.reads'` | **both directions** — count still passes |

The last one is why the test checks both directions rather than just counting: a typo keeps the count equal and breaks the set.

No type-level assertion is included, deliberately — `packages/utils` has no `tsconfig.json` covering `__tests__`, so one would be checked by nothing and would only look like coverage. The runtime parity is sufficient because the union is mechanically derived from the object being pinned.

utils suite **156 files / 1185 passed**, eslint **0** at `--max-warnings=0`, core-app `typecheck:node` **0**.
