### PR TITLE
fix(plugins): tell a missing permission host apart from a denial [#821]

### DIFF
--- a/packages/test/src/plugins/batch-rename.test.ts
+++ b/packages/test/src/plugins/batch-rename.test.ts
@@ -164,6 +164,49 @@ describe('batch rename rules', () => {
 
     expect(applyItem).toBeUndefined()
     expect(storageSetFile).not.toHaveBeenCalled()
+    // The SDK is absent, so there is nothing for the user to grant. Showing "请授予文件读取权限"
+    // here sent them after a permission they may already hold (#821); it is reserved for a
+    // real denial, which the test above covers.
+    expect(pushedItems).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        title: '权限系统不可用',
+        subtitle: '无法确认文件读取权限 · permission-sdk-unavailable',
+      }),
+    ]))
+  })
+
+  it('does tell the user to grant it when fs.read is genuinely denied', async () => {
+    // The other half of the branch above. Without this, moving the grant advice behind a
+    // condition could silently retire it for everyone.
+    const pushedItems: Array<Record<string, any>> = []
+    const pluginModule = loadPluginModule(batchRenameUrl, createPluginGlobals({
+      TuffItemBuilder: FakeBuilder,
+      permission: { check: vi.fn(async () => false) },
+      plugin: {
+        feature: {
+          clearItems() {
+            pushedItems.length = 0
+          },
+          pushItems(items: Array<Record<string, any>>) {
+            pushedItems.push(...items)
+          },
+        },
+        storage: {
+          async getFile() {
+            return null
+          },
+          async setFile() {},
+        },
+      },
+    }))
+
+    await pluginModule.onFeatureTriggered('batch-rename', {
+      text: 'prefix:NEW_',
+      inputs: [
+        { type: 'files', content: JSON.stringify(['/tmp/example.txt']) },
+      ],
+    })
+
     expect(pushedItems).toEqual(expect.arrayContaining([
       expect.objectContaining({
         title: '缺少读取权限',
@@ -172,13 +215,14 @@ describe('batch rename rules', () => {
     ]))
   })
 
-  // hasPermission (index.js:190-196) calls permission.check only. There is no
-  // permission.request path left, so the assertions that one was called with a reason
-  // string were describing a gate that e37c92c8c removed. It also collapses three
-  // distinct situations -- denied, SDK absent, check threw -- into a single false, so
-  // all three surface as 'permission-denied'. That conflation is pinned below rather
-  // than hidden, and reported on #330: a user whose permission host is missing or
-  // broken is currently told they lack a permission.
+  // ensurePermission (index.js) calls permission.check only. There is no permission.request
+  // path left, so the assertions that one was called with a reason string were describing a
+  // gate that e37c92c8c removed.
+  //
+  // It used to collapse three distinct situations -- denied, SDK absent, check threw -- into a
+  // single false, so all three surfaced as 'permission-denied' and a user whose permission host
+  // was missing was told to grant a permission they may already hold. Fixed in #821; the three
+  // tests below now hold the reasons apart, which is what makes the fix checkable.
   function undoModule(permissionOverride: unknown, storageGetFile = vi.fn()) {
     return {
       storageGetFile,
@@ -226,13 +270,14 @@ describe('batch rename rules', () => {
     const result = await harness.module.onItemAction(undoItem)
 
     expect(harness.storageGetFile).not.toHaveBeenCalled()
-    // Reported as a denial, not as a missing SDK: hasPermission returns false for both
-    // and the caller has nothing left to tell them apart with.
+    // Still fail-closed, but named as what it is. Telling this user to grant fs.write would
+    // send them after a permission they may already hold (#821).
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: 'permission-sdk-unavailable',
+      message: '权限系统不可用',
     })
   })
 
@@ -246,12 +291,14 @@ describe('batch rename rules', () => {
 
     expect(check).toHaveBeenCalledWith('fs.write')
     expect(harness.storageGetFile).not.toHaveBeenCalled()
-    // Same collapse: a transport fault is indistinguishable from a denial here.
+    // A transport fault is its own reason now, so it is diagnosable rather than looking like
+    // something the user did wrong.
     expect(result).toMatchObject({
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: 'permission-check-failed',
+      message: '权限检查失败',
     })
   })
 

--- a/plugins/touch-batch-rename/index.js
+++ b/plugins/touch-batch-rename/index.js
@@ -187,14 +187,23 @@ function buildRenamePlan(paths, rules, now = new Date()) {
   return { items }
 }
 
-async function hasPermission(permissionId) {
+/**
+ * Fail-closed either way, but say which way. A missing SDK and a thrown check used to collapse
+ * into the same `false` as a real denial, so a user whose permission host was absent was told to
+ * grant a permission they may already hold (#821). Shape matches touch-browser-data's
+ * ensurePermission.
+ */
+async function ensurePermission(permissionId) {
   if (!permission || typeof permission.check !== 'function')
-    return false
+    return { granted: false, reason: 'permission-sdk-unavailable', message: '权限系统不可用' }
   try {
-    return (await permission.check(permissionId)) === true
+    if ((await permission.check(permissionId)) === true)
+      return { granted: true, reason: '', message: '' }
+    return { granted: false, reason: 'permission-denied', message: `缺少 ${permissionId} 权限` }
   }
   catch {
-    return false
+    logger?.warn?.('[touch-batch-rename] Permission check failed')
+    return { granted: false, reason: 'permission-check-failed', message: '权限检查失败' }
   }
 }
 
@@ -285,13 +294,18 @@ const pluginLifecycle = {
         return true
       }
 
-      if (!(await hasPermission('fs.read'))) {
+      const readAccess = await ensurePermission('fs.read')
+      if (!readAccess.granted) {
+        // "请授予文件读取权限" is the wrong advice when the host is absent or the check threw --
+        // there is nothing for the user to grant. Only the denial says that (#821).
         await publishItems([
           buildItem({
             id: `${featureId}-no-permission`,
             featureId,
-            title: '缺少读取权限',
-            subtitle: '请授予文件读取权限',
+            title: readAccess.reason === 'permission-denied' ? '缺少读取权限' : readAccess.message,
+            subtitle: readAccess.reason === 'permission-denied'
+              ? '请授予文件读取权限'
+              : `无法确认文件读取权限 · ${readAccess.reason}`,
           }),
         ])
         return true
@@ -379,8 +393,9 @@ const pluginLifecycle = {
       const plan = previewCacheByFeature.get(featureId)
       if (!plan)
         return blocked('preview-missing', '请先生成重命名预览')
-      if (!(await hasPermission('fs.write')))
-        return blocked('permission-denied', '缺少 fs.write 权限')
+      const writeAccess = await ensurePermission('fs.write')
+      if (!writeAccess.granted)
+        return blocked(writeAccess.reason, writeAccess.message)
       try {
         const pending = plan.items.filter(entry => !entry.unchanged)
         if (pending.length > 0) {
@@ -403,8 +418,9 @@ const pluginLifecycle = {
     }
 
     if (actionId === 'undo') {
-      if (!(await hasPermission('fs.write')))
-        return blocked('permission-denied', '缺少 fs.write 权限')
+      const writeAccess = await ensurePermission('fs.write')
+      if (!writeAccess.granted)
+        return blocked(writeAccess.reason, writeAccess.message)
       try {
         const entries = normalizeUndoEntries(await plugin.storage.getFile(LAST_RENAME_FILE))
         if (entries.length === 0)


### PR DESCRIPTION
Fixes #821.

`hasPermission` returned a single `false` for three different situations — denied, SDK absent, check threw — and both write call sites mapped it to `permission-denied`. A user whose permission host was not injected was told to grant `fs.write`, a permission they may already hold, with nothing to diagnose the real fault from.

## Change

`ensurePermission(permissionId)` returns `{ granted, reason, message }`:

| situation | reason | message |
|---|---|---|
| host absent | `permission-sdk-unavailable` | 权限系统不可用 |
| check returned false | `permission-denied` | 缺少 `<id>` 权限 |
| check threw | `permission-check-failed` | 权限检查失败 |

Still fail-closed in every branch — `plugins/AGENTS.md` requires that, and also requires the specific reason to survive, which is the half that was missing.

The shape follows `touch-browser-data`'s existing `ensurePermission` rather than inventing one.

**Vocabulary note:** AGENTS.md lists `permission-request-failed`. This is a `check`, not a `request` — there is no `permission.request` path left in this plugin, `e37c92c8c` removed it — so it uses `permission-check-failed`, which is what `touch-browser-data` already ships. The list in AGENTS.md ends in 等, so it reads as open rather than exhaustive.

## The display path had the same bug

The read gate published 请授予文件读取权限 in all three cases. That advice is now reserved for the actual denial; the other two show the reason instead, since there is nothing for the user to grant.

## Tests

`packages/test/src/plugins/batch-rename.test.ts` already had three tests covering exactly these situations — and **pinned the conflation on purpose**, with a comment saying a user with a missing host is told they lack a permission. Those three now hold the reasons apart, which is what makes the fix checkable.

I added a fourth: the denial's display text. Moving 请授予文件读取权限 behind a condition would otherwise have retired it for everyone with no test noticing — the existing display test uses the SDK-absent path.

Verified by collapsing the reasons back to a single `permission-denied`: exactly the three conflation tests fail. 9/9 in the integration suite, 6/6 in `plugins/touch-batch-rename/index.test.cjs`, lint clean.
