### PR TITLE
fix(prelude): bound the early message queue and reply with the handler result

### DIFF
--- a/packages/utils/__tests__/plugin-prelude-queue-and-reply.test.ts
+++ b/packages/utils/__tests__/plugin-prelude-queue-and-reply.test.ts
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+
+/**
+ * Two defects in the injected prelude:
+ *
+ * - #876 a message for an event with no registered listener went into `earlyMessageQueue` with no
+ *   size or age cap. The queue exists for one race - a message arriving before its handler
+ *   registers - so an event the plugin never handles (a broadcast on every search keystroke, say)
+ *   appended the full rawData plus the IpcRendererEvent for the life of the session.
+ * - #874 `__dispatch` called the listener and then replied `undefined` unconditionally, unlike the
+ *   sibling plugin/channel.ts, so every handler return value was discarded.
+ *
+ * The prelude is a generated source string, so these evaluate it with a fake electron and drive
+ * the real handler rather than asserting on the text. jsdom because it assigns to `window`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getPluginChannelPreludeCode } from '../transport/prelude'
+
+const UNIQUE_KEY = 'plugin-unique-key-abc'
+/** Mirrors EARLY_MESSAGE_MAX_PER_EVENT / EARLY_MESSAGE_MAX_AGE_MS, kept private by the prelude. */
+const EARLY_MESSAGE_MAX_PER_EVENT = 32
+const EARLY_MESSAGE_MAX_AGE_MS = 30000
+
+interface PreludeChannel {
+  regChannel: (name: string, cb: (data: any) => unknown) => () => void
+  earlyMessageQueue: Map<string, unknown[]>
+}
+
+interface Harness {
+  deliver: (message: unknown) => void
+  /** Everything the prelude sent back on @plugin-process-message. */
+  sent: any[]
+  channel: PreludeChannel
+}
+
+function loadPrelude(): Harness {
+  const sent: any[] = []
+  let listener: ((event: unknown, arg: unknown) => void) | null = null
+
+  const fakeElectron = {
+    ipcRenderer: {
+      on(channel: string, handler: (event: unknown, arg: unknown) => void) {
+        if (channel === '@plugin-process-message') listener = handler
+      },
+      send(_channel: string, payload: unknown) {
+        sent.push(payload)
+      },
+      removeListener() {},
+    },
+  }
+
+  const code = getPluginChannelPreludeCode({ uniqueKey: UNIQUE_KEY })
+  // eslint-disable-next-line no-new-func
+  new Function('require', 'window', `${code}`)(
+    (name: string) => (name === 'electron' ? fakeElectron : {}),
+    window,
+  )
+
+  const channel = (window as unknown as { $channel: PreludeChannel }).$channel
+  if (!listener) throw new Error('prelude registered no listener')
+
+  return {
+    deliver: (message: unknown) =>
+      (listener as (event: unknown, arg: unknown) => void)({}, message),
+    sent,
+    channel,
+  }
+}
+
+function message(name: string, data: unknown = { n: 1 }) {
+  return {
+    name,
+    code: 200,
+    data,
+    sync: { timeStamp: 1, timeout: 60000, id: `req-${String(data)}` },
+    header: { status: 'request', type: 'main', uniqueKey: UNIQUE_KEY },
+  }
+}
+
+describe('prelude early queue is bounded and dispatch replies with the result', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-01T10:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('无人监听的事件反复到达时,队列有条数上限 (#876)', () => {
+    const harness = loadPrelude()
+
+    for (let i = 0; i < EARLY_MESSAGE_MAX_PER_EVENT * 4; i += 1) {
+      harness.deliver(message('unhandled-event', i))
+    }
+
+    expect(harness.channel.earlyMessageQueue.get('unhandled-event')!.length).toBeLessThanOrEqual(
+      EARLY_MESSAGE_MAX_PER_EVENT,
+    )
+  })
+
+  it('保留的是最新的那些,而不是最旧的(否则注册时会拿到一堆过时消息)', () => {
+    const harness = loadPrelude()
+    for (let i = 0; i < EARLY_MESSAGE_MAX_PER_EVENT + 5; i += 1) {
+      harness.deliver(message('unhandled-event', i))
+    }
+
+    const received: unknown[] = []
+    harness.channel.regChannel('unhandled-event', (data) => {
+      received.push(data.data)
+    })
+
+    expect(received.at(-1)).toBe(EARLY_MESSAGE_MAX_PER_EVENT + 4)
+    expect(received).not.toContain(0)
+  })
+
+  it('过老的排队消息被丢弃:它们已经不可能还在等某次注册 (#876)', () => {
+    const harness = loadPrelude()
+    harness.deliver(message('unhandled-event', 'stale'))
+
+    vi.advanceTimersByTime(EARLY_MESSAGE_MAX_AGE_MS + 1)
+    harness.deliver(message('unhandled-event', 'fresh'))
+
+    const received: unknown[] = []
+    harness.channel.regChannel('unhandled-event', (data) => {
+      received.push(data.data)
+    })
+
+    expect(received).toEqual(['fresh'])
+  })
+
+  it('正常的早到消息仍然会在注册时补投(否则上面几条会掩盖"队列彻底坏掉")', () => {
+    const harness = loadPrelude()
+    harness.deliver(message('handled-later', 'early'))
+
+    const received: unknown[] = []
+    harness.channel.regChannel('handled-later', (data) => {
+      received.push(data.data)
+    })
+
+    expect(received).toEqual(['early'])
+  })
+
+  it('handler 的返回值会被回复出去,而不是恒为 undefined (#874)', () => {
+    const harness = loadPrelude()
+    harness.channel.regChannel('demo-event', () => ({ answer: 42 }))
+
+    harness.deliver(message('demo-event'))
+
+    expect(harness.sent[0]).toMatchObject({ code: 200, data: { answer: 42 } })
+  })
+
+  it('异步 handler 回复的是解析后的值,而不是一个无法结构化克隆的 Promise (#874)', async () => {
+    const harness = loadPrelude()
+    harness.channel.regChannel('demo-event', async () => ({ answer: 'async' }))
+
+    harness.deliver(message('demo-event'))
+    await vi.waitFor(() => expect(harness.sent).toHaveLength(1))
+
+    expect(harness.sent[0].data).toEqual({ answer: 'async' })
+  })
+
+  it('异步 handler 抛错时回复错误码,不留未处理的 rejection (#874)', async () => {
+    const harness = loadPrelude()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    harness.channel.regChannel('demo-event', async () => {
+      throw new Error('handler blew up')
+    })
+
+    harness.deliver(message('demo-event'))
+    await vi.waitFor(() => expect(harness.sent).toHaveLength(1))
+
+    expect(harness.sent[0]).toMatchObject({ code: 100, data: 'handler blew up' })
+    consoleError.mockRestore()
+  })
+
+  it('handler 没有返回值时回复 undefined,而不是塞进别的东西', () => {
+    const harness = loadPrelude()
+    harness.channel.regChannel('demo-event', () => {})
+
+    harness.deliver(message('demo-event'))
+
+    expect(harness.sent[0].data).toBeUndefined()
+  })
+})

