### PR TITLE
fix(plugin-sdk): give onDidChange the new content instead of the envelope

### DIFF
--- a/packages/utils/__tests__/plugin-storage-on-did-change.test.ts
+++ b/packages/utils/__tests__/plugin-storage-on-did-change.test.ts
@@ -1,0 +1,141 @@
+/**
+ * onDidChange is typed and documented as `(newConfig) => void`, but the listener forwarded the
+ * raw broadcast envelope `{ name, fileName }`, which carries no content at all (#868). A plugin
+ * writing `onDidChange('settings.json', cfg => applyTheme(cfg.theme))` read `undefined` on every
+ * write and had no way to reach the new value from the callback.
+ *
+ * The content is read back rather than added to the broadcast: the broadcast goes to every window
+ * on every write, and plugin storage runs to 10MB, so putting file bodies on it would be a worse
+ * trade than one read per subscriber.
+ *
+ * Reading back makes delivery asynchronous, which is a defect this change *introduces* if left
+ * alone - two quick writes can resolve out of order. Hence the ticket, and hence a test for it.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { usePluginStorage } from '../plugin/sdk/storage'
+import { PluginEvents } from '../transport/events'
+
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  on: vi.fn(),
+  usePluginName: vi.fn(() => 'demo-plugin'),
+  ensureRendererChannel: vi.fn(() => ({ send: vi.fn() })),
+}))
+
+vi.mock('../plugin/sdk/channel', () => ({
+  ensureRendererChannel: mocks.ensureRendererChannel,
+}))
+
+vi.mock('../plugin/sdk/plugin-info', () => ({
+  usePluginName: mocks.usePluginName,
+}))
+
+vi.mock('../transport', () => ({
+  createPluginTuffTransport: vi.fn(() => ({ send: mocks.send, on: mocks.on })),
+}))
+
+type Broadcast = { name: string, fileName?: string }
+
+/** Subscribes and hands back the listener the SDK registered on the update event. */
+function subscribe(fileName: string, callback: (value: unknown) => void): (data: Broadcast) => void {
+  mocks.on.mockReturnValueOnce(vi.fn())
+  usePluginStorage().onDidChange(fileName, callback)
+
+  const listener = mocks.on.mock.calls.at(-1)?.[1] as ((data: Broadcast) => void) | undefined
+  if (!listener) throw new Error('onDidChange registered no listener')
+  return listener
+}
+
+describe('onDidChange delivers the new content', () => {
+  beforeEach(() => {
+    mocks.send.mockReset()
+    mocks.on.mockReset()
+  })
+
+  it('回调拿到的是文件新内容,不是 { name, fileName } 信封', async () => {
+    const content = { theme: 'dark' }
+    mocks.send.mockResolvedValue(content)
+    const callback = vi.fn()
+
+    subscribe('settings.json', callback)({ name: 'demo-plugin', fileName: 'settings.json' })
+    await vi.waitFor(() => expect(callback).toHaveBeenCalled())
+
+    expect(callback).toHaveBeenCalledWith(content)
+    expect(mocks.send).toHaveBeenCalledWith(PluginEvents.storage.getFile, {
+      pluginName: 'demo-plugin',
+      fileName: 'settings.json',
+    })
+  })
+
+  it('别的插件、别的文件的广播不触发回调,也不产生回读', async () => {
+    mocks.send.mockResolvedValue({ theme: 'dark' })
+    const callback = vi.fn()
+    const listener = subscribe('settings.json', callback)
+
+    listener({ name: 'other-plugin', fileName: 'settings.json' })
+    listener({ name: 'demo-plugin', fileName: 'other.json' })
+    await Promise.resolve()
+
+    expect(mocks.send).not.toHaveBeenCalled()
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('clearStorage 的无 fileName 广播仍然通知每个订阅者,并读回 null', async () => {
+    // clearStorage() empties every storage root, so settings.json really is gone. Staying silent
+    // here would leave the subscriber serving state for a file that no longer exists.
+    mocks.send.mockResolvedValue(null)
+    const callback = vi.fn()
+
+    subscribe('settings.json', callback)({ name: 'demo-plugin' })
+    await vi.waitFor(() => expect(callback).toHaveBeenCalled())
+
+    expect(callback).toHaveBeenCalledWith(null)
+  })
+
+  it('两次快速写入乱序返回时,回调只看到最后一次请求的内容', async () => {
+    const first = { version: 1 }
+    const second = { version: 2 }
+    let resolveFirst: (value: unknown) => void = () => {}
+    mocks.send
+      .mockReturnValueOnce(new Promise((resolve) => { resolveFirst = resolve }))
+      .mockResolvedValueOnce(second)
+
+    const callback = vi.fn()
+    const listener = subscribe('settings.json', callback)
+    listener({ name: 'demo-plugin', fileName: 'settings.json' })
+    listener({ name: 'demo-plugin', fileName: 'settings.json' })
+    await vi.waitFor(() => expect(callback).toHaveBeenCalledWith(second))
+
+    // The first read resolves last, carrying stale content.
+    resolveFirst(first)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).not.toHaveBeenCalledWith(first)
+  })
+
+  it('回读失败时报错而不是抛出未处理的 rejection', async () => {
+    const failure = new Error('storage unavailable')
+    mocks.send.mockRejectedValue(failure)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const callback = vi.fn()
+
+    subscribe('settings.json', callback)({ name: 'demo-plugin', fileName: 'settings.json' })
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled())
+
+    expect(callback).not.toHaveBeenCalled()
+    expect(consoleError.mock.calls[0]?.[0]).toContain('settings.json')
+    consoleError.mockRestore()
+  })
+
+  it('退订仍然返回 transport 给的取消函数', () => {
+    const dispose = vi.fn()
+    mocks.on.mockReturnValueOnce(dispose)
+
+    usePluginStorage().onDidChange('settings.json', vi.fn())()
+
+    expect(dispose).toHaveBeenCalled()
+  })
+})

