### PR TITLE
refactor(types): give IntelligenceMessage one declaration [#519]

### DIFF
--- a/packages/tuff-intelligence/src/types/intelligence.ts
+++ b/packages/tuff-intelligence/src/types/intelligence.ts
@@ -1,5 +1,36 @@
+/**
+ * The IPC message shape, owned by @talex-touch/utils.
+ *
+ * It was declared here as well, and the two had already drifted — this copy carried `metadata`
+ * and the utils one did not. Main-process code imports the utils copy and renderer components
+ * import this one, so nothing typechecked them against each other and the divergence was
+ * invisible until a message crossed the boundary (#519).
+ *
+ * Re-exported rather than re-declared: tuff-intelligence already depends on utils, so the
+ * direction is settled and there is no second declaration left to drift.
+ */
+
 import { DEFAULT_CAPABILITIES as SHARED_DEFAULT_CAPABILITIES } from "@talex-touch/utils/types/intelligence";
 import { NEXUS_BASE_URL } from "../env";
+/**
+ * The IPC message shape, owned by @talex-touch/utils.
+ *
+ * It was declared here as well, and the two had already drifted — this copy carried `metadata`
+ * and the utils one did not. Main-process code imports the utils copy and renderer components
+ * import this one, so nothing typechecked them against each other and the divergence was
+ * invisible until a message crossed the boundary (#519).
+ *
+ * Re-exported rather than re-declared: tuff-intelligence already depends on utils, so the
+ * direction is settled and there is no second declaration left to drift. The import alongside is
+ * needed because `export type … from` does not bind the name locally, and this file uses it.
+ */
+import type { IntelligenceMessage } from "@talex-touch/utils/types/intelligence";
+
+export type {
+  IntelligenceMessage,
+  IntelligenceMessageAttachment
+} from "@talex-touch/utils/types/intelligence";
+
 
 export type {
   BuildContextInput,
@@ -438,39 +469,7 @@ export interface IntelligenceProviderConfig {
   metadata?: Record<string, any>;
 }
 
-/**
- * A binary the user attached to a turn.
- *
- * Carried inline as a data URL rather than as a path: the renderer holds the bytes in memory and
- * only the main process may write to disk, so a path would name a file the sender cannot produce.
- */
-export interface IntelligenceMessageAttachment {
-  /** Images are the only kind carried today; providers that cannot read one ignore the field. */
-  type: "image";
-  /** `data:image/(png|jpeg|webp|gif);base64,…`, re-validated by whoever consumes it. */
-  dataUrl: string;
-  /** Original filename, for display only — never trusted to decide the on-disk extension. */
-  name?: string;
-}
 
-/**
- * Chat message structure.
- */
-export interface IntelligenceMessage {
-  /** Message role. */
-  role: "system" | "user" | "assistant";
-  /** Message content. */
-  content: string;
-  /** Optional metadata for routing/context policies. */
-  metadata?: Record<string, any>;
-  /** Optional sender name. */
-  name?: string;
-  /**
-   * Attachments the user sent with this turn. Optional by design: a provider that cannot read
-   * binaries simply never looks at it, which is what keeps the degrade silent instead of fatal.
-   */
-  attachments?: IntelligenceMessageAttachment[];
-}
 
 /**
  * Options for invoking an intelligence capability.

--- a/packages/utils/__tests__/intelligence-message-single-declaration.test.ts
+++ b/packages/utils/__tests__/intelligence-message-single-declaration.test.ts
@@ -1,0 +1,73 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * `IntelligenceMessage` must be declared once (#519).
+ *
+ * It was declared in both `@talex-touch/utils` and `@talex-touch/tuff-intelligence`, and the two
+ * had already drifted — the tuff-intelligence copy carried `metadata`, the utils one did not.
+ * Main-process code imports the utils copy and renderer components import the tuff-intelligence
+ * one, so **nothing typechecked them against each other**: the divergence only surfaced when a
+ * message crossed the boundary, as a field that silently vanished.
+ *
+ * That is the property worth guarding. A second declaration is not a style problem here; it is a
+ * type system that has stopped being able to see the mismatch.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const PACKAGES = path.join(REPO_ROOT, 'packages')
+const SKIP = new Set(['node_modules', 'dist', '.git', '__tests__'])
+
+const DECLARED = /^export\s+interface\s+(IntelligenceMessage|IntelligenceMessageAttachment)\b/m
+
+function sourceFiles(dir: string): string[] {
+  const found: string[] = []
+  for (const entry of readdirSync(dir)) {
+    if (SKIP.has(entry)) continue
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) found.push(...sourceFiles(full))
+    else if (entry.endsWith('.ts') && !entry.endsWith('.d.ts')) found.push(full)
+  }
+  return found
+}
+
+const declarations = sourceFiles(PACKAGES).filter((file) =>
+  DECLARED.test(readFileSync(file, 'utf8'))
+)
+
+describe('IntelligenceMessage', () => {
+  it('is declared somewhere', () => {
+    // Positive control: "declared in exactly one place" is also what a scan that reads nothing
+    // reports, except it reports zero — so the count is checked, not just the uniqueness.
+    expect(declarations.length).toBeGreaterThan(0)
+  })
+
+  it('is declared in exactly one package', () => {
+    const owners = [...new Set(declarations.map((file) => path.relative(PACKAGES, file).split(path.sep)[0]))]
+
+    expect(owners).toEqual(['utils'])
+  })
+
+  it('carries the field the forked copy had, so nothing was lost in unforking', () => {
+    // `metadata` existed only in the tuff-intelligence copy and is load-bearing —
+    // agent-runtime.ts spreads it when normalising promptInjection. Dropping it while merging the
+    // two would have been a silent regression rather than a visible one.
+    const source = readFileSync(path.join(PACKAGES, 'utils/types/intelligence.ts'), 'utf8')
+    const declaration = /export interface IntelligenceMessage \{[\s\S]*?\n\}/.exec(source)?.[0] ?? ''
+
+    expect(declaration).toContain('metadata?:')
+    expect(declaration).toContain('attachments?:')
+    expect(declaration).not.toContain('Record<string, any>')
+  })
+
+  it('is re-exported by tuff-intelligence, so its consumers keep their import path', () => {
+    // 13 files import it from tuff-intelligence. Unforking must not become a rename.
+    const source = readFileSync(
+      path.join(PACKAGES, 'tuff-intelligence/src/types/intelligence.ts'),
+      'utf8'
+    )
+
+    expect(source).toMatch(/export type \{[\s\S]*?IntelligenceMessage[\s\S]*?\} from ["']@talex-touch\/utils/)
+  })
+})

--- a/packages/utils/types/intelligence.ts
+++ b/packages/utils/types/intelligence.ts
@@ -405,6 +405,14 @@ export interface IntelligenceMessage {
   /** Optional sender name. */
   name?: string;
   /**
+   * Routing and context-policy hints carried alongside the turn.
+   *
+   * `unknown` rather than `any`: the only consumer spreads it and adds a key
+   * (agent-runtime normalising promptInjection), so nothing needs to index it, and `any` here
+   * would leak through every re-export.
+   */
+  metadata?: Record<string, unknown>;
+  /**
    * Attachments the user sent with this turn. Optional by design: a provider that cannot read
    * binaries simply never looks at it, which is what keeps the degrade silent instead of fatal.
    */


### PR DESCRIPTION
Closes #519.

Confirmed: the two declarations are identical except that the tuff-intelligence copy carries `metadata?: Record<string, any>`.

## Why a second declaration matters here

Not as duplication. Main-process code imports the utils copy, renderer components import the tuff-intelligence one, so **nothing typechecks them against each other** — the drift surfaced only when a message crossed the boundary, as a field that silently vanished. The type system had stopped being able to see the mismatch, which is what the guard pins.

## `metadata` moves rather than disappears

It is load-bearing: `agent-runtime.ts` spreads it in five places when normalising `promptInjection`. Merging the two by keeping the shorter shape would have been a silent regression rather than a visible one, so it lands in utils.

Typed `Record<string, unknown>` rather than the original `Record<string, any>` — verified nothing indexes it by key (only spread and pass-through), and `any` here would leak through every re-export.

`tuff-intelligence` re-exports both names, so its **13** consumers keep their import path. Unforking must not become a rename.

## Two things the compiler caught that tests would not have

- `export type … from` re-exports without binding the name locally, so the file's own uses of `IntelligenceMessage` stopped resolving — `typecheck:node` went **6 → 9**, and the three new errors were all `TS2304 Cannot find name`. Needed an `import type` alongside.
- That import has to sit with the other imports rather than above them, or `import/first` rejects it. Caught by lint, not by the suite.

## Verification

`typecheck:node` = 6 and `typecheck:web` = 9, both back to baseline. `packages/tuff-intelligence`: 9 files, 35 tests pass. New guard, 4 cases: the type is declared, declared in exactly **one** package, still carries `metadata` and `attachments` and no `Record<string, any>`, and is still re-exported so consumers' imports keep working. Mutation-tested — restoring the forked file fails 2 of the 4. ESLint clean in both packages.