### PR TITLE
build: make extract-file-icon optional [#602]

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -124,7 +124,6 @@
     "drizzle-orm": "^0.45.2",
     "echarts": "catalog:",
     "esbuild": "^0.28.1",
-    "extract-file-icon": "^0.3.2",
     "ffmpeg-static": "^5.3.0",
     "ffprobe-static": "^3.1.0",
     "fs-extra": "^11.3.6",
@@ -145,11 +144,12 @@
     "vue-i18n": "^11.4.0",
     "vue-router": "^4.6.4",
     "vue-sonner": "^2.0.9",
-            "zod": "3.25.76"
+    "zod": "3.25.76"
   },
   "optionalDependencies": {
     "@crosscopy/clipboard": "^0.3.6",
     "bufferutil": "^4.1.0",
+    "extract-file-icon": "^0.3.2",
     "uiohook-napi": "^1.5.5",
     "utf-8-validate": "^6.0.6"
   },

--- a/packages/utils/__tests__/native-deps-optional.test.ts
+++ b/packages/utils/__tests__/native-deps-optional.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * A native dependency that compiles from source must be optional (#602).
+ *
+ * `extract-file-icon` ships no prebuilds and pins `node-addon-api` to an exact `1.7.1`, so it runs
+ * node-gyp against the host toolchain on every install. Sitting in `dependencies`, that made
+ * `pnpm install` fail for the **whole workspace** on any machine without Xcode CLT / MSVC /
+ * build-essential, and on any CI image that trims build tools.
+ *
+ * Moving it costs nothing, which is the part worth pinning: its only consumer already loads it
+ * through a dynamic `import()` inside a try/catch and falls back to `null` — a file with no icon —
+ * and plugins are *denied* the module outright, so nothing else can depend on it either.
+ *
+ * The rule generalises: if a native module without prebuilds is required rather than optional, one
+ * missing compiler stops the entire install.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const CORE_APP = path.join(REPO_ROOT, 'apps/core-app')
+
+const manifest = JSON.parse(readFileSync(path.join(CORE_APP, 'package.json'), 'utf8')) as {
+  dependencies: Record<string, string>
+  optionalDependencies: Record<string, string>
+}
+
+/** Native modules that build from source or ship platform binaries. */
+const NATIVE = ['extract-file-icon', 'uiohook-napi', '@crosscopy/clipboard']
+
+describe('native dependencies', () => {
+  it('reads the manifest it means to check', () => {
+    // Positive control: "none of them is in dependencies" is also what an unreadable file reports.
+    expect(Object.keys(manifest.dependencies).length).toBeGreaterThan(20)
+    expect(manifest.optionalDependencies).toBeDefined()
+  })
+
+  it('are optional, so a missing toolchain degrades one feature instead of the install', () => {
+    const required = NATIVE.filter((name) => name in manifest.dependencies)
+
+    expect(required).toEqual([])
+  })
+
+  it('are actually declared somewhere, not just deleted', () => {
+    // Guards the rule above against being satisfied by dropping the dependency entirely.
+    for (const name of NATIVE) {
+      expect(manifest.optionalDependencies, name).toHaveProperty(name)
+    }
+  })
+})
+
+describe('the icon worker survives the module being absent', () => {
+  const source = readFileSync(
+    path.join(CORE_APP, 'src/main/modules/box-tool/addon/files/workers/icon-worker.ts'),
+    'utf8'
+  )
+
+  it('loads it dynamically and tolerates the failure', () => {
+    // This is what makes `optional` safe rather than merely convenient. A static import here would
+    // turn a missing optional dependency into a worker that cannot start.
+    expect(source).toContain("await import('extract-file-icon')")
+    expect(source).toMatch(/catch\s*\{\s*\n\s*extractFileIcon = null/)
+  })
+
+  it('degrades to no icon rather than throwing', () => {
+    expect(source).toContain('extractor ? extractor(next.filePath, next.size) : null')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,9 +384,6 @@ importers:
       esbuild:
         specifier: 0.28.1
         version: 0.28.1
-      extract-file-icon:
-        specifier: ^0.3.2
-        version: 0.3.2
       ffmpeg-static:
         specifier: ^5.3.0
         version: 5.3.0
@@ -572,6 +569,9 @@ importers:
       bufferutil:
         specifier: ^4.1.0
         version: 4.1.0
+      extract-file-icon:
+        specifier: ^0.3.2
+        version: 0.3.2
       uiohook-napi:
         specifier: ^1.5.5
         version: 1.5.5
@@ -22297,6 +22297,7 @@ snapshots:
   extract-file-icon@0.3.2:
     dependencies:
       node-addon-api: 1.7.1
+    optional: true
 
   fast-deep-equal@3.1.3: {}
 
@@ -24740,7 +24741,8 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  node-addon-api@1.7.1: {}
+  node-addon-api@1.7.1:
+    optional: true
 
   node-addon-api@7.1.1: {}
 


### PR DESCRIPTION
Closes #602 for the part that is a defect; the pin is discussed below.

## The failure being removed

`extract-file-icon` ships no prebuilds and pins `node-addon-api` to an exact `1.7.1`, so node-gyp runs against the host toolchain on every install. In `dependencies`, that meant **`pnpm install` failed for the entire workspace** on any machine without Xcode CLT / MSVC / build-essential — for a feature that draws file icons.

It now sits beside `uiohook-napi` and `@crosscopy/clipboard`, which were already optional for exactly this reason.

## Checked that it is safe *before* moving it

The move only helps if the code tolerates the module being absent. It already does:

- The only consumer, `icon-worker.ts`, loads it through `await import('extract-file-icon')` inside a `try/catch`, caches `null` on failure, and renders `extractor ? extractor(…) : null` — a file with no icon.
- `plugin-require.ts` lists it in `DENIED_MODULE_EXACT_IDS`, so plugins are *forbidden* from requiring it. Nothing else can depend on it.

Both are pinned by the new test, because they are what make `optional` correct rather than merely convenient: a static import here would turn a missing optional dependency into a worker that cannot start.

## What I did not change

The exact `node-addon-api@1.7.1` pin. It is the dependency's own declaration, no override can lift it, and the Node 24 headers / Electron 41 mismatch the issue notes survives only because node-addon-api targets the ABI-stable N-API surface. Replacing or vendoring the dependency is a separate decision and I have left it on the issue rather than folding it in here.

## Verification

`native-deps-optional.test.ts`, 5 passed, in `packages/utils` so `ci / CI - utils` enforces it. It also asserts the three are still *declared* — otherwise the rule could be satisfied by deleting the dependency. Mutation-tested: restoring the old manifest fails 2 of the 5.

Lockfile diff is the importer entry moving section plus `optional: true` on `extract-file-icon` and its `node-addon-api`; no package enters or leaves the graph. Worker suites: 5 files, 21 tests pass. `typecheck:node` = 6, unchanged. ESLint clean.