### PR TITLE
fix(home): roll the agent-tools pill back when main refuses the sync

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -983,6 +983,7 @@
     "regenerate": "Regenerate",
     "error": {
       "noProvider": "No AI provider is available yet — configure one in Settings · AI and try again",
+      "agentToolsSync": "Could not reach the tool gateway — agent tools stay off",
       "empty": "The model returned nothing",
       "generic": "This reply failed"
     },

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -983,6 +983,7 @@
     "regenerate": "重新生成",
     "error": {
       "noProvider": "还没有可用的 AI 提供商，去「设置 · AI」配置一个再试",
+      "agentToolsSync": "无法连接工具网关，智能体工具保持关闭",
       "empty": "模型没有返回任何内容",
       "generic": "这轮回复失败了"
     },

--- a/apps/core-app/src/renderer/src/utils/rollback-sync.test.ts
+++ b/apps/core-app/src/renderer/src/utils/rollback-sync.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The agent-tools pill wrote the persisted flag and then called the main-process sync with `void`,
+ * discarding both the result and any rejection. A failed sync left the pill reading `on` and
+ * `aria-pressed="true"` across restarts while the tool gateway was shut, so every tool call the
+ * model attempted failed (#835).
+ *
+ * These drive the policy directly: HomePage.vue has no mounting harness, and the rollback only
+ * runs on a path that is awkward to reach by hand.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+import { createRollbackSync } from './rollback-sync'
+
+describe('createRollbackSync', () => {
+  it('同步成功时不回滚,也不报错', async () => {
+    const rollback = vi.fn()
+    const onError = vi.fn()
+    const run = createRollbackSync<boolean>({ sync: async () => undefined, rollback, onError })
+
+    await run(true, false)
+
+    expect(rollback).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('同步失败时回滚到写入前观察到的值', async () => {
+    const rollback = vi.fn()
+    const run = createRollbackSync<boolean>({
+      sync: async () => {
+        throw new Error('gateway port in use')
+      },
+      rollback,
+      onError: vi.fn()
+    })
+
+    await run(true, false)
+
+    expect(rollback).toHaveBeenCalledWith(false)
+  })
+
+  it('回滚用的是传入的旧值,而不是把新值取反', async () => {
+    const rollback = vi.fn()
+    const run = createRollbackSync<string>({
+      sync: async () => {
+        throw new Error('refused')
+      },
+      rollback,
+      onError: vi.fn()
+    })
+
+    await run('next', 'observed-before')
+
+    expect(rollback).toHaveBeenCalledWith('observed-before')
+  })
+
+  it('失败一定会上报,调用方才能记录原因', async () => {
+    const failure = new Error('handler not registered')
+    const onError = vi.fn()
+    const run = createRollbackSync<boolean>({
+      sync: async () => {
+        throw failure
+      },
+      rollback: vi.fn(),
+      onError
+    })
+
+    await run(true, false)
+
+    expect(onError).toHaveBeenCalledWith(failure)
+  })
+
+  it('调用方永远拿不到 rejection —— 它是绑在事件处理器上的', async () => {
+    const run = createRollbackSync<boolean>({
+      sync: async () => {
+        throw new Error('refused')
+      },
+      rollback: vi.fn(),
+      onError: vi.fn()
+    })
+
+    await expect(run(true, false)).resolves.toBeUndefined()
+  })
+
+  it('较慢的失败不会覆盖之后已经成功的那次切换', async () => {
+    const rollback = vi.fn()
+    let failSlow: (() => void) | undefined
+    let call = 0
+    const run = createRollbackSync<boolean>({
+      sync: () => {
+        call += 1
+        if (call === 1) {
+          return new Promise((_resolve, reject) => {
+            failSlow = () => reject(new Error('slow refusal'))
+          })
+        }
+        return Promise.resolve(undefined)
+      },
+      rollback,
+      onError: vi.fn()
+    })
+
+    const slow = run(true, false)
+    await run(false, true)
+    failSlow?.()
+    await slow
+
+    // The later toggle owns the state; the stale failure must not undo it.
+    expect(rollback).not.toHaveBeenCalled()
+  })
+
+  it('被取代的失败仍然会上报(否则日志里会凭空少一次故障)', async () => {
+    const onError = vi.fn()
+    let failSlow: (() => void) | undefined
+    let call = 0
+    const run = createRollbackSync<boolean>({
+      sync: () => {
+        call += 1
+        if (call === 1) {
+          return new Promise((_resolve, reject) => {
+            failSlow = () => reject(new Error('slow refusal'))
+          })
+        }
+        return Promise.resolve(undefined)
+      },
+      rollback: vi.fn(),
+      onError
+    })
+
+    const slow = run(true, false)
+    await run(false, true)
+    failSlow?.()
+    await slow
+
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/core-app/src/renderer/src/utils/rollback-sync.ts
+++ b/apps/core-app/src/renderer/src/utils/rollback-sync.ts
@@ -1,0 +1,42 @@
+/**
+ * Runs an optimistic write's remote half and puts the local value back when it is refused.
+ *
+ * The agent-tools pill wrote the persisted flag and then called the main-process sync with `void`,
+ * discarding both the result and any rejection. A failed sync left the pill reading `on` and
+ * `aria-pressed="true"` across restarts while the tool gateway was shut (#835).
+ *
+ * Extracted rather than written inline in HomePage.vue, which has no mounting harness: the
+ * rollback only runs on a path that is awkward to reach by hand, and an invariant nobody can
+ * exercise is one that quietly stops holding.
+ */
+export interface RollbackSyncOptions<T> {
+  /** The remote half of the write. Rejecting means the value did not take. */
+  sync: (value: T) => Promise<unknown>
+  /**
+   * Restores the value observed before the write.
+   *
+   * Takes the previous value rather than negating the new one, and runs only when this attempt is
+   * still the newest — otherwise a slow failing write would clobber the state a later successful
+   * one had already established.
+   */
+  rollback: (previous: T) => void
+  /** Always called on failure, including a superseded one: the failure still happened. */
+  onError: (error: unknown) => void
+}
+
+export function createRollbackSync<T>(
+  options: RollbackSyncOptions<T>
+): (value: T, previous: T) => Promise<void> {
+  let latest = 0
+
+  return async (value, previous) => {
+    const token = ++latest
+    try {
+      await options.sync(value)
+    } catch (error) {
+      options.onError(error)
+      if (token !== latest) return
+      options.rollback(previous)
+    }
+  }
+}

--- a/apps/core-app/src/renderer/src/views/base/home/HomePage.vue
+++ b/apps/core-app/src/renderer/src/views/base/home/HomePage.vue
@@ -14,6 +14,8 @@ import { TxToolConfirmation } from '@talex-touch/tuffex/tool-confirmation'
 import { CHART_RESULT_PREFIX } from '@talex-touch/utils/transport/sdk/domains/agent-tools'
 import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { toast } from 'vue-sonner'
+import { createRollbackSync } from '~/utils/rollback-sync'
 import { useRoute, useRouter } from 'vue-router'
 import AppLogo from '~/components/icon/AppLogo.vue'
 import ToolChartCard from '~/components/intelligence/ToolChartCard.vue'
@@ -112,6 +114,23 @@ const autoContext = computed({
 const agentTools = useAgentTools()
 
 /**
+ * Mirrors the flag to main and puts it back if main refuses.
+ *
+ * The setter wrote the persisted flag and discarded both the result and the rejection, so a
+ * failed sync (gateway port in use, handler not registered) left the pill reading `on` and
+ * `aria-pressed="true"` across restarts while the tool gateway was shut — every tool call the
+ * model attempted then failed (#835).
+ */
+const syncAgentTools = createRollbackSync<boolean>({
+  sync: (value) => agentTools.setEnabled(value),
+  rollback: (previous) => {
+    if (appSetting.tools) appSetting.tools.agentTools = previous
+    toast.error(t('home.error.agentToolsSync'))
+  },
+  onError: (error) => homeLog.error('Failed to sync agent tools with main', error)
+})
+
+/**
  * Whether the assistant may run tools. Persisted in `appSetting` like Auto
  * Context, and mirrored to main on change — the gateway only opens, and the
  * allowlist only reaches `pi`, once this is on.
@@ -119,8 +138,9 @@ const agentTools = useAgentTools()
 const agentToolsEnabled = computed({
   get: () => appSetting.tools?.agentTools === true,
   set: (value: boolean) => {
+    const previous = appSetting.tools?.agentTools === true
     if (appSetting.tools) appSetting.tools.agentTools = value
-    void agentTools.setEnabled(value)
+    void syncAgentTools(value, previous)
   }
 })
 


### PR DESCRIPTION
Closes #835.

The setter wrote the persisted flag and called the main-process sync with `void`, discarding both the result and any rejection. A failed sync (gateway port in use, handler not registered) left the pill reading `on` and `aria-pressed="true"` **across restarts** while the tool gateway was shut, so every tool call the model attempted failed. The rejection was unhandled too — the setter is reached from a template binding.

### Two details the fix gets right on purpose

**Roll back to the observed previous value, not `!value`.** Negation happens to agree in the common case and diverges as soon as anything else has touched the flag.

**Skip the rollback when a newer toggle has been issued** — otherwise a slow failing toggle undoes the state a later successful one established. But the failure is **still reported** in that case: suppressing it would lose a fault that really happened. Both are mutations here, and each fails its own test.

### Why an extracted helper

`HomePage.vue` has no mounting harness, and the rollback only runs on a path that is awkward to reach by hand. Inline, this would have shipped with zero coverage — the same reasoning as #826. `createRollbackSync` is ~15 lines and the policy is exactly what the tests drive.

The toast uses **vue-sonner**, already the house mechanism with a `<Toaster />` mounted in `AppEntrance.vue` — not a new UI surface.

### Seven tests, four mutations

| mutation | fails |
|---|---|
| no rollback at all (the original defect) | 2 |
| drop the latest-wins guard | the stale-failure test |
| report only when current | the superseded-still-reported test |
| **over-correct**: roll back on success too | 2 |

### i18n, and a duplicate key avoided

`home.error.agentToolsSync` added to both locales.

My first attempt put it under a new `home.agentTools` object — but `home.agentTools` **already exists as a string** (the pill's label, `"Tools"` / `"工具"`). That produced a duplicate key inside `home`, and JSON's last-wins made the whole namespace parse as a string. Caught by parsing the file back and asserting no duplicate keys, which is now part of the insertion step.

Renderer typecheck delta **zero**: 3 errors at HEAD, 3 after, none in the files touched. eslint **0**, **7/7**.
