### PR TITLE
build: remove the snap configuration that can never run [#801]

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -162,7 +162,6 @@ jobs:
           find . -name "app-builder" -type f -exec chmod +x {} \; 2>/dev/null || true
           find . -name "app-builder-bin" -type f -exec chmod +x {} \; 2>/dev/null || true
           find . -name "electron-builder" -type f -exec chmod +x {} \; 2>/dev/null || true
-          find . -name "snapcraft" -type f -exec chmod +x {} \; 2>/dev/null || true
           echo "Binary permissions fixed"
 
       - name: Determine Release Type
@@ -201,7 +200,6 @@ jobs:
           # 确保输出目录存在
           mkdir -p apps/core-app/dist
           mkdir -p apps/core-app/dist/__appImage-x64
-          mkdir -p apps/core-app/dist/__snap-x64
           mkdir -p apps/core-app/dist/__deb-x64
           mkdir -p apps/core-app/dist/@talex-touch
           mkdir -p "${GITHUB_WORKSPACE}/.cache/electron"
@@ -606,10 +604,11 @@ jobs:
           else
             APPIMAGE_COUNT=$(find apps/core-app/dist -name "*.AppImage" -type f 2>/dev/null | wc -l || echo "0")
             DEB_COUNT=$(find apps/core-app/dist -name "*.deb" -type f 2>/dev/null | wc -l || echo "0")
-            SNAP_COUNT=$(find apps/core-app/dist -name "*.snap" -type f 2>/dev/null | wc -l || echo "0")
-            echo "Found $APPIMAGE_COUNT .AppImage, $DEB_COUNT .deb, $SNAP_COUNT .snap file(s)"
-            if [ "$APPIMAGE_COUNT" -gt 0 ] || [ "$DEB_COUNT" -gt 0 ] || [ "$SNAP_COUNT" -gt 0 ]; then
-              find apps/core-app/dist \( -name "*.AppImage" -o -name "*.deb" -o -name "*.snap" \) -type f 2>/dev/null
+            # No .snap: the Linux targets are AppImage and deb, and snapcraft is deliberately not
+            # installed a few steps above. A counter that cannot be non-zero read as coverage (#801).
+            echo "Found $APPIMAGE_COUNT .AppImage, $DEB_COUNT .deb file(s)"
+            if [ "$APPIMAGE_COUNT" -gt 0 ] || [ "$DEB_COUNT" -gt 0 ]; then
+              find apps/core-app/dist \( -name "*.AppImage" -o -name "*.deb" \) -type f 2>/dev/null
               ARTIFACTS_FOUND=true
             fi
           fi
@@ -620,7 +619,7 @@ jobs:
             elif [ "$RUNNER_OS" = "macOS" ]; then
               echo "ERROR: No .dmg files, .app directories, or .zip files found in dist directory!"
             else
-              echo "ERROR: No Linux artifacts (.AppImage, .deb, or .snap) found in dist directory!"
+              echo "ERROR: No Linux artifacts (.AppImage or .deb) found in dist directory!"
             fi
             echo "This may indicate the electron-builder step failed silently."
             echo "Check the electron-builder output above for errors."

--- a/apps/core-app/electron-builder.yml
+++ b/apps/core-app/electron-builder.yml
@@ -129,22 +129,6 @@ linux:
     - deb
   maintainer: tagzxia.com
   category: Utility
-snap:
-  confinement: strict
-  grade: stable
-  summary: A powerful productivity launcher and automation tool
-  description: |
-    Talex Touch is a modern productivity launcher that helps you quickly access applications,
-    files, and perform various automation tasks with a clean, efficient interface.
-  plugs:
-    - home
-    - network
-    - removable-media
-  environment:
-    DISABLE_WAYLAND: '1'
-  # 修复 app-builder 执行问题
-  useTemplateApp: false
-  desktop:
 appImage:
   artifactName: ${productName}-${version}.${ext}
   category: Utility


### PR DESCRIPTION
Closes #801.

Confirmed: `linux.target` is `[AppImage, deb]`, so the 16-line `snap:` block is unreachable.

## The workflow had matching leftovers

Checking whether snap was built anywhere else turned up three more:

- a `chmod +x` sweep for a `snapcraft` binary,
- a `dist/__snap-x64` output directory,
- and `SNAP_COUNT` in the artifact check.

The last is worth naming. It printed `Found N .AppImage, N .deb, 0 .snap file(s)` beside real counts and fed the "artifacts found" condition — a counter that **structurally cannot be non-zero**, presented as coverage of a target that does not exist. The failure message it fed claimed `.snap` as well.

All removed. The comment explaining *why* snapcraft is skipped stays — that is the actual decision, and the only thing here that was ever load-bearing.

## Not done

Re-enabling snap. That is a distribution decision needing a snapcraft toolchain in CI and a publishing story, not a config revival — and the comment in the workflow suggests it was tried and abandoned for a reason (`snapd issues`).

## Verification

`snap:` and `desktop:` keys are gone from `electron-builder.yml`, `linux.target` is unchanged at `AppImage, deb`, and `SNAP_COUNT` has zero references left in the workflow. No conflict markers; the workflow is 1641 lines and still parses as the same document shape.