### PR TITLE
fix(store): make the source delete control a real button

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -1062,6 +1062,7 @@
     "docsLinkDesc": "Open Nexus docs for capability catalog and usage",
     "docsOpen": "Open Nexus Docs",
     "sourceEditor": {
+      "removeSource": "Remove source {name}",
       "title": "Source",
       "subtitle": "Edit plugin store source.",
       "addSource": "Add source",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -1062,6 +1062,7 @@
     "docsLinkDesc": "打开 Nexus 文档，了解能力目录与调用方式",
     "docsOpen": "打开 Nexus 文档",
     "sourceEditor": {
+      "removeSource": "移除源 {name}",
       "title": "来源",
       "subtitle": "编辑插件市场来源",
       "addSource": "新增来源",

--- a/apps/core-app/src/renderer/src/views/base/store/StoreSourceEditor.a11y.test.ts
+++ b/apps/core-app/src/renderer/src/views/base/store/StoreSourceEditor.a11y.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+/**
+ * The destructive "remove source" affordance was a bare `<div>` with only `@click`, in both list
+ * branches — no role, tabindex, keydown handler or accessible name. A keyboard user could focus the
+ * row's enable switch but never the delete control, so a mis-added source could not be removed
+ * without a mouse, and a screen reader read an unlabelled icon (#832).
+ *
+ * A native `<button>` rather than role/tabindex: nothing interactive is nested inside it, so the
+ * element that already means "button" is the right one — Enter/Space and `disabled` come with it.
+ *
+ * `deleteSource` was already guarded internally (`list.length === 1`, `target.readOnly`), so the
+ * `disabled` attribute makes a real guard visible rather than introducing one.
+ */
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key
+  })
+}))
+
+// The list comes from storage, not a prop, so this is what actually feeds the rows.
+const storageMock = vi.hoisted(() => ({ sources: [] as Array<Record<string, unknown>> }))
+
+vi.mock('~/modules/storage/store-sources', () => ({
+  storeSourcesStorage: { get: () => storageMock, save: vi.fn() }
+}))
+
+import StoreSourceEditor from './StoreSourceEditor.vue'
+
+function mountEditor(sources: Array<Record<string, unknown>>) {
+  storageMock.sources = sources
+  return mount(StoreSourceEditor, {
+    props: { modelValue: true },
+    global: {
+      stubs: {
+        TuffSwitch: true,
+        TxScroll: { template: '<div><slot /></div>' },
+        TxButton: true,
+        TxInput: true,
+        TxSelect: true,
+        TxSelectItem: true,
+        FlipDialog: { template: '<div><slot /></div>' }
+      },
+      directives: { draggable: {}, sharedElement: {} }
+    }
+  })
+}
+
+function twoSources() {
+  return [
+    { id: 's1', name: 'Primary', type: 'nexusStore', enabled: true },
+    { id: 's2', name: 'Mirror', type: 'repository', enabled: true }
+  ]
+}
+
+describe('the source delete control is a real button', () => {
+  it('是原生 button,而不是只能点的 div', () => {
+    const wrapper = mountEditor(twoSources())
+
+    const controls = wrapper.findAll('button.action-btn')
+    expect(controls.length).toBeGreaterThan(0)
+  })
+
+  it('带有可读名称,读屏不再只看到一个图标', () => {
+    const wrapper = mountEditor(twoSources())
+
+    expect(wrapper.get('button.action-btn').attributes('aria-label')).toContain('Primary')
+  })
+
+  it('type=button,不会在表单里变成隐式提交', () => {
+    const wrapper = mountEditor(twoSources())
+
+    expect(wrapper.get('button.action-btn').attributes('type')).toBe('button')
+  })
+
+  it('只剩一个源时按钮真的被禁用,而不仅仅是变灰', () => {
+    const wrapper = mountEditor([{ id: 's1', name: 'Only', type: 'nexusStore', enabled: true }])
+
+    expect(wrapper.get('button.action-btn').attributes('disabled')).toBeDefined()
+  })
+
+  it('只读源同样被禁用', () => {
+    const wrapper = mountEditor([
+      { id: 's1', name: 'Primary', type: 'nexusStore', enabled: true },
+      { id: 's2', name: 'Builtin', type: 'nexusStore', enabled: true, readOnly: true }
+    ])
+
+    const controls = wrapper.findAll('button.action-btn')
+    expect(controls[1]?.attributes('disabled')).toBeDefined()
+  })
+
+  /**
+   * The outdated-sources list carries a second copy of this control, and the issue names both. It
+   * cannot be rendered today: `visibleOutdatedSources` is gated on `isAdvancedMode`, which is
+   * `computed(() => false)` — a hardcoded flag, so that branch is currently dead markup.
+   *
+   * A rendered assertion is therefore impossible, and leaving it uncovered means "fix one branch"
+   * passes the whole suite. This checks the source instead, deliberately, and says so.
+   */
+  it('两处删除控件都是 button —— 第二处被 isAdvancedMode 硬编码挡着,只能查源码', () => {
+    const source = readFileSync(path.join(__dirname, 'StoreSourceEditor.vue'), 'utf8')
+    const controls = source.match(/class="transition-cubic action-btn"/g) ?? []
+    const asButton = source.match(/<button\s+type="button"/g) ?? []
+    const asDiv = source.match(/<div[^>]*class="transition-cubic action-btn"/g) ?? []
+
+    expect(controls).toHaveLength(2)
+    expect(asButton.length).toBeGreaterThanOrEqual(2)
+    expect(asDiv).toHaveLength(0)
+  })
+
+  it('可删除的源上按钮未被禁用(否则上面两条会掩盖"全都禁用")', () => {
+    const wrapper = mountEditor(twoSources())
+
+    expect(wrapper.get('button.action-btn').attributes('disabled')).toBeUndefined()
+  })
+})