--- a/packages/utils/transport/prelude.ts
+++ b/packages/utils/transport/prelude.ts
@@ -21,6 +21,12 @@ export function getPluginChannelPreludeCode(
   const { ipcRenderer } = require('electron');
   const DataCode = ${JSON.stringify(DATA_CODE)};
   const CHANNEL_DEFAULT_TIMEOUT = 60000;
+  // The early queue exists for one race: a message arriving before its handler registers. That
+  // window is short, so an entry older than this is not waiting for anyone. Without a bound, an
+  // event the plugin never handles - a broadcast on every search keystroke, say - appends the
+  // full rawData plus the IpcRendererEvent for the life of the session (#876).
+  const EARLY_MESSAGE_MAX_AGE_MS = 30000;
+  const EARLY_MESSAGE_MAX_PER_EVENT = 32;
 
   class TouchChannel {
     channelMap = new Map();
@@ -81,9 +87,21 @@ export function getPluginChannelPreludeCode(
         this.__dispatch(e, rawData, listeners);
       } else {
         const queue = this.earlyMessageQueue.get(rawData.name) || [];
-        queue.push({ e, rawData });
-        this.earlyMessageQueue.set(rawData.name, queue);
+        queue.push({ e, rawData, at: Date.now() });
+        this.earlyMessageQueue.set(rawData.name, this.__trim_early_queue(queue));
       }
+    }
+
+    /** Drops entries too old to still be racing a registration, then the oldest over the cap. */
+    __trim_early_queue(queue) {
+      const cutoff = Date.now() - EARLY_MESSAGE_MAX_AGE_MS;
+      let start = 0;
+      // Entries are appended in arrival order, so the first live one ends the sweep.
+      while (start < queue.length && queue[start].at < cutoff) start += 1;
+      const fresh = start > 0 ? queue.slice(start) : queue;
+      return fresh.length > EARLY_MESSAGE_MAX_PER_EVENT
+        ? fresh.slice(fresh.length - EARLY_MESSAGE_MAX_PER_EVENT)
+        : fresh;
     }
 
     __dispatch(e, rawData, listeners) {
@@ -97,8 +115,21 @@ export function getPluginChannelPreludeCode(
           },
           ...rawData
         };
-        func(handInData);
-        handInData.reply(DataCode.SUCCESS, undefined);
+        // The result used to be discarded and undefined replied unconditionally, unlike the
+        // sibling plugin/channel.ts implementation (#874). A promise has to be awaited too: a
+        // Promise cannot survive structured clone, so replying with one directly would fail.
+        const result = func(handInData);
+        if (result && typeof result.then === 'function') {
+          result.then(
+            (resolved) => handInData.reply(DataCode.SUCCESS, resolved),
+            (error) => {
+              console.error('[Plugin] handler for', rawData.name, 'rejected:', error);
+              handInData.reply(DataCode.ERROR, error && error.message ? error.message : String(error));
+            }
+          );
+        } else {
+          handInData.reply(DataCode.SUCCESS, result);
+        }
       });
     }
 


