### PR TITLE
fix(conversation): settle a discarded turn instead of only cancelling its stream

### DIFF
--- a/apps/core-app/src/renderer/src/modules/conversation/useHomeConversation.test.ts
+++ b/apps/core-app/src/renderer/src/modules/conversation/useHomeConversation.test.ts
@@ -792,3 +792,110 @@ describe('part assembly', () => {
     expect(conversation.messages.value[1]?.parts).toBeUndefined()
   })
 })
+
+/**
+ * discardActiveTurn() cancelled the StreamController but never concluded the turn, so `settled`
+ * stayed false and `finished` was never resolved:
+ *
+ *   - a non-streaming fallback has no controller to cancel, so when its awaited chat call resolved
+ *     it ran complete() -> conclude() against whatever turn had since replaced it (#824)
+ *   - `await finished` in runTurn stayed pending for the life of the window, retaining the whole
+ *     turn closure per cancelled turn (#825)
+ *
+ * Both are invisible from the message list alone, which is why these assert on the returned
+ * promise and on isStreaming under a *replacement* turn.
+ */
+describe('discarding a turn settles it', () => {
+  /** Resolves when `promise` settles, or to the marker if it is still pending after a tick. */
+  function settledOrPending<T>(promise: Promise<T>): Promise<T | 'pending'> {
+    return Promise.race([promise, flush().then(() => 'pending' as const)])
+  }
+
+  it('restore() 之后,原本 await 的 send() 会结束而不是永远挂起 (#825)', async () => {
+    const double = createSdkDouble()
+    const conversation = useHomeConversation({ sdk: double.sdk })
+
+    const turn = conversation.send('hello')
+    await flush()
+    conversation.restore([])
+
+    await expect(settledOrPending(turn)).resolves.not.toBe('pending')
+  })
+
+  it('reset() 之后同样结束', async () => {
+    const double = createSdkDouble()
+    const conversation = useHomeConversation({ sdk: double.sdk })
+
+    const turn = conversation.send('hello')
+    await flush()
+    conversation.reset()
+
+    await expect(settledOrPending(turn)).resolves.not.toBe('pending')
+  })
+
+  it('丢弃时仍然取消底层的 StreamController(否则只是"提前结束"而没真正停下)', async () => {
+    const double = createSdkDouble()
+    const conversation = useHomeConversation({ sdk: double.sdk })
+
+    void conversation.send('hello')
+    await flush()
+    conversation.reset()
+
+    expect(double.cancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('被丢弃的非流式回合结算后,不会把接替它的新回合掐断 (#824)', async () => {
+    // One conversation, two turns: the first has no stream-capable provider so it goes down the
+    // fallback path (no controller to cancel), the second streams. Using two composables would
+    // prove nothing - they share no state, so a stale turn could not reach the other one anyway.
+    // Held on an object rather than a `let`: TS narrows a local assigned only inside a callback
+    // down to `never` at the call site, which vitest would never have told me about.
+    const staleChat: { release?: (result: IntelligenceInvokeResult<string>) => void } = {}
+    let streamAttempts = 0
+    const double = createSdkDouble({
+      startStream: () => {
+        streamAttempts += 1
+        if (streamAttempts === 1) return Promise.reject(new Error('no chatStream'))
+        return Promise.resolve({ cancel: vi.fn(), cancelled: false, streamId: 'stream-second' })
+      },
+      chat: () =>
+        new Promise<IntelligenceInvokeResult<string>>((resolve) => {
+          staleChat.release = resolve
+        })
+    })
+    const conversation = useHomeConversation({ sdk: double.sdk })
+
+    void conversation.send('first')
+    await flush()
+    conversation.restore([])
+
+    void conversation.send('second')
+    await flush()
+    expect(conversation.isStreaming.value).toBe(true)
+
+    // The abandoned fallback finally answers, into a conversation that has moved on.
+    staleChat.release?.(invokeResult('stale answer'))
+    await flush()
+
+    // Before the fix: complete() -> conclude() ran, flipping streaming off and nulling activeTurn
+    // under the second turn - the Stop button stops working and the composer re-enables mid-stream.
+    expect(conversation.isStreaming.value).toBe(true)
+    expect(conversation.messages.value.map((message) => message.content)).not.toContain(
+      'stale answer'
+    )
+  })
+
+  it('正常结束的回合不受影响(否则上面几条会掩盖"永远立刻结算")', async () => {
+    const double = createSdkDouble()
+    const conversation = useHomeConversation({ sdk: double.sdk })
+
+    const turn = conversation.send('hello')
+    await flush()
+    double.emit().onDelta?.('hi', { type: 'delta', capabilityId: 'text.chat' })
+    double.emit().onEnd?.({ type: 'end', capabilityId: 'text.chat' })
+    await turn
+
+    expect(conversation.messages.value[1]).toMatchObject({ content: 'hi', status: 'complete' })
+    expect(double.cancel).not.toHaveBeenCalled()
+  })
+})

--- a/apps/core-app/src/renderer/src/modules/conversation/useHomeConversation.ts
+++ b/apps/core-app/src/renderer/src/modules/conversation/useHomeConversation.ts
@@ -499,7 +499,18 @@ export function useHomeConversation(
    * whatever thread had replaced it.
    */
   function discardActiveTurn(): void {
-    activeController?.cancel()
+    // Through the turn's own cancel, not the raw controller. Cancelling the controller alone left
+    // `settled` false, with two consequences:
+    //
+    //   - the non-streaming fallback has no controller to cancel, so when its awaited chat call
+    //     resolved it still ran complete() -> conclude(), nulling activeTurn and flipping
+    //     streaming off under whatever turn had since replaced it (#824)
+    //   - `await finished` in runTurn was only ever resolved by conclude(), and StreamController
+    //     guarantees no further callbacks after cancel(), so it stayed pending for the life of the
+    //     window, retaining the whole turn closure (#825)
+    //
+    // cancel() is a no-op on an already-settled turn, so this stays safe to call at any time.
+    activeTurn?.cancel()
     activeController = null
     activeTurn = null
     streaming.value = false
@@ -519,7 +530,9 @@ export function useHomeConversation(
 
   if (getCurrentScope()) {
     onScopeDispose(() => {
-      activeController?.cancel()
+      // Same reason as discardActiveTurn: cancelling the controller alone leaves `await finished`
+      // pending, which retains the turn closure past the scope that owned it.
+      activeTurn?.cancel()
       activeController = null
       activeTurn = null
     })


### PR DESCRIPTION
Closes #824. Closes #825.

Both are the same root cause in `discardActiveTurn()`, which is why they are fixed together rather than in two conflicting branches.

It called `activeController?.cancel()` — the raw StreamController — leaving the turn's `settled` flag false. `activeTurn.cancel()` already does the right thing: cancels the controller **and** runs `conclude()`. Routing through it fixes both.

| # | consequence of `settled` staying false |
|---|---|
| 824 | the non-streaming `fallback()` has no controller to cancel, so when its awaited chat call resolved it ran `complete()` → `conclude()` against whatever turn had since replaced it — Stop stops working, the composer re-enables mid-stream, and the persist watcher writes a half-streamed thread |
| 825 | `await finished` is resolved only by `conclude()`, and `StreamController` guarantees no callbacks after `cancel()`, so it stayed pending for the life of the window, retaining the whole turn closure per cancelled turn |

`fallback()` and `complete()` both already check `settled` after their await, so setting it is all that was needed — no new guards.

`onScopeDispose` had the identical shape and is fixed with it: same leak, on unmount.

### My first #824 test could not have failed

It used **two `useHomeConversation` instances** — they share no state, so a stale turn in one could never have reached the other. It passed against the reverted fix, i.e. it proved nothing. Caught by running the mutation, not by reading it.

Rewritten onto **one** conversation whose first turn falls back (no stream-capable provider, so no controller) and whose second streams. That version fails on revert.

### Six new tests, two mutations

| mutation | fails |
|---|---|
| revert `discardActiveTurn` | **3** — both #825 tests and the #824 one |
| **over-correct**: conclude without cancelling the controller | 4, including a pre-existing test |

The second is why "the underlying controller is still cancelled" has its own test: concluding alone makes the promise settle and the state look right while the stream keeps running.

### On verification

`vue-tsc` caught a real error in my test that vitest could not: TS narrows a `let` assigned only inside a callback down to `never` at the call site. Fixed by holding the resolver on an object.

Renderer typecheck delta is **zero**: 3 errors at HEAD, 3 after, **none** in the files this PR touches (they are missing `@xterm/*` modules in this worktree plus a pre-existing TS6307). eslint **0**, **38/38**.
