### PR TITLE
fix(download): stop a failed single-stream download destroying the old file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,11 @@ jobs:
       - name: Verify search-index writer ownership
         run: pnpm -C apps/core-app check:search-index-writers && pnpm -C apps/core-app check:search-index-writers:self-test
 
+      # Runs here rather than as a core-app vitest file: the App suites job is
+      # continue-on-error, so a test there cannot fail a PR (#915).
+      - name: Verify permission API mapping coverage
+        run: pnpm -C apps/core-app check:permission-api-mappings && pnpm -C apps/core-app check:permission-api-mappings:self-test
+
       # The script existed but no workflow ran it (#555). ~1s: re-derives the sensitive-data
       # inventory's 28 evidence anchors from the TypeScript AST, so it needs the root
       # `typescript` dependency and nothing else.

--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -87,7 +87,9 @@
     "quickops:evidence:verify": "pnpm exec tsx \"scripts/quickops-evidence-verify.ts\"",
     "context:entrypoint:evidence:verify": "pnpm exec tsx \"scripts/context-entrypoint-evidence.ts\"",
     "check:search-index-writers": "node scripts/check-search-index-writers.mjs",
-    "check:search-index-writers:self-test": "node scripts/check-search-index-writers.mjs --self-test"
+    "check:search-index-writers:self-test": "node scripts/check-search-index-writers.mjs --self-test",
+    "check:permission-api-mappings": "node scripts/check-permission-api-mappings.mjs",
+    "check:permission-api-mappings:self-test": "node scripts/check-permission-api-mappings.mjs --self-test"
   },
   "dependencies": {
     "@arrow-js/core": "1.0.6",

--- a/apps/core-app/scripts/check-permission-api-mappings.mjs
+++ b/apps/core-app/scripts/check-permission-api-mappings.mjs
@@ -9,9 +9,10 @@
  * log for exactly that.
  *
  * This guards the other half, which needs no inventory: **every API name written at a call site
- * today must already be in the table.** It is currently true — all 12 literals reaching
- * `enforcePermission` match a pattern — so the value is prospective: adding a call site with an
- * unmapped name stops being a silent allow discovered in production logs, and becomes a red PR.
+ * today must already be in the table.** It is currently true — all 19 literals reaching
+ * `enforcePermission` match one of the 50 patterns — so the value is prospective: adding a call
+ * site with an unmapped name stops being a silent allow discovered in production logs, and becomes
+ * a red PR.
  *
  * Deliberately not a vitest file. The `App suites (core-app)` job is `continue-on-error`, so a
  * test there cannot fail a PR; `PR Quality` runs these scripts as gates.

--- a/apps/core-app/scripts/check-permission-api-mappings.mjs
+++ b/apps/core-app/scripts/check-permission-api-mappings.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * Guards the permission guard's mapping table against silent gaps.
+ *
+ * `PermissionGuard.check()` returns `allowed: true` for any API name that matches no entry in
+ * `API_PERMISSION_MAPPINGS`, so the model is an opt-in denylist keyed on a hand-maintained string
+ * table (#915). Flipping that to default-deny needs an inventory of every name that legitimately
+ * reaches the guard, which only production traffic can build — #1182 added the first-sighting warn
+ * log for exactly that.
+ *
+ * This guards the other half, which needs no inventory: **every API name written at a call site
+ * today must already be in the table.** It is currently true — all 12 literals reaching
+ * `enforcePermission` match a pattern — so the value is prospective: adding a call site with an
+ * unmapped name stops being a silent allow discovered in production logs, and becomes a red PR.
+ *
+ * Deliberately not a vitest file. The `App suites (core-app)` job is `continue-on-error`, so a
+ * test there cannot fail a PR; `PR Quality` runs these scripts as gates.
+ *
+ * Read-only. `--self-test` proves the detector fires, because a scanner that matches nothing looks
+ * exactly like a clean repository.
+ */
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+
+const CORE_APP = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const SRC = path.join(CORE_APP, 'src', 'main')
+const GUARD = path.join('modules', 'permission', 'permission-guard.ts')
+
+/**
+ * `enforcePermission(pluginId, 'api:name', sdkapi)` — the second argument is the API name looked
+ * up in the table. `withPermission({ permissionId })` is not scanned: it names a permission
+ * directly and never consults the table, so it cannot have a mapping gap.
+ */
+const ENFORCE_CALL = /enforcePermission\s*\(\s*[^,()]+,\s*'([^']+)'/g
+
+/** Patterns as written in API_PERMISSION_MAPPINGS. `*` matches any remaining characters. */
+function readPatterns(source) {
+  return [...source.matchAll(/pattern:\s*'([^']+)'/g)].map(match => match[1])
+}
+
+function matchesPattern(apiName, pattern) {
+  if (!pattern.includes('*')) return apiName === pattern
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')
+  return new RegExp(`^${escaped}$`).test(apiName)
+}
+
+function listSourceFiles() {
+  const output = execFileSync('git', ['ls-files', 'src/main/**/*.ts'], {
+    cwd: CORE_APP,
+    encoding: 'utf8'
+  })
+  return output
+    .split('\n')
+    .map(line => line.trim().replace(/^src\/main\//, ''))
+    .filter(file => file.length > 0 && !file.includes('.test.'))
+}
+
+function readFromDisk(file) {
+  try {
+    return readFileSync(path.join(SRC, file), 'utf8')
+  } catch {
+    return null
+  }
+}
+
+/** Every literal API name passed to enforcePermission, with where it was written. */
+function collectGuardedNames(read, files) {
+  const found = []
+  for (const file of files) {
+    const source = read(file)
+    if (!source) continue
+    for (const match of source.matchAll(ENFORCE_CALL)) {
+      const line = source.slice(0, match.index).split('\n').length
+      found.push({ file, line, apiName: match[1] })
+    }
+  }
+  return found
+}
+
+function findUnmapped(read, files, patterns) {
+  return collectGuardedNames(read, files).filter(
+    entry => !patterns.some(pattern => matchesPattern(entry.apiName, pattern))
+  )
+}
+
+function selfTest() {
+  const patterns = ['clipboard:read', 'native:screenshot:*']
+  const cases = [
+    {
+      name: 'a call site with an unmapped name is caught',
+      files: ['modules/some/new-handler.ts'],
+      read: () => "perm.enforcePermission(pluginId, 'brand:new:capability', sdkapi)\n",
+      expectUnmapped: 1
+    },
+    {
+      name: 'an exact match is allowed',
+      files: ['modules/some/new-handler.ts'],
+      read: () => "perm.enforcePermission(pluginId, 'clipboard:read', sdkapi)\n",
+      expectUnmapped: 0
+    },
+    {
+      name: 'a wildcard pattern covers its children',
+      files: ['modules/some/new-handler.ts'],
+      read: () => "perm.enforcePermission(pluginId, 'native:screenshot:capture', sdkapi)\n",
+      expectUnmapped: 0
+    },
+    {
+      name: 'a wildcard does not leak across the namespace boundary it is written at',
+      files: ['modules/some/new-handler.ts'],
+      read: () => "perm.enforcePermission(pluginId, 'native:file:read', sdkapi)\n",
+      expectUnmapped: 1
+    },
+    {
+      name: 'withPermission is not policed: it names a permission, not an API',
+      files: ['modules/some/new-handler.ts'],
+      read: () => "withPermission({ permissionId: 'system.shell' }, handler)\n",
+      expectUnmapped: 0
+    }
+  ]
+
+  let failures = 0
+  for (const testCase of cases) {
+    const found = findUnmapped(testCase.read, testCase.files, patterns)
+    const ok = found.length === testCase.expectUnmapped
+    console.log(`${ok ? 'ok  ' : 'FAIL'} ${testCase.name}`)
+    if (!ok) {
+      failures += 1
+      console.log(`     expected ${testCase.expectUnmapped}, got ${found.length}`)
+    }
+  }
+
+  // The scan must actually reach the real call sites; "zero unmapped" over zero names is vacuous.
+  const realPatterns = readPatterns(readFromDisk(GUARD) ?? '')
+  const realNames = collectGuardedNames(readFromDisk, listSourceFiles())
+  const reaches = realPatterns.length > 0 && realNames.length > 0
+  console.log(`${reaches ? 'ok  ' : 'FAIL'} the scan sees the real table and the real call sites`)
+  if (!reaches) {
+    failures += 1
+    console.log(`     ${realPatterns.length} pattern(s), ${realNames.length} guarded name(s)`)
+  }
+  return failures
+}
+
+if (process.argv.includes('--self-test')) {
+  process.exit(selfTest() > 0 ? 1 : 0)
+}
+
+const guardSource = readFromDisk(GUARD)
+if (!guardSource) {
+  console.error(`[permission-api-mappings] cannot read ${GUARD}`)
+  process.exit(1)
+}
+
+const patterns = readPatterns(guardSource)
+if (patterns.length === 0) {
+  console.error('[permission-api-mappings] API_PERMISSION_MAPPINGS yielded no patterns')
+  process.exit(1)
+}
+
+const files = listSourceFiles()
+const guardedNames = collectGuardedNames(readFromDisk, files)
+const unmapped = findUnmapped(readFromDisk, files, patterns)
+
+if (unmapped.length > 0) {
+  console.error('[permission-api-mappings] API names with no entry in API_PERMISSION_MAPPINGS:\n')
+  for (const entry of unmapped) {
+    console.error(`  - ${entry.file}:${entry.line} enforces "${entry.apiName}"`)
+  }
+  console.error(
+    '\nPermissionGuard.check() returns allowed:true for a name it cannot map, so this call site' +
+      '\nis currently ungated for every plugin (#915). Add a pattern to API_PERMISSION_MAPPINGS' +
+      '\nnaming the permission it requires, or — if it is deliberately public — map it to an' +
+      '\nempty permission list so the intent is written down rather than inferred from silence.'
+  )
+  process.exit(1)
+}
+
+console.log(
+  `[permission-api-mappings] ${guardedNames.length} guarded API name(s) all match one of ` +
+    `${patterns.length} mapping pattern(s)`
+)

--- a/apps/core-app/scripts/check-permission-api-mappings.mjs
+++ b/apps/core-app/scripts/check-permission-api-mappings.mjs
@@ -39,7 +39,7 @@ const ENFORCE_CALL = /enforcePermission\s*\(\s*[^,()]+,\s*'([^']+)'/g
 
 /** Patterns as written in API_PERMISSION_MAPPINGS. `*` matches any remaining characters. */
 function readPatterns(source) {
-  return [...source.matchAll(/pattern:\s*'([^']+)'/g)].map(match => match[1])
+  return [...source.matchAll(/pattern:\s*'([^']+)'/g)].map((match) => match[1])
 }
 
 function matchesPattern(apiName, pattern) {
@@ -55,8 +55,8 @@ function listSourceFiles() {
   })
   return output
     .split('\n')
-    .map(line => line.trim().replace(/^src\/main\//, ''))
-    .filter(file => file.length > 0 && !file.includes('.test.'))
+    .map((line) => line.trim().replace(/^src\/main\//, ''))
+    .filter((file) => file.length > 0 && !file.includes('.test.'))
 }
 
 function readFromDisk(file) {
@@ -83,7 +83,7 @@ function collectGuardedNames(read, files) {
 
 function findUnmapped(read, files, patterns) {
   return collectGuardedNames(read, files).filter(
-    entry => !patterns.some(pattern => matchesPattern(entry.apiName, pattern))
+    (entry) => !patterns.some((pattern) => matchesPattern(entry.apiName, pattern))
   )
 }
 

--- a/apps/core-app/src/main/modules/download/download-worker.ts
+++ b/apps/core-app/src/main/modules/download/download-worker.ts
@@ -406,14 +406,22 @@ export class DownloadWorker {
       progressTracker.updateProgress(downloadedSize, totalSize)
     })
 
-    const writeStream = createWriteStream(outputPath, { flags: 'w' })
+    // Streamed into a sibling temp file and renamed into place, matching the chunked path (#781).
+    // Opening the real filename with 'w' truncated whatever was already there before a single new
+    // byte was known good, and the failure path then unlinked it - so a failed re-download did not
+    // merely corrupt the previous file, it removed it (#1457). A rename within the same directory
+    // is atomic: the destination holds either the previous file or the complete new one.
+    const tempOutputPath = `${outputPath}.${task.id}.part`
+    const writeStream = createWriteStream(tempOutputPath, { flags: 'w' })
 
     try {
       await pipeline(response.stream, writeStream)
+      await fs.rename(tempOutputPath, outputPath)
     } catch (error) {
       writeStream.destroy()
       try {
-        await fs.unlink(outputPath)
+        // The destination was never touched; only the partial download is dropped.
+        await fs.unlink(tempOutputPath)
       } catch (cleanupError: unknown) {
         const code =
           typeof cleanupError === 'object' && cleanupError !== null && 'code' in cleanupError

--- a/apps/core-app/src/main/modules/download/single-stream-atomicity.test.ts
+++ b/apps/core-app/src/main/modules/download/single-stream-atomicity.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The single-stream path opened the destination with 'w', truncating whatever was already there
+ * before one new byte was known good — and its failure path then unlinked that same path, so a
+ * failed re-download did not merely corrupt the previous file, it *removed* it (#1457).
+ *
+ * Found while fixing the chunked merge (#781) and filed rather than folded into that PR. Same fix
+ * shape: stream to a sibling .part and rename into place.
+ *
+ * These run against a real temp directory, because the property under test is what is on disk
+ * after a failed download, which a mocked fs cannot show.
+ */
+import type { DownloadTask } from '@talex-touch/utils'
+import fs from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { Readable } from 'node:stream'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The import graph reaches modules that touch electron at module scope; this harness is the
+// repo's own answer to that.
+import '../ai/intelligence-test-harness'
+
+const requestStream = vi.hoisted(() => vi.fn())
+
+vi.mock('../network', () => ({
+  getNetworkService: () => ({ requestStream })
+}))
+
+vi.mock('./logger', () => ({
+  downloadWorkerLog: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}))
+
+import { DownloadWorker } from './download-worker'
+import { ProgressTracker } from './progress-tracker'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  requestStream.mockReset()
+  await Promise.all(
+    tempDirs.splice(0).map(async (dir) => await fs.rm(dir, { recursive: true, force: true }))
+  )
+})
+
+async function createWorkspace(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'single-stream-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+function task(destination: string): DownloadTask {
+  return {
+    id: 'task-1',
+    destination,
+    filename: 'payload.bin',
+    url: 'https://example.test/f'
+  } as unknown as DownloadTask
+}
+
+/** A worker whose network layer replays `chunks`, optionally failing after emitting them. */
+function createWorker(chunks: string[], failure?: Error): DownloadWorker {
+  requestStream.mockImplementation(async () => ({
+    headers: {},
+    stream: new Readable({
+      read() {
+        for (const chunk of chunks) this.push(Buffer.from(chunk))
+        if (failure) this.destroy(failure)
+        else this.push(null)
+      }
+    })
+  }))
+
+  return new DownloadWorker(1, {} as never, {} as never, { network: { timeout: 5_000 } } as never)
+}
+
+/** downloadWithoutChunks is private; the property under test lives only on that path. */
+function run(worker: DownloadWorker, destination: string): Promise<unknown> {
+  const internals = worker as unknown as {
+    downloadWithoutChunks: (
+      task: DownloadTask,
+      tracker: ProgressTracker,
+      headers?: Record<string, string>
+    ) => Promise<unknown>
+  }
+  return internals.downloadWithoutChunks(task(destination), new ProgressTracker('task-1'))
+}
+
+describe('a single-stream download does not damage the destination', () => {
+  it('成功后目标文件是完整内容,且不留 .part 残留', async () => {
+    const dir = await createWorkspace()
+
+    await run(createWorker(['hello-', 'world']), dir)
+
+    expect(await fs.readFile(path.join(dir, 'payload.bin'), 'utf8')).toBe('hello-world')
+    expect((await fs.readdir(dir)).filter((name) => name.endsWith('.part'))).toEqual([])
+  })
+
+  it('传输中途失败时,已存在的目标文件原封不动', async () => {
+    const dir = await createWorkspace()
+    const destination = path.join(dir, 'payload.bin')
+    await fs.writeFile(destination, 'previous-good-download')
+
+    await expect(
+      run(createWorker(['partial-'], new Error('connection reset')), dir)
+    ).rejects.toThrow(/connection reset/)
+
+    // Before the fix this file did not exist at all: truncated by 'w', then unlinked on failure.
+    expect(await fs.readFile(destination, 'utf8')).toBe('previous-good-download')
+  })
+
+  it('目标文件此前不存在且失败时,不会凭空造出一个截断文件', async () => {
+    const dir = await createWorkspace()
+
+    await expect(
+      run(createWorker(['partial-'], new Error('connection reset')), dir)
+    ).rejects.toThrow()
+
+    expect(existsSync(path.join(dir, 'payload.bin'))).toBe(false)
+  })
+
+  it('失败后不留下 .part 残留文件', async () => {
+    const dir = await createWorkspace()
+
+    await expect(
+      run(createWorker(['partial-'], new Error('connection reset')), dir)
+    ).rejects.toThrow()
+
+    expect((await fs.readdir(dir)).filter((name) => name.endsWith('.part'))).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #1457.

The single-stream path opened the destination with `flags: 'w'` — truncating whatever was already there before one new byte was known good — and its failure path then ran `fs.unlink(outputPath)` on that same path.

So the consequence is worse than the title suggests: **a failed re-download did not merely corrupt the previous file, it deleted it.** Lose the connection halfway through re-fetching a file you already had, and you end up with nothing.

Fixed the same way as the chunked merge (#781): stream into a sibling `.part` and `rename` into place. A rename within one directory is atomic, so the destination holds either the previous file or the complete new one.

I found this while fixing #781 and filed it rather than quietly widening that PR.

### Four tests, three mutations

| mutation | fails |
|---|---|
| revert | the pre-existing-destination test |
| write to `.part` but forget the `rename` | the success test |
| **keep `.part` but still unlink the destination on failure** | 2 |

The third is the one worth having. It fixes the truncation and keeps the deletion, which is most of the harm — a half-fix that a test only asserting "no `.part` residue" would wave through.

The tests use a real temp directory: the property under test is what is on disk after a failure, which a mocked `fs` cannot show.

tsc **0**, eslint **0** with no warnings, **4/4**.
