### PR TITLE
fix(plugins): give touch-dictation failures a reason, and guard plugin.voice [#822]

### DIFF
--- a/plugins/touch-dictation/index.js
+++ b/plugins/touch-dictation/index.js
@@ -86,8 +86,48 @@ async function deliver(text) {
   return false
 }
 
+/**
+ * Map a host capability error to a reason the caller can act on (#821-style contract, #822).
+ *
+ * The catches here took no error binding, so a denied permission, an absent capability and a
+ * transport fault all came back as one message with no `reason` — and the message told the user to
+ * check microphone permissions even when the fault was neither. Shape follows touch-snipaste's
+ * stableFailure. The host's own text never reaches the result; only the code is read.
+ */
+function voiceFailure(error, fallbackReason, fallbackMessage) {
+  const code = error && typeof error === 'object' && typeof error.code === 'string' ? error.code : ''
+  if (code === 'PLUGIN_HOST_CAPABILITY_PERMISSION_DENIED')
+    return failed('permission-denied', '缺少语音权限：请在系统设置中允许麦克风访问')
+  if (code === 'PLUGIN_HOST_CAPABILITY_PERMISSION_UNAVAILABLE')
+    return failed('permission-unavailable', '权限系统不可用')
+  if (code === 'PLUGIN_HOST_CAPABILITY_CANCELLED')
+    return failed('cancelled', '语音操作已取消', 'cancelled')
+  if (code === 'PLUGIN_HOST_CAPABILITY_TIMEOUT')
+    return failed('timeout', '语音服务响应超时')
+  return failed(fallbackReason, fallbackMessage)
+}
+
+function failed(reason, message, status = 'failed') {
+  return {
+    externalAction: true,
+    success: false,
+    status,
+    reason,
+    message,
+  }
+}
+
 async function dictate() {
-  if (typeof plugin.voice?.asrStream !== 'function') {
+  // plugin.voice is undefined when the capability is not injected. The old guard read
+  // `plugin.voice?.asrStream`, which is satisfied by undefined, and the next line then
+  // dereferenced plugin.voice — a TypeError the bare catch reported as a microphone
+  // permission problem (#822).
+  if (!plugin.voice)
+    throw Object.assign(new Error('voice capability unavailable'), { code: 'TUFF_VOICE_UNAVAILABLE' })
+
+  if (typeof plugin.voice.asrStream !== 'function') {
+    if (typeof plugin.voice.dictate !== 'function')
+      throw Object.assign(new Error('voice capability unavailable'), { code: 'TUFF_VOICE_UNAVAILABLE' })
     const result = await plugin.voice.dictate({ cleanup: true })
     return String(result?.text ?? '').trim()
   }
@@ -126,13 +166,8 @@ async function onDictateAction() {
   await showRecording('🎙️ 录音中…', '请说话，停顿后自动结束')
   try {
     const text = truncate(await dictate(), 4000)
-    if (!text) {
-      return {
-        externalAction: true,
-        success: false,
-        message: '没有识别到语音，请靠近麦克风再试一次',
-      }
-    }
+    if (!text)
+      return failed('no-speech-detected', '没有识别到语音，请靠近麦克风再试一次')
     const delivered = await deliver(text)
     return {
       externalAction: true,
@@ -140,31 +175,34 @@ async function onDictateAction() {
       message: delivered ? `已听写并粘贴：${truncate(text)}` : truncate(text),
     }
   }
-  catch {
-    logger?.error?.('[touch-dictation] dictation failed')
-    return {
-      externalAction: true,
-      success: false,
-      message: '听写失败：请检查麦克风权限与语音服务配置后重试',
-    }
+  catch (error) {
+    const failure = error?.code === 'TUFF_VOICE_UNAVAILABLE'
+      ? failed('voice-capability-unavailable', '语音能力不可用：当前环境未提供语音服务')
+      : voiceFailure(error, 'dictation-failed', '听写失败：请检查麦克风权限与语音服务配置后重试')
+    logger?.error?.(`[touch-dictation] ${failure.reason}`)
+    return failure
   }
 }
 
 async function onSpeakAction(text) {
-  if (!text) {
-    return { externalAction: true, success: false, message: '没有可朗读的文字' }
+  if (!text)
+    return failed('no-text-to-speak', '没有可朗读的文字')
+
+  // Same unguarded dereference as dictate had: plugin.voice is undefined when the capability
+  // is not injected, and the bare catch below blamed the TTS configuration for it (#822).
+  if (typeof plugin.voice?.speak !== 'function') {
+    logger?.error?.('[touch-dictation] voice-capability-unavailable')
+    return failed('voice-capability-unavailable', '语音能力不可用：当前环境未提供语音服务')
   }
+
   try {
     await plugin.voice.speak({ text })
     return { externalAction: true, success: true, message: `正在朗读：${truncate(text)}` }
   }
-  catch {
-    logger?.error?.('[touch-dictation] speak failed')
-    return {
-      externalAction: true,
-      success: false,
-      message: '朗读失败：请检查语音合成(TTS)服务配置',
-    }
+  catch (error) {
+    const failure = voiceFailure(error, 'speak-failed', '朗读失败：请检查语音合成(TTS)服务配置')
+    logger?.error?.(`[touch-dictation] ${failure.reason}`)
+    return failure
   }
 }
 

--- a/plugins/touch-dictation/index.test.cjs
+++ b/plugins/touch-dictation/index.test.cjs
@@ -105,6 +105,10 @@ function createHarness(overrides = {}) {
     },
   }
   Object.assign(plugin.voice, overrides.voice)
+  // `voice: undefined` cannot express this — Object.assign ignores it and the default survives.
+  // The capability being absent entirely is its own case (#822), so it needs its own switch.
+  if (overrides.withoutVoice)
+    delete plugin.voice
   Object.assign(clipboard, overrides.clipboard)
 
   const context = {
@@ -172,10 +176,60 @@ test('contains voice failures without leaking host details', async () => {
   const result = await lifecycle.onItemAction(state.items[0])
 
   assert.equal(result.success, false)
-  assert.match(result.message, /听写失败/)
+  // A denied permission is now named as one rather than sharing the generic 听写失败 text with
+  // transport faults and an absent capability (#822).
+  assert.equal(result.reason, 'permission-denied')
+  assert.equal(result.status, 'failed')
+  assert.match(result.message, /缺少语音权限/)
+  // The part that matters most is unchanged: the host's own error text carries a device path,
+  // and none of it may reach the result.
   assert.doesNotMatch(JSON.stringify(result), /private|native|microphone device/)
   assert.deepEqual(state.pasted, [])
-  assert.deepEqual(state.logs, ['[touch-dictation] dictation failed'])
+  assert.deepEqual(state.logs, ['[touch-dictation] permission-denied'])
+})
+
+test('names an absent voice capability instead of blaming the microphone', async () => {
+  // The reported defect: the guard read plugin.voice?.asrStream, which undefined satisfies, and
+  // the next line dereferenced plugin.voice. The TypeError was reported as a microphone
+  // permission problem — advice with nothing behind it, since no capability was injected at all.
+  const { lifecycle, state } = createHarness({ withoutVoice: true })
+  await lifecycle.onFeatureTriggered('dictate', { text: '' })
+
+  const result = await lifecycle.onItemAction(state.items[0])
+
+  assert.equal(result.success, false)
+  assert.equal(result.reason, 'voice-capability-unavailable')
+  assert.doesNotMatch(result.message, /麦克风权限/)
+  assert.deepEqual(state.logs, ['[touch-dictation] voice-capability-unavailable'])
+})
+
+test('names an absent voice capability on speak, rather than the TTS configuration', async () => {
+  const { lifecycle, state } = createHarness({ withoutVoice: true })
+
+  await lifecycle.onFeatureTriggered('speak', { text: '' })
+  const result = await lifecycle.onItemAction(state.items[0])
+
+  assert.equal(result.success, false)
+  assert.equal(result.reason, 'voice-capability-unavailable')
+  assert.doesNotMatch(result.message, /TTS/)
+})
+
+test('maps a timeout to its own reason rather than the catch-all', async () => {
+  const { lifecycle, state } = createHarness({
+    voice: {
+      async asrStream() {
+        throw Object.assign(new Error('upstream stalled'), {
+          code: 'PLUGIN_HOST_CAPABILITY_TIMEOUT',
+        })
+      },
+    },
+  })
+  await lifecycle.onFeatureTriggered('dictate', { text: '' })
+
+  const result = await lifecycle.onItemAction(state.items[0])
+
+  assert.equal(result.reason, 'timeout')
+  assert.match(result.message, /超时/)
 })
 
 test('reads clipboard asynchronously and invokes only the typed speak facade', async () => {


### PR DESCRIPTION
Fixes #822.

## The dereference

```js
if (typeof plugin.voice?.asrStream !== 'function') {
  const result = await plugin.voice.dictate({ cleanup: true })
```

`undefined !== 'function'` is true, so with no voice capability injected the guard passes and the next line throws `TypeError: Cannot read properties of undefined`. The bare `catch` reported that as 听写失败：请检查麦克风权限与语音服务配置后重试 — advice with nothing behind it, since there was no capability to permit. `onSpeakAction` had the same shape and blamed the TTS configuration.

`plugin.voice` is now checked before use on both paths, and the one-shot `dictate` fallback is checked too — it was reachable whenever `asrStream` was missing but `voice` was present.

## The reasons

Both catches bind the error and map `PLUGIN_HOST_CAPABILITY_*` through `voiceFailure`, following `touch-snipaste`'s `stableFailure`:

| code | reason |
|---|---|
| `…PERMISSION_DENIED` | `permission-denied` |
| `…PERMISSION_UNAVAILABLE` | `permission-unavailable` |
| `…CANCELLED` | `cancelled` |
| `…TIMEOUT` | `timeout` |
| capability absent | `voice-capability-unavailable` |
| anything else | `dictation-failed` / `speak-failed` |

Results now carry `status` and `reason`, which `plugins/AGENTS.md` requires and this plugin alone among its siblings did not. The early returns got them too — "没有识别到语音" and "没有可朗读的文字" were equally reason-less.

The host's error text is still never copied into a result; only `error.code` is read.

## Tests

`plugins/touch-dictation/index.test.cjs` had a test asserting that a `PERMISSION_DENIED` error produces the generic 听写失败 message — the defect, written down as the expectation. It now asserts `reason: 'permission-denied'` and the specific text. **Its redaction assertion is untouched**: the fixture error carries `/private/native/microphone device` and none of it may reach the result.

Three added:
- absent capability on dictate — the reported TypeError path
- absent capability on speak
- a timeout, so the code table is not satisfied by a single branch

The harness needed a `withoutVoice` switch: it merges overrides with `Object.assign(plugin.voice, overrides.voice)`, so `voice: undefined` is a no-op and the default capability survived. Both new tests passed against the *unfixed* plugin until I noticed.

Verified by restoring the unguarded dereference: the absent-capability test fails. 7/7, lint clean.