### PR DESCRIPTION
Closes #876. Closes #874.

Two defects in the injected prelude, same generated source.

### #876 — the early queue had no bound

The queue exists for exactly one race: a message arriving before its handler registers. An event the plugin *never* handles — a broadcast on every search keystroke — appended the full `rawData` plus the `IpcRendererEvent` forever.

Bounded the way `renderer-transport.ts` bounds its abandoned ports: sweep entries older than the race window, then trim the oldest over the per-event cap. **Newest kept, not oldest** — dropping the tail would hand a freshly-registered handler a queue of stale messages and discard the current one, which has its own test.

### #874 — the handler's return value was discarded

`__dispatch` replied `undefined` unconditionally, unlike the sibling `plugin/channel.ts`.

Promises are **awaited** rather than replied directly. That is not gold-plating: a `Promise` cannot survive structured clone, so simply passing `result` through would trade a discarded value for a failed reply. Mutating that branch away fails two tests.

### Eight tests, six mutations

| mutation | fails |
|---|---|
| revert both | 6 |
| drop the count cap | 2 |
| drop the age sweep | the age test |
| **over-correct**: keep the oldest | the newest-kept test |
| reply `undefined` again | the return-value test |
| **over-correct**: reply the Promise itself | 2 |

The prelude is a generated source string, so the tests evaluate it with a fake electron and drive the real handler rather than asserting on the text — following `plugin-prelude-unique-key.test.ts`.

utils suite **156 files / 1188 passed**, eslint **0** at `--max-warnings=0`.
