### PR TITLE
docs(transport): make the batch queue's ordering guarantee checkable

### DIFF
--- a/packages/utils/__tests__/renderer-transport-batch-ordering.test.ts
+++ b/packages/utils/__tests__/renderer-transport-batch-ordering.test.ts
@@ -1,0 +1,79 @@
+/**
+ * `flushEvent` chains the default `queue` strategy through reduce(...).then(...), serialising what
+ * could be concurrent IPC calls. #866 is right that this costs latency, and suggested either
+ * Promise.all or the real batch envelope.
+ *
+ * Promise.all is not safe here. The events using this strategy include BoxItemEvents.upsert and
+ * delete, and plugin log writes - a delete overtaking its own upsert is a corruption, not a slow
+ * response. Ordering is exactly what `queue` means, and it was an unwritten property of one
+ * reduce() call that any latency-minded reader would remove. These make it a checked one.
+ *
+ * The real fix is the BatchPayload envelope (#867), which has no main-process handler. That is a
+ * feature, not an audit remediation.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { defineRawEvent } from '../transport/event/builder'
+import { TuffRendererTransport } from '../transport/sdk/renderer-transport'
+
+let currentChannel: { send: (eventName: string, payload?: unknown) => Promise<unknown> }
+
+vi.mock('../renderer/hooks/use-channel', () => ({
+  useChannel: () => currentChannel,
+}))
+
+const queueEvent = defineRawEvent<{ seq: number }, string>('test:batch:queue', {
+  batch: { enabled: true, windowMs: 1, maxSize: 50 },
+})
+
+const dedupeEvent = defineRawEvent<{ seq: number }, string>('test:batch:concurrent', {
+  batch: { enabled: true, windowMs: 1, maxSize: 50, mergeStrategy: 'dedupe' },
+})
+
+/**
+ * Each send resolves after a delay that shrinks as `seq` grows, so a concurrent dispatch finishes
+ * in reverse order and a sequential one cannot.
+ */
+function createTransport() {
+  const started: number[] = []
+  const finished: number[] = []
+  currentChannel = {
+    send: vi.fn(async (_eventName: string, payload?: any) => {
+      const seq = payload?.payload?.seq ?? payload?.seq
+      started.push(seq)
+      await new Promise(resolve => setTimeout(resolve, (10 - seq) * 5))
+      finished.push(seq)
+      return `done-${seq}`
+    }),
+  }
+  return { transport: new TuffRendererTransport(), started, finished }
+}
+
+describe('the queue strategy dispatches in order', () => {
+  it('queue 策略下,第 N 个请求在第 N-1 个完成之后才发出', async () => {
+    const { transport, started, finished } = createTransport()
+
+    await Promise.all([1, 2, 3].map(seq => transport.send(queueEvent, { seq })))
+
+    expect(started).toEqual([1, 2, 3])
+    // The point: despite later entries being faster, none of them overtakes an earlier one.
+    expect(finished).toEqual([1, 2, 3])
+  })
+
+  it('每个调用方仍然拿到属于自己的响应,没有被串行化搞错对应关系', async () => {
+    const { transport } = createTransport()
+
+    const results = await Promise.all([1, 2, 3].map(seq => transport.send(queueEvent, { seq })))
+
+    expect(results).toEqual(['done-1', 'done-2', 'done-3'])
+  })
+
+  it('dedupe 策略是并发的:顺序保证只属于 queue(否则上面两条可能只是"全都串行")', async () => {
+    const { transport, started, finished } = createTransport()
+
+    await Promise.all([1, 2, 3].map(seq => transport.send(dedupeEvent, { seq })))
+
+    expect(started).toEqual([1, 2, 3])
+    // Concurrent dispatch lets the fastest finish first, which serialised dispatch cannot produce.
+    expect(finished).toEqual([3, 2, 1])
+  })
+})

--- a/packages/utils/transport/event/types.ts
+++ b/packages/utils/transport/event/types.ts
@@ -22,8 +22,11 @@ declare const _TuffEventBrand: unique symbol
  * Merge strategy for batch requests.
  *
  * @remarks
