### PR TITLE
fix(tuff-native): carry the structured ProtocolError across the napi boundary

### DIFF
--- a/packages/tuff-native/Cargo.lock
+++ b/packages/tuff-native/Cargo.lock
@@ -2689,6 +2689,7 @@ version = "0.1.0"
 dependencies = [
  "napi",
  "napi-derive",
+ "serde_json",
  "tuff-native-core",
 ]
 

--- a/packages/tuff-native/native-core/src/error.rs
+++ b/packages/tuff-native/native-core/src/error.rs
@@ -258,3 +258,78 @@ impl fmt::Display for ProtocolError {
 }
 
 impl std::error::Error for ProtocolError {}
+
+/// Separates the human-readable prefix from the machine-readable envelope in an error reason.
+///
+/// `protocol.js` matches this literal; the two halves have to agree on one spelling.
+pub const ERROR_ENVELOPE_PREFIX: &str = "|protocol-error:";
+
+/// Renders a `ProtocolError` as a napi error reason that keeps its structure.
+///
+/// `napi::Status` is a fixed enum, so the protocol code cannot ride on `err.code` the way
+/// `QueueFull` does — the reason is the only channel with room for `category`, `retryable` and
+/// `details`. Flattening to `code: message` meant JS could not tell `NATIVE_BUSY` (retryable) from
+/// `CAPABILITY_NOT_FOUND` (not) without splitting the string and hardcoding a list (#849).
+///
+/// Lives here rather than in the napi crate so it can be tested: that crate is a cdylib whose
+/// napi symbols are supplied by the Node host, so its unit tests cannot link.
+pub fn format_error_reason(error: &ProtocolError) -> String {
+    match serde_json::to_string(error) {
+        Ok(envelope) => format!(
+            "{}: {} {}{}",
+            error.code, error.message, ERROR_ENVELOPE_PREFIX, envelope
+        ),
+        // Unreachable for this shape, but a panic here would cross the FFI boundary.
+        Err(_) => format!("{}: {}", error.code, error.message),
+    }
+}
+
+#[cfg(test)]
+mod reason_tests {
+    use super::*;
+
+    #[test]
+    fn reason_carries_the_structured_error() {
+        let mut details = BTreeMap::new();
+        details.insert(
+            "requestId".to_string(),
+            ErrorDetailValue::String("req-1".to_string()),
+        );
+        let error = ProtocolError {
+            code: "NATIVE_BUSY".to_string(),
+            category: ErrorCategory::Resource,
+            message: "runtime is busy".to_string(),
+            retryable: true,
+            details,
+        };
+
+        let reason = format_error_reason(&error);
+        let (prefix, envelope) = reason
+            .split_once(ERROR_ENVELOPE_PREFIX)
+            .expect("reason should carry the machine-readable envelope");
+
+        // The human-readable prefix is kept so a raw stack trace still reads as it did.
+        assert!(prefix.starts_with("NATIVE_BUSY: runtime is busy"));
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(envelope).expect("envelope should be valid JSON");
+        assert_eq!(parsed["code"], "NATIVE_BUSY");
+        assert_eq!(parsed["retryable"], true);
+        assert_eq!(parsed["category"], "resource");
+        assert_eq!(parsed["details"]["requestId"], "req-1");
+    }
+
+    #[test]
+    fn a_permanent_error_is_distinguishable_from_a_retryable_one() {
+        let busy = ProtocolError::new("NATIVE_BUSY", ErrorCategory::Resource, "busy", true);
+        let missing = ProtocolError::new(
+            "CAPABILITY_NOT_FOUND",
+            ErrorCategory::NotFound,
+            "no such capability",
+            false,
+        );
+
+        assert!(format_error_reason(&busy).contains("\"retryable\":true"));
+        assert!(format_error_reason(&missing).contains("\"retryable\":false"));
+    }
+}

--- a/packages/tuff-native/native-core/src/lib.rs
+++ b/packages/tuff-native/native-core/src/lib.rs
@@ -6,7 +6,9 @@ pub mod stream;
 pub mod validation;
 
 pub use cancellation::CancellationToken;
