### PR TITLE
fix(plugin-sdk): repair the legacy channel receive path

### DIFF
--- a/packages/utils/__tests__/plugin-channel-handle-main.test.ts
+++ b/packages/utils/__tests__/plugin-channel-handle-main.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Three defects in the same 40 lines of the legacy TouchChannel receive path:
+ *
+ * - #863 `JSON.parse(_arg)` assumed a JSON string, but the main process sends a plain object
+ *   (`webContents.send(RAW_PLUGIN_PROCESS_CHANNEL, JSON.parse(encoded))`) and so does `send()`
+ *   in the same class. The throw escaped straight out of the IPC listener.
+ * - #862 a handler returning a Promise was dropped on the floor - `reply()` never ran and the
+ *   main-process caller waited out its full 60s timeout.
+ * - #861 `__parse_sender` copied the live `IpcRendererEvent` onto the reply, which carries
+ *   `sender`/`ports` and cannot survive structured clone, so the reply throws on send.
+ *
+ * TouchChannel is `@deprecated` and cannot actually be constructed inside a shipped plugin view -
+ * the plugin-view preload exposes `$plugin`/`$config`/`$channel` and neither `electron` nor
+ * `require`, so `genChannel()` throws there. These fix the fallback rather than justify it.
+ *
+ * genChannel caches one instance per module, so each test re-imports with a fresh registry.
+ */
+
+interface Harness {
+  /** Delivers a message as the main process would, through the registered IPC listener. */
+  deliver: (payload: unknown) => void
+  /** Everything the channel sent back on @plugin-process-message. */
+  sent: unknown[]
+  regChannel: (name: string, callback: (data: any) => unknown) => () => void
+}
+
+async function loadChannel(): Promise<Harness> {
+  vi.resetModules()
+  const sent: unknown[] = []
+  let listener: ((event: unknown, arg: unknown) => void) | null = null
+
+  const ipcRenderer = {
+    on(channel: string, handler: (event: unknown, arg: unknown) => void) {
+      if (channel === '@plugin-process-message') listener = handler
+    },
+    send(_channel: string, payload: unknown) {
+      // Electron structured-clones this. A live IpcRendererEvent would throw here for real, so
+      // the fake refuses the same shapes rather than silently accepting them.
+      sent.push(structuredClone(payload))
+    },
+    removeListener() {},
+  }
+
+  Object.assign(window as unknown as Record<string, unknown>, {
+    $plugin: { name: 'demo-plugin' },
+    electron: { ipcRenderer },
+    $channel: undefined,
+  })
+
+  const { genChannel } = await import('../plugin/channel')
+  const channel = genChannel()
+  if (!listener) throw new Error('TouchChannel registered no IPC listener')
+
+  return {
+    deliver: (payload: unknown) =>
+      (listener as (event: unknown, arg: unknown) => void)({ sender: ipcRenderer }, payload),
+    sent,
+    // regChannel reads this.channelMap, so it has to stay attached to the instance.
+    regChannel: channel.regChannel.bind(channel) as Harness['regChannel'],
+  }
+}
+
+/** A request in the shape the main process actually sends. */
+function request(name: string, data: unknown = { hello: 'world' }) {
+  return {
+    name,
+    code: 200,
+    data,
+    plugin: 'demo-plugin',
+    sync: { timeStamp: 1, timeout: 60_000, id: 'req-1' },
+    header: { status: 'request', type: 'plugin' },
+  }
+}
+
+describe('legacy plugin channel receive path', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('主进程发来的是普通对象,不再因为 JSON.parse 抛出 (#863)', async () => {
+    const harness = await loadChannel()
+    const handler = vi.fn(() => 'ok')
+    harness.regChannel('demo-event', handler)
+
+    expect(() => harness.deliver(request('demo-event'))).not.toThrow()
+    expect(handler).toHaveBeenCalled()
+  })
+
+  it('JSON 字符串仍然照常解析(否则上一条会掩盖功能损坏)', async () => {
+    const harness = await loadChannel()
+    const handler = vi.fn(() => 'ok')
+    harness.regChannel('demo-event', handler)
+
+    harness.deliver(JSON.stringify(request('demo-event')))
+
+    expect(handler).toHaveBeenCalled()
+  })
+
+  it('无法解析的载荷被丢弃,不会掀翻整个监听器', async () => {
+    const harness = await loadChannel()
+    const handler = vi.fn()
+    harness.regChannel('demo-event', handler)
+
+    expect(() => harness.deliver('}{ not json')).not.toThrow()
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('异步 handler 的结果会被回复,而不是让调用方等到超时 (#862)', async () => {
+    const harness = await loadChannel()
+    harness.regChannel('demo-event', async () => ({ answer: 42 }))
+
+    harness.deliver(request('demo-event'))
+    await vi.waitFor(() => expect(harness.sent).toHaveLength(1))
+
+    expect(harness.sent[0]).toMatchObject({ code: 200, data: { answer: 42 } })
+  })
+
+  it('异步 handler 抛错时回复错误码,同样不让调用方挂死 (#862)', async () => {
+    const harness = await loadChannel()
+    harness.regChannel('demo-event', async () => {
+      throw new Error('handler blew up')
+    })
+
+    harness.deliver(request('demo-event'))
+    await vi.waitFor(() => expect(harness.sent).toHaveLength(1))
+
+    expect(harness.sent[0]).toMatchObject({ code: 100, data: 'handler blew up' })
+  })
+
+  it('同步 handler 的返回值仍然照常回复', async () => {
+    const harness = await loadChannel()
+    harness.regChannel('demo-event', () => 'sync-result')
+
+    harness.deliver(request('demo-event'))
+
+    expect(harness.sent[0]).toMatchObject({ code: 200, data: 'sync-result' })
+  })
+
+  it('回复里不再夹带无法结构化克隆的 IpcRendererEvent (#861)', async () => {
+    const harness = await loadChannel()
+    harness.regChannel('demo-event', () => 'ok')
+
+    // The fake send() structured-clones; before the fix the live event made this throw.
+    expect(() => harness.deliver(request('demo-event'))).not.toThrow()
+    expect(harness.sent).toHaveLength(1)
+    expect((harness.sent[0] as { header: Record<string, unknown> }).header).not.toHaveProperty(
+      'event',
+    )
+  })
+
+  it('回复仍然带回 sync.id,否则主进程无法把它配对回请求', async () => {
+    const harness = await loadChannel()
+    harness.regChannel('demo-event', () => 'ok')
+
+    harness.deliver(request('demo-event'))
+
+    expect(harness.sent[0]).toMatchObject({
+      name: 'demo-event',
+      sync: { id: 'req-1' },
+      header: { status: 'reply' },
+    })
+  })
+})

--- a/packages/utils/plugin/channel.ts
+++ b/packages/utils/plugin/channel.ts
@@ -169,7 +169,12 @@ class TouchChannel implements ITouchClientChannel {
   }
 
   __handle_main(e: IpcRendererEvent, _arg: any): any {
-    const arg = JSON.parse(_arg);
+    // The main process sends a plain object on this channel, and so does send() below - only some
+    // senders use a JSON string. Parsing unconditionally threw straight out of the IPC listener,
+    // where nothing can catch it.
+    const arg = this.__decode_payload(_arg);
+    if (arg === undefined) return;
+
     const rawData = this.__parse_raw_data(e, arg);
     if (!rawData) return;
 
@@ -194,10 +199,42 @@ class TouchChannel implements ITouchClientChannel {
 
       const res = func(handInData);
 
-      if (res && res instanceof Promise) return;
+      // An async handler used to return here and never reply at all, leaving the caller to wait
+      // out its full timeout.
+      if (res instanceof Promise) {
+        res.then(
+          (resolved) => handInData.reply(DataCode.SUCCESS, resolved),
+          (error: unknown) => {
+            channelLog.error(`Handler for \"${rawData.name}\" rejected`, { error });
+            handInData.reply(
+              DataCode.ERROR,
+              error instanceof Error ? error.message : String(error),
+            );
+          },
+        );
+        return;
+      }
 
       handInData.reply(DataCode.SUCCESS, res);
     });
+  }
+
+  /**
+   * Accepts either a JSON string or an already-decoded object, and returns undefined for anything
+   * that cannot be read - a malformed message must not take down the listener for every other one.
+   */
+  __decode_payload(payload: unknown): any {
+    if (typeof payload !== "string") return payload;
+
+    try {
+      return JSON.parse(payload);
+    } catch (error) {
+      channelLog.error("Discarded unparseable channel payload", {
+        meta: { payloadPreview: formatPayloadPreview(payload) },
+        error,
+      });
+      return undefined;
+    }
   }
 
   __parse_sender(
@@ -219,7 +256,8 @@ class TouchChannel implements ITouchClientChannel {
           },
       name: rawData.name,
       header: {
-        event: rawData.header.event,
+        // header.event holds the live IpcRendererEvent, which carries sender and ports and cannot
+        // survive structured clone. Copying it here made every reply throw inside ipcRenderer.send.
         status: "reply",
         type: rawData.header.type,
         _originData: rawData.header._originData,


### PR DESCRIPTION
Closes #862. Closes #863. Closes #861.

Three audit findings land in the same 40 lines of `TouchChannel.__handle_main` / `__parse_sender` and overlap line-for-line, so they are fixed and tested together rather than in three conflicting branches.

| # | defect | fix |
|---|---|---|
| 863 | `JSON.parse(_arg)` assumed a JSON string | accept string **or** object; discard unreadable payloads |
| 862 | a `Promise`-returning handler was dropped, `reply()` never ran | await it; reply `ERROR` on rejection |
| 861 | the live `IpcRendererEvent` was copied onto the reply | drop it from `__parse_sender` |

### The premises, checked rather than taken

**#863** — main sends `webContents.send(RAW_PLUGIN_PROCESS_CHANNEL, finalData)` where `finalData = JSON.parse(encoded)`: a **plain object**. `JSON.parse(object)` coerces to `"[object Object]"` and throws, out of an IPC listener where nothing catches it. `send()` in this same class also posts an object.

**#861** — `__parse_raw_data` stores the live event as `header.event`, and `__parse_sender` copied it into the object handed to `ipcRenderer.send`. It carries `sender`/`ports`, so the reply throws. The test's fake `send` structured-clones its argument, so this is measured, not argued: **restoring that one line fails 7 of the 8 tests.**

### This path is deprecated and unreachable in the shipped app

Worth stating plainly, because it bears on whether these are worth fixing at all:

- `TouchChannel` carries `@deprecated This class is deprecated and will be removed in the future`
- it is reachable only via `usePluginRendererChannel()` → `createPluginRendererChannel()` → `genChannel()`, and **`usePluginRendererChannel` has no caller in the repo**
- `genChannel()` needs `window.electron.ipcRenderer` / `globalThis.require`. The plugin-view preload exposes `$plugin`, `$config`, `$channel` — **neither** — so it throws there
- `ensureRendererChannel()`, which every SDK hook uses, returns the preload's `$channel` instead

So this repairs a fallback, not a live path. **Deleting the class would be the better fix**, and that is the maintainer's call, not something to smuggle into an audit remediation PR — the class is still shipped in the `@talex-touch/utils` package tree and deep-importable.

### Eight tests, five mutations

| mutation | fails |
|---|---|
| revert all three | 8 |
| restore unconditional `JSON.parse` | 7 |
| restore the dropped promise | the two async tests |
| restore `header.event` on the reply | 7 |
| **over-correct**: reply `SUCCESS` when the handler rejects | the rejection test only |

utils suite **156 files / 1188 passed**, eslint **0** at `--max-warnings=0`.
