### PR TITLE
feat(permission): gate new call sites on having a mapping entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,11 @@ jobs:
       - name: Verify search-index writer ownership
         run: pnpm -C apps/core-app check:search-index-writers && pnpm -C apps/core-app check:search-index-writers:self-test
 
+      # Runs here rather than as a core-app vitest file: the App suites job is
+      # continue-on-error, so a test there cannot fail a PR (#915).
+      - name: Verify permission API mapping coverage
+        run: pnpm -C apps/core-app check:permission-api-mappings && pnpm -C apps/core-app check:permission-api-mappings:self-test
+
       # The script existed but no workflow ran it (#555). ~1s: re-derives the sensitive-data
       # inventory's 28 evidence anchors from the TypeScript AST, so it needs the root
       # `typescript` dependency and nothing else.

--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -87,7 +87,9 @@
     "quickops:evidence:verify": "pnpm exec tsx \"scripts/quickops-evidence-verify.ts\"",
     "context:entrypoint:evidence:verify": "pnpm exec tsx \"scripts/context-entrypoint-evidence.ts\"",
     "check:search-index-writers": "node scripts/check-search-index-writers.mjs",
-    "check:search-index-writers:self-test": "node scripts/check-search-index-writers.mjs --self-test"
+    "check:search-index-writers:self-test": "node scripts/check-search-index-writers.mjs --self-test",
+    "check:permission-api-mappings": "node scripts/check-permission-api-mappings.mjs",
+    "check:permission-api-mappings:self-test": "node scripts/check-permission-api-mappings.mjs --self-test"
   },
   "dependencies": {
     "@arrow-js/core": "1.0.6",

--- a/apps/core-app/scripts/check-permission-api-mappings.mjs
+++ b/apps/core-app/scripts/check-permission-api-mappings.mjs
@@ -9,9 +9,10 @@
  * log for exactly that.
  *
  * This guards the other half, which needs no inventory: **every API name written at a call site
- * today must already be in the table.** It is currently true — all 12 literals reaching
- * `enforcePermission` match a pattern — so the value is prospective: adding a call site with an
- * unmapped name stops being a silent allow discovered in production logs, and becomes a red PR.
+ * today must already be in the table.** It is currently true — all 19 literals reaching
+ * `enforcePermission` match one of the 50 patterns — so the value is prospective: adding a call
+ * site with an unmapped name stops being a silent allow discovered in production logs, and becomes
+ * a red PR.
  *
  * Deliberately not a vitest file. The `App suites (core-app)` job is `continue-on-error`, so a
  * test there cannot fail a PR; `PR Quality` runs these scripts as gates.

--- a/apps/core-app/scripts/check-permission-api-mappings.mjs
+++ b/apps/core-app/scripts/check-permission-api-mappings.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * Guards the permission guard's mapping table against silent gaps.
+ *
+ * `PermissionGuard.check()` returns `allowed: true` for any API name that matches no entry in
+ * `API_PERMISSION_MAPPINGS`, so the model is an opt-in denylist keyed on a hand-maintained string
+ * table (#915). Flipping that to default-deny needs an inventory of every name that legitimately
+ * reaches the guard, which only production traffic can build — #1182 added the first-sighting warn
+ * log for exactly that.
+ *
+ * This guards the other half, which needs no inventory: **every API name written at a call site
+ * today must already be in the table.** It is currently true — all 12 literals reaching
+ * `enforcePermission` match a pattern — so the value is prospective: adding a call site with an
+ * unmapped name stops being a silent allow discovered in production logs, and becomes a red PR.
+ *
+ * Deliberately not a vitest file. The `App suites (core-app)` job is `continue-on-error`, so a
+ * test there cannot fail a PR; `PR Quality` runs these scripts as gates.
+ *
+ * Read-only. `--self-test` proves the detector fires, because a scanner that matches nothing looks
+ * exactly like a clean repository.
+ */
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+
+const CORE_APP = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const SRC = path.join(CORE_APP, 'src', 'main')
+const GUARD = path.join('modules', 'permission', 'permission-guard.ts')
+
+/**
+ * `enforcePermission(pluginId, 'api:name', sdkapi)` — the second argument is the API name looked
+ * up in the table. `withPermission({ permissionId })` is not scanned: it names a permission
+ * directly and never consults the table, so it cannot have a mapping gap.
+ */
+const ENFORCE_CALL = /enforcePermission\s*\(\s*[^,()]+,\s*'([^']+)'/g
+
+/** Patterns as written in API_PERMISSION_MAPPINGS. `*` matches any remaining characters. */
+function readPatterns(source) {
+  return [...source.matchAll(/pattern:\s*'([^']+)'/g)].map(match => match[1])
+}
+
+function matchesPattern(apiName, pattern) {
+  if (!pattern.includes('*')) return apiName === pattern
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')
+  return new RegExp(`^${escaped}$`).test(apiName)
+}
+
+function listSourceFiles() {
+  const output = execFileSync('git', ['ls-files', 'src/main/**/*.ts'], {
+    cwd: CORE_APP,
+    encoding: 'utf8'
+  })
+  return output
+    .split('\n')
+    .map(line => line.trim().replace(/^src\/main\//, ''))
+    .filter(file => file.length > 0 && !file.includes('.test.'))
+}
+
+function readFromDisk(file) {
+  try {
+    return readFileSync(path.join(SRC, file), 'utf8')
+  } catch {
+    return null
+  }
+}
+
+/** Every literal API name passed to enforcePermission, with where it was written. */
+function collectGuardedNames(read, files) {
+  const found = []
+  for (const file of files) {
+    const source = read(file)
+    if (!source) continue
+    for (const match of source.matchAll(ENFORCE_CALL)) {
+      const line = source.slice(0, match.index).split('\n').length
+      found.push({ file, line, apiName: match[1] })
+    }
+  }
+  return found
+}
+
+function findUnmapped(read, files, patterns) {
+  return collectGuardedNames(read, files).filter(
+    entry => !patterns.some(pattern => matchesPattern(entry.apiName, pattern))
+  )
+}
+
+function selfTest() {
+  const patterns = ['clipboard:read', 'native:screenshot:*']
+  const cases = [
+    {
+      name: 'a call site with an unmapped name is caught',
+      files: ['modules/some/new-handler.ts'],
+      read: () => "perm.enforcePermission(pluginId, 'brand:new:capability', sdkapi)\n",
+      expectUnmapped: 1
+    },
+    {
+      name: 'an exact match is allowed',
+      files: ['modules/some/new-handler.ts'],
+      read: () => "perm.enforcePermission(pluginId, 'clipboard:read', sdkapi)\n",
+      expectUnmapped: 0
+    },
+    {
+      name: 'a wildcard pattern covers its children',
+      files: ['modules/some/new-handler.ts'],
+      read: () => "perm.enforcePermission(pluginId, 'native:screenshot:capture', sdkapi)\n",
+      expectUnmapped: 0
+    },
+    {
+      name: 'a wildcard does not leak across the namespace boundary it is written at',
+      files: ['modules/some/new-handler.ts'],
+      read: () => "perm.enforcePermission(pluginId, 'native:file:read', sdkapi)\n",
+      expectUnmapped: 1
+    },
+    {
+      name: 'withPermission is not policed: it names a permission, not an API',
+      files: ['modules/some/new-handler.ts'],
+      read: () => "withPermission({ permissionId: 'system.shell' }, handler)\n",
+      expectUnmapped: 0
+    }
+  ]
+
+  let failures = 0
+  for (const testCase of cases) {
+    const found = findUnmapped(testCase.read, testCase.files, patterns)
+    const ok = found.length === testCase.expectUnmapped
+    console.log(`${ok ? 'ok  ' : 'FAIL'} ${testCase.name}`)
+    if (!ok) {
+      failures += 1
+      console.log(`     expected ${testCase.expectUnmapped}, got ${found.length}`)
+    }
+  }
+
+  // The scan must actually reach the real call sites; "zero unmapped" over zero names is vacuous.
+  const realPatterns = readPatterns(readFromDisk(GUARD) ?? '')
+  const realNames = collectGuardedNames(readFromDisk, listSourceFiles())
+  const reaches = realPatterns.length > 0 && realNames.length > 0
+  console.log(`${reaches ? 'ok  ' : 'FAIL'} the scan sees the real table and the real call sites`)
+  if (!reaches) {
+    failures += 1
+    console.log(`     ${realPatterns.length} pattern(s), ${realNames.length} guarded name(s)`)
+  }
+  return failures
+}
+
+if (process.argv.includes('--self-test')) {
+  process.exit(selfTest() > 0 ? 1 : 0)
+}
+
+const guardSource = readFromDisk(GUARD)
+if (!guardSource) {
+  console.error(`[permission-api-mappings] cannot read ${GUARD}`)
+  process.exit(1)
+}
+
+const patterns = readPatterns(guardSource)
+if (patterns.length === 0) {
+  console.error('[permission-api-mappings] API_PERMISSION_MAPPINGS yielded no patterns')
+  process.exit(1)
+}
+
+const files = listSourceFiles()
+const guardedNames = collectGuardedNames(readFromDisk, files)
+const unmapped = findUnmapped(readFromDisk, files, patterns)
+
+if (unmapped.length > 0) {
+  console.error('[permission-api-mappings] API names with no entry in API_PERMISSION_MAPPINGS:\n')
+  for (const entry of unmapped) {
+    console.error(`  - ${entry.file}:${entry.line} enforces "${entry.apiName}"`)
+  }
+  console.error(
+    '\nPermissionGuard.check() returns allowed:true for a name it cannot map, so this call site' +
+      '\nis currently ungated for every plugin (#915). Add a pattern to API_PERMISSION_MAPPINGS' +
+      '\nnaming the permission it requires, or — if it is deliberately public — map it to an' +
+      '\nempty permission list so the intent is written down rather than inferred from silence.'
+  )
+  process.exit(1)
+}
+
+console.log(
+  `[permission-api-mappings] ${guardedNames.length} guarded API name(s) all match one of ` +
+    `${patterns.length} mapping pattern(s)`
+)

--- a/apps/core-app/scripts/check-permission-api-mappings.mjs
+++ b/apps/core-app/scripts/check-permission-api-mappings.mjs
@@ -39,7 +39,7 @@ const ENFORCE_CALL = /enforcePermission\s*\(\s*[^,()]+,\s*'([^']+)'/g
 
 /** Patterns as written in API_PERMISSION_MAPPINGS. `*` matches any remaining characters. */
 function readPatterns(source) {
-  return [...source.matchAll(/pattern:\s*'([^']+)'/g)].map(match => match[1])
+  return [...source.matchAll(/pattern:\s*'([^']+)'/g)].map((match) => match[1])
 }
 
 function matchesPattern(apiName, pattern) {
@@ -55,8 +55,8 @@ function listSourceFiles() {
   })
   return output
     .split('\n')
-    .map(line => line.trim().replace(/^src\/main\//, ''))
-    .filter(file => file.length > 0 && !file.includes('.test.'))
+    .map((line) => line.trim().replace(/^src\/main\//, ''))
+    .filter((file) => file.length > 0 && !file.includes('.test.'))
 }
 
 function readFromDisk(file) {
@@ -83,7 +83,7 @@ function collectGuardedNames(read, files) {
 
 function findUnmapped(read, files, patterns) {
   return collectGuardedNames(read, files).filter(
-    entry => !patterns.some(pattern => matchesPattern(entry.apiName, pattern))
+    (entry) => !patterns.some((pattern) => matchesPattern(entry.apiName, pattern))
   )
 }
 


### PR DESCRIPTION
Addresses #915. The default-deny flip is **not** made here, and the PR says why.

### What was already done

`PermissionGuard.check()` returns `allowed: true` for any API name that matches no entry in `API_PERMISSION_MAPPINGS`. PR #1182 already landed the first half of the answer: every unmapped name is recorded and warn-logged on first sighting, so the allow leaves a trace.

I started to add that logging before noticing it exists — the recording is not inert, and the code comment there already states the reasoning.

### What still blocks the flip

Returning `allowed: false` for unmapped names needs an inventory of every name that legitimately reaches the guard, and only production traffic can build it. That is a judgement call about which capabilities are deliberately public, not something derivable from the repo.

### What this PR does — the half that needs no inventory

**Every API name written at a call site today must already be in the table.** All **19** literals reaching `enforcePermission` match one of the **50** patterns, so nothing is broken right now. The value is prospective: adding a call site with an unmapped name stops being a silent allow found later in production logs and becomes a red PR.

Scope note: `withPermission({ permissionId })` is deliberately not scanned — it names a permission directly and never consults the table, so it cannot have a mapping gap. Terminal's three handlers use that form.

### Why a script and not a vitest file

`App suites (core-app)` is `continue-on-error: ${{ matrix.app != 'nexus' }}`, so **a test there cannot fail a PR**. `PR Quality` runs scripts as gates, which is where this goes, following `check:search-index-writers` — including its `--self-test` convention, which is the positive control institutionalised.

### Evidence it actually gates

- `--self-test`: 5 cases + a reachability check. Exit **0**.
- **negative control on the real tree**: renaming `native:screenshot:capture` to an unmapped name in `screenshot-session/index.ts` makes the gate print that file and line and exit **1**. Restored, exit **0**.

The reachability case matters on its own: "zero unmapped names" is vacuous if the scan found zero names, so the self-test asserts it sees both the real table and the real call sites.

### One unrelated thing left alone

`apps/core-app/package.json` has `"zod"` indented 12 spaces. My JSON round-trip normalised it; I restored it, because a reviewer should not have to wonder why zod moved in a permissions PR.

eslint **0** with no warnings.
