### PR TITLE
refactor(plugins): drop the onInputChanged handler the host never calls [#823]

### DIFF
--- a/packages/utils/__tests__/prelude-oninputchanged-dead.test.ts
+++ b/packages/utils/__tests__/prelude-oninputchanged-dead.test.ts
@@ -1,0 +1,72 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * No Prelude may export `onInputChanged` — the host never calls it (#823).
+ *
+ * The name exists on two SDK interfaces with the same doc comment, and only one is wired:
+ *
+ * - `ITargetFeatureLifeCycle.onInputChanged` **is** called — `plugin.ts` iterates
+ *   `_featureEvent: Map<string, ITargetFeatureLifeCycle[]>` and invokes it on every input change.
+ * - `IFeatureLifeCycle.onInputChanged`, which is what a Prelude exports, is **not**.
+ *   `triggerInputChanged` calls `pluginLifecycle.onFeatureTriggered` and the listeners above, and
+ *   nothing else.
+ *
+ * So the hook is not fictional, it is on the wrong object — which is exactly why
+ * `touch-browser-open` implemented it in good faith and kept 4 lines of unreachable code plus the
+ * `activeSearch` state feeding it. Suggestions still refreshed, because the re-invoked
+ * `onFeatureTriggered` was doing the same work.
+ *
+ * Wiring it instead was the other option and is not a drop-in: the Prelude's handler pushes items,
+ * and `onFeatureTriggered` already pushed them for the same event, so every existing plugin would
+ * double-publish. That is a design decision for #823, not a fix to smuggle in here.
+ *
+ * Lives in packages/utils because `ci / CI - utils` is a blocking check, whereas
+ * `App suites (core-app)` is continue-on-error and reports success whatever the suite does.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const PLUGINS = path.join(REPO_ROOT, 'plugins')
+
+/** Prelude entry points: the `index.js` each plugin root exposes. */
+function preludes(): Array<{ name: string, source: string }> {
+  return readdirSync(PLUGINS)
+    .filter(name => statSync(path.join(PLUGINS, name)).isDirectory())
+    .map(name => ({ name, file: path.join(PLUGINS, name, 'index.js') }))
+    .filter(({ file }) => {
+      try {
+        return statSync(file).isFile()
+      }
+      catch {
+        return false
+      }
+    })
+    .map(({ name, file }) => ({ name, source: readFileSync(file, 'utf8') }))
+}
+
+const found = preludes()
+
+describe('prelude lifecycle exports', () => {
+  it('reads the preludes it means to check', () => {
+    // Positive control. "No prelude declares onInputChanged" is also what an empty file list
+    // reports, and a wrong root produces exactly that.
+    expect(found.length).toBeGreaterThan(10)
+  })
+
+  it('finds the hook that is wired, so the scan is known to work', () => {
+    // Second control, on the same query shape as the rule below. onFeatureTriggered is called
+    // from plugin.ts and every searching plugin implements it.
+    const implementing = found.filter(({ source }) => /\bonFeatureTriggered\s*\(/.test(source))
+
+    expect(implementing.length).toBeGreaterThan(5)
+  })
+
+  it('declares no onInputChanged, which would never run', () => {
+    const dead = found
+      .filter(({ source }) => /^\s*(?:async\s+)?onInputChanged\s*\(/m.test(source))
+      .map(({ name }) => name)
+
+    expect(dead).toEqual([])
+  })
+})

--- a/packages/utils/plugin/index.ts
+++ b/packages/utils/plugin/index.ts
@@ -394,6 +394,13 @@ export interface IFeatureLifeCycle {
   /**
    * Called when user input changes within this feature’s input box.
    * For example, search text or commands typed.
+   *
+   * @deprecated Not invoked on a Prelude. `triggerInputChanged` calls {@link onFeatureTriggered}
+   * again and then the per-feature listeners registered as {@link ITargetFeatureLifeCycle}, which
+   * declares an identically named hook that *is* called. A Prelude implementing this one gets a
+   * handler that never runs (#823) — handle input changes in `onFeatureTriggered`, which is
+   * re-entered on every keystroke.
+   *
    * @param input - The new input value
    */
   onInputChanged?: (input: string) => void

--- a/plugins/touch-browser-open/index.js
+++ b/plugins/touch-browser-open/index.js
@@ -58,7 +58,6 @@ for (const engine of SEARCH_ENGINES) {
 }
 
 let requestSequence = 0
-let activeSearch = null
 let browsersByToken = new Map()
 
 function normalizeText(value) {
@@ -492,7 +491,6 @@ function buildSearchItems(featureId, engine, query, suggestions, warning) {
 async function handleSearchFeature(featureId, engine, query, signal) {
   const sequence = nextRequest()
   const text = normalizeSearchText(query)
-  activeSearch = { featureId, engine }
   await publishItems(buildSearchItems(featureId, engine, text, [], ''), sequence)
   if (!text || signal?.aborted)
     return true
@@ -584,16 +582,9 @@ const pluginLifecycle = {
       const parsed = parseSearchQuery(getQueryText(query), settings)
       return handleSearchFeature(featureId, parsed.engine, parsed.query, signal)
     }
-    activeSearch = null
     if (featureId !== BROWSER_FEATURE_ID)
       return false
     return handleBrowserFeature(featureId, query)
-  },
-
-  async onInputChanged(input, signal) {
-    if (!activeSearch)
-      return false
-    return handleSearchFeature(activeSearch.featureId, activeSearch.engine, getQueryText(input), signal)
   },
 
   async onItemAction(item, context = {}) {
@@ -615,7 +606,6 @@ const pluginLifecycle = {
         return external({ status: result?.status || 'failed', reason: result?.reason || 'open-failed' })
       if (browser)
         await saveRecentBrowser(browser)
-      activeSearch = null
       return external({ status: 'completed' }, true)
     }
     catch (error) {
@@ -627,7 +617,6 @@ const pluginLifecycle = {
 
   async onDestroy() {
     requestSequence += 1
-    activeSearch = null
     browsersByToken.clear()
   },
 }

--- a/plugins/touch-browser-open/index.test.cjs
+++ b/plugins/touch-browser-open/index.test.cjs
@@ -179,11 +179,12 @@ test('production Prelude contains no privileged child surface or test export', (
   ]) {
     assert.doesNotMatch(source, pattern)
   }
+  // No onInputChanged: the host never calls the prelude's copy of it (#823). Input changes
+  // arrive as a re-invocation of onFeatureTriggered, which is where the refresh happens.
   assert.deepEqual(Object.keys(pluginModule).sort(), [
     'onDestroy',
     'onFeatureTriggered',
     'onInit',
-    'onInputChanged',
     'onItemAction',
   ])
 })


### PR DESCRIPTION
Fixes #823. Took the *drop it* half of the suggested direction; wiring it is not a drop-in and I explain why below.

## The hook is on the wrong object, not missing

`onInputChanged` is declared on **two** SDK interfaces in `packages/utils/plugin/index.ts`, with identical doc comments:

| interface | line | invoked? |
|---|---|---|
| `ITargetFeatureLifeCycle` | 471 | **yes** — `plugin.ts:1030` iterates `_featureEvent: Map<string, ITargetFeatureLifeCycle[]>` and calls it on every input change |
| `IFeatureLifeCycle` — what a Prelude exports | 399 | **no** |

`triggerInputChanged` calls `pluginLifecycle.onFeatureTriggered(...)` and then those per-feature listeners, and nothing else. So a Prelude implementing the hook gets a handler that never runs — which is how `touch-browser-open` ended up with it in good faith.

Verified with a positive control rather than a bare absence scan: the same query shape finds `this.pluginLifecycle?.onFeatureTriggered` at `plugin.ts:985` and `:1021`, and finds nothing for `onInputChanged`.

## Changes

- **Handler removed** from `plugins/touch-browser-open/index.js`, plus the `activeSearch` state that existed only to feed it — once the handler goes, every remaining reference is a write, which ESLint confirms.
- **Behaviour is unchanged.** Suggestions refreshed via the re-invoked `onFeatureTriggered`, which is where `handleSearchFeature` already runs.
- **SDK doc corrected.** `IFeatureLifeCycle.onInputChanged` is now `@deprecated` and names `ITargetFeatureLifeCycle` as the one that is called, so the next plugin author does not repeat this.
- **Guard** at `packages/utils/__tests__/prelude-oninputchanged-dead.test.ts` — no Prelude may export the hook. Two positive controls: one asserts more than 10 preludes were read (a wrong root makes the rule vacuous), one asserts the same query shape finds `onFeatureTriggered` in more than 5 of them, so the scan is known to work.

## One thing the deletion nearly hid

`activeSearch = null` sat between a braceless `if (browser)` and a `return`. Removing it left the `return` indented as though it were the `if` body — behaviour identical, since JS takes one statement, but misleading to read. The lint delta caught it and it is re-indented. The file is at 0 errors, same as HEAD.

## Why not wire it

The Prelude handler pushes items, and `onFeatureTriggered` already pushed them for the same event. Calling both would make every existing plugin double-publish on every keystroke. That is a design decision for whoever owns the lifecycle, and #817 has just moved in the opposite direction — treating the `onFeatureTriggered` re-invocation as *the* input-change path. I have said so on the issue.

Tests: `plugins/touch-browser-open/index.test.cjs` 7/7, `packages/test` browser-open 4/4, the new guard 3/3, and the guard fails when the handler is restored.
