### PR TITLE
fix(security): stop the renderer-not-found dialog printing internal paths [#800]

### DIFF
--- a/apps/core-app/src/main/core/touch-app.ts
+++ b/apps/core-app/src/main/core/touch-app.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import process from 'node:process'
 import { StorageList } from '@talex-touch/utils'
-import { app, BrowserWindow, dialog, screen } from 'electron'
+import { BrowserWindow, app, dialog, screen, shell } from 'electron'
 import fse from 'fs-extra'
 import { MainWindowOption } from '../config/default'
 import { getAnalyticsMessageStore } from '../modules/analytics/message-store'
@@ -308,18 +308,43 @@ export class TouchApp implements TalexTouch.TouchApp {
   private async showFileNotFoundDialog(filePath: string, triedPaths: string[]): Promise<void> {
     const window = BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0]
 
-    const triedPathsText = triedPaths.join('\n')
-    const detail = `Cannot find renderer entry file:\n${filePath}\n\nPlease check if the application installation is complete.\n\nDebug information:\n- app.getAppPath(): ${app.getAppPath()}\n- __dirname: ${__dirname}\n- process.resourcesPath: ${process.resourcesPath || 'N/A'}\n- Tried paths:\n${triedPathsText}`
+    // The paths stay out of the dialog. Every one of them — app.getAppPath(), __dirname,
+    // process.resourcesPath and each candidate — is already written to the log by the caller, and
+    // they are actionable only for a developer. In the dialog they are something a user screenshots
+    // into a support request, disclosing their OS username and directory layout for nothing (#800).
+    const detail = [
+      'The application files appear to be incomplete or damaged.',
+      '',
+      'Reinstalling usually fixes this.',
+      '',
+      'If you are reporting the problem, please attach the log file.'
+    ].join('\n')
+    mainLog.error('Renderer entry missing, showing recovery dialog', {
+      meta: { filePath, triedPaths: triedPaths.join(', ') }
+    })
 
-    await dialog.showMessageBox(window || undefined, {
+    // A button rather than the path in the text. The user still gets to the log — which is the only
+    // reason to show them a path at all — without the folder location, and their OS username with
+    // it, ending up in a screenshot.
+    const { response } = await dialog.showMessageBox(window || undefined, {
       type: 'error',
       title: 'File Not Found',
       message: 'Cannot find this file.',
       detail,
-      buttons: ['OK'],
+      buttons: ['OK', 'Open Log Folder'],
       defaultId: 0,
+      cancelId: 0,
       noLink: true
     })
+
+    if (response === 1) {
+      const opened = await shell.openPath(app.getPath('logs'))
+      if (opened) {
+        mainLog.warn('Failed to open the log folder from the recovery dialog', {
+          meta: { reason: opened }
+        })
+      }
+    }
   }
 
   constructor(app: Electron.App, startupAppSettings: Record<string, unknown> = {}) {

--- a/packages/utils/__tests__/dialog-path-disclosure.test.ts
+++ b/packages/utils/__tests__/dialog-path-disclosure.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * A user-facing dialog must not print internal paths (#800).
+ *
+ * The renderer-not-found modal concatenated `app.getAppPath()`, `__dirname`, `process.resourcesPath`
+ * and every candidate path into its detail text. A user hitting a broken install screenshots that
+ * for a support request and shares their OS username and directory layout — for information that
+ * is actionable only to a developer, and which the caller had already written to the log.
+ *
+ * The log path is not a substitute: `app.getPath('logs')` is itself an absolute path containing the
+ * username, so naming it in the text reintroduces the same leak in miniature. The dialog offers a
+ * button instead.
+ *
+ * Lives in packages/utils because `ci / CI - utils` is blocking, while `App suites (core-app)` is
+ * continue-on-error and reports success however the suite does.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const TOUCH_APP = path.join(REPO_ROOT, 'apps/core-app/src/main/core/touch-app.ts')
+const source = readFileSync(TOUCH_APP, 'utf8')
+
+const dialogBody = (() => {
+  const start = source.indexOf('private async showFileNotFoundDialog')
+  if (start === -1) return ''
+  const end = source.indexOf('\n  }\n', start)
+  return source.slice(start, end === -1 ? undefined : end)
+})()
+
+/** Expressions that resolve to an absolute path on the user's machine. */
+const PATH_SOURCES = [
+  'app.getAppPath()',
+  '__dirname',
+  'process.resourcesPath',
+  "app.getPath('logs')"
+]
+
+describe('renderer-not-found dialog', () => {
+  it('is found', () => {
+    // Positive control: an empty slice satisfies every "does not contain" assertion below.
+    expect(dialogBody).not.toBe('')
+    expect(dialogBody).toContain('dialog.showMessageBox')
+  })
+
+  it('builds its detail text without any machine path', () => {
+    const detail = /const detail = \[[\s\S]*?\]\.join/.exec(dialogBody)?.[0] ?? ''
+
+    expect(detail).not.toBe('')
+    for (const expression of PATH_SOURCES) {
+      expect(detail, expression).not.toContain(expression)
+    }
+    expect(detail).not.toContain('triedPaths')
+  })
+
+  it('still records the paths where they are useful', () => {
+    // Removing the disclosure must not remove the diagnosis: the same values go to the log, which
+    // is where a developer reads them.
+    expect(dialogBody).toContain('mainLog.error')
+    expect(dialogBody).toMatch(/meta: \{ filePath, triedPaths/)
+  })
+
+  it('offers the log folder as an action rather than as text', () => {
+    // The user still needs to reach the log; a button gets them there without the folder location
+    // appearing on screen.
+    expect(dialogBody).toContain("buttons: ['OK', 'Open Log Folder']")
+    expect(dialogBody).toContain("shell.openPath(app.getPath('logs'))")
+  })
+})


### PR DESCRIPTION
Closes #800.

Confirmed: the detail string concatenates `app.getAppPath()`, `__dirname`, `process.resourcesPath` and every candidate path, and the caller already logs all of it at `touch-app.ts:571-585`.

## The fix, and a mistake I made inside it

The dialog now states what happened and what to do, and the paths go to the log only.

My first version put `app.getPath('logs')` in the text so the user could find the log. That reintroduces the same leak in miniature — the log folder is an absolute path containing the OS username, which is precisely what this issue is about. Replaced with an **"Open Log Folder" button**: the user still reaches the log, without the address appearing on screen to be screenshotted.

## Removing the disclosure must not remove the diagnosis

The helper now logs `filePath` and `triedPaths` itself, so the information survives where a developer reads it. The guard asserts that too — otherwise "no paths in the dialog" could be satisfied by deleting the diagnosis along with the leak.

## Verification

`dialog-path-disclosure.test.ts`, 4 passed, in `packages/utils` so `ci / CI - utils` enforces it. It extracts the dialog helper's body and checks the detail array against all four path expressions, plus a positive control — an empty slice satisfies every "does not contain" assertion, which is what a renamed method would produce.

Mutation-tested: restoring the previous file fails 3 of the 4. `typecheck:node` = 6, unchanged. ESLint clean in both packages.