--- a/packages/utils/__tests__/plugin-storage-sdk.test.ts
+++ b/packages/utils/__tests__/plugin-storage-sdk.test.ts
@@ -108,9 +108,13 @@ describe('Plugin Storage SDK', () => {
     )
   })
 
-  it('listens to storage updates through typed plugin storage event', () => {
+  // This asserted `callback` received `{ name, fileName }` - the broadcast envelope, which is
+  // exactly the defect reported in #868. The filtering half was always right and is kept; the
+  // payload assertion was encoding the bug and now checks the file content instead.
+  it('listens to storage updates through typed plugin storage event', async () => {
     const dispose = vi.fn()
     mocks.on.mockReturnValueOnce(dispose)
+    mocks.send.mockResolvedValue({ theme: 'dark' })
     const sdk = usePluginStorage()
     const callback = vi.fn()
 
@@ -128,12 +132,10 @@ describe('Plugin Storage SDK', () => {
     listener?.({ name: 'other-plugin', fileName: 'settings.json' })
     listener?.({ name: 'demo-plugin', fileName: 'other.json' })
     listener?.({ name: 'demo-plugin', fileName: 'settings.json' })
+    await vi.waitFor(() => expect(callback).toHaveBeenCalled())
 
     expect(callback).toHaveBeenCalledTimes(1)
-    expect(callback).toHaveBeenCalledWith({
-      name: 'demo-plugin',
-      fileName: 'settings.json',
-    })
+    expect(callback).toHaveBeenCalledWith({ theme: 'dark' })
 
     unsubscribe()
     expect(dispose).toHaveBeenCalled()

--- a/packages/utils/plugin/sdk/storage.ts
+++ b/packages/utils/plugin/sdk/storage.ts
@@ -97,16 +97,41 @@ export function usePluginStorage() {
 
     /**
      * Listens for changes to the storage.
+     *
+     * The broadcast carries only `{ name, fileName }`, so the new content is read back before the
+     * callback runs - the callback receives what `getFile` would return, or `null` once the file
+     * is gone.
+     *
+     * A broadcast with no `fileName` is `clearStorage()`, which empties every storage root. Every
+     * subscribed file really did change, so every subscriber is notified and each reads back
+     * `null`. Suppressing those would leave subscribers serving state for files that no longer
+     * exist.
+     *
      * @param fileName The file name to listen for changes
      * @param callback The function to call when the storage changes for the current plugin.
      * @returns A function to unsubscribe from the listener.
      */
     onDidChange: (fileName: string, callback: (newConfig: any) => void) => {
+      let latestTicket = 0
+
       const listener = (data: { name: string, fileName?: string }) => {
-        if (data.name === pluginName
-          && (data.fileName === fileName || data.fileName === undefined)) {
-          callback(data)
-        }
+        if (data.name !== pluginName)
+          return
+        if (data.fileName !== undefined && data.fileName !== fileName)
+          return
+
+        // Reading back is asynchronous, so two quick writes can resolve out of order. Only the
+        // most recently requested read is allowed to reach the callback.
+        const ticket = ++latestTicket
+        transport
+          .send(PluginEvents.storage.getFile, { pluginName, fileName })
+          .then((content: unknown) => {
+            if (ticket === latestTicket)
+              callback(content)
+          })
+          .catch((error: unknown) => {
+            console.error(`[Plugin Storage] Failed to read "${fileName}" after a change notification:`, error)
+          })
       }
 
       return transport.on(PluginEvents.storage.update, listener)


### PR DESCRIPTION
Closes #868. Also carries the evidence that closes #869 as not-a-bug — see below.

`onDidChange` is typed `(newConfig: any) => void` and the docs call the argument `newConfig` ("Config updated"), but the listener forwarded the raw broadcast `{ name, fileName }`, which carries no content. A plugin doing `onDidChange('settings.json', cfg => applyTheme(cfg.theme))` read `undefined` on every write, with no way to reach the new value from the callback. The docs were right; the code disagreed with them.

### Read back, don't enlarge the broadcast

The issue offered both. The broadcast goes to **every window on every write**, and plugin storage runs to 10MB per plugin — putting file bodies on it is the worse trade. One read per subscriber is the cheaper side.

### The defect this change introduces, and pays for

Reading back makes delivery asynchronous, so two quick writes can resolve out of order and the callback ends up holding the older content. A ticket lets only the most recently requested read through. That is not a hypothetical: dropping the ticket fails a test on its own.

Same for the `.catch` — an unhandled rejection inside a transport listener has no owner.

---

### #869 is refuted, and its suggested fix would cause the harm it describes

#869 says a broadcast with no `fileName` "fires for unrelated files". I traced all four emitters of `PluginEvents.storage.update` in `plugin.ts`:

| line | `fileName` | when |
|---|---|---|
| 1855 | present | business-storage write |
| 3723 | present | `savePluginFile` |
| 3749 | present | `deletePluginFile` |
| **3981** | **absent** | **`clearStorage()`** |

`clearStorage()` runs `fse.emptyDirSync` over **every** storage root. There are no unrelated files — every subscribed file really was deleted. Notifying every subscriber is correct.

Its suggested direction — treat missing `fileName` as an opt-in "all files" signal — would mean a subscriber to `settings.json` hears **nothing** when `clearAll()` deletes it, and keeps serving state for a file that no longer exists. That is the stale-state bug #869 is worried about, made permanent.

The reported symptom ("each reloads and rewrites state that was just cleared") is entirely #868: with no content in the callback, the subscriber cannot tell the file is gone and re-writes its stale in-memory copy. With this PR it reads back `null` and knows.

That behaviour has its own test, and the mutation applying #869's suggestion fails exactly that one.

### Six new tests, four mutations

| mutation | fails |
|---|---|
| revert to forwarding the envelope | 5 (incl. the updated pre-existing test) |
| drop the out-of-order ticket | the ordering test only |
| **apply #869's suggestion** | the `clearStorage` test only |
| drop the `.catch` | the rejection test only |

### One pre-existing test changed

`plugin-storage-sdk.test.ts` asserted `callback` received `{ name: 'demo-plugin', fileName: 'settings.json' }` — the envelope, i.e. it encoded the defect. Its filtering half was always right and is kept; only the payload assertion changed, with a comment saying why.

utils suite **156 files / 1186 passed**, eslint **0** at `--max-warnings=0`.
