### PR TITLE
fix(security): make the window security profile select something [#792]

### DIFF
--- a/apps/core-app/src/main/core/window-security-profile.test.ts
+++ b/apps/core-app/src/main/core/window-security-profile.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import { buildWindowWebPreferences } from './window-security-profile'
 
@@ -79,5 +80,60 @@ describe('buildWindowWebPreferences', () => {
       sandbox: true,
       webviewTag: false
     })
+  })
+})
+
+describe('the profile parameter is not decorative', () => {
+  /**
+   * `buildWindowWebPreferences` used to ignore its profile argument entirely, so 'app' and
+   * 'trusted-plugin-view' produced byte-identical preferences and the API advertised a tiering that
+   * did not exist. The danger was not the current output — both got the strictest baseline — but
+   * that a future relaxation of the plugin-view profile would silently apply to every window in the
+   * app, including the main one (#792).
+   *
+   * These cases pin the shape rather than the values: each profile resolves its own baseline, and
+   * every baseline still equals the strict one. A divergence has to be written down here to land.
+   */
+
+  const STRICT = {
+    webSecurity: true,
+    nodeIntegration: false,
+    nodeIntegrationInSubFrames: false,
+    contextIsolation: true,
+    sandbox: true,
+    webviewTag: false
+  } as const
+
+  it('keeps every profile on the strict baseline', () => {
+    for (const profile of ['app', 'trusted-plugin-view'] as const) {
+      expect(buildWindowWebPreferences(profile), profile).toMatchObject(STRICT)
+    }
+  })
+
+  it('reads the profile it is given, rather than a constant', () => {
+    // Positive control on the plumbing: an implementation that still ignored the argument would
+    // satisfy the case above, since both baselines are equal today. This asserts the lookup exists.
+    const source = readFileSync(new URL('./window-security-profile.ts', import.meta.url), 'utf8')
+
+    expect(source).toContain('SECURITY_BASELINES[profile]')
+    expect(source).not.toMatch(/buildWindowWebPreferences\(\s*_profile/)
+  })
+
+  it('falls back to the strict base when the profile is not a known one', () => {
+    // The lookup must not hand back `undefined` — spreading nothing produces preferences with no
+    // managed keys at all, which is how a retired profile name becomes an unsandboxed window.
+    expect(buildWindowWebPreferences('retired-profile' as never)).toMatchObject(STRICT)
+  })
+
+  it('is forwarded by the plugin-view builder instead of being hard-coded', () => {
+    // plugin-view-controller resolves the profile through resolvePluginViewSecurityProfile; pinning
+    // it inside the builder made that resolution decorative.
+    const host = readFileSync(
+      new URL('../modules/plugin/runtime/plugin-view-host.ts', import.meta.url),
+      'utf8'
+    )
+
+    expect(host).toContain('buildWindowWebPreferences(profile, {')
+    expect(host).not.toContain("buildWindowWebPreferences('trusted-plugin-view'")
   })
 })

--- a/apps/core-app/src/main/core/window-security-profile.ts
+++ b/apps/core-app/src/main/core/window-security-profile.ts
@@ -19,13 +19,33 @@ const MANAGED_KEYS: ManagedWebPreferenceKey[] = [
   'webviewTag'
 ]
 
-const SECURITY_BASE: Required<Pick<Electron.WebPreferences, ManagedWebPreferenceKey>> = {
+type ManagedPreferences = Required<Pick<Electron.WebPreferences, ManagedWebPreferenceKey>>
+
+/** The strictest set Electron offers. Every profile starts here; none is allowed to leave it. */
+const SECURITY_BASE: ManagedPreferences = {
   webSecurity: true,
   nodeIntegration: false,
   nodeIntegrationInSubFrames: false,
   contextIsolation: true,
   sandbox: true,
   webviewTag: false
+}
+
+/**
+ * One baseline per profile.
+ *
+ * The two are identical today, and the point of writing them out separately is that they stay
+ * separable: `buildWindowWebPreferences` previously ignored its profile argument, so 'app' and
+ * 'trusted-plugin-view' produced byte-identical preferences and the API advertised a tiering that
+ * did not exist. A future relaxation of the plugin-view profile would have silently applied to
+ * every window in the app, including the main one (#792).
+ *
+ * `window-security-profile.contract.test.ts` asserts every profile still matches SECURITY_BASE, so
+ * a divergence has to be deliberate rather than inherited.
+ */
+const SECURITY_BASELINES: Record<WindowSecurityProfile, ManagedPreferences> = {
+  app: { ...SECURITY_BASE },
+  'trusted-plugin-view': { ...SECURITY_BASE }
 }
 
 function stripManagedPreferences(overrides: Electron.WebPreferences): WindowWebPreferenceOverrides {
@@ -37,12 +57,16 @@ function stripManagedPreferences(overrides: Electron.WebPreferences): WindowWebP
 }
 
 export function buildWindowWebPreferences(
-  _profile: WindowSecurityProfile,
+  profile: WindowSecurityProfile,
   overrides: WindowWebPreferenceOverrides = {}
 ): Electron.WebPreferences {
   const safeOverrides = stripManagedPreferences(overrides as Electron.WebPreferences)
+  // Unknown profile falls back to the strict base rather than to `undefined`. Indexing the record
+  // directly would spread nothing and hand back preferences with no managed keys at all — which is
+  // how a retired profile name reaching runtime turns into an unsandboxed window.
+  const baseline = SECURITY_BASELINES[profile] ?? SECURITY_BASE
   return {
-    ...SECURITY_BASE,
+    ...baseline,
     ...safeOverrides
   }
 }

--- a/apps/core-app/src/main/modules/plugin/runtime/plugin-view-host.ts
+++ b/apps/core-app/src/main/modules/plugin/runtime/plugin-view-host.ts
@@ -46,7 +46,7 @@ function stripHostControlledPreferences(
 }
 
 export function buildPluginViewWebPreferences(
-  _profile: PluginViewSecurityProfile,
+  profile: PluginViewSecurityProfile,
   options: PluginViewWebPreferenceOptions
 ): Electron.WebPreferences {
   const safeOverrides = stripHostControlledPreferences(options.overrides)
@@ -64,7 +64,9 @@ export function buildPluginViewWebPreferences(
     }
   })
 
-  return buildWindowWebPreferences('trusted-plugin-view', {
+  // Forwarded rather than hard-coded: the caller resolves this through
+  // resolvePluginViewSecurityProfile, and pinning it here made that resolution decorative (#792).
+  return buildWindowWebPreferences(profile, {
     ...safeOverrides,
     partition,
     preload: resolvePluginViewPreloadPath(),


### PR DESCRIPTION
Closes #792.

Confirmed on both counts: `buildWindowWebPreferences` took `_profile` and never read it, and `buildPluginViewWebPreferences` did the same *and* then hard-coded `'trusted-plugin-view'` at the call it forwards to — so `plugin-view-controller`'s `resolvePluginViewSecurityProfile` had its conclusion computed and discarded.

## What was actually at risk

Not the current output — both profiles got the strictest baseline, and still do. The risk is the next change: a relaxation of the plugin-view profile would have applied to **every** window including the main one, because the parameter meant to separate them was not read.

So each profile now resolves its own baseline. The two are deliberately identical today; writing them separately is what turns a future divergence into a decision rather than something inherited. `resolvePluginViewSecurityProfile`'s result is forwarded instead of overwritten.

## A regression an existing test caught mid-change

Indexing `SECURITY_BASELINES[profile]` returns `undefined` for a profile name that is no longer valid, and spreading `undefined` yields preferences with **no managed keys at all** — an unsandboxed window. `fails secure when an obsolete compatibility profile reaches runtime` failed immediately, which is exactly what that test is for. The lookup falls back to `SECURITY_BASE`.

Worth stating because it is the failure mode this issue warns about, arriving through the fix rather than through a later relaxation.

## Verification

14 passed across `window-security-profile.test.ts` and its contract suite — the five pre-existing cases untouched, plus four new ones: every profile still equals the strict baseline, the builder reads the argument it is given (a **positive control on the plumbing** — an implementation that still ignored it would satisfy the equality case, since the two baselines are equal today), the unknown-profile fallback, and that the plugin-view builder forwards rather than hard-codes.

Mutation-tested: restoring both files to the previous version fails 2 of the 4. `typecheck:node` = 6, unchanged. ESLint clean.