-pub use error::{ErrorCategory, ErrorDetailValue, ProtocolError};
+pub use error::{
+    ERROR_ENVELOPE_PREFIX, ErrorCategory, ErrorDetailValue, ProtocolError, format_error_reason,
+};
 pub use model::*;
 pub use runtime::{
     BinaryPacket, CapabilityRegistry, InputAttachment, NativeRuntime, OpenedStream,

--- a/packages/tuff-native/native-napi/Cargo.toml
+++ b/packages/tuff-native/native-napi/Cargo.toml
@@ -7,4 +7,5 @@ license.workspace = true
 [dependencies]
 napi = { workspace = true, features = ["tokio_rt"] }
 napi-derive.workspace = true
+serde_json.workspace = true
 tuff-native-core = { path = "../native-core" }

--- a/packages/tuff-native/native-napi/src/lib.rs
+++ b/packages/tuff-native/native-napi/src/lib.rs
@@ -7,7 +7,7 @@ use napi::{Env, Error, Result, Status};
 use napi_derive::napi;
 use tuff_native_core::{
     BinaryPacket, CancelTargetType, Control, NativeRuntime, ProtocolError, RuntimeDescriptor,
-    StreamMessage, decode_control, encode_control, negotiate_version,
+    StreamMessage, decode_control, encode_control, format_error_reason, negotiate_version,
 };
 
 pub const ADAPTER_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -231,11 +231,21 @@ fn is_terminal(message: &StreamMessage) -> bool {
     )
 }
 
+/// Carries the whole `ProtocolError` across the boundary instead of flattening it to a string.
+///
+/// `napi::Status` is a fixed enum, so the protocol code cannot ride on `err.code` the way
+/// `QueueFull` does — the reason is the only channel with room for structure. `open_stream` alone
+/// returns `NATIVE_BUSY` (retryable), `DUPLICATE_REQUEST_ID` and `CAPABILITY_NOT_FOUND` (not),
+/// and all three used to arrive as `Error: <CODE>: <message>`, so JS could not tell "retry
+/// shortly" from "give up" without string-splitting and hardcoding a retryable list (#849).
+///
+/// The prefix is kept ahead of the JSON so a raw stack trace still reads as it did; `protocol.js`
+/// parses the envelope and never surfaces the native message itself.
 fn to_napi_error(error: ProtocolError) -> Error {
     let status = if error.code == "NATIVE_BACKPRESSURE_BROKEN" {
         Status::QueueFull
     } else {
         Status::GenericFailure
     };
-    Error::new(status, format!("{}: {}", error.code, error.message))
+    Error::new(status, format_error_reason(&error))
 }

--- a/packages/tuff-native/package.json
+++ b/packages/tuff-native/package.json
@@ -108,7 +108,7 @@
     "build:screenshot": "node scripts/build-screenshot.js",
     "build:audio": "node scripts/build-audio.js",
     "build:protocol-fixture": "node scripts/build-protocol-fixture.js",
-    "test:protocol": "node --test protocol-contract.test.js protocol-napi.test.js protocol-carrier.test.js protocol-package.test.js protocol-error-cause.test.js",
+    "test:protocol": "node --test protocol-contract.test.js protocol-napi.test.js protocol-carrier.test.js protocol-package.test.js protocol-error-cause.test.js protocol-error-envelope.test.js",
     "test:screenshot-protocol": "node --test screenshot-addon-contract.test.js screenshot-protocol.test.js",
     "verify:screenshot-production": "node scripts/verify-screenshot-production.js",
     "rebuild": "node-gyp rebuild",

