### PR TITLE
fix(conversation): sequence route restores and stop load() rejecting

### DIFF
--- a/apps/core-app/src/renderer/src/modules/conversation/latest-only.test.ts
+++ b/apps/core-app/src/renderer/src/modules/conversation/latest-only.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The route watcher awaits history.load(target) and then assigns unconditionally, so two
+ * overlapping navigations raced: a slower earlier load landed after a faster later one and left the
+ * URL naming one thread while the view showed another (#826).
+ *
+ * The guard lives here rather than inline in HomePage.vue because that SFC has no mounting harness,
+ * and an invariant nobody can exercise is one that quietly stops holding. The last test drives the
+ * exact interleaving from the report.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { createLatestOnly } from './latest-only'
+
+describe('createLatestOnly', () => {
+  it('单独一次认领始终是最新的', () => {
+    const isCurrent = createLatestOnly().claim()
+
+    expect(isCurrent()).toBe(true)
+  })
+
+  it('后一次认领会让前一次失效', () => {
+    const sequence = createLatestOnly()
+
+    const first = sequence.claim()
+    const second = sequence.claim()
+
+    expect(first()).toBe(false)
+    expect(second()).toBe(true)
+  })
+
+  it('失效是永久的:更晚的认领结束后,旧的也不会复活', () => {
+    const sequence = createLatestOnly()
+    const first = sequence.claim()
+    sequence.claim()
+
+    expect(first()).toBe(false)
+    expect(first()).toBe(false)
+  })
+
+  it('两个独立序列互不影响', () => {
+    const one = createLatestOnly()
+    const other = createLatestOnly()
+
+    const claimed = one.claim()
+    other.claim()
+
+    expect(claimed()).toBe(true)
+  })
+
+  it('慢的旧请求先发后到时,不会覆盖快的新请求', async () => {
+    const sequence = createLatestOnly()
+    const applied: string[] = []
+
+    /** Mirrors the watcher: claim, await a load, apply only if still current. */
+    async function restore(target: string, delayMs: number): Promise<void> {
+      const isCurrent = sequence.claim()
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+      if (!isCurrent()) return
+      applied.push(target)
+    }
+
+    // 'slow' is navigated to first and resolves last — the interleaving from the report.
+    await Promise.all([restore('slow', 30), restore('fast', 5)])
+
+    expect(applied).toEqual(['fast'])
+  })
+})

--- a/apps/core-app/src/renderer/src/modules/conversation/latest-only.ts
+++ b/apps/core-app/src/renderer/src/modules/conversation/latest-only.ts
@@ -1,0 +1,28 @@
+/**
+ * Sequences overlapping async work so only the newest claim may apply its result.
+ *
+ * The route watcher awaits `history.load(target)` and then assigns unconditionally. Two overlapping
+ * navigations are not sequenced by anything else, so a slower earlier load landed after a faster
+ * later one — the URL named one thread while the view showed another (#826).
+ *
+ * Extracted rather than left as two inline lines because the watcher lives in a large SFC with no
+ * mounting harness, and an invariant nobody can exercise is one that quietly stops holding.
+ */
+export interface LatestOnly {
+  /**
+   * Claims the newest slot and returns a predicate for whether this claim is still the newest.
+   * Call it *before* the first await, so a claim made later invalidates this one.
+   */
+  claim: () => () => boolean
+}
+
+export function createLatestOnly(): LatestOnly {
+  let current = 0
+
+  return {
+    claim() {
+      const token = ++current
+      return () => token === current
+    }
+  }
+}

--- a/apps/core-app/src/renderer/src/modules/conversation/useConversationHistory.test.ts
+++ b/apps/core-app/src/renderer/src/modules/conversation/useConversationHistory.test.ts
@@ -203,3 +203,44 @@ describe('parts persistence', () => {
     expect(send.mock.calls[0]?.[1].messages[0].meta).toBeUndefined()
   })
 })
