### PR TITLE
fix(channel): report a missing plugin name instead of throwing synchronously

### DIFF
--- a/apps/core-app/src/main/core/channel-core.send-to-plugin-guard.test.ts
+++ b/apps/core-app/src/main/core/channel-core.send-to-plugin-guard.test.ts
@@ -1,0 +1,89 @@
+/**
+ * `_sendTo` is declared `Promise<unknown>` and every other error path returns a resolved error
+ * object. One path threw synchronously instead, so `_sendTo(...).catch(handler)` could not catch
+ * it — the exception left before the promise existed. The main process has no production
+ * uncaughtException handler (dev-process-manager returns early when app.isPackaged), so it could
+ * end the app (#808).
+ *
+ * The same shape as #784, which is why that file's harness is reused here rather than a parallel
+ * copy of the mocks.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+// The import chain reaches talex-mica-electron, @sentry/electron and precore, all of which touch
+// Electron at module scope.
+import '../modules/ai/intelligence-test-harness'
+
+import { genTouchChannel } from './channel-core'
+
+interface SendToCapable {
+  _sendTo: (
+    win: unknown,
+    type: string,
+    eventName: string,
+    arg: unknown,
+    header?: Record<string, unknown>
+  ) => Promise<unknown>
+}
+
+/** A live-looking target: the guard under test must be reached before anything is sent. */
+function fakeWindow(): { win: unknown; sent: unknown[] } {
+  const sent: unknown[] = []
+  return {
+    sent,
+    win: {
+      webContents: {
+        isDestroyed: () => false,
+        send: (channel: string, payload: unknown) => sent.push({ channel, payload })
+      }
+    }
+  }
+}
+
+const channel = genTouchChannel({
+  window: { window: {} },
+  app: { on: vi.fn() }
+} as never) as unknown as SendToCapable
+
+describe('_sendTo reports a missing plugin name instead of throwing', () => {
+  it('缺少 plugin 名时不同步抛出,而是返回一个 promise', () => {
+    const { win } = fakeWindow()
+
+    // The defect: this threw before the promise existed, so no .catch() could ever see it.
+    expect(() => channel._sendTo(win, 'plugin', 'some:event', { data: 1 })).not.toThrow()
+  })
+
+  it('返回的 promise 解析为错误对象,与该函数其它错误路径一致', async () => {
+    const { win } = fakeWindow()
+
+    await expect(channel._sendTo(win, 'plugin', 'some:event', { data: 1 })).resolves.toMatchObject({
+      data: { reason: 'invalid_plugin', eventName: 'some:event' }
+    })
+  })
+
+  it('被拒绝的调用不会真的发出去', async () => {
+    const { win, sent } = fakeWindow()
+
+    await channel._sendTo(win, 'plugin', 'some:event', { data: 1 })
+
+    expect(sent).toEqual([])
+  })
+
+  it('带 plugin 名的调用仍然照常发送(否则上面几条会掩盖"永远拒绝")', async () => {
+    const { win, sent } = fakeWindow()
+
+    void channel._sendTo(win, 'plugin', 'some:event', { plugin: 'com.acme.demo', data: 1 })
+    await Promise.resolve()
+
+    expect(sent).toHaveLength(1)
+  })
+
+  it('非 plugin 类型不受这条守卫影响', async () => {
+    const { win, sent } = fakeWindow()
+
+    void channel._sendTo(win, 'main', 'some:event', { data: 1 })
+    await Promise.resolve()
+
+    expect(sent).toHaveLength(1)
+  })
+})

--- a/apps/core-app/src/main/core/channel-core.ts
+++ b/apps/core-app/src/main/core/channel-core.ts
@@ -679,7 +679,20 @@ class TouchChannel {
     if (type === ChannelType.PLUGIN) {
       const argRecord = toRecord(arg)
       if (argRecord.plugin === void 0) {
-        throw new Error('Invalid plugin name!')
+        // Resolved, not thrown. This is the only path in a Promise-returning function that threw
+        // synchronously, so `_sendTo(...).catch(handler)` could not catch it: the exception left
+        // before the promise existed, and the main process has no production uncaughtException
+        // handler to stop it terminating (#808).
+        channelLog.error(`[Channel] Cannot send "${eventName}" without a plugin name.`)
+        traceIpc(eventName, startedAt, false)
+        return Promise.resolve({
+          code: DataCode.ERROR,
+          data: {
+            message: 'Invalid plugin name',
+            reason: 'invalid_plugin',
+            eventName
+          }
+        })
       }
       _channelCategory = RAW_PLUGIN_PROCESS_CHANNEL
       if (webContents.isDestroyed()) {


### PR DESCRIPTION
Closes #808.

`_sendTo` is declared `Promise<unknown>` and every other error path — serialization failure, destroyed webContents, missing webContents, timeout — returns a **resolved** error object. One path threw synchronously instead, so `_sendTo(...).catch(handler)` could not catch it: the exception left before the promise existed.

Same hazard class as #784: the main process has no production `uncaughtException` handler (`dev-process-manager` returns early when `app.isPackaged`), so this could end the app. That is why this file's harness is reused rather than a parallel copy of the mocks.

### Resolved, not rejected

The issue suggested `Promise.resolve({ code: DataCode.ERROR, ... })` and that is right, for a reason worth stating: switching to `Promise.reject` would fix the synchronous throw and hand every existing caller a **new unhandled rejection**, since none of them expect this function to reject. A caller that awaits and reads `.code` keeps working.

`reject` is a real mutation here and fails 2 tests.

### Five tests, three mutations

| mutation | fails |
|---|---|
| revert (throw again) | 3 |
| **over-correct**: reject instead of resolve | 2 |
| **over-correct**: reject every plugin send | the valid-plugin control |

The last control matters because the guard sits at the top of the plugin branch — "always take the error path" is the easy way to make the first three pass.

tsc **0**, eslint **0** with no warnings, **5/5**.