- * - `queue` - All requests are queued in order
- * - `dedupe` - Duplicate payloads share a single request/response
+ * - `queue` - All requests are queued and dispatched **in arrival order**, one at a time. The
+ *   ordering is the guarantee; the cost is that N queued sends become N serialised round-trips,
+ *   so for an event whose handler is order-independent this is slower than not batching. Use
+ *   `dedupe` there instead.
+ * - `dedupe` - Duplicate payloads share a single request/response, and are dispatched concurrently
  * - `latest` - Only the latest request for a given key is kept
  */
 export type BatchMergeStrategy = 'queue' | 'dedupe' | 'latest'

--- a/packages/utils/transport/sdk/renderer-transport.ts
+++ b/packages/utils/transport/sdk/renderer-transport.ts
@@ -475,6 +475,15 @@ export class TuffRendererTransport implements ITuffTransport {
       return
     }
 
+    // Sequential on purpose, and it costs latency: N queued sends become N serialised
+    // round-trips, which for a pure read is worse than not batching at all (#866).
+    //
+    // Promise.all here would reorder them, and the events using this strategy include
+    // BoxItemEvents.upsert / delete and plugin log writes - a delete overtaking its own upsert is
+    // a corruption, not a slow response. Ordering is what `queue` means; see BatchMergeStrategy.
+    //
+    // Real batching - one round-trip carrying all N, order preserved inside it - needs the
+    // BatchPayload envelope in transport/types.ts, which has no main-process handler (#867).
     await queue.queue.reduce<Promise<void>>(
       (promise, entry) => promise.then(() => this.flushEntry(eventName, entry)),
       Promise.resolve(),

--- a/packages/utils/transport/types.ts
+++ b/packages/utils/transport/types.ts
@@ -231,9 +231,19 @@ export interface StreamContext<TChunk> {
 // ============================================================================
 // Batch Types
 // ============================================================================
+//
+// Reserved wire format, not implemented (#867). Nothing builds or parses this envelope: the
+// transports batch on the *client* side only - they collect sends within a window and then issue
+// them individually. Turning these into a real single round-trip needs a main-process handler
+// that unpacks `requests` and answers with `results`.
+//
+// They are exported from the package's public surface, so they are documented rather than
+// deleted; do not write code that expects a peer to understand them.
 
 /**
  * Payload for a batched request.
+ *
+ * @remarks Reserved. No producer or consumer exists yet - see the note above.
  */
 export interface BatchPayload {
   /**


### PR DESCRIPTION
Addresses #866 and #867. Neither is *implemented* here, and the PR says why.

### #866 — the observation is right, the cheap fix is not

`flushEvent` chains the default `queue` strategy through `reduce(...).then(...)`, so N queued sends become N serialised round-trips. For an order-independent handler that is worse than not batching. All true.

The suggestion offers `Promise.all` or the real envelope. **`Promise.all` is unsafe here** — I checked which events actually use the strategy:

| event | kind |
|---|---|
| `StorageEvents.*.get` / `getVersioned` | read — reordering harmless |
| plugin log `write` | **mutation** |
| `BoxItemEvents.upsert` | **mutation** |
| `BoxItemEvents.delete` | **mutation** |

A delete overtaking its own upsert is a corruption, not a slow response. And `BatchMergeStrategy` documents `queue` as *"All requests are queued in order"* — the ordering **is** the strategy.

So the ordering guarantee was an unwritten property of a single `reduce()` that any latency-minded reader would happily rewrite. It is now a test that **fails under exactly that rewrite** — applying #866's own first suggestion breaks it. The docs now state the trade-off, and point at `dedupe` for order-independent events.

### #867 — reserved, not deleted

`BatchPayload` / `BatchResult` / `BatchResponse` have no producer or consumer; the transports batch on the *client* side only. They are exported from the package's public surface, so deleting them is a breaking change and the maintainer's call. They now carry a note saying nothing understands the envelope, so nobody writes a peer expecting it to.

**What both actually need** is a main-process handler that unpacks `requests` and answers with `results` — one round-trip carrying all N with order preserved inside it, which fixes #866 *without* giving up ordering. That is a feature, not an audit remediation, so I have not built it.

### Three tests, two mutations

| mutation | fails |
|---|---|
| **apply #866's `Promise.all` suggestion** | the ordering test |
| make `dedupe` sequential too | the concurrency control |

The second control matters: without it, "everything is ordered" would pass on a build where *all* strategies serialise, which would hide the regression the first test is meant to catch.

utils suite **156 files / 1183 passed**, eslint **0** at `--max-warnings=0`.
