### PR TITLE
fix(security): stop baking --inspect into the tuff:// OS registration [#803]

### DIFF
--- a/apps/core-app/src/main/modules/addon-opener.ts
+++ b/apps/core-app/src/main/modules/addon-opener.ts
@@ -202,8 +202,12 @@ export class AddonOpenerModule extends BaseModule {
         // Remove old registration first to ensure clean state
         app.removeAsDefaultProtocolClient(APP_SCHEMA)
 
-        // Register with electron binary and project path
-        app.setAsDefaultProtocolClient(APP_SCHEMA, electronPath, ['--inspect', appPath])
+        // No --inspect. This registration is what the OS launches for a tuff:// link, so baking
+        // the flag in meant any web page containing one could start Electron with an open Node
+        // inspector port — and anything able to reach that port has main-process code execution.
+        // A developer who wants the inspector passes it on their own `pnpm core:dev` invocation;
+        // nothing about protocol handling needs it (#803).
+        app.setAsDefaultProtocolClient(APP_SCHEMA, electronPath, [appPath])
 
         addonOpenerLog.debug('Dev mode protocol registration', {
           meta: {
@@ -215,7 +219,11 @@ export class AddonOpenerModule extends BaseModule {
       addonOpenerLog.debug(`Set as default protocol handler: ${APP_SCHEMA}`)
     }
 
-    if (!app.isDefaultProtocolClient(APP_SCHEMA)) {
+    // A packaged build registers unconditionally. `isDefaultProtocolClient` answers "is this
+    // scheme mine", not "does the registration point at this binary", so skipping on true let a
+    // dev registration — pointing at a checkout that may no longer exist — survive into packaged
+    // runs with nothing ever replacing it (#803).
+    if (app.isPackaged || !app.isDefaultProtocolClient(APP_SCHEMA)) {
       registerProtocol()
     } else {
       addonOpenerLog.debug(`Already registered as protocol handler: ${APP_SCHEMA}`)

--- a/packages/utils/__tests__/protocol-registration-no-inspect.test.ts
+++ b/packages/utils/__tests__/protocol-registration-no-inspect.test.ts
@@ -1,0 +1,75 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * No debug flag may be baked into an OS protocol registration (#803).
+ *
+ * `setAsDefaultProtocolClient` records the command line the OS runs for a `tuff://` link. The dev
+ * registration passed `--inspect`, so any web page containing such a link could start Electron with
+ * an open Node inspector port — and anything able to reach that port has main-process code
+ * execution. The developer's own `pnpm core:dev` is where an inspector belongs; protocol handling
+ * needs nothing from it.
+ *
+ * The second half is quieter. `isDefaultProtocolClient` answers "is this scheme mine", not "does
+ * the registration point at this binary" — so a packaged build that skipped registration on `true`
+ * left a stale dev registration in place, pointing at a checkout that may no longer exist, with
+ * nothing ever replacing it.
+ *
+ * Lives in packages/utils because `ci / CI - utils` is blocking, while `App suites (core-app)` is
+ * continue-on-error and reports success however the suite does.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const MAIN = path.join(REPO_ROOT, 'apps/core-app/src/main')
+
+/** Flags that open a debugging surface if the OS launches with them. */
+const DEBUG_FLAGS = ['--inspect', '--inspect-brk', '--remote-debugging-port']
+
+function sourceFiles(dir: string): string[] {
+  const found: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) found.push(...sourceFiles(full))
+    else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) found.push(full)
+  }
+  return found
+}
+
+const registrations = sourceFiles(MAIN)
+  .map((file) => ({ file, source: readFileSync(file, 'utf8') }))
+  .filter(({ source }) => source.includes('setAsDefaultProtocolClient'))
+
+describe('protocol registration', () => {
+  it('is found where it is expected', () => {
+    // Positive control: "no registration carries a debug flag" is also what an empty scan reports.
+    expect(registrations.length).toBeGreaterThan(0)
+    expect(registrations.some(({ file }) => file.endsWith('addon-opener.ts'))).toBe(true)
+  })
+
+  it('bakes no debug flag into the command the OS will run', () => {
+    const offenders = registrations.flatMap(({ file, source }) =>
+      [...source.matchAll(/setAsDefaultProtocolClient\([^)]*\)/g)]
+        .filter((call) => DEBUG_FLAGS.some((flag) => call[0].includes(flag)))
+        .map((call) => `${path.relative(REPO_ROOT, file)}: ${call[0].slice(0, 80)}`)
+    )
+
+    expect(offenders).toEqual([])
+  })
+
+  it('still registers the dev build against the checkout', () => {
+    // The flag goes; the registration does not. Dropping the whole call would also satisfy the
+    // rule above and would silently stop tuff:// links working in development.
+    const source = registrations.find(({ file }) => file.endsWith('addon-opener.ts'))!.source
+
+    expect(source).toContain('setAsDefaultProtocolClient(APP_SCHEMA, electronPath, [appPath])')
+  })
+
+  it('lets a packaged build replace a stale registration', () => {
+    // Without this a dev registration survives into packaged runs: isDefaultProtocolClient returns
+    // true for it, so the packaged branch never ran.
+    const source = registrations.find(({ file }) => file.endsWith('addon-opener.ts'))!.source
+
+    expect(source).toContain('if (app.isPackaged || !app.isDefaultProtocolClient(APP_SCHEMA))')
+  })
+})


### PR DESCRIPTION
Closes #803.

Confirmed at `addon-opener.ts:205`, and both halves of the report hold.

## The flag

`setAsDefaultProtocolClient` records the command line **the OS runs** for a `tuff://` link. With `--inspect` baked in, any web page containing such a link starts Electron with an open Node inspector port, and anything able to reach that port has main-process code execution.

Nothing about protocol handling needs it: a developer who wants the inspector passes it on their own `pnpm core:dev`, where it applies to the process they started rather than to one a web page can trigger.

## The quieter half, which is what let it outlive development

`isDefaultProtocolClient` answers *"is this scheme mine"*, not *"does the registration point at this binary"*. So a packaged build skipped registering whenever a dev registration was already present — leaving it in place, pointing at a checkout that may no longer exist, with nothing ever replacing it. Packaged now registers unconditionally; dev keeps the existing remove-then-set.

## Verification

`protocol-registration-no-inspect.test.ts`, 4 passed, in `packages/utils` so `ci / CI - utils` enforces it. It scans **every** `setAsDefaultProtocolClient` call under `src/main` rather than the one file, and rejects `--inspect-brk` and `--remote-debugging-port` as well — the same mistake in a different spelling.

Two of the four cases exist to stop the rule being satisfied the wrong way: one asserts the dev registration **still happens** (deleting the call would pass a flag check while silently breaking `tuff://` links in development), and one asserts the packaged re-registration.

Mutation-tested: restoring the previous file fails 3 of the 4; the survivor is the positive control that a registration was found at all. `addon-opener` suites: 7 tests pass. `typecheck:node` = 6, unchanged. ESLint clean in both packages.