### PR TITLE
fix(plugin-sdk): stop lifecycle hooks from being one-shot

### DIFF
--- a/packages/utils/__tests__/plugin-lifecycle-hook-sdk.test.ts
+++ b/packages/utils/__tests__/plugin-lifecycle-hook-sdk.test.ts
@@ -7,7 +7,10 @@ const channel = {
   send: vi.fn(),
 }
 
-const sdk: { __hooks?: Record<string, Array<(data: unknown) => void>> } = {}
+const sdk: {
+  __hooks?: Record<string, Array<(data: unknown) => void>>
+  __signalDisposers?: Record<string, () => void>
+} = {}
 
 const mocks = vi.hoisted(() => ({
   on: vi.fn(),
@@ -32,6 +35,9 @@ vi.mock('../transport', () => ({
 describe('Plugin lifecycle hooks SDK', () => {
   beforeEach(() => {
     delete sdk.__hooks
+    // Signal subscriptions live on the SDK object now, so a stale registry would stop a later
+    // test from registering at all.
+    delete sdk.__signalDisposers
     channel.regChannel.mockReset()
     channel.send.mockReset()
     mocks.on.mockReset()
@@ -65,7 +71,9 @@ describe('Plugin lifecycle hooks SDK', () => {
     expect(listener?.({ id: 'plugin-a' })).toBe(false)
     expect(processFunc).toHaveBeenCalled()
     expect(hook).toHaveBeenCalledWith({ id: 'plugin-a' })
-    expect(sdk.__hooks?.[LifecycleHooks.ACTIVE]).toBeUndefined()
+    // This asserted the hook array was `undefined` after the signal - i.e. it pinned the delete
+    // that made every lifecycle hook one-shot (#858). Hooks outlive the signal that delivered them.
+    expect(sdk.__hooks?.[LifecycleHooks.ACTIVE]).toHaveLength(1)
   })
 
   it('maps every public lifecycle hook to the current lifecycle signal catalog', () => {

--- a/packages/utils/__tests__/plugin-lifecycle-hooks-persist.test.ts
+++ b/packages/utils/__tests__/plugin-lifecycle-hooks-persist.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Three defects in one file, all in the same registration block:
+ *
+ * - #858 the signal listener ran `delete sdk.__hooks[type]`, so every lifecycle hook was
+ *   one-shot. The second activate signal found no hooks and silently did nothing.
+ * - #860 the listener was attached whenever `hooks.length === 0` and the unsubscribe function was
+ *   thrown away. Combined with the delete above, each re-registration attached *another* listener
+ *   for the same signal and none could be detached.
+ * - #859 the JSDoc promised `if return false, the plugin will not be activated`, which the
+ *   protocol cannot deliver - see the last test.
+ *
+ * #860 is caused by #858: fix the delete and the array never empties, so the old guard stops
+ * misfiring. The guard is still replaced by an explicit registry, because "a listener is attached"
+ * and "the hook array is non-empty" agreeing was an accident, not a design.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { injectHook, LifecycleHooks } from '../plugin/sdk/hooks/life-cycle'
+
+const mocks = vi.hoisted(() => ({
+  /** eventName -> listeners attached through transport.on */
+  listeners: new Map<string, ((data: unknown) => unknown)[]>(),
+  dispose: vi.fn(),
+  sdk: { hooks: {}, __hooks: {} } as Record<string, unknown>,
+}))
+
+vi.mock('../plugin/sdk/channel', () => ({
+  ensureRendererChannel: () => ({ send: vi.fn(), regChannel: vi.fn() }),
+}))
+
+vi.mock('../plugin/sdk/touch-sdk', () => ({
+  useTouchSDK: () => mocks.sdk,
+}))
+
+vi.mock('../transport', () => ({
+  createPluginTuffTransport: () => ({
+    on: (event: { toEventName: () => string }, handler: (data: unknown) => unknown) => {
+      const name = event.toEventName()
+      mocks.listeners.set(name, [...(mocks.listeners.get(name) ?? []), handler])
+      return mocks.dispose
+    },
+    send: vi.fn(),
+  }),
+}))
+
+/** Delivers one lifecycle signal to every listener attached for that type. */
+function signal(type: LifecycleHooks, data: unknown = { at: 1 }): unknown[] {
+  const name = eventNameFor(type)
+  return (mocks.listeners.get(name) ?? []).map(listener => listener(data))
+}
+
+function eventNameFor(type: LifecycleHooks): string {
+  return [...mocks.listeners.keys()].find(key => key.includes(SIGNAL_FRAGMENT[type])) ?? ''
+}
+
+const SIGNAL_FRAGMENT: Record<LifecycleHooks, string> = {
+  [LifecycleHooks.ENABLE]: 'enabled',
+  [LifecycleHooks.DISABLE]: 'disabled',
+  [LifecycleHooks.ACTIVE]: 'active',
+  [LifecycleHooks.INACTIVE]: 'inactive',
+  [LifecycleHooks.CRASH]: 'crash',
+}
+
+function listenerCount(type: LifecycleHooks): number {
+  return (mocks.listeners.get(eventNameFor(type)) ?? []).length
+}
+
+describe('lifecycle hooks survive the first signal', () => {
+  beforeEach(() => {
+    mocks.listeners.clear()
+    mocks.dispose.mockClear()
+    mocks.sdk = { hooks: {}, __hooks: {} }
+  })
+
+  it('第一次信号就会触发(否则下面几条会掩盖"从来不触发")', () => {
+    const hook = vi.fn()
+    injectHook(LifecycleHooks.ACTIVE, hook)
+
+    signal(LifecycleHooks.ACTIVE)
+
+    expect(hook).toHaveBeenCalledTimes(1)
+  })
+
+  it('第二、第三次信号同样触发,钩子不再是一次性的 (#858)', () => {
+    const hook = vi.fn()
+    injectHook(LifecycleHooks.ACTIVE, hook)
+
+    signal(LifecycleHooks.ACTIVE)
+    signal(LifecycleHooks.ACTIVE)
+    signal(LifecycleHooks.ACTIVE)
+
+    expect(hook).toHaveBeenCalledTimes(3)
+  })
+
+  it('信号送达后钩子数组仍在,没有被删掉 (#858)', () => {
+    injectHook(LifecycleHooks.ACTIVE, vi.fn())
+
+    signal(LifecycleHooks.ACTIVE)
+
+    expect((mocks.sdk.__hooks as Record<string, unknown[]>)[LifecycleHooks.ACTIVE]).toHaveLength(1)
+  })
+
+  it('同一类型反复注册只挂一个 transport listener (#860)', () => {
+    injectHook(LifecycleHooks.ACTIVE, vi.fn())
+    signal(LifecycleHooks.ACTIVE)
+    injectHook(LifecycleHooks.ACTIVE, vi.fn())
+    signal(LifecycleHooks.ACTIVE)
+    injectHook(LifecycleHooks.ACTIVE, vi.fn())
+
+    expect(listenerCount(LifecycleHooks.ACTIVE)).toBe(1)
+  })
+
+  it('注册两次后两个钩子都会被调用(否则上一条会被"只留一个钩子"蒙混过去)', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    injectHook(LifecycleHooks.ACTIVE, first)
+    injectHook(LifecycleHooks.ACTIVE, second)
+
+    signal(LifecycleHooks.ACTIVE)
+
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+
+  // The invariant the registry buys, stated directly. With #858 fixed the hook array never
+  // empties on its own, so `hooks.length === 0` happens to behave identically on every path -
+  // it is equivalent by coincidence, not by design. This is the case where they diverge.
+  it('钩子数组被清空后再注册,仍然只有一个 listener (#860)', () => {
+    injectHook(LifecycleHooks.ACTIVE, vi.fn())
+    ;(mocks.sdk.__hooks as Record<string, unknown[]>)[LifecycleHooks.ACTIVE] = []
+    injectHook(LifecycleHooks.ACTIVE, vi.fn())
+
+    expect(listenerCount(LifecycleHooks.ACTIVE)).toBe(1)
+  })
+
+  it('不同生命周期类型各自有自己的 listener,不会被合并成一个', () => {
+    injectHook(LifecycleHooks.ACTIVE, vi.fn())
+    injectHook(LifecycleHooks.INACTIVE, vi.fn())
+
+    expect(listenerCount(LifecycleHooks.ACTIVE)).toBe(1)
+    expect(listenerCount(LifecycleHooks.INACTIVE)).toBe(1)
+  })
+
+  it('某个钩子抛错不影响其它钩子,也不打断信号', () => {
+    const healthy = vi.fn()
+    injectHook(LifecycleHooks.ACTIVE, () => {
+      throw new Error('hook blew up')
+    })
+    injectHook(LifecycleHooks.ACTIVE, healthy)
+
+    expect(() => signal(LifecycleHooks.ACTIVE)).not.toThrow()
+    expect(healthy).toHaveBeenCalledTimes(1)
+  })
+
+  // Pins the corrected contract from #859, not a permanent ban on the feature: the main process
+  // sends active/inactive through broadcastPlugin, typed TuffEvent<TReq, void> with no reply
+  // channel, and sets PluginStatus.ACTIVE before signalling. There is nothing for a veto to
+  // reach. Implementing one means changing the signal and the main-side gate - and this test.
+  it('钩子返回 false 不构成否决,回复仍是 true (#859)', () => {
+    injectHook(LifecycleHooks.ACTIVE, () => false as unknown as void)
+
+    expect(signal(LifecycleHooks.ACTIVE)).toEqual([true])
+  })
+})

--- a/packages/utils/plugin/sdk/hooks/life-cycle.ts
+++ b/packages/utils/plugin/sdk/hooks/life-cycle.ts
@@ -28,6 +28,22 @@ const lifecycleSignalEvents = {
   [LifecycleHooks.CRASH]: PluginEvents.lifecycleSignal.crashed,
 } as const
 
+type SignalRegistry = Partial<Record<LifecycleHooks, () => void>>
+
+/**
+ * Per-signal transport subscriptions, kept on the SDK object so they survive across the repeated
+ * injectHook calls a plugin makes over its own mount cycles. One listener per lifecycle type for
+ * the life of the renderer; the disposers are retained so a host can release them.
+ */
+function getSignalRegistry(
+  sdk: { __hooks: Record<string, unknown>, __signalDisposers?: SignalRegistry },
+): SignalRegistry {
+  if (!sdk.__signalDisposers || typeof sdk.__signalDisposers !== 'object')
+    sdk.__signalDisposers = {}
+
+  return sdk.__signalDisposers
+}
+
 export function injectHook(
   type: LifecycleHooks,
   hook: LifecycleHook,
@@ -48,7 +64,12 @@ export function injectHook(
   const hooksMap = sdk.__hooks as Record<LifecycleHooks, LifecycleHook[]>
   const hooks = hooksMap[type] || (hooksMap[type] = [])
 
-  if (hooks.length === 0) {
+  // Registration is tracked explicitly rather than inferred from `hooks.length === 0`. Those two
+  // only agreed by accident, and the moment they disagreed - which is exactly what deleting the
+  // hook array below used to cause - every re-registration attached another listener for the same
+  // signal, with no way to detach any of them.
+  const registered = getSignalRegistry(sdk)
+  if (!registered[type]) {
     const channel = ensureRendererChannel('[Lifecycle Hook] Channel not available. Make sure hooks run in plugin renderer context.')
     const transport = createPluginTuffTransport(channel as any)
     const listener: LifecycleSignalListener = (data) => {
@@ -62,14 +83,16 @@ export function injectHook(
         },
       })
 
-      if (sdk?.__hooks) {
-        delete sdk.__hooks[type]
-      }
-
+      // The hooks used to be deleted here, which made every lifecycle hook one-shot: the next
+      // signal of the same type found an empty array and silently did nothing. Hooks live as long
+      // as the plugin renderer does.
       return replyResult
     }
 
-    transport.on(lifecycleSignalEvents[type], listener as (data: unknown) => void)
+    registered[type] = transport.on(
+      lifecycleSignalEvents[type],
+      listener as (data: unknown) => void,
+    ) ?? (() => {})
   }
 
   const wrappedHook = (data: any) => {
@@ -107,14 +130,24 @@ export const onPluginEnable = createHook(LifecycleHooks.ENABLE)
 export const onPluginDisable = createHook(LifecycleHooks.DISABLE)
 
 /**
- * The plugin is activated
- * @returns boolean If return false, the plugin will not be activated (User can force to activate the plugin)
+ * The plugin is activated.
+ *
+ * The return value is not consulted. The main process sends this through `broadcastPlugin`, which
+ * is typed `TuffEvent<TReq, void>` and has no reply channel, and it sets `PluginStatus.ACTIVE`
+ * before signalling - so there is nothing for a veto to reach. The JSDoc used to promise
+ * "if return false, the plugin will not be activated"; honouring that needs a request/response
+ * signal and a main-side gate ahead of the state change, not an SDK-side return value.
+ *
+ * @returns void
  */
 export const onPluginActive = createHook(LifecycleHooks.ACTIVE)
 
 /**
- * The plugin is inactivated
- * @returns boolean If return false, the plugin will not be inactivated (User can force to inactivate the plugin)
+ * The plugin is inactivated.
+ *
+ * As with {@link onPluginActive}, the return value is not consulted - see the note there.
+ *
+ * @returns void
  */
 export const onPluginInactive = createHook(LifecycleHooks.INACTIVE)
 


### PR DESCRIPTION
Closes #858. Closes #860. Closes #859 — as documentation, with the reason below.

Three findings in one file, all in the same registration block.

### #858 — hooks were one-shot

The signal listener ran `delete sdk.__hooks[type]` after delivering. Every subsequent signal of that type found no hooks and silently did nothing. A plugin's `onPluginActive` fired on the first activation and never again.

### #860 — the leak was caused by #858

Registration was guarded by `hooks.length === 0`, and the unsubscribe function was discarded. With the array being deleted on every signal, the next `injectHook` saw length 0 and attached **another** listener for the same event, with none detachable.

Fixing the delete removes that entirely. The guard is still replaced by an explicit registry that holds its disposer — and I checked whether that was worth doing rather than assuming it:

**restoring `hooks.length === 0` on its own passes every test but one.** They are equivalent by coincidence once the delete is gone, not by design. The one test that separates them empties the hook array and re-registers — the case where the two stop agreeing. Without that test the registry would be unfalsifiable, so it is in the suite.

### #859 — the veto cannot be implemented from the SDK side

The JSDoc promised *"if return false, the plugin will not be activated"*. Checking the other end first:

- `active` / `inactive` are sent with **`transport.broadcastPlugin`**, typed `TuffEvent<TReq, void>` — **no reply channel at all**
- `plugin.status = PluginStatus.ACTIVE` is set **before** the broadcast
- `enabled` uses `sendToPlugin(...).catch(() => {})` — reply discarded

So there is nothing for a veto to reach. Honouring the return value would produce a value nothing reads, and would make the docs *look* true — worse than the current state. The JSDoc now says what actually happens and what implementing the veto would require: a request/response signal plus a main-side gate ahead of the state change. That is a feature, and the maintainer's call.

A test pins the current contract (`false` from a hook does not change the reply). It is not a ban on the feature — implementing it means changing the signal, the main-side gate, and that test together.

### Nine tests, four mutations

| mutation | fails |
|---|---|
| revert all three | 3 |
| restore only the delete | the two #858 tests |
| restore only the `hooks.length` guard | the array-emptied test only |
| **over-correct**: honour the veto | the #859 contract test only |

### One pre-existing assertion changed

`plugin-lifecycle-hook-sdk.test.ts:68` asserted `sdk.__hooks?.[ACTIVE]` was **undefined** after a signal — it pinned the delete, i.e. the defect, as if it were the spec. Now asserts the array survives. Everything else in that test was valid and is untouched; its `beforeEach` also clears the new registry, or a stale one would stop a later test registering at all.

utils suite **156 files / 1189 passed**, eslint **0** at `--max-warnings=0`.
