### PR TITLE
fix(corebox): keep the session id a snapshot does not carry

### DIFF
--- a/apps/core-app/src/renderer/src/modules/box/adapter/hooks/useSearch.core.test.ts
+++ b/apps/core-app/src/renderer/src/modules/box/adapter/hooks/useSearch.core.test.ts
@@ -29,6 +29,15 @@ const state = vi.hoisted(() => ({
   searchResultForRequest: null as
     | null
     | ((payload: unknown, requestIndex: number) => TuffSearchResult | Promise<TuffSearchResult>),
+  /**
+   * Emit the snapshot without merging the session id into the result. `sessionId` is optional on
+   * TuffSearchResult, and the harness used to inject it unconditionally - which is exactly why no
+   * existing test could reach #830.
+   */
+  snapshotOmitsSessionId: false,
+  /** Hold back `complete`/`onEnd` so a test can drive the updates that stream in before it. */
+  deferCompletion: false,
+  releaseCompletion: null as null | (() => void),
   streamCancel: vi.fn(),
   beforeUnmountCallbacks: [] as Array<() => void>,
   send: vi.fn(),
@@ -89,13 +98,21 @@ vi.mock('@talex-touch/utils/transport', () => ({
         state.searchResultForRequest?.(payload, requestIndex) ??
         createSearchResult(getSearchQueryText(payload), requestIndex)
       void Promise.resolve(result).then((snapshot) => {
+        // Genuinely removed, not merely left unmerged: createSearchResult bakes in its own
+        // `session-N`, so skipping the merge would hand the caller a *different* id rather than
+        // none - a test that then failed for the wrong reason.
+        const { sessionId: _omitted, ...withoutSessionId } = snapshot
         options.onData({
           type: 'snapshot',
           sessionId,
-          result: { ...snapshot, sessionId }
+          result: state.snapshotOmitsSessionId ? withoutSessionId : { ...snapshot, sessionId }
         })
-        options.onData({ type: 'complete', sessionId, sources: snapshot.sources })
-        options.onEnd?.()
+        const complete = (): void => {
+          options.onData({ type: 'complete', sessionId, sources: snapshot.sources })
+          options.onEnd?.()
+        }
+        if (state.deferCompletion) state.releaseCompletion = complete
+        else complete()
       })
       return controller
     },
@@ -244,6 +261,9 @@ describe('useSearch CoreBox reopen behavior', () => {
     state.streams.clear()
     state.searchRequests.length = 0
     state.searchResultForRequest = null
+    state.snapshotOmitsSessionId = false
+    state.deferCompletion = false
+    state.releaseCompletion = null
     state.streamCancel.mockClear()
     state.beforeUnmountCallbacks.length = 0
     state.boxItems = []
@@ -1292,5 +1312,86 @@ describe('useSearch CoreBox reopen behavior', () => {
     await flushPromises()
 
     expect(hook.res.value.map((item) => item.id)).toEqual(['item-100'])
+  })
+
+  /**
+   * The `session` chunk establishes the search identity and the snapshot handler already proves the
+   * ids match. The caller then reassigned `currentSearchId` from `initialResult.sessionId`, which is
+   * *optional* on TuffSearchResult — so a provider result without it downgraded the id to null, every
+   * later update/no-results/complete chunk failed its session guard, applySearchEnd never ran, and
+   * the spinner stayed up with the send button disabled until the box was closed (#830).
+   *
+   * No existing test could reach this: the harness merged `sessionId` into every snapshot result, and
+   * emitted `complete` synchronously — before the awaiting caller had even resumed to run the
+   * reassignment. Both are now opt-in flags.
+   */
+  describe('a snapshot without a session id does not strand the search', () => {
+    it('后续 complete 仍然被接受,loading 回到 false', async () => {
+      state.snapshotOmitsSessionId = true
+      state.deferCompletion = true
+      const hook = useSearch(createBoxOptions(), createClipboardOptions())
+      await flushPromises()
+
+      hook.searchVal.value = 'stranded'
+      await nextTick()
+      await flushPromises()
+
+      // The snapshot has landed and the caller has resumed; completion is still outstanding.
+      expect(hook.loading.value).toBe(true)
+      state.releaseCompletion?.()
+      await flushPromises()
+
+      expect(hook.loading.value).toBe(false)
+    })
+
+    it('流中后到的 update 分片仍然会被合入结果', async () => {
+      state.snapshotOmitsSessionId = true
+      state.deferCompletion = true
+      const hook = useSearch(createBoxOptions(), createClipboardOptions())
+      await flushPromises()
+
+      hook.searchVal.value = 'streamed'
+      await nextTick()
+      await flushPromises()
+
+      const before = hook.res.value.length
+      // Derived, not hardcoded: the hook issues its own requests before this one, so the stream
+      // counter is not necessarily 1.
+      const liveSessionId = `stream-session-${state.searchRequests.length}`
+      state.streams.get('core-box:search:session')?.onData({
+        type: 'update',
+        sessionId: liveSessionId,
+        items: [
+          {
+            id: 'late-item',
+            kind: 'app',
+            source: { id: 'test-source', type: 'system' },
+            render: { mode: 'default', basic: { title: 'late-item' } }
+          } as TuffItem
+        ]
+      })
+      await flushPromises()
+
+      expect(hook.res.value.length).toBeGreaterThan(before)
+      expect(hook.res.value.some((item) => item.id === 'late-item')).toBe(true)
+      state.releaseCompletion?.()
+      await flushPromises()
+    })
+
+    it('快照自带 sessionId 时行为不变(否则上面两条会掩盖"干脆不再赋值")', async () => {
+      state.deferCompletion = true
+      const hook = useSearch(createBoxOptions(), createClipboardOptions())
+      await flushPromises()
+
+      hook.searchVal.value = 'with-id'
+      await nextTick()
+      await flushPromises()
+
+      expect(hook.loading.value).toBe(true)
+      state.releaseCompletion?.()
+      await flushPromises()
+
+      expect(hook.loading.value).toBe(false)
+    })
   })
 })

--- a/apps/core-app/src/renderer/src/modules/box/adapter/hooks/useSearch.ts
+++ b/apps/core-app/src/renderer/src/modules/box/adapter/hooks/useSearch.ts
@@ -1229,7 +1229,13 @@ export function useSearch(
         return
       }
 
-      currentSearchId.value = initialResult.sessionId || null
+      // Only when the snapshot actually carries an id. `sessionId` is optional on
+      // TuffSearchResult, and the unconditional `|| null` threw away the identity the `session`
+      // chunk had already established - after which every later update/no-results/complete chunk
+      // failed its session guard, applySearchEnd never ran, and the spinner stayed up forever
+      // (#830). The snapshot handler has already proven the ids match, so this is at most a
+      // no-op reassignment and never a downgrade.
+      if (initialResult.sessionId) currentSearchId.value = initialResult.sessionId
       // The snapshot arrives ranked, so the quota only decides which of the
       // overflow survives — a cache hit (which carries the whole accumulated
       // set) then shows what the live run ended with instead of a plain top cut.


### PR DESCRIPTION
Closes #830.

The `session` chunk establishes the search identity, and the snapshot handler already asserts `currentSearchId === chunk.sessionId` before resolving. The caller then reassigned from `initialResult.sessionId` — **optional** on `TuffSearchResult` — so a provider result without it downgraded the id to `null`. Every later `update` / `no-results` / `complete` chunk then failed its session guard, `applySearchEnd` never ran, and `loading` stayed `true`: spinner forever, send button disabled until the box was closed.

### Why no existing test caught it

Two things in the shared harness, both now opt-in flags:

- it merged `sessionId` into **every** snapshot result, so the field was never absent
- it emitted `complete` **synchronously** after the snapshot — before the awaiting caller had even resumed to run the reassignment, so the guard still passed

The omission flag **deletes** the field rather than skipping the merge. `createSearchResult` bakes in its own `session-N`, so an unmerged result carries a *different* id, not none — my first version failed for that reason rather than the bug's.

### Two things the issue asked for that I did not do, and why

**"set loading=false on the snapshot path as a backstop"** — the snapshot arrives *before* the streamed updates, so this would stop the spinner while results were still arriving. It is also unnecessary once the id survives, because `complete` reaches `applySearchEnd`.

**"Same fix needed at line 930 in applyRecommendationResult"** — checked, and it cannot strand anything. `currentSearchId` is already `null` from line 1104 of the same flow, that flow has no live session, its only caller sets `loading.value = false` unconditionally on the next line, and `applyRecommendationResult` has exactly one caller. The change there would be a no-op, so I did not make one and call it a fix.

### The guarded assignment is defensive, not load-bearing — measured

Deleting the line outright passes **all 22 tests**. That is expected: the snapshot handler has already proven the ids match, so the assignment is at most a no-op. I kept the guarded form the issue suggested, but the honest statement is that its value is intent, not behaviour.

| mutation | fails |
|---|---|
| revert to `|| null` | both #830 tests |
| **remove the assignment entirely** | nothing — see above |

Renderer typecheck delta **zero**: 3 errors at HEAD, 3 after, none in the files touched. eslint **0**, **22/22**.
