### PR TITLE
fix(transport): release channel registrations when the plugin transport is destroyed

### DIFF
--- a/packages/utils/__tests__/plugin-transport-destroy-cleanup.test.ts
+++ b/packages/utils/__tests__/plugin-transport-destroy-cleanup.test.ts
@@ -1,0 +1,135 @@
+/**
+ * on() registers through onMain/regChannel and hands the disposer to the caller. destroy() cleared
+ * only the handlers map, so a plugin view that tore down with transport.destroy() without keeping
+ * each per-handler disposer left the registration attached - the handler kept running against a
+ * destroyed transport on every later main-process message, and re-creating the transport
+ * double-dispatched (#879).
+ *
+ * handlers.clear() makes the transport *look* torn down, so these assert on the channel, which is
+ * where the registration actually lives. Both branches of on() are covered: onMain is preferred
+ * and regChannel is the fallback, and only one of them runs per channel.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { defineRawEvent } from '../transport/event/builder'
+import { createPluginTuffTransport } from '../transport/sdk/plugin-transport'
+
+const probeEvent = defineRawEvent<Record<string, unknown>, void>('test:destroy:probe')
+const EVENT_NAME = probeEvent.toEventName()
+
+type Registration = (raw: unknown) => void
+
+interface FakeChannel {
+  sendToMain: (eventName: string, payload?: unknown) => Promise<unknown>
+  /** Live registrations, i.e. what would still fire after a teardown. */
+  live: Map<string, Set<Registration>>
+  deliver: (eventName: string, payload: unknown) => void
+  onMain?: (eventName: string, handler: Registration) => () => void
+  regChannel?: (eventName: string, handler: Registration) => () => void
+}
+
+/** `kind` selects which of on()'s two registration branches the channel offers. */
+function createChannel(kind: 'onMain' | 'regChannel'): FakeChannel {
+  const live = new Map<string, Set<Registration>>()
+  const register = (eventName: string, handler: Registration): (() => void) => {
+    const set = live.get(eventName) ?? new Set()
+    set.add(handler)
+    live.set(eventName, set)
+    return () => {
+      set.delete(handler)
+      if (set.size === 0) live.delete(eventName)
+    }
+  }
+
+  const channel: FakeChannel = {
+    live,
+    sendToMain: async () => undefined,
+    deliver(eventName, payload) {
+      for (const handler of live.get(eventName) ?? []) handler(payload)
+    },
+  }
+  channel[kind] = register
+  return channel
+}
+
+function createTransport(kind: 'onMain' | 'regChannel' = 'onMain') {
+  const channel = createChannel(kind)
+  return { transport: createPluginTuffTransport(channel as never), channel }
+}
+
+describe('destroy releases the channel registrations on() made', () => {
+  it.each(['onMain', 'regChannel'] as const)(
+    '经由 %s 注册的也会在 destroy 时释放',
+    (kind) => {
+      const { transport, channel } = createTransport(kind)
+      transport.on(probeEvent, vi.fn())
+
+      expect(channel.live.get(EVENT_NAME)?.size).toBe(1)
+      transport.destroy()
+
+      expect(channel.live.has(EVENT_NAME)).toBe(false)
+    },
+  )
+
+  it('destroy 之后再来的消息不会触发已注销的 handler', () => {
+    const { transport, channel } = createTransport()
+    const handler = vi.fn()
+    transport.on(probeEvent, handler)
+    transport.destroy()
+
+    channel.deliver(EVENT_NAME, { payload: { id: 'after teardown' } })
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('destroy 之前 handler 正常收到消息(否则上面几条会掩盖"从来不投递")', () => {
+    const { transport, channel } = createTransport()
+    const handler = vi.fn()
+    transport.on(probeEvent, handler)
+
+    channel.deliver(EVENT_NAME, { payload: { id: 'before teardown' } })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('调用方自己拿到的 dispose 仍然只注销自己那一个', () => {
+    const { transport, channel } = createTransport()
+    const disposeFirst = transport.on(probeEvent, vi.fn())
+    transport.on(probeEvent, vi.fn())
+
+    disposeFirst()
+
+    expect(channel.live.get(EVENT_NAME)?.size).toBe(1)
+  })
+
+  it('先手动 dispose 再 destroy 不会把同一个 cleanup 调用两次', () => {
+    const { transport, channel } = createTransport()
+    const cleanupCalls: number[] = []
+    const originalOnMain = channel.onMain!
+    channel.onMain = (eventName, handler) => {
+      const dispose = originalOnMain(eventName, handler)
+      return () => {
+        cleanupCalls.push(1)
+        dispose()
+      }
+    }
+    const dispose = transport.on(probeEvent, vi.fn())
+
+    dispose()
+    transport.destroy()
+
+    expect(cleanupCalls).toHaveLength(1)
+  })
+
+  it('某个 cleanup 抛错不会阻断 destroy 的其余部分', () => {
+    const { transport, channel } = createTransport()
+    channel.onMain = () => () => {
+      throw new Error('cleanup blew up')
+    }
+    transport.on(probeEvent, vi.fn())
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() => transport.destroy()).not.toThrow()
+    expect(consoleError).toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+})

--- a/packages/utils/transport/sdk/plugin-transport.ts
+++ b/packages/utils/transport/sdk/plugin-transport.ts
@@ -148,6 +148,11 @@ function unwrapPayload<T>(raw: unknown): T {
 export class TuffPluginTransport implements ITuffTransport {
   private cache = new Map<string, CacheEntry>()
   private handlers = new Map<string, Set<(payload: any) => any>>()
+  /**
+   * Channel-level registrations made by on(). The per-handler disposer goes to the caller, but
+   * destroy() has to be able to release the ones the caller never held.
+   */
+  private channelCleanups = new Set<() => void>()
   private streamControllers = new Map<string, StreamController>()
   private portCache = new Map<string, TransportPortHandle>()
   private portHandlesById = new Map<string, TransportPortHandle>()
@@ -689,13 +694,18 @@ export class TuffPluginTransport implements ITuffTransport {
       throw new TypeError('[TuffPluginTransport] Channel on function not available')
     }
 
+    const releaseChannel = cleanupChannel
+    this.channelCleanups.add(releaseChannel)
+
     return () => {
       handlerSet.delete(handler)
       if (handlerSet.size === 0) {
         this.handlers.delete(eventName)
         this.releasePortEventSubscription(eventName)
       }
-      cleanupChannel?.()
+      // Dropping it first keeps destroy() from calling the same cleanup a second time.
+      if (this.channelCleanups.delete(releaseChannel))
+        releaseChannel()
     }
   }
 
@@ -708,6 +718,18 @@ export class TuffPluginTransport implements ITuffTransport {
       controller.cancel()
     }
     this.streamControllers.clear()
+    // The channel registrations go too: on() hands its disposer to the caller, and a caller that
+    // only kept the transport left the underlying onMain/regChannel attached, still firing
+    // handlers against a destroyed transport.
+    for (const cleanup of this.channelCleanups) {
+      try {
+        cleanup()
+      }
+      catch (error) {
+        console.error('[TuffPluginTransport] Channel cleanup failed during destroy:', error)
+      }
+    }
+    this.channelCleanups.clear()
     this.handlers.clear()
 
     if (this.portListenerCleanup) {


### PR DESCRIPTION
Closes #879.

Same defect as #864 (PR #1476), in the sibling class. `on()` registers through `onMain`/`regChannel` and returns the disposer to the caller; `destroy()` cleared only the `handlers` map. A plugin view tearing down with `transport.destroy()` without holding each per-handler disposer left the registration attached — the handler kept running against a destroyed transport on every later main-process message, and re-creating the transport double-dispatched.

Kept as a separate branch from #864 because they are different files with no overlap.

### Both registration branches are covered

`on()` prefers `onMain` and falls back to `regChannel`, and a channel offers only one of them — so the release test is parameterised over both. A fix that only tracked the `onMain` branch would look complete against a single-branch test.

### Seven tests, four mutations

| mutation | fails |
|---|---|
| revert | 4 |
| **over-correct**: dispose always calls, destroy calls again | the double-call test |
| **over-correct**: dispose tears down every registration | the isolation test |
| drop the `try/catch` in destroy | the throwing-cleanup test |

Each mutation was applied through a patch that asserts its pattern matched exactly once — on #864 a silently-unmatched `perl` substitution produced a fully green run that read like a coverage gap.

utils suite **156 files / 1187 passed**, eslint **0** at `--max-warnings=0`.
