### PR TITLE
fix(plugin-sdk): make setFile report unserializable content, not throw

### DIFF
--- a/packages/utils/__tests__/plugin-storage-set-file.test.ts
+++ b/packages/utils/__tests__/plugin-storage-set-file.test.ts
@@ -1,0 +1,95 @@
+/**
+ * setFile round-trips content through JSON to drop non-cloneables, and neither failure mode of
+ * that round trip was caught (#870): JSON.stringify *throws* on circular references and BigInt,
+ * and it *returns* undefined for a top-level undefined/function/symbol - which JSON.parse then
+ * reads as the string "undefined" and rejects. Either way a method declared to resolve
+ * `{ success, error? }` threw synchronously instead.
+ *
+ * The returns-undefined half is the one worth having tests for: it is not an exception being
+ * forwarded, so a bare try/catch around the expression fixes only half the issue and still throws
+ * SyntaxError for `setFile('state.json', undefined)`.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { usePluginStorage } from '../plugin/sdk/storage'
+import { PluginEvents } from '../transport/events'
+
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  usePluginName: vi.fn(() => 'demo-plugin'),
+  ensureRendererChannel: vi.fn(() => ({ send: vi.fn() })),
+}))
+
+vi.mock('../plugin/sdk/channel', () => ({
+  ensureRendererChannel: mocks.ensureRendererChannel,
+}))
+
+vi.mock('../plugin/sdk/plugin-info', () => ({
+  usePluginName: mocks.usePluginName,
+}))
+
+vi.mock('../transport', () => ({
+  createPluginTuffTransport: vi.fn(() => ({ send: mocks.send, on: vi.fn() })),
+}))
+
+describe('setFile reports non-serializable content instead of throwing', () => {
+  beforeEach(() => {
+    mocks.send.mockReset()
+    mocks.send.mockResolvedValue({ success: true })
+  })
+
+  it('可序列化的内容照常发送,并剥掉不可克隆的部分', async () => {
+    const content = { items: [1, 2], when: new Date('2026-02-01T10:00:00.000Z'), skip: undefined }
+
+    await expect(usePluginStorage().setFile('state.json', content)).resolves.toEqual({
+      success: true,
+    })
+    expect(mocks.send).toHaveBeenCalledWith(PluginEvents.storage.setFile, {
+      pluginName: 'demo-plugin',
+      fileName: 'state.json',
+      // Date became a string and the undefined property is gone - that is what the round trip is for.
+      content: { items: [1, 2], when: '2026-02-01T10:00:00.000Z' },
+    })
+  })
+
+  it.each([
+    ['undefined', undefined],
+    ['函数', () => 'nope'],
+    ['symbol', Symbol('nope')],
+  ])('顶层 %s 没有 JSON 表示,返回失败而不是抛 SyntaxError', async (_label, content) => {
+    const result = await usePluginStorage().setFile('state.json', content)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('state.json')
+    expect(mocks.send).not.toHaveBeenCalled()
+  })
+
+  it('循环引用返回失败而不是抛 TypeError', async () => {
+    const content: Record<string, unknown> = { name: 'loop' }
+    content.self = content
+
+    const result = await usePluginStorage().setFile('state.json', content)
+
+    expect(result.success).toBe(false)
+    expect(mocks.send).not.toHaveBeenCalled()
+  })
+
+  it('BigInt 返回失败而不是抛 TypeError', async () => {
+    const result = await usePluginStorage().setFile('state.json', { size: 1n })
+
+    expect(result.success).toBe(false)
+    expect(mocks.send).not.toHaveBeenCalled()
+  })
+
+  it('null 与 false 是合法内容,不能被当成"不可序列化"一起挡掉', async () => {
+    await expect(usePluginStorage().setFile('a.json', null)).resolves.toEqual({ success: true })
+    await expect(usePluginStorage().setFile('b.json', false)).resolves.toEqual({ success: true })
+
+    expect(mocks.send).toHaveBeenCalledTimes(2)
+    expect(mocks.send).toHaveBeenNthCalledWith(1, PluginEvents.storage.setFile, {
+      pluginName: 'demo-plugin',
+      fileName: 'a.json',
+      content: null,
+    })
+  })
+})

--- a/packages/utils/plugin/sdk/storage.ts
+++ b/packages/utils/plugin/sdk/storage.ts
@@ -34,7 +34,11 @@ export function usePluginStorage() {
      * @returns A promise that resolves when the file has been stored.
      */
     setFile: async (fileName: string, content: any): Promise<{ success: boolean, error?: string }> => {
-      return transport.send(PluginEvents.storage.setFile, { pluginName, fileName, content: JSON.parse(JSON.stringify(content)) })
+      const serialized = serializeStorageContent(content)
+      if (!serialized.ok)
+        return { success: false, error: `Cannot store "${fileName}": ${serialized.reason}` }
+
+      return transport.send(PluginEvents.storage.setFile, { pluginName, fileName, content: serialized.value })
     },
 
     /**
@@ -112,4 +116,31 @@ export function usePluginStorage() {
       return transport.on(PluginEvents.storage.update, listener)
     },
   }
+}
+
+/**
+ * Round-trips content through JSON to drop the non-cloneables that would break structured clone
+ * on the way to the main process.
+ *
+ * The round trip itself has two failure modes and neither used to be caught: `JSON.stringify`
+ * throws on circular references and BigInt, and it *returns* `undefined` for a top-level
+ * `undefined`, function or symbol - which `JSON.parse` then reads as the string "undefined" and
+ * rejects. Both escaped as a synchronous throw from a method declared to resolve
+ * `{ success, error? }`.
+ */
+function serializeStorageContent(
+  content: unknown,
+): { ok: true, value: unknown } | { ok: false, reason: string } {
+  let json: string | undefined
+  try {
+    json = JSON.stringify(content)
+  }
+  catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) }
+  }
+
+  if (json === undefined)
+    return { ok: false, reason: `content of type ${typeof content} has no JSON representation` }
+
+  return { ok: true, value: JSON.parse(json) }
 }


### PR DESCRIPTION
Closes #870.

`setFile` round-trips content through JSON to drop non-cloneables. That round trip has **two** failure modes and neither was caught:

- `JSON.stringify` **throws** on circular references and BigInt
- `JSON.stringify` **returns `undefined`** for a top-level `undefined`, function or symbol — which `JSON.parse` then reads as the string `"undefined"` and rejects

Either way a method declared to resolve `Promise<{ success, error? }>` threw synchronously.

### The half that is easy to miss

The second mode is not an exception being forwarded, so a bare `try/catch` around the expression fixes circular and BigInt and **still throws `SyntaxError` for `setFile('state.json', undefined)`** — the exact call the report is about.

That is a real mutation here, not a hypothetical: removing only the `json === undefined` branch leaves 4 of 7 tests green.

### Seven tests, four mutations

| mutation | fails |
|---|---|
| revert the whole fix | 5 |
| **half fix**: `try/catch` only, no `undefined` branch | **3** — undefined / function / symbol |
| **over-correct**: treat falsy JSON as unserializable | the `null` / `false` control |
| **over-correct**: always fail | the happy path and the control |

The third mutation is why `null` and `false` have their own test: both are legitimate content, and `!json` is the natural way to write the check that quietly rejects them.

### Scope

No caller in the repo passes unserializable content, so this is hardening rather than a live break. The docs describe `setFile` as returning `{ success: true }` and say nothing about throwing, so the fix makes reality match what they already imply — no doc change.

utils suite **156 files / 1187 passed**, eslint **0** at `--max-warnings=0`.
