### PR TITLE
fix(storage): define the cleanup events through the typed builder [#527]

### DIFF
--- a/apps/core-app/src/main/channel/common.ts
+++ b/apps/core-app/src/main/channel/common.ts
@@ -42,12 +42,8 @@ import type {
   TraySettingsUpdateRequest,
   TraySettingsUpdateResponse
 } from '@talex-touch/utils/transport/events/types'
-import type {
-  CleanupDownloadsOptions,
-  CleanupFileIndexOptions
-} from '../service/storage-maintenance'
-import type { StorageCleanupResult } from '../service/types/storage-maintenance'
 import { cleanupDownloads, cleanupFileIndex, cleanupUpdates } from '../service/storage-maintenance'
+import { StorageEvents } from '@talex-touch/utils/transport/events'
 import { validateExternalUrl } from '../utils/external-url-policy'
 import type { Locale } from '../utils/i18n-helper'
 import { Buffer } from 'node:buffer'
@@ -269,25 +265,6 @@ const systemGetStorageUsageEvent = defineRawEvent<StorageUsageRequest, StorageUs
   'system:get-storage-usage'
 )
 
-/**
- * Storage cleanup, one event per domain the storage view offers a button for.
- *
- * Storagable.vue has rendered these buttons and sent these names since it was written, and nothing
- * answered them — so a user clicked "清理索引", confirmed the dialog and got "清理失败". Meanwhile
- * storage-maintenance.ts held the working implementation with no importer, so anyone debugging
- * "cleanup did not free space" read that file and found the logic correct (#527).
- *
- * The payload shapes are the ones the view already sends, matched to the service's option types.
- */
-const storageCleanupFileIndexEvent = defineRawEvent<CleanupFileIndexOptions, StorageCleanupResult>(
-  'storage:cleanup:file-index'
-)
-const storageCleanupDownloadsEvent = defineRawEvent<CleanupDownloadsOptions, StorageCleanupResult>(
-  'storage:cleanup:downloads'
-)
-const storageCleanupUpdatesEvent = defineRawEvent<void, StorageCleanupResult>(
-  'storage:cleanup:updates'
-)
 const wallpaperListImagesEvent = defineRawEvent<
   { folderPath: string; recursive?: boolean },
   { images: string[] }
@@ -1629,13 +1606,13 @@ export class CommonChannelModule extends BaseModule {
           perfMonitor.recordRendererReport(payload)
         }
       }),
