### PR TITLE
fix(storage): wire the cleanup buttons to the service that implements them [#527]

### DIFF
--- a/apps/core-app/src/main/channel/common.ts
+++ b/apps/core-app/src/main/channel/common.ts
@@ -42,6 +42,12 @@ import type {
   TraySettingsUpdateRequest,
   TraySettingsUpdateResponse
 } from '@talex-touch/utils/transport/events/types'
+import type {
+  CleanupDownloadsOptions,
+  CleanupFileIndexOptions
+} from '../service/storage-maintenance'
+import type { StorageCleanupResult } from '../service/types/storage-maintenance'
+import { cleanupDownloads, cleanupFileIndex, cleanupUpdates } from '../service/storage-maintenance'
 import { validateExternalUrl } from '../utils/external-url-policy'
 import type { Locale } from '../utils/i18n-helper'
 import { Buffer } from 'node:buffer'
@@ -261,6 +267,26 @@ interface StorageUsageRequest {
 }
 const systemGetStorageUsageEvent = defineRawEvent<StorageUsageRequest, StorageUsageReport>(
   'system:get-storage-usage'
+)
+
+/**
+ * Storage cleanup, one event per domain the storage view offers a button for.
+ *
+ * Storagable.vue has rendered these buttons and sent these names since it was written, and nothing
+ * answered them — so a user clicked "清理索引", confirmed the dialog and got "清理失败". Meanwhile
+ * storage-maintenance.ts held the working implementation with no importer, so anyone debugging
+ * "cleanup did not free space" read that file and found the logic correct (#527).
+ *
+ * The payload shapes are the ones the view already sends, matched to the service's option types.
+ */
+const storageCleanupFileIndexEvent = defineRawEvent<CleanupFileIndexOptions, StorageCleanupResult>(
+  'storage:cleanup:file-index'
+)
+const storageCleanupDownloadsEvent = defineRawEvent<CleanupDownloadsOptions, StorageCleanupResult>(
+  'storage:cleanup:downloads'
+)
+const storageCleanupUpdatesEvent = defineRawEvent<void, StorageCleanupResult>(
+  'storage:cleanup:updates'
 )
 const wallpaperListImagesEvent = defineRawEvent<
   { folderPath: string; recursive?: boolean },
@@ -1602,6 +1628,15 @@ export class CommonChannelModule extends BaseModule {
         if (isRendererPerfReport(payload)) {
           perfMonitor.recordRendererReport(payload)
         }
+      }),
+      transport.on(storageCleanupFileIndexEvent, async (payload) => {
+        return await cleanupFileIndex(payload ?? {})
+      }),
+      transport.on(storageCleanupDownloadsEvent, async (payload) => {
+        return await cleanupDownloads(payload ?? {})
+      }),
+      transport.on(storageCleanupUpdatesEvent, async () => {
+        return await cleanupUpdates()
       }),
       transport.on(systemGetStorageUsageEvent, async (payload) => {
         const storageStats = storageModule.getCacheStats()

--- a/apps/core-app/src/renderer/src/views/storage/storage-cleanup-channels.test.ts
+++ b/apps/core-app/src/renderer/src/views/storage/storage-cleanup-channels.test.ts
@@ -11,20 +11,22 @@ import { describe, expect, it } from 'vitest'
  * src/main/service/storage-maintenance.ts holds 357 lines of cleanup logic that nothing imports.
  * Anyone debugging "cleanup did not free space" reads that file and finds the logic correct.
  *
- * Whether those three get wired up or the surface gets withdrawn is a product decision, so this
- * records the gap as a list that must shrink rather than asserting either outcome. A *new*
- * unhandled channel fails the run.
+ * Resolved by wiring rather than by withdrawing the buttons: the view, the service and the shared
+ * StorageCleanupResult type already agreed on the contract, so the only missing piece was the
+ * registration. The inventory below is now empty and the assertion is an equality, which means a
+ * *new* unhandled channel fails the run — the same guarantee, with nothing left to excuse.
  */
 
 const VIEW = path.resolve(process.cwd(), 'src/renderer/src/views/storage/Storagable.vue')
 const MAIN = path.resolve(process.cwd(), 'src/main')
 
-/** Channels the view sends that no main-process handler answers. Shrink, never grow. */
-const KNOWN_UNHANDLED = [
-  'storage:cleanup:downloads',
-  'storage:cleanup:file-index',
-  'storage:cleanup:updates'
-]
+/**
+ * Channels the view sends that no main-process handler answers.
+ *
+ * Empty since #527 wired the three cleanup events. Keep it empty: an entry here is a button that
+ * shows a confirmation dialog and then fails, which is worse than a button that is not there.
+ */
+const KNOWN_UNHANDLED: string[] = []
 
 /** A channel the same view sends through the same helper, and which *is* handled. */
 const CONTROL_CHANNEL = 'system:get-storage-usage'
@@ -36,13 +38,36 @@ function channelsSentByView(): string[] {
   return [...found].sort()
 }
 
+/**
+ * Whether main registers a handler for a channel — not merely whether the name appears there.
+ *
+ * The first version of this grepped for the channel string. That reports "handled" for a channel
+ * whose event is *defined* in main and never registered, which is a state this repo actually
+ * reached: removing the three `transport.on` calls left the `defineRawEvent` lines behind and the
+ * check stayed green. So it now resolves the event constant the name is bound to, and requires a
+ * `transport.on(<constant>` for it.
+ */
 function isHandledInMain(channel: string): boolean {
+  let hits: string
   try {
-    execFileSync('grep', ['-rqF', channel, MAIN], { stdio: 'ignore' })
-    return true
+    hits = execFileSync('grep', ['-rlF', channel, MAIN], { encoding: 'utf8' })
   } catch {
     return false
   }
+
+  for (const file of hits.split('\n').filter(Boolean)) {
+    const source = readFileSync(file, 'utf8')
+    // `const someEvent = defineRawEvent<…>(\n  'channel'\n)` — the binding may be lines away.
+    const binding = new RegExp(
+      `const\\s+(\\w+)\\s*=\\s*define\\w*Event[\\s\\S]{0,200}?['"\`]${channel}['"\`]`
+    ).exec(source)
+    const constant = binding?.[1]
+    if (constant && new RegExp(`transport\\.on\\(\\s*${constant}\\b`).test(source)) return true
+    // A handler may also register the literal directly.
+    if (new RegExp(`(?:transport\\.on|regChannel)\\([^)]{0,80}['"\`]${channel}['"\`]`).test(source))
+      return true
+  }
+  return false
 }
 
 describe('storage cleanup channels', () => {
@@ -63,7 +88,7 @@ describe('storage cleanup channels', () => {
     expect(isHandledInMain('storage:cleanup:definitely-not-a-real-channel')).toBe(false)
   })
 
-  it('has no unhandled channel beyond the ones already known', () => {
+  it('leaves no channel the view sends without a handler', () => {
     const unhandled = channelsSentByView().filter((channel) => !isHandledInMain(channel))
 
     expect(unhandled).toEqual(KNOWN_UNHANDLED)


### PR DESCRIPTION
Closes #527.

## The dead code is only half of it

`storage-maintenance.ts` has no production importer, as reported. What the issue does not say is what happens at the other end: `Storagable.vue` renders three cleanup buttons that `sendRaw` to `storage:cleanup:file-index`, `…:downloads` and `…:updates`, and **nothing in main answers any of them**.

So the user clicks 清理索引, confirms a warning dialog, and gets 清理失败. Meanwhile the working implementation sits in a file with no importer — anyone debugging "cleanup did not free space" reads it and finds the logic correct.

## Wired rather than withdrawn

The view, the service and the shared `StorageCleanupResult` type already agreed on the contract, payload shapes included (`{ clearSearchIndex, rebuild }`, `{ beforeDays }`, none). The only missing piece was the registration. Removing the buttons would have discarded three working implementations in order to make a promise disappear.

Stating the assumption plainly, since it is the product half of the decision: this makes the buttons actually delete data — the file index (rebuildable by rescanning), download bookkeeping rows, and update records — all user-initiated behind the confirmation dialogs the view already shows. If the intended answer was to withdraw the surface instead, this is one revert away.

## The ratchet earned its keep twice

The guard added with the original analysis inventoried the three unhandled channels and asserted equality, so:

1. It **failed when the inventory went to zero**, forcing the shrink to be recorded rather than silently absorbed.
2. Mutation-testing exposed that its detection was too weak for the reverse direction: it grepped `src/main` for the channel string, which still matches when the event is `defineRawEvent`-ed and never registered. Deleting the three `transport.on` calls left it **green**.

It now resolves the constant each channel name is bound to and requires a `transport.on(<constant>` for it. Re-mutated: removing the registrations fails the run.

## Verification

5 tests across the channel guard and `storage-maintenance.test.ts`. `typecheck:node` = 6, unchanged — the first attempt was 3, because the handlers landed inside an array literal and broke its commas, which is worth noting as it looked like an improvement. ESLint clean.