### PR TITLE
build(db): stop db:generate running against a stale snapshot baseline [#1303]

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -28,7 +28,7 @@
     "build": "pnpm run release:notes:catalog && pnpm run typecheck && electron-vite build",
     "build:vite": "pnpm run release:notes:catalog && electron-vite build",
     "postinstall": "echo 'Skipping electron-builder install-app-deps - will run during build'",
-    "db:generate": "drizzle-kit generate",
+    "db:generate": "node scripts/db/assert-snapshot-baseline.mjs && drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "build:unpack": "pnpm run build && electron-builder --dir",
     "build:beta": "node scripts/build-target.js --type=beta",

--- a/apps/core-app/scripts/db/assert-snapshot-baseline.mjs
+++ b/apps/core-app/scripts/db/assert-snapshot-baseline.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Refuse to run `drizzle-kit generate` while its snapshot baseline is behind the journal (#1303).
+ *
+ * drizzle-kit diffs `schema.ts` against the highest `meta/NNNN_snapshot.json`. That file stopped at
+ * 0014 (2025-12-10) while migrations reached 0037, because the 23 in between were written by hand
+ * — which is what happens when the generator cannot run. So `generate` re-proposes everything
+ * 0015-0037 already created: 45 CREATE TABLE statements, none of them with IF NOT EXISTS.
+ *
+ * A developer following CLAUDE.md would commit that and break every upgrading installation, and
+ * nothing in the command's output says so. An installed, runnable command that must not be used is
+ * worse than an absent one, so this makes the state loud instead of silent.
+ *
+ * It is not the fix. The baseline still has to be rebuilt — replayed for 0015-0037, or rebaselined
+ * at the current schema — and that decision belongs to whoever owns the migration history. This
+ * only stops the trap from being sprung in the meantime, and disappears on its own once the
+ * highest snapshot catches up.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const MIGRATIONS_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../resources/db/migrations'
+)
+
+/** Highest migration index drizzle has recorded as applied-in-order. */
+function highestJournalIndex() {
+  const journal = JSON.parse(readFileSync(path.join(MIGRATIONS_DIR, 'meta/_journal.json'), 'utf8'))
+  return journal.entries.reduce((highest, entry) => Math.max(highest, entry.idx), -1)
+}
+
+/** Highest index the generator can diff against. */
+function highestSnapshotIndex() {
+  return readdirSync(path.join(MIGRATIONS_DIR, 'meta'))
+    .filter((name) => name.endsWith('_snapshot.json'))
+    .map((name) => Number.parseInt(name.slice(0, 4), 10))
+    .filter((index) => Number.isInteger(index))
+    .reduce((highest, index) => Math.max(highest, index), -1)
+}
+
+const journalIndex = highestJournalIndex()
+const snapshotIndex = highestSnapshotIndex()
+
+if (snapshotIndex >= journalIndex) {
+  process.exit(0)
+}
+
+process.stderr.write(
+  `\ndb:generate is blocked — the drizzle snapshot baseline is stale (#1303).\n\n` +
+    `  highest snapshot   meta/${String(snapshotIndex).padStart(4, '0')}_snapshot.json\n` +
+    `  highest migration  ${String(journalIndex).padStart(4, '0')} (from meta/_journal.json)\n\n` +
+    `drizzle-kit diffs schema.ts against the snapshot, so it would re-propose every table the\n` +
+    `${journalIndex - snapshotIndex} migrations in between already created — as CREATE TABLE without IF NOT EXISTS,\n` +
+    `which fails on any existing installation.\n\n` +
+    `Write the migration by hand until the baseline is rebuilt, and see #1303 for the two ways\n` +
+    `to rebuild it. This check passes on its own once the highest snapshot reaches the journal.\n\n`
+)
+process.exit(1)

--- a/packages/utils/__tests__/drizzle-snapshot-baseline.test.ts
+++ b/packages/utils/__tests__/drizzle-snapshot-baseline.test.ts
@@ -1,0 +1,94 @@
+import { execFileSync } from 'node:child_process'
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * `db:generate` must not run against a stale snapshot baseline (#1303).
+ *
+ * drizzle-kit diffs `schema.ts` against the highest `meta/NNNN_snapshot.json`. That stopped at 0014
+ * on 2025-12-10 while migrations reached 0037 — the 23 in between were hand-written, which is what
+ * happens when the generator cannot run. So `generate` re-proposes every table those migrations
+ * already created: 45 CREATE TABLE statements, none carrying IF NOT EXISTS, which fails on any
+ * existing installation.
+ *
+ * CLAUDE.md documents the command. Nothing in its output said any of this, so the failure mode was
+ * a developer committing its first output in good faith.
+ *
+ * This pins the preflight that makes the state loud, not the drift itself: rebuilding the baseline
+ * changes files that run against users' databases, and that decision is on #1303. Both assertions
+ * below stop applying on their own once the baseline catches up, so this does not have to be
+ * remembered and removed.
+ *
+ * Lives in packages/utils because `ci / CI - utils` is a blocking check, whereas
+ * `App suites (core-app)` is continue-on-error and reports success whatever the suite does.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const CORE_APP = path.join(REPO_ROOT, 'apps/core-app')
+const MIGRATIONS = path.join(CORE_APP, 'resources/db/migrations')
+
+const manifest = JSON.parse(readFileSync(path.join(CORE_APP, 'package.json'), 'utf8')) as {
+  scripts: Record<string, string>
+}
+
+const journal = JSON.parse(readFileSync(path.join(MIGRATIONS, 'meta/_journal.json'), 'utf8')) as {
+  entries: Array<{ idx: number, tag: string }>
+}
+
+const highestJournalIndex = journal.entries.reduce((highest, entry) => Math.max(highest, entry.idx), -1)
+
+const highestSnapshotIndex = readdirSync(path.join(MIGRATIONS, 'meta'))
+  .filter(name => name.endsWith('_snapshot.json'))
+  .map(name => Number.parseInt(name.slice(0, 4), 10))
+  .filter(index => Number.isInteger(index))
+  .reduce((highest, index) => Math.max(highest, index), -1)
+
+describe('drizzle migration bookkeeping', () => {
+  it('reads the journal and snapshots it means to compare', () => {
+    // Positive control: an unreadable directory or a wrong root yields -1 for both, which would
+    // satisfy "the snapshot is not behind" without having compared anything.
+    expect(journal.entries.length).toBeGreaterThan(30)
+    expect(highestJournalIndex).toBeGreaterThan(-1)
+    expect(highestSnapshotIndex).toBeGreaterThan(-1)
+  })
+})
+
+describe('db:generate', () => {
+  it('runs the baseline preflight before the generator', () => {
+    expect(manifest.scripts['db:generate']).toBe(
+      'node scripts/db/assert-snapshot-baseline.mjs && drizzle-kit generate',
+    )
+  })
+
+  it('refuses to run while the baseline is behind, and says why', () => {
+    if (highestSnapshotIndex >= highestJournalIndex) {
+      // The baseline was rebuilt. The preflight is now a no-op by its own logic, and this
+      // assertion is what proves it rather than the test quietly passing on a broken check.
+      expect(run().status).toBe(0)
+      return
+    }
+
+    const { status, stderr } = run()
+
+    expect(status).toBe(1)
+    expect(stderr).toContain('#1303')
+    // The two numbers a reader needs to act, not just a refusal.
+    expect(stderr).toContain(`meta/${String(highestSnapshotIndex).padStart(4, '0')}_snapshot.json`)
+    expect(stderr).toContain(String(highestJournalIndex).padStart(4, '0'))
+  })
+})
+
+function run(): { status: number, stderr: string } {
+  try {
+    execFileSync('node', ['scripts/db/assert-snapshot-baseline.mjs'], {
+      cwd: CORE_APP,
+      encoding: 'utf8',
+    })
+    return { status: 0, stderr: '' }
+  }
+  catch (error) {
+    const failure = error as { status?: number, stderr?: string }
+    return { status: failure.status ?? -1, stderr: failure.stderr ?? '' }
+  }
+}


### PR DESCRIPTION
Refs #1303. **Not** the fix that issue asks for — that one changes files which run against users' databases and needs a decision I should not make. This closes the trap in the meantime.

## Confirmed, and worse than filed

| | |
|---|---|
| highest snapshot | `meta/0014_snapshot.json` (2025-12-10) |
| highest migration | **0037** (`_journal.json`, 38 entries) |
| migrations with no snapshot | 25 — `0011`, `0012`, `0015`–`0037` |

The journal itself is intact, so migrations apply correctly. Only the generator's baseline is stale, and the drift has widened by one since filing.

## What this ships

`db:generate` becomes `node scripts/db/assert-snapshot-baseline.mjs && drizzle-kit generate`. The preflight compares the highest snapshot against the highest journal index and, while behind, refuses with the two numbers a reader needs:

```
db:generate is blocked — the drizzle snapshot baseline is stale (#1303).

  highest snapshot   meta/0014_snapshot.json
  highest migration  0037 (from meta/_journal.json)

drizzle-kit diffs schema.ts against the snapshot, so it would re-propose every table the
23 migrations in between already created — as CREATE TABLE without IF NOT EXISTS,
which fails on any existing installation.

Write the migration by hand until the baseline is rebuilt, and see #1303 for the two ways
to rebuild it. This check passes on its own once the highest snapshot reaches the journal.
```

The issue's own words for why this is worth doing separately: *"the documented workflow is installed and runnable but must not be used — arguably a worse state than the command being absent, because nothing signals it."* CLAUDE.md documents the command, so the failure mode is someone committing its first output in good faith.

Nothing in CI or any script calls `db:generate` — only CLAUDE.md and task notes — so making it exit non-zero blocks no pipeline.

## Self-disabling, not a permanent gate

Both the preflight and the guard stop applying once the highest snapshot reaches the journal, whichever way #1303 is resolved. The test asserts that explicitly rather than passing quietly: if the baseline is rebuilt it requires exit 0, so a preflight broken into always-succeeding is caught either way.

`packages/utils/__tests__/drizzle-snapshot-baseline.test.ts` — in utils because `ci / CI - utils` blocks, whereas `App suites (core-app)` is continue-on-error.

Mutation-tested: reverting `db:generate` to the bare command fails the wiring test; making the preflight always exit 0 fails the refusal test. Positive control asserts the journal and snapshot lists were actually read, since a wrong root yields -1 for both and would satisfy "not behind" without comparing anything.

## Still open on #1303

The baseline rebuild — replay `0015`–`0037`, or rebaseline at the current schema and treat `0038` onward as the generated era. I have posted the trade-off there; say which and I will do it.