### PR TITLE
fix(tuff-native): keep the native error reachable as cause

### DIFF
--- a/packages/tuff-native/package.json
+++ b/packages/tuff-native/package.json
@@ -108,7 +108,7 @@
     "build:screenshot": "node scripts/build-screenshot.js",
     "build:audio": "node scripts/build-audio.js",
     "build:protocol-fixture": "node scripts/build-protocol-fixture.js",
-    "test:protocol": "node --test protocol-contract.test.js protocol-napi.test.js protocol-carrier.test.js protocol-package.test.js",
+    "test:protocol": "node --test protocol-contract.test.js protocol-napi.test.js protocol-carrier.test.js protocol-package.test.js protocol-error-cause.test.js",
     "test:screenshot-protocol": "node --test screenshot-addon-contract.test.js screenshot-protocol.test.js",
     "verify:screenshot-production": "node scripts/verify-screenshot-production.js",
     "rebuild": "node-gyp rebuild",

--- a/packages/tuff-native/protocol-error-cause.test.js
+++ b/packages/tuff-native/protocol-error-cause.test.js
@@ -1,0 +1,222 @@
+'use strict'
+
+/**
+ * Every carrier method replaced a native failure with a generic NativeCarrierError and dropped the
+ * original — the only place the native code and message survive (#850). A caller saw
+ * 'Native carrier invocation failed' and had nothing to diagnose with.
+ *
+ * The tension worth naming: this file's siblings assert a deliberate sanitisation contract — a
+ * carrier error's `message`, and anything logged, must not leak native payload content. Attaching
+ * the original as `cause` is only safe alongside that, so `cause` is defined **non-enumerable**:
+ * `JSON.stringify(error)` still cannot reach it, which is what those assertions serialise. The
+ * last two tests here pin exactly that, so a later change from defineProperty to a plain
+ * assignment fails rather than quietly widening what a log can carry.
+ */
+
+const assert = require('node:assert/strict')
+const test = require('node:test')
+const golden = require('./fixtures/protocol-v1/golden.json')
+const { NapiCarrier, NativeCarrierError } = require('./protocol')
+const { PROTOCOL_V1 } = require('./protocol-contract')
+
+const NATIVE_DETAIL = 'ENOENT: native addon vanished at /private/path'
+
+function fakeBinding(overrides = {}) {
+  return {
+    nativeProtocolV1Handshake: () => JSON.stringify(golden.serverHello),
+    nativeProtocolV1Invoke: async control => ({
+      control: JSON.stringify({
+        kind: 'response',
+        protocol: PROTOCOL_V1,
+        requestId: JSON.parse(control).requestId,
+        ok: true,
+        payload: null,
+        attachments: [],
+        meta: { durationMs: 0 },
+      }),
+      attachments: [],
+    }),
+    nativeProtocolV1OpenStream: control => ({
+      control: JSON.stringify({
+        kind: 'response',
+        protocol: PROTOCOL_V1,
+        requestId: JSON.parse(control).requestId,
+        ok: true,
+        payload: {
+          streamId: JSON.parse(control).payload.streamId,
+          effectiveWindow: 1,
+          cancellation: 'cooperative',
+        },
+        attachments: [],
+        meta: { durationMs: 0 },
+      }),
+      attachments: [],
+    }),
+    nativeProtocolV1Ack: () => {},
+    nativeProtocolV1Cancel: () => {},
+    nativeProtocolV1Dispose: async () => {},
+    ...overrides,
+  }
+}
+
+function request(requestId) {
+  return {
+    kind: 'request',
+    protocol: PROTOCOL_V1,
+    requestId,
+    capability: 'fixture.echo',
+    operation: 'echo',
+    payload: null,
+    attachments: [],
+  }
+}
+
+test('handshake failure carries the native error as cause', () => {
+  const native = new Error(NATIVE_DETAIL)
+  const carrier = new NapiCarrier({
+    id: 'cause-handshake',
+    binding: fakeBinding({
+      nativeProtocolV1Handshake() {
+        throw native
+      },
+    }),
+  })
+
+  assert.throws(
+    () => carrier.handshake(),
+    error =>
+      error instanceof NativeCarrierError
+      && error.code === 'CARRIER_HANDSHAKE_FAILED'
+      && error.cause === native,
+  )
+})
+
+test('invoke failure carries the native error as cause', async () => {
+  const native = new Error(NATIVE_DETAIL)
+  const carrier = new NapiCarrier({
+    id: 'cause-invoke',
+    binding: fakeBinding({
+      nativeProtocolV1Invoke() {
+        throw native
+      },
+    }),
+  })
+  carrier.handshake()
+
+  await assert.rejects(
+    carrier.invoke(request('cause-request')),
+    error =>
+      error instanceof NativeCarrierError
+      && error.code === 'CARRIER_INVOKE_FAILED'
+      && error.cause === native,
+  )
+})
+
+test('openStream failure carries the native error as cause', () => {
+  const native = new Error(NATIVE_DETAIL)
+  const carrier = new NapiCarrier({
+    id: 'cause-stream',
+    binding: fakeBinding({
+      nativeProtocolV1OpenStream() {
+        throw native
+      },
+    }),
+  })
+  carrier.handshake()
+
+  assert.throws(
+    () =>
+      carrier.openStream(
+        {
+          ...request('cause-stream-request'),
+          payload: { streamId: 'cause-stream-1', initialWindow: 1 },
+        },
+        [],
+        () => {},
+      ),
+    error =>
+      error instanceof NativeCarrierError
+      && error.code === 'CARRIER_OPEN_STREAM_FAILED'
+      && error.cause === native,
+  )
+})
+
+test('dispose failure carries the native error as cause', async () => {
+  const native = new Error(NATIVE_DETAIL)
+  const carrier = new NapiCarrier({
+    id: 'cause-dispose',
+    binding: fakeBinding({
+      nativeProtocolV1Dispose: async () => {
+        throw native
+      },
+    }),
+  })
+  carrier.handshake()
+
+  await assert.rejects(
+    carrier.dispose(),
+    error =>
+      error instanceof NativeCarrierError
+      && error.code === 'CARRIER_DISPOSE_FAILED'
+      && error.cause === native,
+  )
+})
+
+test('a successful call still returns normally: cause is not attached to everything', async () => {
+  const carrier = new NapiCarrier({ id: 'cause-success', binding: fakeBinding() })
+  carrier.handshake()
+
+  const packet = await carrier.invoke(request('cause-ok'))
+
+  assert.equal(packet.control.ok, true)
+  await carrier.dispose()
+})
+
+test('the sanitisation contract still holds: the message never carries the native detail', () => {
+  const carrier = new NapiCarrier({
+    id: 'cause-sanitised',
+    binding: fakeBinding({
+      nativeProtocolV1Handshake() {
+        throw new Error(NATIVE_DETAIL)
+      },
+    }),
+  })
+
+  assert.throws(
+    () => carrier.handshake(),
+    error => !error.message.includes(NATIVE_DETAIL) && !String(error).includes(NATIVE_DETAIL),
+  )
+})
+
+test('cause is non-enumerable, so serialising a carrier error cannot leak the native detail', () => {
+  const carrier = new NapiCarrier({
+    id: 'cause-not-serialised',
+    binding: fakeBinding({
+      nativeProtocolV1Handshake() {
+        throw new Error(NATIVE_DETAIL)
+      },
+    }),
+  })
+
+  let thrown
+  try {
+    carrier.handshake()
+  }
+  catch (error) {
+    thrown = error
+  }
+
+  assert.ok(thrown, 'handshake was expected to throw')
+
+  // Asserting on JSON.stringify(thrown) alone proves nothing: Error's own properties are
+  // non-enumerable, so it is '{}' whether or not cause is enumerable. The property descriptor is
+  // the thing that differs, and a logger that unwraps nested Errors is what would leak.
+  assert.equal(Object.prototype.propertyIsEnumerable.call(thrown, 'cause'), false)
+
+  const unwrapErrors = (_key, value) =>
+    value instanceof Error ? { name: value.name, message: value.message } : value
+  assert.doesNotMatch(JSON.stringify({ ...thrown }, unwrapErrors), new RegExp(NATIVE_DETAIL))
+
+  // Still reachable for a caller that asks for it — that is the whole point of #850.
+  assert.equal(thrown.cause.message, NATIVE_DETAIL)
+})

