### PR TITLE
fix(dialog): stop a failed touch tip poisoning its atomic key forever

### DIFF
--- a/apps/core-app/src/renderer/src/modules/mention/dialog-mention.atomic.test.ts
+++ b/apps/core-app/src/renderer/src/modules/mention/dialog-mention.atomic.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+/**
+ * The atomic entry was removed only inside the dialog's close callback. `renderComponent` throws
+ * when no app context has been captured, and that throw happens inside the promise executor — so
+ * the rejected promise was still stored under `atomicKey`, and every later call with that key
+ * returned the same rejection instead of showing a dialog (#834).
+ *
+ * The failure is permanent by construction, so a single "it rejects" assertion proves nothing. The
+ * point is what the *second* call does, which is what these drive.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  register: vi.fn(),
+  unregister: vi.fn()
+}))
+
+vi.mock('./dialog-manager', () => ({
+  useDialogManager: () => ({ register: mocks.register, unregister: mocks.unregister })
+}))
+
+vi.mock('@talex-touch/tuffex/utils', () => ({ nextZIndex: () => 1000 }))
+
+vi.mock('~/components/base/dialog/TouchTip.vue', () => ({ default: { name: 'TouchTip' } }))
+vi.mock('~/components/base/dialog/TBlowDialog.vue', () => ({ default: { name: 'TBlowDialog' } }))
+vi.mock('~/components/base/dialog/TBottomDialog.vue', () => ({
+  default: { name: 'TBottomDialog' }
+}))
+vi.mock('~/components/base/dialog/TDialogMention.vue', () => ({
+  default: { name: 'TDialogMention' }
+}))
+vi.mock('~/components/base/dialog/TPopperDialog.vue', () => ({
+  default: { name: 'TPopperDialog' }
+}))
+
+import { forTouchTip } from './dialog-mention'
+
+/** No captureAppContext() has run, so renderComponent throws — the failure mode from the report. */
+async function attempt(key: string): Promise<unknown> {
+  return await forTouchTip('Title', 'Message', undefined, key).catch((error) => error)
+}
+
+describe('a dialog that never rendered does not poison its atomic key', () => {
+  beforeEach(() => {
+    mocks.register.mockClear()
+    mocks.unregister.mockClear()
+    document.body.innerHTML = ''
+  })
+
+  it('第一次尝试如实失败', async () => {
+    const error = await attempt('audit-834-a')
+
+    expect(error).toBeInstanceOf(Error)
+    expect(String(error)).toContain('No app context')
+  })
+
+  it('第二次调用会重新尝试,而不是原样吐回同一个失败的 promise', async () => {
+    const first = await attempt('audit-834-b')
+    const second = await attempt('audit-834-b')
+
+    expect(first).toBeInstanceOf(Error)
+    expect(second).toBeInstanceOf(Error)
+    // Same message, different object: a fresh attempt rather than the cached rejection.
+    expect(second).not.toBe(first)
+  })
+
+  it('失败后 DOM 里不留下宿主节点', async () => {
+    await attempt('audit-834-c')
+    await attempt('audit-834-c')
+
+    expect(document.body.children).toHaveLength(0)
+  })
+
+  it('不同的 key 之间互不影响', async () => {
+    const first = await attempt('audit-834-d')
+    const second = await attempt('audit-834-e')
+
+    expect(second).not.toBe(first)
+  })
+
+  it('不带 atomicKey 时同样只是失败,不做任何缓存', async () => {
+    const first = await forTouchTip('Title', 'Message').catch((error) => error)
+    const second = await forTouchTip('Title', 'Message').catch((error) => error)
+
+    expect(first).toBeInstanceOf(Error)
+    expect(second).not.toBe(first)
+  })
+})

--- a/apps/core-app/src/renderer/src/modules/mention/dialog-mention.ts
+++ b/apps/core-app/src/renderer/src/modules/mention/dialog-mention.ts
@@ -171,7 +171,7 @@ export async function forTouchTip(
     if (activeDialog) return activeDialog
   }
 
