### PR TITLE
fix(plugins): degrade workspace-scripts instead of throwing at the host [#819]

### DIFF
--- a/packages/test/src/plugins/workspace-scripts.test.ts
+++ b/packages/test/src/plugins/workspace-scripts.test.ts
@@ -158,4 +158,67 @@ describe('workspace scripts isolated Prelude', () => {
     ).resolves.toMatchObject({ status: 'blocked', reason: 'invalid-action' })
     expect(harness.run).not.toHaveBeenCalled()
   })
+
+  it('degrades to an item when the capability is absent, instead of throwing at the host', async () => {
+    // onFeatureTriggered used to throw here, outside its own try, so the error escaped into the
+    // host. It fires on every input change, and the host marks a plugin CRASHED and disables it
+    // after ten errors in 60s — so typing the keyword with no capability was enough to take the
+    // plugin down until someone re-enabled it by hand (#819).
+    const items: Array<Record<string, any>> = []
+    const pluginModule = loadPluginModule(
+      scriptsUrl,
+      createPluginGlobals({
+        TuffItemBuilder: FakeTuffItemBuilder,
+        plugin: {
+          getLocale: () => 'en-US',
+          feature: {
+            async clearItems() {
+              items.length = 0
+            },
+            async pushItems(next: Array<Record<string, any>>) {
+              items.push(...next)
+            },
+          },
+        },
+      }),
+    )
+
+    // Ten in a row, which is what the host's sliding window counts.
+    for (let attempt = 0; attempt < 10; attempt += 1)
+      await expect(pluginModule.onFeatureTriggered('workspace-scripts', { text: 'lint' })).resolves.toBe(true)
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        title: 'Workspace Scripts Unavailable',
+        subtitle: 'capability-unavailable',
+      }),
+    ])
+  })
+
+  it('still blocks the action itself when the capability is absent', async () => {
+    // The other half: degrading the display must not make the action look runnable.
+    const pluginModule = loadPluginModule(
+      scriptsUrl,
+      createPluginGlobals({
+        TuffItemBuilder: FakeTuffItemBuilder,
+        plugin: {
+          getLocale: () => 'en-US',
+          feature: {
+            async clearItems() {},
+            async pushItems() {},
+          },
+        },
+      }),
+    )
+
+    await expect(
+      pluginModule.onItemAction(
+        {
+          meta: { defaultAction: 'run-script' },
+          actions: [{ id: 'run-script', payload: { scriptToken: SCRIPT_TOKEN } }],
+        },
+        { actionId: 'run-script' },
+      ),
+    ).resolves.toMatchObject({ status: 'blocked', reason: 'capability-unavailable' })
+  })
 })

--- a/plugins/touch-workspace-scripts/index.js
+++ b/plugins/touch-workspace-scripts/index.js
@@ -188,10 +188,23 @@ const pluginLifecycle = {
   async onFeatureTriggered(featureId, query) {
     if (featureId !== FEATURE_ID)
       return false
+    // Publish a degraded item rather than throwing (#819). The throw sat outside the try below,
+    // so it escaped into the host, and onFeatureTriggered fires on every input change: typing
+    // the keyword with the capability absent produced more than ten errors inside the host's 60s
+    // window, which marks the plugin CRASHED and disables it until someone re-enables it by hand.
+    // onItemAction already answered the same condition with a blocked result.
     if (!plugin.workspaceScripts) {
-      throw Object.assign(new Error('workspace scripts capability unavailable'), {
-        code: 'PLUGIN_WORKSPACE_SCRIPT_CAPABILITY_UNAVAILABLE',
-      })
+      logger?.error?.('[touch-workspace-scripts] capability-unavailable')
+      await plugin.feature.clearItems()
+      await plugin.feature.pushItems([
+        buildInfoItem({
+          id: `${featureId}-unavailable`,
+          featureId,
+          title: t('工作区脚本不可用', 'Workspace Scripts Unavailable'),
+          subtitle: 'capability-unavailable',
+        }),
+      ])
+      return true
     }
 
     try {


### PR DESCRIPTION
Fixes #819.

The capability guard threw, and the throw sat **outside** the `try` on the next line, so it escaped into the plugin host. `onFeatureTriggered` fires on every input change, and the host marks a plugin `CRASHED` and disables it after ten errors inside a 60-second window — so typing the keyword with the capability absent was enough to take the plugin down until someone re-enabled it by hand.

It now publishes the same degraded item the `catch` below already builds, and returns `true`. `onItemAction` answered this exact condition with `{ status: 'blocked', reason: 'capability-unavailable' }` all along; the two paths now agree on the vocabulary too.

## Neither suite covered it

`plugins/touch-workspace-scripts/index.test.cjs` (5 tests) and `packages/test/src/plugins/workspace-scripts.test.ts` (3 tests) both passed **before and after** the change — nothing exercised the capability-absent path, which is how a throw on the hottest lifecycle hook survived.

Added two:
- **the degradation**, called ten times in a row — the number the host's sliding window counts — asserting each resolves `true` and exactly one item is published
- **the action stays blocked**, so degrading the display cannot make the action look runnable

Verified by restoring the throw: `promise rejected "Error: workspace scripts capability unavailable" instead of resolving`.

5/5 integration, 5/5 in-plugin, lint clean.

Note `PLUGIN_WORKSPACE_SCRIPT_CAPABILITY_UNAVAILABLE` still exists in `apps/core-app/src/main/modules/plugin/plugin.ts:2169` — that is the host's own throw on the capability call, which is correct and unaffected. Only the Prelude's copy is gone.