--- a/packages/tuff-native/protocol.js
+++ b/packages/tuff-native/protocol.js
@@ -25,6 +25,17 @@ class NativeCarrierError extends Error {
     this.code = code
     this.category = options.category ?? 'availability'
     this.retryable = options.retryable ?? false
+    // The native error is the only place the real code and message survive; without it a caller
+    // sees 'Native carrier invocation failed' and nothing about why (#850). Non-enumerable so it
+    // does not widen anything that serialises this error.
+    if (options.cause !== undefined) {
+      Object.defineProperty(this, 'cause', {
+        value: options.cause,
+        configurable: true,
+        enumerable: false,
+        writable: true,
+      })
+    }
     if (options.carrierId)
       this.carrierId = options.carrierId
     if (options.requestId)
@@ -69,12 +80,13 @@ class NapiCarrier {
     try {
       encoded = this.binding.nativeProtocolV1Handshake(encodeControl(hello))
     }
-    catch {
+    catch (error) {
       this.safeLog('warn', 'handshake-failed', { code: 'CARRIER_HANDSHAKE_FAILED' })
       throw carrierError(
         'CARRIER_HANDSHAKE_FAILED',
         'Native carrier handshake failed',
         this.id,
+        { cause: error },
       )
     }
 
@@ -82,11 +94,12 @@ class NapiCarrier {
     try {
       snapshot = decodeControl(encoded)
     }
-    catch {
+    catch (error) {
       throw carrierError(
         'CARRIER_PROTOCOL_VIOLATION',
         'Native carrier returned an invalid handshake',
         this.id,
+        { cause: error },
       )
     }
     if (snapshot.kind !== 'server_hello') {
@@ -127,7 +140,7 @@ class NapiCarrier {
         attachments,
       )
     }
-    catch {
+    catch (error) {
       this.safeLog('warn', 'invoke-failed', {
         code: 'CARRIER_INVOKE_FAILED',
         requestId: safeIdentifier(control.requestId),
@@ -136,7 +149,7 @@ class NapiCarrier {
         'CARRIER_INVOKE_FAILED',
         'Native carrier invocation failed',
         this.id,
-        { requestId: control.requestId },
+        { requestId: control.requestId, cause: error },
       )
     }
     const packet = this.decodePacket(raw, 'invoke')
@@ -181,13 +194,13 @@ class NapiCarrier {
         raw => this.handleFrame(state, raw),
       )
     }
-    catch {
+    catch (error) {
       this.streams.delete(streamId)
       throw carrierError(
         'CARRIER_OPEN_STREAM_FAILED',
         'Native carrier could not open the stream',
         this.id,
-        { requestId: control.requestId, streamId },
+        { requestId: control.requestId, streamId, cause: error },
       )
     }
     const accepted = this.decodePacket(rawAccepted, 'open-stream')
@@ -247,12 +260,14 @@ class NapiCarrier {
       }))
       return true
     }
-    catch {
+    catch (error) {
       throw carrierError(
         'CARRIER_CANCEL_FAILED',
         'Native cancellation failed',
         this.id,
-        targetType === 'stream' ? { streamId: id } : { requestId: id },
+        targetType === 'stream'
+          ? { streamId: id, cause: error }
+          : { requestId: id, cause: error },
       )
     }
   }
@@ -291,11 +306,12 @@ class NapiCarrier {
     try {
       await this.binding.nativeProtocolV1Dispose()
     }
-    catch {
+    catch (error) {
       throw carrierError(
         'CARRIER_DISPOSE_FAILED',
         'Native carrier disposal failed',
         this.id,
+        { cause: error },
       )
     }
     finally {
@@ -396,7 +412,7 @@ class NapiCarrier {
     try {
       return validatePacket(raw.control, raw.attachments)
     }
-    catch {
+    catch (error) {
       this.safeLog('warn', 'packet-invalid', {
         code: 'CARRIER_PROTOCOL_VIOLATION',
         source,
@@ -405,6 +421,7 @@ class NapiCarrier {
         'CARRIER_PROTOCOL_VIOLATION',
         'Native carrier returned an invalid packet',
         this.id,
+        { cause: error },
       )
     }
   }
@@ -464,6 +481,7 @@ function carrierError(code, message, carrierId, correlation = {}) {
     carrierId,
     requestId: safeIdentifier(correlation.requestId),
     streamId: safeIdentifier(correlation.streamId),
+    cause: correlation.cause,
   })
 }
 


### PR DESCRIPTION
Closes #850.

Seven `catch` blocks replaced a native failure with a generic `NativeCarrierError` and dropped the original — the only place the native code and message survive. A caller saw `Native carrier invocation failed` and had nothing to diagnose with.

Covered: `handshake` (both the call and the decode), `invoke`, `openStream`, `cancel`, `dispose`, `decodePacket`.

### The part that needed care: this file has a deliberate secrecy contract

Its sibling tests assert that a carrier error's `message`, and anything logged, must **not** carry native payload content — `'never includes payload or attachment secrets in contract errors'`, `'packet violations and logs are sanitized'`. Attaching the original error could have re-opened exactly what those exist to close.

So `cause` is **defined non-enumerable**, not assigned:

- reachable for a caller that asks for `.cause` — the point of the issue
- out of anything that walks own enumerable properties — what the sanitisation tests serialise
- `message` is untouched; a mutation that folds the native message into it fails the sanitisation test

All 6 sibling carrier tests still pass.

### A test of mine that could not have failed

My first version asserted `JSON.stringify(thrown)` did not contain the native detail. **That proves nothing**: `Error`'s own properties are already non-enumerable, so it is `'{}'` whether or not `cause` is enumerable. The mutation that makes `cause` enumerable passed all 7 tests.

It now asserts the property descriptor directly, and serialises through a replacer that unwraps nested `Error`s — the logger shape that would actually leak.

### Seven tests, four mutations

| mutation | fails |
|---|---|
| revert | 5 |
| factory stops threading `cause` | 5 |
| **make `cause` enumerable** | the descriptor test |
| **over-correct**: fold the native message into the carrier message | the sanitisation test |

### Out of scope, reported not changed

Five bare `catch` blocks remain. Three (`catch {}` around cleanup/cancel) are deliberate best-effort. Two discard an error on stream-teardown paths without surfacing it — a real adjacent gap, but they call `failStream(state, code)` rather than throwing a carrier error, so threading a cause there changes that method's contract. Left for a separate issue rather than widened into this one.

### On verification

`npm run test:protocol` cannot run in full here: `protocol-napi.test.js` needs `build/fixtures/tuff_native_protocol_fixture.node`, and `build:protocol-fixture` fails in this environment. **Identical at HEAD** — pre-existing, not this change. The other four suites, including both sanitisation ones, run: **22 passing**. CI is the verifier for the napi suite.
