### PR TITLE
fix(transport): bound the plugin transport's port retention

### DIFF
--- a/packages/utils/__tests__/plugin-transport-port-bounds.test.ts
+++ b/packages/utils/__tests__/plugin-transport-port-bounds.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Two retention leaks in the plugin transport's port handling, both of which the sibling renderer
+ * transport already solved:
+ *
+ * - #877 a confirm arriving before its `openPort` waiter was queued with no expiry, so a live
+ *   MessagePort stayed pinned until destroy(). Each failed open leaked one native port plus the
+ *   entangled main-side channel.
+ * - #878 `abandonedPorts` was a Set cleared only in destroy(). A confirm can never arrive once the
+ *   main process has reaped the record, so those ids are worthless immediately and the set only
+ *   ever grew.
+ *
+ * Both bounds are invisible from the public surface - nothing observable changes until the heap
+ * does - so these read the private maps directly, the same way the renderer's own lifecycle test
+ * does. The constants are mirrored here because the module keeps them private.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPluginTuffTransport } from '../transport/sdk/plugin-transport'
+import { TransportEvents } from '../transport/events'
+
+/** Mirrors PORT_CONFIRM_TIMEOUT_MS, the retention window for an unclaimed confirm. */
+const PORT_CONFIRM_TIMEOUT_MS = 10000
+/** Mirrors ABANDONED_PORT_RETENTION_MS / ABANDONED_PORT_MAX_ENTRIES. */
+const ABANDONED_PORT_RETENTION_MS = 30000
+const ABANDONED_PORT_MAX_ENTRIES = 64
+
+const CHANNEL = 'test:port:channel'
+
+interface Internals {
+  handlePortConfirm: (port: unknown, payload: unknown) => void
+  rememberAbandonedPort: (portId: string) => void
+  waitForPortConfirm: (portId: string, channel: string, timeoutMs: number) => Promise<unknown>
+  queuedPortConfirms: Map<string, { port: FakePort, timeout?: unknown }>
+  abandonedPorts: Map<string, number>
+}
+
+class FakePort {
+  closed = false
+  close(): void {
+    this.closed = true
+  }
+
+  start(): void {}
+  postMessage(): void {}
+  addEventListener(): void {}
+  removeEventListener(): void {}
+}
+
+function createTransport() {
+  const sent: Array<{ eventName: string, payload: unknown }> = []
+  const sendToMain = vi.fn(async (eventName: string, payload?: unknown) => {
+    sent.push({ eventName, payload })
+    return undefined
+  })
+  const transport = createPluginTuffTransport({ sendToMain } as never)
+  return { transport, internals: transport as unknown as Internals, sent }
+}
+
+function confirmPayload(portId: string) {
+  return { portId, channel: CHANNEL }
+}
+
+describe('plugin transport port retention is bounded', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-01T10:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('无人认领的排队 confirm 会过期,并关闭那个 MessagePort (#877)', () => {
+    const { internals, sent } = createTransport()
+    const port = new FakePort()
+
+    internals.handlePortConfirm(port, confirmPayload('port-1'))
+    expect(internals.queuedPortConfirms.has('port-1')).toBe(true)
+
+    vi.advanceTimersByTime(PORT_CONFIRM_TIMEOUT_MS + 1)
+
+    expect(internals.queuedPortConfirms.has('port-1')).toBe(false)
+    expect(port.closed).toBe(true)
+    expect(
+      sent.some(
+        entry =>
+          entry.eventName === TransportEvents.port.close.toEventName()
+          && (entry.payload as { reason?: string })?.reason === 'confirm_unclaimed',
+      ),
+    ).toBe(true)
+  })
+
+  it('过期之前认领仍然拿得到那个 port(否则上一条会掩盖"永远拿不到")', async () => {
+    const { internals } = createTransport()
+    const port = new FakePort()
+
+    internals.handlePortConfirm(port, confirmPayload('port-2'))
+    const claimed = await internals.waitForPortConfirm('port-2', CHANNEL, PORT_CONFIRM_TIMEOUT_MS)
+
+    expect(claimed).toMatchObject({ port })
+    expect(port.closed).toBe(false)
+  })
+
+  // Asserting only "the claimed port is not closed later" does NOT detect a missing clearTimeout:
+  // discardQueuedPortConfirm early-returns once the entry is gone, so the stale timer fires
+  // harmlessly. The observable difference is the pending timer itself, so that is what is checked.
+  it('认领之后计时器被清掉,不留悬挂的 timer (#877)', async () => {
+    const { internals } = createTransport()
+    const port = new FakePort()
+
+    internals.handlePortConfirm(port, confirmPayload('port-3'))
+    expect(vi.getTimerCount()).toBe(1)
+
+    await internals.waitForPortConfirm('port-3', CHANNEL, PORT_CONFIRM_TIMEOUT_MS)
+
+    expect(vi.getTimerCount()).toBe(0)
+    vi.advanceTimersByTime(PORT_CONFIRM_TIMEOUT_MS + 1)
+    expect(port.closed).toBe(false)
+  })
+
+  it('abandonedPorts 有条数上限,不再无限增长 (#878)', () => {
+    const { internals } = createTransport()
+
+    for (let i = 0; i < ABANDONED_PORT_MAX_ENTRIES * 3; i += 1) {
+      internals.rememberAbandonedPort(`port-${i}`)
+    }
+
+    expect(internals.abandonedPorts.size).toBeLessThanOrEqual(ABANDONED_PORT_MAX_ENTRIES)
+  })
+
+  it('abandonedPorts 也按年龄淘汰:主进程已回收记录后那些 id 一文不值 (#878)', () => {
+    const { internals } = createTransport()
+    internals.rememberAbandonedPort('stale')
+
+    vi.advanceTimersByTime(ABANDONED_PORT_RETENTION_MS + 1)
+    internals.rememberAbandonedPort('fresh')
+
+    expect(internals.abandonedPorts.has('stale')).toBe(false)
+    expect(internals.abandonedPorts.has('fresh')).toBe(true)
+  })
+
+  // A later rememberAbandonedPort is what runs the sweep, so it has to happen between recording
+  // and the late confirm. Without it, an entry born already-expired is still *present* in the map
+  // and the rejection passes for the wrong reason.
+  it('仍在保留期内的 id,经过一次淘汰扫描后依然会拒绝迟到的 confirm', () => {
+    const { internals } = createTransport()
+    const port = new FakePort()
+    internals.rememberAbandonedPort('port-late')
+
+    vi.advanceTimersByTime(1000)
+    internals.rememberAbandonedPort('port-other')
+    expect(internals.abandonedPorts.has('port-late')).toBe(true)
+
+    internals.handlePortConfirm(port, confirmPayload('port-late'))
+
+    expect(port.closed).toBe(true)
+    expect(internals.queuedPortConfirms.has('port-late')).toBe(false)
+    // Consumed, so a second confirm for the same id is treated as a fresh one.
+    expect(internals.abandonedPorts.has('port-late')).toBe(false)
+  })
+})