-      transport.on(storageCleanupFileIndexEvent, async (payload) => {
+      transport.on(StorageEvents.cleanup.fileIndex, async (payload) => {
         return await cleanupFileIndex(payload ?? {})
       }),
-      transport.on(storageCleanupDownloadsEvent, async (payload) => {
+      transport.on(StorageEvents.cleanup.downloads, async (payload) => {
         return await cleanupDownloads(payload ?? {})
       }),
-      transport.on(storageCleanupUpdatesEvent, async () => {
+      transport.on(StorageEvents.cleanup.updates, async () => {
         return await cleanupUpdates()
       }),
       transport.on(systemGetStorageUsageEvent, async (payload) => {

--- a/apps/core-app/src/renderer/src/views/storage/storage-cleanup-channels.test.ts
+++ b/apps/core-app/src/renderer/src/views/storage/storage-cleanup-channels.test.ts
@@ -19,6 +19,10 @@ import { describe, expect, it } from 'vitest'
 
 const VIEW = path.resolve(process.cwd(), 'src/renderer/src/views/storage/Storagable.vue')
 const MAIN = path.resolve(process.cwd(), 'src/main')
+const EVENTS_REGISTRY = path.resolve(
+  process.cwd(),
+  '../../packages/utils/transport/events/index.ts'
+)
 
 /**
  * Channels the view sends that no main-process handler answers.
@@ -52,22 +56,59 @@ function isHandledInMain(channel: string): boolean {
   try {
     hits = execFileSync('grep', ['-rlF', channel, MAIN], { encoding: 'utf8' })
   } catch {
-    return false
+    hits = ''
   }
 
   for (const file of hits.split('\n').filter(Boolean)) {
-    const source = readFileSync(file, 'utf8')
-    // `const someEvent = defineRawEvent<…>(\n  'channel'\n)` — the binding may be lines away.
-    const binding = new RegExp(
-      `const\\s+(\\w+)\\s*=\\s*define\\w*Event[\\s\\S]{0,200}?['"\`]${channel}['"\`]`
-    ).exec(source)
-    const constant = binding?.[1]
-    if (constant && new RegExp(`transport\\.on\\(\\s*${constant}\\b`).test(source)) return true
-    // A handler may also register the literal directly.
-    if (new RegExp(`(?:transport\\.on|regChannel)\\([^)]{0,80}['"\`]${channel}['"\`]`).test(source))
-      return true
+    if (registersChannel(readFileSync(file, 'utf8'), channel)) return true
   }
-  return false
+
+  // A typed event lives in the shared registry, so its name never appears under src/main at all —
+  // the handler reads `transport.on(StorageEvents.cleanup.fileIndex, …)`. Resolve the accessor
+  // path from the registry source, then look for a registration of that path.
+  const accessor = accessorForChannel(channel)
+  if (!accessor) return false
+  try {
+    execFileSync('grep', ['-rqF', `transport.on(${accessor}`, MAIN], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** A handler registered against a literal or a locally-defined event constant. */
+function registersChannel(source: string, channel: string): boolean {
+  const binding = new RegExp(
+    `const\\s+(\\w+)\\s*=\\s*define\\w*Event[\\s\\S]{0,200}?['"\`]${channel}['"\`]`
+  ).exec(source)
+  const constant = binding?.[1]
+  if (constant && new RegExp(`transport\\.on\\(\\s*${constant}\\b`).test(source)) return true
+  return new RegExp(`(?:transport\\.on|regChannel)\\([^)]{0,80}['"\`]${channel}['"\`]`).test(source)
+}
+
+/**
+ * `StorageEvents.cleanup.fileIndex` for `storage:cleanup:file-index`, read out of the registry.
+ *
+ * Derived rather than hard-coded: the point of this file is to notice a channel nobody handles, and
+ * a hand-written map would have to be updated by the same person who forgot the handler.
+ */
+function accessorForChannel(channel: string): string | null {
+  const registry = readFileSync(EVENTS_REGISTRY, 'utf8')
+  const [domain, ...rest] = channel.split(':')
+  const event = rest.at(-1)
+  const module = rest.length > 1 ? rest[0] : undefined
+  if (!domain || !event) return null
+
+  const pattern = new RegExp(
+    `(\\w+):\\s*defineEvent\\('${domain}'\\)\\s*` +
+      (module ? `\\.module\\('${module}'\\)\\s*` : '') +
+      `\\.event\\('${event}'\\)`
+  )
+  const key = pattern.exec(registry)?.[1]
+  if (!key) return null
+
+  const registryName = `${domain[0]!.toUpperCase()}${domain.slice(1)}Events`
+  return module ? `${registryName}.${module}.${key}` : `${registryName}.${key}`
 }
 
 describe('storage cleanup channels', () => {

--- a/packages/utils/transport/events/index.ts
+++ b/packages/utils/transport/events/index.ts
@@ -517,6 +517,9 @@ import type {
   PluginStorageGetRequest,
   PluginStorageSetRequest,
   StorageDeleteRequest,
+  StorageCleanupDownloadsRequest,
+  StorageCleanupFileIndexRequest,
+  StorageCleanupResponse,
   StorageGetRequest,
   StorageGetVersionedResponse,
   StorageSaveRequest,
@@ -1532,6 +1535,33 @@ export const StorageEvents = {
      * Delete a value from plugin storage.
      */
     delete: defineEvent('storage').module('plugin').event('delete').define<PluginStorageDeleteRequest, void>(),
+  },
+
+  /**
+   * Per-domain storage cleanup, one event per button the storage view offers.
+   *
+   * Typed rather than raw: a three-segment name fits the builder, and
+   * transport-event-boundary.test.ts rejects `defineRawEvent` for those — the first wiring of
+   * these used raw definitions and broke that rule for every PR touching utils (#527).
+   */
+  cleanup: {
+    /** Clears file-index tables; the caller decides whether to also clear and rebuild search. */
+    fileIndex: defineEvent('storage')
+      .module('cleanup')
+      .event('file-index')
+      .define<StorageCleanupFileIndexRequest, StorageCleanupResponse>(),
+
+    /** Deletes download bookkeeping rows, all of them or those older than `beforeDays`. */
+    downloads: defineEvent('storage')
+      .module('cleanup')
+      .event('downloads')
+      .define<StorageCleanupDownloadsRequest, StorageCleanupResponse>(),
+
+    /** Deletes the update history records. */
+    updates: defineEvent('storage')
+      .module('cleanup')
+      .event('updates')
+      .define<void, StorageCleanupResponse>(),
   },
 } as const
 

--- a/packages/utils/transport/events/types/storage.ts
+++ b/packages/utils/transport/events/types/storage.ts
@@ -200,3 +200,32 @@ export interface PluginStorageUpdateNotification extends StorageUpdateNotificati
    */
   pluginName: string
 }
+
+/**
+ * Options for clearing the file index.
+ *
+ * Mirrors `CleanupFileIndexOptions` in the main-process service; the storage view already sends
+ * this shape, and typing it here is what lets the transport check the two agree (#527).
+ */
+export interface StorageCleanupFileIndexRequest {
+  includeEmbeddings?: boolean
+  clearSearchIndex?: boolean
+  rebuild?: boolean
+}
+
+/** Options for clearing download bookkeeping. Omitting `beforeDays` clears everything. */
+export interface StorageCleanupDownloadsRequest {
+  beforeDays?: number
+}
+
+/**
+ * What a cleanup reports back.
+ *
+ * `removedCount` is optional because not every domain can count what it deleted, and the view
+ * renders the detail only when it is present.
+ */
+export interface StorageCleanupResponse {
+  success: boolean
+  removedCount?: number
+  error?: string
+}


### PR DESCRIPTION
Follow-up to #1483 (#527), fixing a rule that PR broke.

## What I got wrong

#1483 defined the three cleanup events with `defineRawEvent`. `transport-event-boundary.test.ts` rejects that for any name with three or more colon-separated segments — `storage:cleanup:file-index` qualifies. So `ci / CI - utils` went red **on the base**, and two unrelated PRs (#1487, #1481) failed on it before I traced it back to my own change.

Worth stating plainly: I ran the storage tests and the typecheck on that PR, and neither covers this. The rule lives in a `packages/utils` suite that a `apps/core-app` change does not obviously touch.

## The fix

The three events move into `StorageEvents.cleanup` with real request and response types (`StorageCleanupFileIndexRequest`, `StorageCleanupDownloadsRequest`, `StorageCleanupResponse`). That is better than a mechanical rule-satisfying edit: the transport now checks that the view's payloads and the service's option shapes agree, instead of taking both on trust the way a raw event does.

## The channel guard needed extending a second time

A typed event's name never appears under `src/main` at all — the handler reads `transport.on(StorageEvents.cleanup.fileIndex, …)`. The version from #1483 looked for a literal or a locally-defined constant, so it reported all three as unhandled again.

It now resolves the accessor path out of the registry source and looks for a registration of that path. Derived rather than hard-coded, because a hand-written channel-to-accessor map would have to be maintained by the same person who forgot the handler.

## Verification

`transport-event-boundary.test.ts`: 5 passed (was 1 failing on the base). Channel guard: 3 passed, and mutation-tested again — removing the three registrations fails it. `typecheck:node` = 6, unchanged; removing the now-dead type imports was needed to get there, since the typed registry supplies them. ESLint clean in both packages.