### PR TITLE
fix(plugins): make plugins:validate catch committed dev leakage [#812]

### DIFF
--- a/plugins/touch-image/package.json
+++ b/plugins/touch-image/package.json
@@ -15,12 +15,6 @@
       "type": "class",
       "value": "i-ri-image-2-line"
     },
-    "plugin": {
-      "dev": {
-        "enable": true,
-        "address": "http://127.0.0.1:6001"
-      }
-    },
     "build": {
       "files": [
         "README.md"

--- a/scripts/validate-plugins.dev-leakage.test.mjs
+++ b/scripts/validate-plugins.dev-leakage.test.mjs
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it } from 'vitest'
+
+/**
+ * `plugins:validate` must fail a plugin that ships with its dev loader on (#812).
+ *
+ * AGENTS.md cites this script as the manifest gate, and it never looked at the `dev` block — three
+ * manifests shipped `dev.enable: true` while it reported *24/24 plugins passed*. The gate could not
+ * catch the exact class of defect it is cited for.
+ *
+ * The check has to cover both places the block lives: `manifest.json` for most plugins, and
+ * `package.json` under `talex-touch.plugin.dev` for package-backed ones. The second is where it was
+ * still hiding when this was written — in `touch-image`, a directory the manifest check skips
+ * entirely as "Surface-only", so a manifest-only check would have reported green.
+ */
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const VALIDATOR = path.join(REPO_ROOT, 'scripts/validate-plugins.mjs')
+
+function runValidator(pluginsDir) {
+  try {
+    const stdout = execFileSync('node', [VALIDATOR], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: { ...process.env, TUFF_PLUGINS_DIR: pluginsDir },
+    })
+    return { ok: true, stdout }
+  }
+  catch (error) {
+    return { ok: false, stdout: `${error.stdout ?? ''}${error.stderr ?? ''}` }
+  }
+}
+
+/** A minimal plugin directory the validator accepts, plus whatever the caller wants to break. */
+function makePlugin(root, name, { manifest, packageJson }) {
+  const dir = path.join(root, name)
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: `@talex-touch/${name}-plugin`, version: '1.0.0', ...packageJson }),
+  )
+  if (manifest)
+    fs.writeFileSync(path.join(dir, 'manifest.json'), JSON.stringify(manifest))
+  return dir
+}
+
+const baseManifest = { id: 'com.tuff.fixture', name: 'fixture', version: '1.0.0' }
+
+describe('plugins:validate dev leakage', () => {
+  it('passes a plugin with no dev block', () => {
+    // Positive control. Every failure assertion below is satisfied by a validator that rejects
+    // everything, which would be a worse gate than none.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tuff-plugins-clean-'))
+    makePlugin(root, 'fixture', { manifest: baseManifest })
+
+    assert.equal(runValidator(root).ok, true)
+  })
+
+  it('fails a manifest that ships dev.enable: true', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tuff-plugins-manifest-'))
+    makePlugin(root, 'fixture', {
+      manifest: { ...baseManifest, dev: { enable: true, address: 'http://127.0.0.1:6001' } },
+    })
+
+    const result = runValidator(root)
+    assert.equal(result.ok, false)
+    assert.match(result.stdout, /manifest\.json ships dev\.enable: true/)
+  })
+
+  it('fails a package.json that ships dev.enable: true, with no manifest at all', () => {
+    // The case the real tree was in. `touch-image` has no manifest.json, so the manifest checks
+    // skip it as "Surface-only" — a check that only read manifests would have reported green while
+    // the dev block sat in package.json.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tuff-plugins-package-'))
+    makePlugin(root, 'fixture', {
+      packageJson: {
+        'talex-touch': { plugin: { dev: { enable: true, address: 'http://127.0.0.1:6001' } } },
+      },
+    })
+
+    const result = runValidator(root)
+    assert.equal(result.ok, false)
+    assert.match(result.stdout, /package\.json ships dev\.enable: true/)
+  })
+
+  it('tolerates a dev block that is present but switched off', () => {
+    // `dev.enable: false` with an address is how a developer keeps their local address on hand.
+    // Failing that would push people to delete the block and retype it, which is worse.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tuff-plugins-off-'))
+    makePlugin(root, 'fixture', {
+      manifest: { ...baseManifest, dev: { enable: false, address: 'http://127.0.0.1:6001' } },
+    })
+
+    assert.equal(runValidator(root).ok, true)
+  })
+})