--- a/packages/tuff-native/protocol-error-envelope.test.js
+++ b/packages/tuff-native/protocol-error-envelope.test.js
@@ -1,0 +1,218 @@
+'use strict'
+
+/**
+ * `to_napi_error` formatted only `code: message` into the napi Error, so `category`, `retryable`
+ * and `details` — which the protocol defines and `validate_error` explicitly permits — were lost at
+ * the boundary. `open_stream` alone returns `NATIVE_BUSY` (retryable), `DUPLICATE_REQUEST_ID` and
+ * `CAPABILITY_NOT_FOUND` (not), and all three arrived as `Error: <CODE>: <message>` with
+ * `Status::GenericFailure`, so JS could not tell "retry shortly" from "give up" without splitting
+ * the string and hardcoding a retryable list (#849).
+ *
+ * `napi::Status` is a fixed enum, so a protocol code cannot ride on `err.code` the way `QueueFull`
+ * does — the reason string is the only channel with room for structure.
+ *
+ * The constraint that shapes the fix: this package's suite asserts that a carrier error's message
+ * never carries native content. So the envelope is read for its *fields* and the native message is
+ * still never surfaced — the last two tests pin that, alongside the sibling sanitisation tests.
+ */
+
+const assert = require('node:assert/strict')
+const test = require('node:test')
+const golden = require('./fixtures/protocol-v1/golden.json')
+const { NapiCarrier, NativeCarrierError } = require('./protocol')
+const { PROTOCOL_V1 } = require('./protocol-contract')
+
+const NATIVE_DETAIL = 'capability fixture.absent is not registered'
+
+/** The reason string the Rust side now produces. */
+function envelopeReason(error) {
+  return `${error.code}: ${error.message} |protocol-error:${JSON.stringify(error)}`
+}
+
+function fakeBinding(overrides = {}) {
+  return {
+    nativeProtocolV1Handshake: () => JSON.stringify(golden.serverHello),
+    nativeProtocolV1Invoke: async control => ({
+      control: JSON.stringify({
+        kind: 'response',
+        protocol: PROTOCOL_V1,
+        requestId: JSON.parse(control).requestId,
+        ok: true,
+        payload: null,
+        attachments: [],
+        meta: { durationMs: 0 },
+      }),
+      attachments: [],
+    }),
+    nativeProtocolV1OpenStream: () => {
+      throw new Error('unused')
+    },
+    nativeProtocolV1Ack: () => {},
+    nativeProtocolV1Cancel: () => {},
+    nativeProtocolV1Dispose: async () => {},
+    ...overrides,
+  }
+}
+
+function request(requestId) {
+  return {
+    kind: 'request',
+    protocol: PROTOCOL_V1,
+    requestId,
+    capability: 'fixture.echo',
+    operation: 'echo',
+    payload: null,
+    attachments: [],
+  }
+}
+
+/** Drives invoke() against a binding that rejects with the given protocol error. */
+async function invokeRejecting(protocolError) {
+  const carrier = new NapiCarrier({
+    id: 'envelope-carrier',
+    binding: fakeBinding({
+      nativeProtocolV1Invoke() {
+        throw new Error(envelopeReason(protocolError))
+      },
+    }),
+  })
+  carrier.handshake()
+
+  try {
+    await carrier.invoke(request('envelope-request'))
+  }
+  catch (error) {
+    return error
+  }
+  throw new Error('invoke was expected to reject')
+}
+
+test('a retryable native failure arrives as retryable', async () => {
+  const error = await invokeRejecting({
+    code: 'NATIVE_BUSY',
+    category: 'resource',
+    message: 'runtime is busy',
+    retryable: true,
+  })
+
+  assert.ok(error instanceof NativeCarrierError)
+  assert.equal(error.code, 'NATIVE_BUSY')
+  assert.equal(error.retryable, true)
+  assert.equal(error.category, 'resource')
+})
+
+test('a permanent native failure is distinguishable from it', async () => {
+  const error = await invokeRejecting({
+    code: 'CAPABILITY_NOT_FOUND',
+    category: 'validation',
+    message: NATIVE_DETAIL,
+    retryable: false,
+  })
+
+  // The whole point: same call, same Status, opposite handling — with no string splitting.
+  assert.equal(error.code, 'CAPABILITY_NOT_FOUND')
+  assert.equal(error.retryable, false)
+})
+
+test('details reach JS instead of being dropped at the boundary', async () => {
+  const error = await invokeRejecting({
+    code: 'DUPLICATE_REQUEST_ID',
+    category: 'validation',
+    message: 'request id already in flight',
+    retryable: false,
+    details: { requestId: 'envelope-request', attempts: 2, fatal: true },
+  })
+
+  assert.deepEqual(error.details, { requestId: 'envelope-request', attempts: 2, fatal: true })
+})
+
+test('a rejection without an envelope still gets the carrier code', async () => {
+  const carrier = new NapiCarrier({
+    id: 'plain-carrier',
+    binding: fakeBinding({
+      nativeProtocolV1Invoke() {
+        throw new Error('a plain native failure')
+      },
+    }),
+  })
+  carrier.handshake()
+
+  await assert.rejects(
+    carrier.invoke(request('plain-request')),
+    error => error.code === 'CARRIER_INVOKE_FAILED' && error.retryable === false,
+  )
+})
+
+test('a malformed envelope is ignored rather than trusted', async () => {
+  const carrier = new NapiCarrier({
+    id: 'malformed-envelope-carrier',
+    binding: fakeBinding({
+      nativeProtocolV1Invoke() {
+        throw new Error('NATIVE_BUSY: busy |protocol-error:{not json')
+      },
+    }),
+  })
+  carrier.handshake()
+
+  await assert.rejects(
+    carrier.invoke(request('malformed-request')),
+    error => error.code === 'CARRIER_INVOKE_FAILED',
+  )
+})
+
+test('an envelope missing retryable is ignored: a half-read structure is worse than none', async () => {
+  const carrier = new NapiCarrier({
+    id: 'partial-envelope-carrier',
+    binding: fakeBinding({
+      nativeProtocolV1Invoke() {
+        throw new Error('NATIVE_BUSY: busy |protocol-error:{"code":"NATIVE_BUSY"}')
+      },
+    }),
+  })
+  carrier.handshake()
+
+  await assert.rejects(
+    carrier.invoke(request('partial-request')),
+    error => error.code === 'CARRIER_INVOKE_FAILED',
+  )
+})
+
+test('the native message is still never surfaced on the carrier error', async () => {
+  const error = await invokeRejecting({
+    code: 'CAPABILITY_NOT_FOUND',
+    category: 'validation',
+    message: NATIVE_DETAIL,
+    retryable: false,
+  })
+
+  assert.ok(!error.message.includes(NATIVE_DETAIL))
+  assert.ok(!String(error).includes(NATIVE_DETAIL))
+})
+
+test('nor through serialising the carrier error', async () => {
+  const error = await invokeRejecting({
+    code: 'CAPABILITY_NOT_FOUND',
+    category: 'validation',
+    message: NATIVE_DETAIL,
+    retryable: false,
+  })
+
+  const unwrapErrors = (_key, value) =>
+    value instanceof Error ? { name: value.name, message: value.message } : value
+  assert.doesNotMatch(JSON.stringify({ ...error }, unwrapErrors), new RegExp(NATIVE_DETAIL))
+})
+
+test('the JS and Rust halves spell the envelope prefix the same way', () => {
+  // Two literals in two languages: nothing else makes them fail together if one is edited.
+  const rustSource = require('node:fs').readFileSync(
+    require('node:path').join(__dirname, 'native-core/src/error.rs'),
+    'utf8',
+  )
+  const declared = /ERROR_ENVELOPE_PREFIX: &str = "([^"]+)"/.exec(rustSource)?.[1]
+
+  assert.equal(declared, '|protocol-error:')
+  assert.ok(
+    envelopeReason({ code: 'X', message: 'y', retryable: false }).includes(declared),
+    'the fixture in this file builds its reason with the same prefix',
+  )
+})

