### PR TITLE
fix(transport): stop batch dedupe merging payloads it cannot compare

### DIFF
--- a/packages/utils/__tests__/renderer-transport-batch-dedupe-key.test.ts
+++ b/packages/utils/__tests__/renderer-transport-batch-dedupe-key.test.ts
@@ -1,0 +1,97 @@
+/**
+ * `buildBatchKey` fell back to `Object.prototype.toString.call(payload)` when JSON.stringify threw.
+ * That string is '[object Object]' for every plain object, so under `mergeStrategy: 'dedupe'` two
+ * unrelated circular payloads collapsed onto one key: one request went out and both callers were
+ * handed the same response - wrong data, no error (#865).
+ *
+ * The cache half of #865 was already fixed by the work on #880 (`buildCacheKey` returns null for
+ * unkeyable payloads, in both transports). The dedupe half was still live, and only in the
+ * renderer transport - the plugin transport has no batch queue at all.
+ *
+ * Real events use this: two in the event catalogue declare `mergeStrategy: 'dedupe'`.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { defineRawEvent } from '../transport/event/builder'
+import { TuffRendererTransport } from '../transport/sdk/renderer-transport'
+
+let currentChannel: { send: (eventName: string, payload?: unknown) => Promise<unknown> }
+
+vi.mock('../renderer/hooks/use-channel', () => ({
+  useChannel: () => currentChannel,
+}))
+
+const dedupeEvent = defineRawEvent<Record<string, unknown>, string>('test:batch:dedupe', {
+  batch: { enabled: true, windowMs: 1, maxSize: 50, mergeStrategy: 'dedupe' },
+})
+
+function circular(marker: string): Record<string, unknown> {
+  const node: Record<string, unknown> = { marker }
+  node.self = node
+  return node
+}
+
+function createTransport() {
+  const seen: unknown[] = []
+  currentChannel = {
+    send: vi.fn(async (_eventName: string, payload?: any) => {
+      const marker = payload?.payload?.marker ?? payload?.marker ?? 'void'
+      seen.push(marker)
+      return `response-for-${marker}`
+    }),
+  }
+  return { transport: new TuffRendererTransport(), seen }
+}
+
+describe('batch dedupe does not merge payloads it cannot compare', () => {
+  it('两个不同的循环引用 payload 各自发出请求,各自拿到自己的响应', async () => {
+    const { transport, seen } = createTransport()
+
+    const [first, second] = await Promise.all([
+      transport.send(dedupeEvent, circular('alpha')),
+      transport.send(dedupeEvent, circular('beta')),
+    ])
+
+    // The defect: one request went out and both callers got 'response-for-alpha'.
+    expect(seen).toHaveLength(2)
+    expect(first).toBe('response-for-alpha')
+    expect(second).toBe('response-for-beta')
+  })
+
+  it('可序列化的相同 payload 仍然合并成一次请求(否则"人人独一份"会把 dedupe 悄悄废掉)', async () => {
+    const { transport, seen } = createTransport()
+
+    const [first, second] = await Promise.all([
+      transport.send(dedupeEvent, { marker: 'same' }),
+      transport.send(dedupeEvent, { marker: 'same' }),
+    ])
+
+    expect(seen).toHaveLength(1)
+    expect(first).toBe('response-for-same')
+    expect(second).toBe('response-for-same')
+  })
+
+  it('可序列化的不同 payload 仍然各发各的', async () => {
+    const { transport, seen } = createTransport()
+
+    await Promise.all([
+      transport.send(dedupeEvent, { marker: 'one' }),
+      transport.send(dedupeEvent, { marker: 'two' }),
+    ])
+
+    expect(seen.sort()).toEqual(['one', 'two'])
+  })
+
+  it('同一个循环引用对象连发两次也不合并:无法序列化就无法证明相等', async () => {
+    const { transport, seen } = createTransport()
+    const shared = circular('shared')
+
+    await Promise.all([
+      transport.send(dedupeEvent, shared),
+      transport.send(dedupeEvent, shared),
+    ])
+
+    // Conservative on purpose: the key cannot express "these two are the same object", and
+    // answering the wrong question quickly is not an optimisation.
+    expect(seen).toHaveLength(2)
+  })
+})

--- a/packages/utils/transport/sdk/renderer-transport.ts
+++ b/packages/utils/transport/sdk/renderer-transport.ts
@@ -216,6 +216,8 @@ export class TuffRendererTransport implements ITuffTransport {
    */
   private channelCleanups = new Set<() => void>()
   private streamControllers = new Map<string, StreamController>()
+  /** Distinguishes batch payloads that cannot be serialised into a comparable key. */
+  private unkeyableBatchSeq = 0
   private batchQueues = new Map<string, BatchQueue<any>>()
   private portCache = new Map<string, TransportPortHandle>()
   private portEventSubscriptions = new Map<string, PortEventSubscription>()
@@ -450,7 +452,13 @@ export class TuffRendererTransport implements ITuffTransport {
       return `json:${JSON.stringify(payload)}`
     }
     catch {
-      return `ref:${Object.prototype.toString.call(payload)}`
+      // Object.prototype.toString.call is '[object Object]' for every plain object, so under
+      // mergeStrategy 'dedupe' two unrelated circular payloads merged into one request and both
+      // callers were handed the same response (#865). A payload we cannot serialise is a payload
+      // we cannot prove equal to anything, so it gets a key of its own and merges with nothing.
+      // Dedupe is an optimisation; answering the wrong question quickly is not one.
+      this.unkeyableBatchSeq += 1
+      return `ref:${this.unkeyableBatchSeq}`
     }
   }
 


### PR DESCRIPTION
Closes #865.

### Half of this was already fixed — checked before touching anything

The report points at `buildCacheKey`:80. That fallback is **already gone**, fixed by the work on #880: `buildCacheKey` now returns `null` (unkeyable ⇒ uncacheable) in **both** transports.

The report's second claim — *"the same collision merges unrelated requests under `mergeStrategy: 'dedupe'`"* — was still live, in `buildBatchKey`. That is what this PR fixes.

Scope check: `plugin-transport.ts` has no `buildBatchKey` and no batch queue at all, so there is no sibling copy this time. (The same scan does find `buildCacheKey` in that file, so it is not a broken search.)

### The defect

`Object.prototype.toString.call(payload)` is `'[object Object]'` for every plain object. Two unrelated circular payloads produced the same batch key, so one request went out and **both callers were handed the same response** — wrong data, no error. Two events in the catalogue declare `mergeStrategy: 'dedupe'`.

### Deliberately conservative

An unserialisable payload now gets a key of its own and merges with nothing — **including a second send of the same object**. The key cannot express "these are the same object", and dedupe is an optimisation; answering the wrong question quickly is not one. That case has its own test so the choice is visible rather than incidental.

### Four tests, three mutations

| mutation | fails |
|---|---|
| revert | 2 |
| **over-correct**: unique key for *every* payload | the "identical payloads still merge" control |
| counter never advances | 2 |

The second row is why that control exists: "give everything a unique key" fixes the collision and silently disables dedupe for every well-behaved payload.

### On the suite

The first full run showed 1 failure in `preview-sdk.benchmark.test.ts` (`exceededBudget` 1, not 0). That is a **latency budget under CPU contention**, not this change: it passes in isolation, and my branch touches only `renderer-transport.ts`, which that test does not import. The re-run was clean — **156 files / 1184 passed**. Flagging it because a timing-budget assertion in the shared suite will do this again on a loaded CI runner.

eslint **0** at `--max-warnings=0`.
