### PR TITLE
fix(sentry): stop tracing every transaction in shipped builds [#799]

### DIFF
--- a/apps/core-app/src/main/modules/sentry/sentry-service.ts
+++ b/apps/core-app/src/main/modules/sentry/sentry-service.ts
@@ -15,6 +15,7 @@ import { StorageList } from '@talex-touch/utils'
 import { PollingService } from '@talex-touch/utils/common/utils/polling'
 import { getTuffTransportMain, SentryEvents } from '@talex-touch/utils/transport/main'
 import { app, BrowserWindow } from 'electron'
+import { resolveSentryTracesSampleRate } from '@talex-touch/utils/base/sentry-sampling'
 import { innerRootPath } from '../../core/precore'
 import type { TalexEvents } from '../../core/eventbus/touch-event'
 import { resolveMainRuntime } from '../../core/runtime-accessor'
@@ -793,8 +794,12 @@ export class SentryServiceModule extends BaseModule {
         environment: process.env.BUILD_TYPE || (app.isPackaged ? 'production' : 'development'),
         // Release information
         release: `${getAppVersionSafe()}@${process.env.BUILD_TYPE || 'release'}`,
-        // Sample rate for performance monitoring
-        tracesSampleRate: 1.0,
+        // Sample rate for performance monitoring. isDevelopmentRuntime is computed just above and
+        // was already branching `environment`; sampling now uses it too (#799).
+        tracesSampleRate: resolveSentryTracesSampleRate({
+          isDevelopment: isDevelopmentRuntime,
+          override: process.env.TUFF_SENTRY_TRACES_SAMPLE_RATE
+        }),
         // Before send hook to filter sensitive data
         beforeSend(event) {
           event.contexts = {

--- a/apps/core-app/src/renderer/src/modules/sentry/sentry-renderer.ts
+++ b/apps/core-app/src/renderer/src/modules/sentry/sentry-renderer.ts
@@ -17,6 +17,7 @@ import {
 import { devLog } from '~/utils/dev-log'
 import { createRendererLogger } from '~/utils/renderer-log'
 import { sanitizeRendererSentryEvent } from './sentry-renderer-sanitizer'
+import { resolveSentryTracesSampleRate } from '@talex-touch/utils/base/sentry-sampling'
 
 // Initialize Sentry in renderer process
 let isInitialized = false
@@ -58,7 +59,9 @@ export async function initSentryRenderer(): Promise<void> {
       dsn: 'https://f8019096132f03a7a66c879a53462a67@o4508024637620224.ingest.us.sentry.io/4510196503871488',
       environment: buildType,
       release: `${buildInfo.version}@${buildType}`,
-      tracesSampleRate: 1.0,
+      // Same policy as the main process, from the same module so the two cannot drift (#799).
+      // isRelease is the renderer's equivalent of app.isPackaged.
+      tracesSampleRate: resolveSentryTracesSampleRate({ isDevelopment: !buildInfo.isRelease }),
       beforeSend(event) {
         event.contexts = {
           ...event.contexts,

--- a/packages/utils/__tests__/sentry-sampling.test.ts
+++ b/packages/utils/__tests__/sentry-sampling.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  resolveSentryTracesSampleRate,
+  SENTRY_TRACES_SAMPLE_RATE_DEVELOPMENT,
+  SENTRY_TRACES_SAMPLE_RATE_PRODUCTION
+} from '../base/sentry-sampling'
+
+/**
+ * Shipped builds must not trace every transaction (#799).
+ *
+ * A flat 1.0 uploads every transaction from a long-running desktop app, on the user's machine and
+ * network. The failure that matters is not the overhead: once the project quota is hit Sentry
+ * rate-limits it, and genuine **error** events start being dropped — so full trace sampling
+ * degrades exactly the observability it exists to provide.
+ *
+ * Both initialisers already knew whether they were a shipped build (`app.isPackaged` in main,
+ * `buildInfo.isRelease` in the renderer) and used it for `environment` while sampling ignored it.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+
+describe('resolveSentryTracesSampleRate', () => {
+  it('traces everything in development', () => {
+    expect(resolveSentryTracesSampleRate({ isDevelopment: true })).toBe(
+      SENTRY_TRACES_SAMPLE_RATE_DEVELOPMENT
+    )
+  })
+
+  it('samples a shipped build', () => {
+    // Positive control for the case above: a resolver that always returned 1 would satisfy it.
+    const rate = resolveSentryTracesSampleRate({ isDevelopment: false })
+
+    expect(rate).toBe(SENTRY_TRACES_SAMPLE_RATE_PRODUCTION)
+    expect(rate).toBeLessThan(1)
+    expect(rate).toBeGreaterThan(0)
+  })
+
+  it('honours an explicit override for a targeted investigation', () => {
+    expect(resolveSentryTracesSampleRate({ isDevelopment: false, override: '0.5' })).toBe(0.5)
+    expect(resolveSentryTracesSampleRate({ isDevelopment: false, override: '0' })).toBe(0)
+  })
+
+  it('ignores an override that is out of range rather than clamping it', () => {
+    // `10` meaning "10 percent" is the plausible typo. Clamping it to 1 would silently restore the
+    // state being fixed, so it falls back to the default instead.
+    for (const override of ['10', '-1', 'half', '', '   ']) {
+      expect(resolveSentryTracesSampleRate({ isDevelopment: false, override }), override).toBe(
+        SENTRY_TRACES_SAMPLE_RATE_PRODUCTION
+      )
+    }
+  })
+})
+
+describe('both initialisers use it', () => {
+  const sources = [
+    'apps/core-app/src/main/modules/sentry/sentry-service.ts',
+    'apps/core-app/src/renderer/src/modules/sentry/sentry-renderer.ts'
+  ].map((file) => ({ file, source: readFileSync(path.join(REPO_ROOT, file), 'utf8') }))
+
+  it('reads both files', () => {
+    // Positive control: the absence checks below are satisfied by an unreadable path.
+    expect(sources).toHaveLength(2)
+    for (const { source } of sources) expect(source).toContain('Sentry.init(')
+  })
+
+  it('resolves the rate instead of hard-coding it', () => {
+    for (const { file, source } of sources) {
+      expect(source, file).toContain('resolveSentryTracesSampleRate(')
+      expect(source, file).not.toMatch(/tracesSampleRate:\s*1(\.0)?\s*,/)
+    }
+  })
+})

--- a/packages/utils/base/sentry-sampling.ts
+++ b/packages/utils/base/sentry-sampling.ts
@@ -1,0 +1,45 @@
+/**
+ * Trace sampling rates for Sentry, shared by the main and renderer initialisers.
+ *
+ * A flat 1.0 uploads every transaction from a long-running desktop app on the user's own machine
+ * and network, and burns the project quota. Once the quota is hit Sentry rate-limits the project,
+ * so genuine **error** events start getting dropped — the setting degrades exactly the observability
+ * it exists to provide (#799).
+ *
+ * Development keeps 1.0: the traffic is one developer's, and a trace you cannot see is worse than a
+ * trace you did not need.
+ */
+
+/** Every transaction, for a build a developer is running themselves. */
+export const SENTRY_TRACES_SAMPLE_RATE_DEVELOPMENT = 1
+
+/**
+ * One transaction in ten, for builds on users' machines.
+ *
+ * The conservative end of the 0.01–0.1 range: performance data stays statistically usable at this
+ * volume, and moving further down is a decision that wants real quota numbers rather than a guess.
+ * Override with TUFF_SENTRY_TRACES_SAMPLE_RATE when investigating something specific.
+ */
+export const SENTRY_TRACES_SAMPLE_RATE_PRODUCTION = 0.1
+
+/**
+ * Resolves the rate for a runtime, honouring an explicit override.
+ *
+ * An out-of-range or unparseable override is ignored rather than clamped: a typo like `10` meaning
+ * "10 percent" would otherwise silently become full sampling, which is the state being fixed.
+ */
+export function resolveSentryTracesSampleRate(options: {
+  isDevelopment: boolean
+  override?: string | null
+}): number {
+  const raw = options.override?.trim()
+  if (raw) {
+    const parsed = Number(raw)
+    if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 1) {
+      return parsed
+    }
+  }
+  return options.isDevelopment
+    ? SENTRY_TRACES_SAMPLE_RATE_DEVELOPMENT
+    : SENTRY_TRACES_SAMPLE_RATE_PRODUCTION
+}


### PR DESCRIPTION
Closes #799.

Confirmed at `sentry-service.ts:797`, and the adjacent `environment` field really does already branch on `app.isPackaged` — `isDevelopmentRuntime` is computed one line above and was simply unused by sampling.

## The renderer has the same bug

The issue names only the main process. `sentry-renderer.ts:61` was also a flat `1.0`, with `buildInfo.isRelease` available for the same branch. Fixing one and not the other would have halved the quota problem and left the two to drift, so both now resolve through **one module** in `@talex-touch/utils`.

## Why this is worse than "some overhead"

Once the project quota is exhausted, Sentry rate-limits the project — and **error** events start being dropped along with the traces. Full trace sampling degrades exactly the observability it exists to provide.

## The value, and one deliberate refusal to be clever

**0.1**, the conservative end of the suggested 0.01–0.1: performance data stays statistically usable at a tenth, and going lower is a decision that wants real quota and user numbers rather than a guess from a source reading. `TUFF_SENTRY_TRACES_SAMPLE_RATE` overrides it for a targeted investigation.

An out-of-range override is **ignored rather than clamped**. `10` meaning "10 percent" is the plausible typo, and clamping it to `1` would silently restore the exact state this PR fixes. There is a test for that.

## Verification

`sentry-sampling.test.ts`, 6 passed: development keeps 1.0, a shipped build is strictly between 0 and 1 (a positive control — a resolver that always returned 1 would satisfy the development case), overrides are honoured including `0`, and five malformed overrides fall back rather than clamp. Two further cases assert **both** initialisers call the resolver and neither hard-codes `1.0`, with a control that the files were actually read.

Mutation-tested: restoring `tracesSampleRate: 1.0` in main fails it. `typecheck:node` = 6 and `typecheck:web` = 9, both unchanged. ESLint clean in all three packages.