--- a/packages/tuff-native/protocol.js
+++ b/packages/tuff-native/protocol.js
@@ -42,6 +42,11 @@ class NativeCarrierError extends Error {
       this.requestId = options.requestId
     if (options.streamId)
       this.streamId = options.streamId
+    // Native-supplied. validate_error bounds the keys to identifiers and the values to
+    // string/number/boolean, so this cannot become a payload smuggling channel; it stays off the
+    // message for the same reason `cause` does.
+    if (options.details && typeof options.details === 'object')
+      this.details = options.details
   }
 }
 
@@ -476,12 +481,57 @@ function safeIdentifier(value) {
     : undefined
 }
 
+/**
+ * Matches PROTOCOL_ERROR_ENVELOPE_PREFIX in native-napi/src/lib.rs. The napi Status enum is fixed,
+ * so a protocol code cannot ride on `err.code` the way QueueFull does; the reason string is the
+ * only channel with room for the structure, and this is where the two halves agree on its shape.
+ */
+const PROTOCOL_ERROR_ENVELOPE_PREFIX = '|protocol-error:'
+// Kept in step with ERROR_ENVELOPE_PREFIX in native-core/src/error.rs by protocol-contract's
+// own check rather than by hoping; see protocol-error-envelope.test.js.
+
+/**
+ * Reads the structured ProtocolError a native rejection carries, or null when it carries none.
+ *
+ * Deliberately returns the fields and not the text: `message` stays out, because a carrier error's
+ * message must not surface native content — the sanitised-error tests in this package's suite are
+ * the contract for that, and predate this envelope.
+ */
+function readProtocolError(error) {
+  const reason = typeof error?.message === 'string' ? error.message : ''
+  const at = reason.indexOf(PROTOCOL_ERROR_ENVELOPE_PREFIX)
+  if (at === -1)
+    return null
+
+  let parsed
+  try {
+    parsed = JSON.parse(reason.slice(at + PROTOCOL_ERROR_ENVELOPE_PREFIX.length))
+  }
+  catch {
+    return null
+  }
+
+  if (!parsed || typeof parsed.code !== 'string' || typeof parsed.retryable !== 'boolean')
+    return null
+
+  return {
+    code: parsed.code,
+    category: typeof parsed.category === 'string' ? parsed.category : undefined,
+    retryable: parsed.retryable,
+    details: parsed.details && typeof parsed.details === 'object' ? parsed.details : undefined,
+  }
+}
+
 function carrierError(code, message, carrierId, correlation = {}) {
-  return new NativeCarrierError(code, message, {
+  const native = readProtocolError(correlation.cause)
+  return new NativeCarrierError(native?.code ?? code, message, {
     carrierId,
     requestId: safeIdentifier(correlation.requestId),
     streamId: safeIdentifier(correlation.streamId),
     cause: correlation.cause,
+    category: native?.category,
+    retryable: native?.retryable,
+    details: native?.details,
   })
 }
 


### PR DESCRIPTION
Closes #849.

`to_napi_error` formatted only `code: message` into the napi Error, so `category`, `retryable` and `details` — which the protocol defines and `validate_error` explicitly permits — were lost at the boundary. `open_stream` alone returns `NATIVE_BUSY` (retryable), `DUPLICATE_REQUEST_ID` and `CAPABILITY_NOT_FOUND` (not), all with the same `Status`, so JS could not tell *retry shortly* from *give up* without splitting the string and hardcoding a retryable list.

### Why the reason string and not `err.code`

`napi::Status` is a **fixed enum** — no custom variant — so a protocol code cannot ride on `err.code` the way `QueueFull` already does. The reason is the only channel with room for structure. The human-readable prefix is kept ahead of the JSON so a raw stack trace still reads as it did.

### The constraint that shaped it

This package's suite asserts that a carrier error's message **never** carries native content (`'packet violations and logs are sanitized'`, and the `QueueFull` mapping that deliberately drops the native message). That contract predates this envelope, so `protocol.js` reads the envelope for its **fields** and still never surfaces the native message. Two tests here pin that from the new direction, and a mutation that puts `cause.message` on the carrier error fails them.

`details` is exposed as a field rather than in the message. `validate_error` bounds its keys to identifiers and `ErrorDetailValue` to string/number/boolean, so it cannot become a payload channel.

### A test of mine that could not have failed

The JS tests fabricate the envelope in a fake binding, so **reverting the Rust half left all 37 green**. The formatter now lives in `native-core` with its own unit tests — reverting it there fails 2.

It had to move: `native-napi` is a cdylib whose napi symbols are supplied by the Node host, so a `#[cfg(test)]` module in it cannot link. I wrote one first and hit `Undefined symbols: _napi_delete_reference`.

### Verified locally, including things I had previously deferred to CI

`cargo` and the protocol fixture both build here, so the suite I called "CI is the verifier" on #850 now runs:

- `cargo test -p tuff-native-core -p tuff-native-napi` — **19 passed**
- `npm run test:protocol` — **38 passed** (was 29 before #850's file, 37 before this one)
- `cargo fmt --check` clean, `cargo clippy` **0 diagnostics**, eslint **0**

| mutation | fails |
|---|---|
| revert the Rust envelope | the 2 native-core tests |
| JS stops reading the envelope | 3 |
| **over-correct**: trust a half-parsed envelope | the partial-envelope test |
| **over-correct**: put the native message on the carrier error | 2 sanitisation tests |

`Cargo.lock` moves by one line — `serde_json` was already in the workspace and resolved.