--- a/packages/utils/transport/sdk/plugin-transport.ts
+++ b/packages/utils/transport/sdk/plugin-transport.ts
@@ -32,7 +32,16 @@ interface PortConfirmRecord {
   payload: TransportPortConfirmPayload
 }
 
+interface QueuedPortConfirm extends PortConfirmRecord {
+  timeout?: ReturnType<typeof setTimeout>
+}
+
 const PORT_CONFIRM_TIMEOUT_MS = 10000
+// A confirm can only arrive while the main process still holds the record, so an abandoned id is
+// worthless once the main-side reap window has elapsed. Bounding by age and count keeps a long
+// session from accumulating one string per failed open. Mirrors renderer-transport.ts.
+const ABANDONED_PORT_RETENTION_MS = 30000
+const ABANDONED_PORT_MAX_ENTRIES = 64
 
 function resolveIpcRenderer(): IpcRendererLike | null {
   if (typeof globalThis === 'undefined') {
@@ -160,8 +169,9 @@ export class TuffPluginTransport implements ITuffTransport {
     }
   >()
 
-  private queuedPortConfirms = new Map<string, PortConfirmRecord>()
-  private abandonedPorts = new Set<string>()
+  private queuedPortConfirms = new Map<string, QueuedPortConfirm>()
+  /** portId -> expiry timestamp. A Set here grew for the life of the plugin session. */
+  private abandonedPorts = new Map<string, number>()
   private portListenerCleanup: (() => void) | null = null
   private portEventSubscriptions = new Map<string, PortEventSubscription>()
 
@@ -280,8 +290,7 @@ export class TuffPluginTransport implements ITuffTransport {
     }
 
     const { portId, channel } = confirmPayload
-    if (this.abandonedPorts.has(portId)) {
-      this.abandonedPorts.delete(portId)
+    if (this.abandonedPorts.delete(portId)) {
       try {
         port.close()
       }
@@ -308,7 +317,14 @@ export class TuffPluginTransport implements ITuffTransport {
       pending.resolve(record)
     }
     else {
-      this.queuedPortConfirms.set(portId, record)
+      // The confirm beat its `openPort` waiter. Expire it if the waiter never shows up (the
+      // upgrade round-trip rejected, or the opener was torn down), otherwise a live MessagePort
+      // stays pinned here for the lifetime of the transport.
+      const queued: QueuedPortConfirm = { ...record }
+      queued.timeout = setTimeout(() => {
+        this.discardQueuedPortConfirm(portId, 'confirm_unclaimed')
+      }, PORT_CONFIRM_TIMEOUT_MS)
+      this.queuedPortConfirms.set(portId, queued)
     }
 
     void this.send(TransportEvents.port.confirm, confirmPayload).catch(() => {})
@@ -322,11 +338,14 @@ export class TuffPluginTransport implements ITuffTransport {
     const queued = this.queuedPortConfirms.get(portId)
     if (queued) {
       this.queuedPortConfirms.delete(portId)
+      if (queued.timeout) {
+        clearTimeout(queued.timeout)
+      }
       return Promise.resolve(queued)
     }
 
     if (timeoutMs <= 0) {
-      this.abandonedPorts.add(portId)
+      this.rememberAbandonedPort(portId)
       void this.send(TransportEvents.port.close, { channel, portId, reason: 'confirm_timeout' }).catch(() => {})
       return Promise.resolve(null)
     }
@@ -334,13 +353,61 @@ export class TuffPluginTransport implements ITuffTransport {
     return new Promise((resolve) => {
       const timeout = setTimeout(() => {
         this.pendingPortConfirms.delete(portId)
-        this.abandonedPorts.add(portId)
+        this.rememberAbandonedPort(portId)
         void this.send(TransportEvents.port.close, { channel, portId, reason: 'confirm_timeout' }).catch(() => {})
         resolve(null)
       }, timeoutMs)
 
       this.pendingPortConfirms.set(portId, { channel, resolve, timeout })
     })
+  }
+
+  /**
+   * Records a port the plugin stopped waiting for so a late confirm is rejected instead of
+   * building a handle nobody owns. Entries are evicted by age and count because a confirm can
+   * never arrive once the main process has reaped the record.
+   */
+  private rememberAbandonedPort(portId: string): void {
+    const now = Date.now()
+    // Constant retention means insertion order is expiry order, so the first live entry ends
+    // the sweep.
+    for (const [id, expiresAt] of this.abandonedPorts) {
+      if (expiresAt > now) {
+        break
+      }
+      this.abandonedPorts.delete(id)
+    }
+
+    while (this.abandonedPorts.size >= ABANDONED_PORT_MAX_ENTRIES) {
+      const oldest = this.abandonedPorts.keys().next().value
+      if (oldest === undefined) {
+        break
+      }
+      this.abandonedPorts.delete(oldest)
+    }
+
+    this.abandonedPorts.set(portId, now + ABANDONED_PORT_RETENTION_MS)
+  }
+
+  private discardQueuedPortConfirm(portId: string, reason: string): void {
+    const queued = this.queuedPortConfirms.get(portId)
+    if (!queued) {
+      return
+    }
+
+    this.queuedPortConfirms.delete(portId)
+    if (queued.timeout) {
+      clearTimeout(queued.timeout)
+    }
+    try {
+      queued.port.close()
+    }
+    catch {}
+    void this.send(TransportEvents.port.close, {
+      channel: queued.payload.channel,
+      portId,
+      reason,
+    }).catch(() => {})
   }
 
   private evictPortHandle(portId: string, channel?: string): void {
@@ -744,6 +811,9 @@ export class TuffPluginTransport implements ITuffTransport {
     this.pendingPortConfirms.clear()
 
     for (const [portId, record] of this.queuedPortConfirms) {
+      if (record.timeout) {
+        clearTimeout(record.timeout)
+      }
       try {
         record.port.close()
       }


### PR DESCRIPTION
Closes #877. Closes #878.

Two retention leaks in the same port-handling code, both of which `renderer-transport.ts` had already solved. Its constants and its reasoning are ported across rather than reinvented.

| # | leak | fix |
|---|---|---|
| 877 | a confirm beating its `openPort` waiter was queued **with no expiry**, pinning a live `MessagePort` until `destroy()` | `PORT_CONFIRM_TIMEOUT_MS` timer + `discardQueuedPortConfirm` |
| 878 | `abandonedPorts` was a `Set` cleared only in `destroy()` | `Map<portId, expiresAt>` bounded by `ABANDONED_PORT_RETENTION_MS` and `ABANDONED_PORT_MAX_ENTRIES` |

### Two of my six tests were weaker than their names claimed

Both mutations *applied* (the patch asserts its pattern matched) and both suites still came back green. That is a test defect, not a passing control:

- **missing `clearTimeout` on claim** — asserting "the claimed port is not closed later" cannot detect it: `discardQueuedPortConfirm` early-returns once the entry is gone, so the stale timer fires harmlessly. What actually differs is the **pending timer**, so the test now asserts `vi.getTimerCount()`.
- **entries born already expired** (`now - 1`) — the late-confirm rejection still passed, because the sweep only runs on a *later* `rememberAbandonedPort`, so the dead entry was still present in the map. The test now runs a sweep between recording and the late confirm, which is the only arrangement where the two differ.

### Six tests, six mutations

| mutation | fails |
|---|---|
| revert both | 4 |
| queue with no expiry (#877) | the expiry test |
| drop `clearTimeout` on claim | the pending-timer test |
| drop the count bound (#878) | the count test |
| drop the age sweep (#878) | the age test |
| **over-correct**: entries born expired | the late-confirm test |

utils suite **156 files / 1186 passed**, eslint **0** at `--max-warnings=0`.