+
+/**
+ * `load()` called sdk.get with no try/catch, unlike its sibling refresh(). Its only caller is
+ * HomePage's async route watcher, which has none either, so an IPC failure became an unhandled
+ * rejection: the view kept showing the previous thread while the URL named the new one (#827).
+ */
+describe('load survives a store failure', () => {
+  it('sdk 拒绝时返回 null,而不是把 rejection 抛给路由 watcher', async () => {
+    send.mockRejectedValue(new Error('conversation store unavailable'))
+    const history = useConversationHistory()
+
+    await expect(history.load('c1')).resolves.toBeNull()
+  })
+
+  it('依然会记录失败原因,而不是静默吞掉', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    send.mockRejectedValue(new Error('conversation store unavailable'))
+
+    await useConversationHistory().load('c1')
+
+    expect(consoleError).toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
+  it('正常返回的会话仍然被还原(否则上面两条会掩盖"永远返回 null")', async () => {
+    send.mockResolvedValue({
+      id: 'c1',
+      messages: [{ id: 'm1', role: 'user', content: 'hi', status: 'complete', meta: {} }]
+    })
+
+    await expect(useConversationHistory().load('c1')).resolves.toMatchObject([
+      { id: 'm1', role: 'user', content: 'hi' }
+    ])
+  })
+
+  it('不存在的会话仍然返回 null', async () => {
+    send.mockResolvedValue(null)
+
+    await expect(useConversationHistory().load('missing')).resolves.toBeNull()
+  })
+})

--- a/apps/core-app/src/renderer/src/modules/conversation/useConversationHistory.ts
+++ b/apps/core-app/src/renderer/src/modules/conversation/useConversationHistory.ts
@@ -3,6 +3,7 @@ import type {
   ConversationRecord,
   ConversationSaveRequest
 } from '@talex-touch/utils/transport/sdk/domains/conversation'
+import { createRendererLogger } from '~/utils/renderer-log'
 import { useTuffTransport } from '@talex-touch/utils/transport'
 import { createConversationSdk } from '@talex-touch/utils/transport/sdk/domains/conversation'
 import { ref, toRaw, type Ref } from 'vue'
@@ -15,6 +16,8 @@ export interface UseConversationHistoryReturn {
   persist: (id: string, title: string, messages: ConversationMessage[]) => Promise<void>
   remove: (id: string) => Promise<void>
 }
+
+const conversationHistoryLog = createRendererLogger('ConversationHistory')
 
 /** `crypto.randomUUID` is available in every renderer this ships to; no polyfill path is needed. */
 export function createConversationId(): string {
@@ -97,7 +100,16 @@ export function useConversationHistory(): UseConversationHistoryReturn {
   }
 
   async function load(id: string): Promise<ConversationMessage[] | null> {
-    const detail = await sdk.get(id)
+    let detail: Awaited<ReturnType<typeof sdk.get>>
+    try {
+      detail = await sdk.get(id)
+    } catch (error) {
+      // Degrades to "nothing to restore", the same policy refresh() already uses. Without this the
+      // rejection escaped through HomePage's async route watcher, where Vue can only log it as an
+      // unhandled rejection (#827).
+      conversationHistoryLog.error(`Failed to load conversation ${id}`, error)
+      return null
+    }
     if (!detail) return null
     return detail.messages.map((message) => {
       // Parts ride inside meta for storage; pull them back out so the meta the

--- a/apps/core-app/src/renderer/src/views/base/home/HomePage.vue
+++ b/apps/core-app/src/renderer/src/views/base/home/HomePage.vue
@@ -18,6 +18,7 @@ import { useRoute, useRouter } from 'vue-router'
 import AppLogo from '~/components/icon/AppLogo.vue'
 import ToolChartCard from '~/components/intelligence/ToolChartCard.vue'
 import { toChainSteps } from '~/modules/conversation/chain-steps'
+import { createLatestOnly } from '~/modules/conversation/latest-only'
 import {
   CONVERSATION_ERROR_EMPTY_RESPONSE,
   CONVERSATION_ERROR_PROVIDER_UNAVAILABLE
@@ -483,6 +484,13 @@ const history = useConversationHistory()
 let conversationId: string | null = null
 
 /**
+ * Which navigation the watcher is currently serving. Two overlapping restores are not sequenced by
+ * anything else, so a slower earlier load used to land after a faster later one and leave the URL
+ * naming one thread while the view showed another (#826).
+ */
+const restoreSequence = createLatestOnly()
+
+/**
  * Restores the thread named by `/home/c/:id`, and resets to a blank one on plain `/home`.
  *
  * Watching the param rather than loading once on mount is what makes the sidebar work: navigating
@@ -492,6 +500,9 @@ watch(
   () => route.params.id,
   async (id) => {
     const target = typeof id === 'string' ? id : null
+    // Claimed before any await, so a plain /home navigation also invalidates a restore in flight -
+    // otherwise it would land on top of the blank thread reset() just produced.
+    const isCurrentRestore = restoreSequence.claim()
     if (!target) {
       conversationId = null
       conversation.reset()
@@ -500,6 +511,8 @@ watch(
     if (target === conversationId) return
 
     const restored = await history.load(target)
+    // A newer navigation started while this load was in flight; it owns the view now.
+    if (!isCurrentRestore()) return
     if (!restored) return
     conversationId = target
     conversation.restore(restored)


### PR DESCRIPTION
Closes #826. Closes #827.

Both live in the same route-restore flow — one branch rather than two that conflict on the same watcher.

### #826 — overlapping navigations were not sequenced

The watcher awaited `history.load(target)` then assigned unconditionally. A slower earlier load landed after a faster later one, leaving the URL naming one thread while the view showed another.

The claim is taken **before any await**, which also covers a case the issue does not mention: navigating to plain `/home` mid-restore. Without the early claim, the in-flight restore would land on top of the blank thread `reset()` had just produced.

### #827 — `load()` had no catch, unlike its sibling

`refresh()` already degrades to empty on failure; `load()` rethrew into an async watcher that has no catch either, so Vue could only log an unhandled rejection. It now returns `null` and logs, matching that policy.

**What this does not do:** the issue also asks to "surface a load-failed state in HomePage". That is a new error affordance — a feature — so it is not built here. The URL/content mismatch is unchanged; what is fixed is the unhandled rejection and the silent swallow.

### Why the guard is an extracted unit

`HomePage.vue` has no mounting harness and stubbing it would be large and brittle. Two inline lines would have shipped a "high" severity correctness fix with **zero** test coverage. `createLatestOnly()` is 8 lines, exercises the exact interleaving from the report, and is reusable — #830 describes the same race in the search snapshot.

### Nine tests, four mutations

| mutation | fails |
|---|---|
| revert #827 (`load` rethrows) | 2 |
| **over-correct**: swallow silently, no log | the logging test |
| `claim()` always reports current | 3, incl. the slow-then-fast interleaving |
| **over-correct**: `claim()` never reports current | 4 |

The last one is why "a lone claim is current" and "two sequences are independent" exist: returning `false` unconditionally fixes the race by never applying anything.

Renderer typecheck delta **zero**: 3 errors at HEAD, 3 after, **none** in the files touched. eslint **0**, **21/21** across both suites.
