### PR TITLE
fix(store): make the plugin card reachable without a mouse

### DIFF
--- a/apps/core-app/src/renderer/src/components/store/StoreItemCard.a11y.test.ts
+++ b/apps/core-app/src/renderer/src/components/store/StoreItemCard.a11y.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+/**
+ * The plugin card carried the only affordance that opens plugin details and was a plain `<div>`
+ * with `@click` — no role, no tabindex, no keydown handler. A keyboard user tabbing the grid never
+ * focused a card, and a screen reader announced an unlabelled group rather than a control. The one
+ * reachable action was installing a plugin whose details could not be read (#831).
+ *
+ * Not turned into a native `<button>`: the card *contains* one (StoreInstallButton), and nesting
+ * interactive elements is invalid. `role="button"` plus tabindex and a keydown handler is the
+ * pattern that fits — and the last test is the reason the handler checks the event target, since a
+ * native button raises `click` from Enter/Space and StoreInstallButton stops only the click.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key
+  })
+}))
+
+import StoreItemCard from './StoreItemCard.vue'
+
+function mountCard() {
+  return mount(StoreItemCard, {
+    props: {
+      item: { id: 'p1', name: 'Demo Plugin', version: '1.0.0' } as never
+    },
+    global: {
+      stubs: {
+        TxPluginMetaHeader: { template: '<div><slot name="title-extra" /></div>' },
+        TxPopover: true,
+        TxTag: true,
+        StoreIcon: true,
+        StoreInstallButton: {
+          template: '<button class="install-stub" @keydown="() => {}">Install</button>'
+        }
+      },
+      directives: { sharedElement: {} }
+    }
+  })
+}
+
+describe('the store card is reachable without a mouse', () => {
+  it('卡片本身是可聚焦的按钮语义,并带可读名称', () => {
+    const card = mountCard().get('.store-item-card')
+
+    expect(card.attributes('role')).toBe('button')
+    expect(card.attributes('tabindex')).toBe('0')
+    expect(card.attributes('aria-label')).toContain('Demo Plugin')
+  })
+
+  it.each(['Enter', ' '])('按 %s 打开详情', async (key) => {
+    const wrapper = mountCard()
+
+    await wrapper.get('.store-item-card').trigger('keydown', { key })
+
+    expect(wrapper.emitted('open')).toHaveLength(1)
+  })
+
+  it('其它按键不触发打开', async () => {
+    const wrapper = mountCard()
+
+    await wrapper.get('.store-item-card').trigger('keydown', { key: 'a' })
+    await wrapper.get('.store-item-card').trigger('keydown', { key: 'Tab' })
+
+    expect(wrapper.emitted('open')).toBeUndefined()
+  })
+
+  it('鼠标点击仍然照常打开(否则上面几条会掩盖"只剩键盘可用")', async () => {
+    const wrapper = mountCard()
+
+    await wrapper.get('.store-item-card').trigger('click')
+
+    expect(wrapper.emitted('open')).toHaveLength(1)
+  })
+
+  it('从内部安装按钮冒泡上来的 Enter 不会顺带打开卡片', async () => {
+    const wrapper = mountCard()
+
+    // A native button raises click from Enter/Space; StoreInstallButton stops that click, but its
+    // keydown still reaches the card.
+    await wrapper.get('.install-stub').trigger('keydown', { key: 'Enter' })
+
+    expect(wrapper.emitted('open')).toBeUndefined()
+  })
+})

--- a/apps/core-app/src/renderer/src/components/store/StoreItemCard.vue
+++ b/apps/core-app/src/renderer/src/components/store/StoreItemCard.vue
@@ -88,9 +88,24 @@ const descriptionText = computed(() => props.item.description || t('store.noDesc
 /**
  * Handles card click to open plugin details
  */
-function handleOpen(event: MouseEvent): void {
+function handleOpen(event: MouseEvent | KeyboardEvent): void {
   const source = event.currentTarget instanceof HTMLElement ? event.currentTarget : null
   emit('open', source)
+}
+
+/**
+ * Enter/Space open the card, matching what `role="button"` promises a screen reader.
+ *
+ * The card is not a native `<button>` because it contains one (StoreInstallButton), and nesting
+ * interactive elements is invalid. The target check is what keeps that safe: a native button fires
+ * `click` from Enter/Space, and StoreInstallButton stops only that click - its keydown still
+ * bubbles here, so without the check installing with the keyboard would also open the card.
+ */
+function handleOpenKeydown(event: KeyboardEvent): void {
+  if (event.target !== event.currentTarget) return
+  if (event.key !== 'Enter' && event.key !== ' ') return
+  event.preventDefault()
+  handleOpen(event)
 }
 
 /**
@@ -105,7 +120,11 @@ function handleInstall(): void {
   <div
     class="store-item-card"
     :class="{ 'official-provider': item.providerTrustLevel === 'official' }"
+    role="button"
+    tabindex="0"
+    :aria-label="t('store.openPluginDetails', { name: item.name || 'Unnamed Plugin' })"
     @click="handleOpen"
+    @keydown="handleOpenKeydown"
   >
     <div class="StoreItemCard-Inner">
       <TxPluginMetaHeader

--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -1050,6 +1050,7 @@
     "upgrade": "Upgrade",
     "upgradeAvailable": "Update available",
     "officialBadge": "Official",
+    "openPluginDetails": "Open details for {name}",
     "lastUpdated": "Last updated {time}",
     "cliGroupTitle": "Tuff CLI",
     "cliGroupDesc": "Tuff CLI is detected on this machine. Beta preview capabilities are available now.",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -1050,6 +1050,7 @@
     "upgrade": "升级",
     "upgradeAvailable": "有新版本",
     "officialBadge": "官方",
+    "openPluginDetails": "查看 {name} 的详情",
     "lastUpdated": "上次更新 {time}",
     "cliGroupTitle": "Tuff CLI",
     "cliGroupDesc": "检测到本机已安装 Tuff CLI，当前可体验 Beta 预览能力。",


### PR DESCRIPTION
Closes #831.

The card carried the only affordance that opens plugin details and was a plain `<div>` with `@click` — no role, no tabindex, no keydown handler. Tabbing the grid never focused a card, and a screen reader announced an unlabelled group rather than a control. The one reachable action was **installing a plugin whose details the user could not read**.

### Why not a native `<button>`

The card **contains** one — `StoreInstallButton` — and nesting interactive elements is invalid HTML and worse for assistive tech than the div was. `role="button"` + `tabindex="0"` + a keydown handler is the pattern that fits, and it is exactly what the issue lists as missing.

An `aria-label` names the card, since its content is a composed header rather than a label.

### The target check is load-bearing, not defensive

`StoreInstallButton` already calls `event.stopPropagation()` on **click**. A native button raises `click` from Enter/Space — but its **keydown still bubbles**. Without `event.target !== event.currentTarget`, installing with the keyboard would also open the details page. Dropping that line is a mutation here and fails its own test.

### Six tests, four mutations

| mutation | fails |
|---|---|
| revert | 3 |
| **drop the target check** | the nested-Enter test |
| Enter only, no Space | the Space case |
| **over-correct**: any key opens | the other-keys test |

### i18n

`store.openPluginDetails` added to both locales. Inserted textually next to `officialBadge` rather than by re-serialising the JSON — a round-trip reformatted 76 and 136 lines respectively, which would have buried a one-line addition.

Renderer typecheck delta **zero**: 3 errors at HEAD, 3 after, none in the files touched. eslint **0**, **6/6**.