--- a/scripts/validate-plugins.mjs
+++ b/scripts/validate-plugins.mjs
@@ -17,7 +17,11 @@ import { fileURLToPath } from 'node:url'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const rootDir = path.resolve(__dirname, '..')
-const pluginsDir = path.resolve(rootDir, 'plugins')
+// TUFF_PLUGINS_DIR lets the gate's own tests point it at a fixture tree. Without it the only way
+// to prove the checks fire is to break a real plugin, which is how a gate ends up untested.
+const pluginsDir = process.env.TUFF_PLUGINS_DIR
+  ? path.resolve(process.env.TUFF_PLUGINS_DIR)
+  : path.resolve(rootDir, 'plugins')
 
 // Known permission IDs from packages/utils/permission/registry.ts
 const KNOWN_PERMISSION_IDS = new Set([
@@ -103,6 +107,29 @@ const pluginDirs = entries
 
 console.log(`\nValidating ${pluginDirs.length} plugins in plugins/\n`)
 
+/**
+ * Fails a plugin that ships with its development loader switched on.
+ *
+ * `dev.enable: true` makes the runtime fetch the Surface from `dev.address` — a localhost port —
+ * instead of the packaged files, so a committed one is a plugin that silently does nothing on a
+ * user's machine. AGENTS.md cites `pnpm plugins:validate` as the manifest gate, and it did not
+ * look at the dev block at all: three manifests shipped `dev.enable: true` while it reported
+ * 24/24 passed (#812).
+ *
+ * Both sources are checked. The block lives in `manifest.json` for most plugins and in
+ * `package.json` under `talex-touch.plugin.dev` for package-backed ones — and the second is where
+ * it was actually still hiding, in a directory the manifest check skips entirely.
+ *
+ * @returns true when the plugin should fail.
+ */
+function checkDevLeakage(pluginName, dev, source) {
+  if (!dev || dev.enable !== true)
+    return false
+  const address = typeof dev.address === 'string' ? ` (${dev.address})` : ''
+  logError(pluginName, `${source} ships dev.enable: true${address} — the runtime would load the Surface from a dev server instead of the packaged files`)
+  return true
+}
+
 for (const pluginName of pluginDirs) {
   totalPlugins++
   const pluginPath = path.join(pluginsDir, pluginName)
@@ -120,6 +147,8 @@ for (const pluginName of pluginDirs) {
         logError(pluginName, `package.json name must be "${expectedPackageName}" (received "${packageManifest.name || '<missing>'}")`)
         pluginHasError = true
       }
+      if (checkDevLeakage(pluginName, packageManifest?.['talex-touch']?.plugin?.dev, 'package.json'))
+        pluginHasError = true
     }
     catch (e) {
       logError(pluginName, `package.json parse error: ${e.message}`)
@@ -146,6 +175,9 @@ for (const pluginName of pluginDirs) {
     pluginHasError = true
     continue
   }
+
+  if (checkDevLeakage(pluginName, manifest?.dev, 'manifest.json'))
+    pluginHasError = true
 
   // 2. Required fields: id (or name), name, version
   if (!manifest.name) {


### PR DESCRIPTION
Closes #812 and #815 — they cannot be separated, for the reason below.

## Confirmed, with one correction

`plugins:validate` never inspected the dev block. The three manifests the issue names have since been cleaned, so a run today reports *24/24 passed* legitimately — but the gate still could not catch the defect it is cited for.

**One case was still live:** `touch-image/package.json` carried `talex-touch.plugin.dev = { enable: true, address: 'http://127.0.0.1:6001' }`. That is #815, and it is what makes the two issues inseparable — adding the check turns the gate red until it is removed, and a gate that cannot run green is not a gate.

## Both sources, and why the second is the one that mattered

The dev block lives in `manifest.json` for most plugins and in `package.json` under `talex-touch.plugin.dev` for package-backed ones. `touch-image` has **no manifest.json at all**, so the manifest checks skip it as *"Surface-only"* and `continue` — a manifest-only check would have reported green with the leak sitting in `package.json`.

`dev.enable: false` with an address is deliberately allowed. That is how a developer keeps their local address on hand, and failing it would push people to delete and retype the block, which is worse.

## The validator can now test itself

Added a `TUFF_PLUGINS_DIR` override so the tests point at a fixture tree. Without one, the only way to prove the checks fire is to break a real plugin — which is how a gate ends up untested in the first place.

## Verification

4 tests: a clean plugin passes (**positive control** — every failure assertion is also satisfied by a validator that rejects everything, which would be a worse gate than none), a manifest leak fails, a package.json leak *with no manifest present* fails, and `enable: false` passes.

Mutation-tested: removing the two check calls fails 2 of the 4. The real tree now reports *All plugins validated successfully*; before removing touch-image's block it reported the failure with the address. ESLint clean.

Note #813 (touch-image has no manifest, so it cannot load) is untouched — writing a manifest is content work with real decisions, not a gate fix.