### PR TITLE
fix(division-box): leave a failed getState in a terminal state, not loading

### DIFF
--- a/apps/core-app/src/renderer/src/modules/division-box/components/DivisionBoxShell.loading.test.ts
+++ b/apps/core-app/src/renderer/src/modules/division-box/components/DivisionBoxShell.loading.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+/**
+ * `isLoading` was set true on mount and only cleared when getState resolved with an active state.
+ * The `.catch()` only logged, so a rejected or non-success response left the shell in its loading
+ * state permanently (#829).
+ *
+ * The issue's suggested fix — "clear isLoading in the catch and in the non-success branch" — is
+ * **not sufficient on its own**, which is what the second test pins: `showLoadingIndicator` is also
+ * true while `currentState` is `prepare` or `attach`, and the session starts at `prepare`. Clearing
+ * only the flag leaves the same overlay up, now reading 'Preparing...' forever.
+ */
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  on: vi.fn(() => vi.fn())
+}))
+
+vi.mock('@talex-touch/utils/transport', () => ({
+  useTuffTransport: () => ({ send: mocks.send, on: mocks.on })
+}))
+
+vi.mock('~/utils/dev-log', () => ({ devLog: vi.fn() }))
+
+vi.mock('~/utils/renderer-log', () => ({
+  createRendererLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+vi.mock('../store/division-box', () => ({
+  useDivisionBoxStore: () => ({
+    togglePin: vi.fn(),
+    close: vi.fn(),
+    updatePosition: vi.fn(),
+    updateSize: vi.fn()
+  })
+}))
+
+// Names match what the SFC destructures; a wrong one surfaces as `undefined.value` inside a
+// computed rather than as a missing mock.
+vi.mock('../composables/useDrag', () => ({
+  useDrag: () => ({
+    isDragging: ref(false),
+    position: ref({ x: 0, y: 0 }),
+    showDockHint: ref(false),
+    dockHintPosition: ref(null),
+    startDrag: vi.fn()
+  })
+}))
+
+vi.mock('../composables/useResize', () => ({
+  useResize: () => ({
+    isResizing: ref(false),
+    dimensions: ref({ width: 400, height: 300 }),
+    startResize: vi.fn()
+  })
+}))
+
+import DivisionBoxShell from './DivisionBoxShell.vue'
+
+function mountShell() {
+  return mount(DivisionBoxShell, {
+    props: { sessionId: 'session-1', title: 'Demo' },
+    global: {
+      stubs: {
+        DivisionBoxHeader: { template: '<div class="header-stub" />' },
+        DockHint: true
+      }
+    }
+  })
+}
+
+describe('DivisionBoxShell does not hang on the loading overlay', () => {
+  beforeEach(() => {
+    mocks.send.mockReset()
+    mocks.on.mockClear()
+  })
+
+  it('getState 被拒绝时,遮罩消失并给出失败徽章', async () => {
+    mocks.send.mockRejectedValue(new Error('session torn down'))
+    const wrapper = mountShell()
+    await flushPromises()
+
+    expect(wrapper.find('.loading-indicator').exists()).toBe(false)
+    expect(wrapper.find('.state-badge.state-failed').exists()).toBe(true)
+  })
+
+  // The exact half the issue's suggested fix would have missed.
+  it('仅清 isLoading 不够:currentState 必须离开 prepare,否则遮罩照旧', async () => {
+    mocks.send.mockRejectedValue(new Error('session torn down'))
+    const wrapper = mountShell()
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('Preparing...')
+  })
+
+  it('响应非 success 时同样是终态,而不是继续等一个不会来的事件', async () => {
+    mocks.send.mockResolvedValue({ success: false })
+    const wrapper = mountShell()
+    await flushPromises()
+
+    expect(wrapper.find('.loading-indicator').exists()).toBe(false)
+    expect(wrapper.find('.state-badge.state-failed').exists()).toBe(true)
+  })
+
+  it('成功且 active 时既无遮罩也无徽章(否则上面几条会掩盖"永远失败")', async () => {
+    mocks.send.mockResolvedValue({ success: true, data: { state: 'active' } })
+    const wrapper = mountShell()
+    await flushPromises()
+
+    expect(wrapper.find('.loading-indicator').exists()).toBe(false)
+    expect(wrapper.find('.state-badge').exists()).toBe(false)
+  })
+
+  it('成功但仍在 prepare 时,遮罩要留着 —— 那是真正还在加载', async () => {
+    mocks.send.mockResolvedValue({ success: true, data: { state: 'prepare' } })
+    const wrapper = mountShell()
+    await flushPromises()
+
+    expect(wrapper.find('.loading-indicator').exists()).toBe(true)
+  })
+})

--- a/apps/core-app/src/renderer/src/modules/division-box/components/DivisionBoxShell.vue
+++ b/apps/core-app/src/renderer/src/modules/division-box/components/DivisionBoxShell.vue
@@ -142,9 +142,28 @@ function getStateBadgeIcon(state: string) {
       return '🔌'
     case 'destroy':
       return '🗑️'
+    case 'failed':
+      return '⚠️'
     default:
       return '•'
   }
+}
+
+/**
+ * Leaves the shell in a terminal, non-loading state.
+ *
+ * Clearing `isLoading` alone is not enough: `showLoadingIndicator` is also true while
+ * `currentState` is `prepare` or `attach`, and the session is initialised to `prepare`. The
+ * overlay therefore stayed up on a failed getState no matter what `isLoading` said (#829), with
+ * 'Preparing...' under it forever.
+ *
+ * `failed` rides the existing state-badge path rather than a new error surface: the badge already
+ * renders any non-active state, so it needs an icon and a colour, not a component.
+ */
+function failInitialState(reason: unknown): void {
+  divisionBoxShellLog.error(`Failed to get initial state for ${props.sessionId}:`, reason)
+  currentState.value = 'failed'
+  isLoading.value = false
 }
 
 // State change listener cleanup
@@ -186,18 +205,22 @@ onMounted(() => {
   transport
     .send(DivisionBoxEvents.getState, { sessionId: props.sessionId })
     .then((response) => {
-      if (response?.success) {
-        const state = (response.data as { state?: string } | null | undefined)?.state
-        if (state) {
-          currentState.value = state
-        }
-        if (state === 'active') {
-          isLoading.value = false
-        }
+      if (!response?.success) {
+        // A non-success response is as terminal as a rejection: no stateChanged event for this
+        // session will follow, so leaving the shell in `prepare` means the overlay never lifts.
+        failInitialState('Initial state request was refused')
+        return
+      }
+      const state = (response.data as { state?: string } | null | undefined)?.state
+      if (state) {
+        currentState.value = state
+      }
+      if (state === 'active') {
+        isLoading.value = false
       }
     })
     .catch((error: Error) => {
-      divisionBoxShellLog.error(`Failed to get initial state for ${props.sessionId}:`, error)
+      failInitialState(error)
     })
 })
 
@@ -390,6 +413,12 @@ onUnmounted(() => {
   }
 
   &.state-destroy {
+    background: rgba(245, 108, 108, 0.15);
+    color: var(--tx-color-danger);
+    border: 1px solid rgba(245, 108, 108, 0.3);
+  }
+
+  &.state-failed {
     background: rgba(245, 108, 108, 0.15);
     color: var(--tx-color-danger);
     border: 1px solid rgba(245, 108, 108, 0.3);


### PR DESCRIPTION
Closes #829.

The `.catch()` only logged, so a rejected `getState` left `isLoading` true with no `stateChanged` event for that session ever arriving. A non-success response did the same by falling out of the `.then()` untouched.

### The suggested fix would not have worked, and there is a test for that

> Clear isLoading in the catch and in the non-success branch

That is **not sufficient**. `showLoadingIndicator` is:

```ts
isLoading.value || currentState.value === 'prepare' || currentState.value === 'attach'
```

and `currentState` starts at `'prepare'`. Clearing the flag leaves the same overlay up, now reading **'Preparing...' forever**.

Applying that suggestion literally is one of the mutations here, and it **still fails three tests**.

`currentState` moves to a terminal `'failed'` instead. That rides the **existing** state-badge path — the badge already renders any non-active state — so it needed an icon and a colour, not a new component.

### One claim in the issue is overstated

> the user is left staring at 'Loading...' with no close path from within the shell

`showHeader` defaults to **true**, and `DivisionBoxHeader` carries `@close`. So there is a close path in the default configuration; the claim holds only for `showHeader: false` (immersive). The overlay hang is real either way — this is a correction to the severity of the described symptom, not to the defect.

**Not done:** "render an error state with a retry/close action". A retry affordance is a feature. What lands here is that the shell stops lying about loading and shows a failed badge.

### Five tests, four mutations

| mutation | fails |
|---|---|
| revert | 3 |
| **the issue's suggestion**: clear `isLoading` only | **3** |
| handle the rejection but not the non-success branch | the non-success test |
| **over-correct**: always fail regardless of response | 2, incl. the still-preparing test |

The last two controls matter: a real `prepare` must keep its overlay, because that one is genuinely still loading.

Renderer typecheck delta **zero**: 3 errors at HEAD, 3 after, none in the files touched. eslint **0**, **5/5**.