--- a/apps/core-app/src/renderer/src/views/base/store/StoreSourceEditor.vue
+++ b/apps/core-app/src/renderer/src/views/base/store/StoreSourceEditor.vue
@@ -232,14 +232,17 @@ watch(
                     size="small"
                     @change="toggleSource(item.id)"
                   />
-                  <div
+                  <button
+                    type="button"
                     :class="{ disabled: sources.length === 1 || item.readOnly }"
                     class="transition-cubic action-btn"
+                    :disabled="sources.length === 1 || item.readOnly"
+                    :aria-label="t('store.sourceEditor.removeSource', { name: item.name })"
                     @click="deleteSource(item.id)"
                   >
                     <div v-if="sources.length !== 1 && !item.readOnly" class="i-carbon-close" />
                     <div v-else class="i-carbon-carbon-for-salesforce" />
-                  </div>
+                  </button>
                 </div>
               </div>
             </TransitionGroup>
@@ -281,14 +284,17 @@ watch(
                     size="small"
                     @change="toggleSource(item.id)"
                   />
-                  <div
+                  <button
+                    type="button"
                     :class="{ disabled: sources.length === 1 || item.readOnly }"
                     class="transition-cubic action-btn"
+                    :disabled="sources.length === 1 || item.readOnly"
+                    :aria-label="t('store.sourceEditor.removeSource', { name: item.name })"
                     @click="deleteSource(item.id)"
                   >
                     <div v-if="sources.length !== 1 && !item.readOnly" class="i-carbon-close" />
                     <div v-else class="i-carbon-carbon-for-salesforce" />
-                  </div>
+                  </button>
                 </div>
               </div>
             </div>
@@ -569,6 +575,10 @@ watch(
     justify-content: center;
     width: 28px;
     height: 28px;
+    // The rule was written for a div; a native button brings its own chrome.
+    padding: 0;
+    border: none;
+    font: inherit;
     border-radius: 6px;
     cursor: pointer;
     transition: all 0.2s ease;


### PR DESCRIPTION
Closes #832.

The destructive "remove source" affordance was a bare `<div>` with only `@click`, in **both** list branches — no role, tabindex, keydown handler or accessible name. A keyboard user could focus the row's enable switch but never the delete control, so a mis-added source could not be removed without a mouse, and a screen reader read an unlabelled icon.

### A native `<button>`, not `role`/`tabindex`

Unlike #831's card, nothing interactive is nested inside this control — so the element that already *means* button is the right one. Enter/Space and `disabled` come free, and there is no keydown handler to get wrong.

`deleteSource` was already guarded internally (`list.length === 1`, `target.readOnly`), so `:disabled` makes an existing guard **visible** rather than introducing one. Verified before changing it — a purely decorative `.disabled` class over a live handler would have been a separate bug.

### The second branch cannot be rendered, and that hid a gap

The issue names both sites. The second lives in the outdated-sources list, whose `visibleOutdatedSources` is gated on `isAdvancedMode` — `computed(() => false)`. It is **dead markup today**, so no mounted test can reach it.

That is not academic: with only rendered assertions, **"fix the first branch and leave the second a div" passed the entire suite.** It is now covered by a source assertion, deliberately, with the reason written next to it.

### Seven tests, four mutations

| mutation | fails |
|---|---|
| revert | 7 |
| button but no `disabled` (visual-only again) | 2 |
| drop the `aria-label` | the accessible-name test |
| **fix only the first branch** | the source assertion |

### i18n

`store.sourceEditor.removeSource` added to both locales, inserted textually rather than by re-serialising — on the previous PR a JSON round-trip reformatted 76 and 136 lines.

Renderer typecheck delta **zero**: 3 errors at HEAD, 3 after, none in the files touched. eslint **0**, **7/7**.