-  const pending = new Promise<void>((resolve) => {
+  const pending = new Promise<void>((resolve, reject) => {
     const root = document.createElement('div')
     const dialogId = generateDialogId('touch-tip')
     const dialogManager = useDialogManager()
@@ -183,30 +183,46 @@ export async function forTouchTip(
 
     document.body.appendChild(root)
 
-    const { cleanup, id } = renderComponent(
-      TouchTip,
-      {
-        message,
-        title,
-        buttons,
-        close: async () => {
-          dialogManager.unregister(id)
-          cleanup()
-          document.body.removeChild(root)
-          if (atomicKey) {
-            activeAtomicDialogs.delete(atomicKey)
+    try {
+      const { cleanup, id } = renderComponent(
+        TouchTip,
+        {
+          message,
+          title,
+          buttons,
+          close: async () => {
+            dialogManager.unregister(id)
+            cleanup()
+            document.body.removeChild(root)
+            if (atomicKey) {
+              activeAtomicDialogs.delete(atomicKey)
+            }
+            resolve()
           }
-          resolve()
-        }
-      },
-      root,
-      dialogId,
-      true
-    )
+        },
+        root,
+        dialogId,
+        true
+      )
+    } catch (error) {
+      // renderComponent throws when no app context was ever captured. The host node is already in
+      // the document by this point, so it has to come back out or every failed attempt leaves one
+      // behind.
+      root.remove()
+      reject(error)
+    }
   })
 
   if (atomicKey) {
     activeAtomicDialogs.set(atomicKey, pending)
+    // The entry was only removed in the dialog's close callback, so a dialog that never rendered
+    // left its rejected promise under the key - and every later call with it returned that same
+    // rejection instead of showing a dialog (#834). A failure must not become the permanent answer.
+    void pending.catch(() => {
+      if (activeAtomicDialogs.get(atomicKey) === pending) {
+        activeAtomicDialogs.delete(atomicKey)
+      }
+    })
   }
 
   return pending


### PR DESCRIPTION
Closes #834.

The atomic entry was removed only inside the dialog's **close** callback. `renderComponent` throws when no app context has been captured, and that throw happens inside the promise executor — so the rejected promise was still stored under `atomicKey`, and every later call with that key returned the same rejection instead of showing a dialog.

The host node is appended to `document.body` before that point, so each failed attempt also left one behind. The catch removes it.

### Why a single "it rejects" test would prove nothing

The failure is permanent **by construction** — the first call rejects either way. What distinguishes fixed from broken is what the **second** call does, which is what these drive.

### Four mutations, and one that survives

| mutation | fails |
|---|---|
| revert | 2 |
| keep the `try/catch` but never evict the key | the second-attempt test |
| evict the key but leave the host node | the DOM test |
| **evict unconditionally, ignoring identity** | **nothing** |

That last one is worth stating rather than hiding: the `activeAtomicDialogs.get(key) === pending` check is **not falsifiable** in the current design. A second call while the first is pending returns the first promise via the early return, so a newer entry can never exist for the same key while an older one is settling. I kept the guard as cheap insurance if that early return is ever changed, but its value today is intent, not behaviour — the same honest status as the guarded assignment in #830.

### Out of scope, reported not changed

The same throw reaches `forDialogMention`, `forApplyMention` and two more entry points in this file — none wrapped. **None of them takes an `atomicKey`**, so none can poison a key; they only leak the host node on failure. That is a smaller, separate defect and folding four more call sites into an audit fix for one would widen it past what was reported.

Renderer typecheck delta **zero**: 3 errors at HEAD, 3 after, none in the files touched. eslint **0**, **5/5**.

The diff on `dialog-mention.ts` reads as 36/20 lines; ignoring whitespace it is **17/1** — the rest is the reindent from wrapping the existing block in `try`.
