### PR TITLE
fix(plugins): make plugins:validate reject committed dev leakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       # until #1099 removed it (#1128). If the declaration this commit adds is wrong, this
       # step is where it shows up rather than in whichever release script runs next.
       - name: Validate plugin manifests and package policy
-        run: pnpm plugins:validate
+        run: pnpm plugins:validate && pnpm plugins:validate:self-test
 
       # `pnpm lint` reaches plugins either as workspaces or through a hand-maintained brace
       # list, and touch-dictation was in neither (#562). The list is the kind that drifts

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "release:notes:prepare": "node scripts/release-notes-gateway.mjs prepare",
     "release:notes:verify": "node scripts/release-notes-gateway.mjs verify",
     "plugins:validate": "tsx scripts/validate-plugin-package-policy.ts && node scripts/validate-plugins.mjs",
+    "plugins:validate:self-test": "node scripts/validate-plugins.mjs --self-test",
     "plugins:release:audit": "tsx scripts/plugin-source-package-audit.ts",
     "publish:check": "node scripts/validate-publish-manifests.mjs",
     "publish:check:pack": "node scripts/validate-publish-manifests.mjs --pack",

--- a/plugins/touch-image/package.json
+++ b/plugins/touch-image/package.json
@@ -17,7 +17,7 @@
     },
     "plugin": {
       "dev": {
-        "enable": true,
+        "enable": false,
         "address": "http://127.0.0.1:6001"
       }
     },

--- a/scripts/validate-plugins.mjs
+++ b/scripts/validate-plugins.mjs
@@ -51,6 +51,31 @@ const KNOWN_PERMISSION_IDS = new Set([
   'lexicon.register',
 ])
 
+/**
+ * A committed `dev.enable: true` points the loader at a developer's local server, so a shipped
+ * plugin either fails to load or loads whatever is answering on that port.
+ *
+ * AGENTS.md prescribes `pnpm plugins:validate` as the manifest gate, but neither validator
+ * inspected the dev block at all — the prescribed gate could not catch the exact class of defect
+ * it is cited for (#812).
+ *
+ * Only `enable` is policed. A `dev.address` alongside `enable: false` is the normal way to keep a
+ * local server configured without turning it on, and every manifest in the tree uses it that way.
+ *
+ * @returns true when an error was logged.
+ */
+function reportDevLeakage(pluginName, dev, source) {
+  if (!dev || typeof dev !== 'object' || dev.enable !== true)
+    return false
+
+  const address = typeof dev.address === 'string' ? ` (address: ${dev.address})` : ''
+  logError(
+    pluginName,
+    `${source} declares dev.enable: true${address} — a released plugin must not point at a local dev server`,
+  )
+  return true
+}
+
 function resolveSearchProviderPermissionIds(scopes = []) {
   const permissionIds = scopes.flatMap((scope) => {
     switch (scope) {
@@ -97,6 +122,34 @@ function logOk(pluginName, message) {
 
 // Discover plugin directories
 const entries = fs.readdirSync(pluginsDir, { withFileTypes: true })
+/**
+ * `--self-test` proves the dev-leakage detector fires, because "no plugin declares dev.enable"
+ * looks exactly the same whether the check works or does nothing — which is the state this script
+ * was in before (#812).
+ *
+ * Placed before the scan so it can answer without validating the tree, and after logError so the
+ * counters it flips are already declared.
+ */
+if (process.argv.includes('--self-test')) {
+  const cases = [
+    { name: 'enable true is rejected', dev: { enable: true, address: 'http://127.0.0.1:6001' }, expected: true },
+    { name: 'enable true without an address is still rejected', dev: { enable: true }, expected: true },
+    { name: 'enable false with an address is allowed', dev: { enable: false, address: 'http://127.0.0.1:3488' }, expected: false },
+    { name: 'no dev block is allowed', dev: undefined, expected: false },
+    { name: 'a non-object dev block is ignored rather than crashing', dev: 'yes', expected: false },
+  ]
+
+  let failures = 0
+  for (const testCase of cases) {
+    const actual = reportDevLeakage('self-test', testCase.dev, 'fixture')
+    const ok = actual === testCase.expected
+    console.log(`${ok ? 'ok  ' : 'FAIL'} ${testCase.name}`)
+    if (!ok)
+      failures += 1
+  }
+  process.exit(failures > 0 ? 1 : 0)
+}
+
 const pluginDirs = entries
   .filter(e => e.isDirectory())
   .map(e => e.name)
@@ -120,6 +173,10 @@ for (const pluginName of pluginDirs) {
         logError(pluginName, `package.json name must be "${expectedPackageName}" (received "${packageManifest.name || '<missing>'}")`)
         pluginHasError = true
       }
+      // The build copies this block into dist/manifest.json, so dev leakage reaches a shipped
+      // plugin through package.json just as readily as through a tracked manifest.
+      if (reportDevLeakage(pluginName, packageManifest['talex-touch']?.plugin?.dev, 'package.json'))
+        pluginHasError = true
     }
     catch (e) {
       logError(pluginName, `package.json parse error: ${e.message}`)
@@ -146,6 +203,9 @@ for (const pluginName of pluginDirs) {
     pluginHasError = true
     continue
   }
+
+  if (reportDevLeakage(pluginName, manifest.dev, 'manifest.json'))
+    pluginHasError = true
 
   // 2. Required fields: id (or name), name, version
   if (!manifest.name) {


### PR DESCRIPTION
Closes #812. Closes #815.

Fixed together because a gate that lands red is not a gate: `touch-image` was the **only** violation the new check found, so the check and its one casualty go in one commit.

### The gate could not catch what it is cited for

`plugins/AGENTS.md` prescribes `pnpm plugins:validate` as the manifest gate. Neither `validate-plugins.mjs` nor `validate-plugin-package-policy.ts` mentioned `dev` at all — grep returns **zero** matches in both.

Now checked in `manifest.json` **and** in `package.json`'s `talex-touch.plugin` block, because the build copies the latter into `dist/manifest.json` — which is exactly how `touch-image` was leaking.

Only `enable` is policed. A `dev.address` alongside `enable: false` is the normal way to keep a local server configured without turning it on, and every other manifest in the tree uses it that way.

### The issue's evidence is stale — the conclusion is not

#812 cites *"three manifests ship dev.enable:true"* (clipboard-history / touch-intelligence / touch-translation). Read directly, **all three are `enable: false` today**; they keep localhost addresses, which is the supported configuration. Someone fixed them after the sweep.

I verified that with a positive control first, because an empty scan is exactly what a broken scan looks like: the same query does find their `"dev"` blocks.

So the leakage claim is out of date. **The gate claim is not** — and that is the part worth fixing, since it is what lets the next one through.

### Evidence the gate actually gates

- **negative control on the real tree**: with `touch-image` restored to `enable: true`, `plugins:validate` names the file and exits **1**. Fixed, exits **0**.
- **`--self-test`**: 5 cases including `enable: true` with no address, `enable: false` with an address, and a non-object `dev` block. Wired into the same blocking `PR Quality` step, following the repo's `check:X && check:X:self-test` convention.

The self-test exists because "no plugin declares `dev.enable`" reads identically whether the check works or does nothing — which is the state this script was in.
