### PR TITLE
build(plugins): pin the manifest feature.platform shape [#820]

### DIFF
--- a/scripts/validate-plugins.feature-platform.test.mjs
+++ b/scripts/validate-plugins.feature-platform.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it } from 'vitest'
+
+/**
+ * `plugins:validate` must pin a manifest feature's `platform` shape (#820).
+ *
+ * Two shapes exist and they are easy to confuse:
+ *
+ * - **manifest** — `{ win32, darwin, linux }` booleans. All 20 manifests use it.
+ * - **runtime registration** — `{ win|darwin|linux: { enable, arch, os } }`, the `IPlatform` type,
+ *   which the host validates with `exactRecord` when a Prelude calls `features.addFeature`.
+ *
+ * `touch-browser-open` writes both, one per file, so holding them side by side is not enough to
+ * keep them apart. Nothing validated the manifest one, and nothing in the main process reads it —
+ * so a plugin author who wrote the runtime shape into a manifest got silence either way.
+ *
+ * This pins the shape only. Whether a manifest `platform` should *gate* feature registration is a
+ * behaviour change affecting five shipped features, and is still open on #820.
+ */
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const VALIDATOR = path.join(REPO_ROOT, 'scripts/validate-plugins.mjs')
+
+function runValidator(pluginsDir) {
+  try {
+    const stdout = execFileSync('node', [VALIDATOR], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: { ...process.env, TUFF_PLUGINS_DIR: pluginsDir },
+    })
+    return { ok: true, stdout }
+  }
+  catch (error) {
+    return { ok: false, stdout: `${error.stdout ?? ''}${error.stderr ?? ''}` }
+  }
+}
+
+function makePlugin(root, platform) {
+  const dir = path.join(root, 'fixture')
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: '@talex-touch/fixture-plugin', version: '1.0.0' }),
+  )
+  fs.writeFileSync(path.join(dir, 'manifest.json'), JSON.stringify({
+    id: 'com.tuff.fixture',
+    name: 'fixture',
+    version: '1.0.0',
+    features: [{
+      id: 'fixture-feature',
+      name: 'Fixture',
+      commands: [{ type: 'over', value: ['fixture'] }],
+      ...(platform === undefined ? {} : { platform }),
+    }],
+  }))
+  return root
+}
+
+function withFixture(platform) {
+  return runValidator(makePlugin(fs.mkdtempSync(path.join(os.tmpdir(), 'tuff-platform-')), platform))
+}
+
+describe('plugins:validate feature platform shape', () => {
+  it('accepts the manifest shape', () => {
+    // Positive control. Every failure assertion below is satisfied by a validator that rejects
+    // everything, which would be a worse gate than none.
+    assert.equal(withFixture({ win32: true, darwin: true, linux: false }).ok, true)
+  })
+
+  it('accepts a feature with no platform at all', () => {
+    // 25 of the 30 shipped features declare nothing. Requiring it would fail the whole tree.
+    assert.equal(withFixture(undefined).ok, true)
+  })
+
+  it('rejects the runtime addFeature shape, which a manifest is not read as', () => {
+    const result = withFixture({
+      win: { enable: true, arch: [], os: [] },
+      darwin: { enable: true, arch: [], os: [] },
+      linux: { enable: false, arch: [], os: [] },
+    })
+
+    assert.equal(result.ok, false)
+    assert.match(result.stdout, /runtime addFeature shape/)
+  })
+
+  it('rejects a missing platform key', () => {
+    const result = withFixture({ win32: true, darwin: true })
+
+    assert.equal(result.ok, false)
+    assert.match(result.stdout, /needs exactly/)
+  })
+
+  it('rejects a non-boolean value', () => {
+    // The shape that reads as correct at a glance and is not.
+    const result = withFixture({ win32: 'yes', darwin: true, linux: false })
+
+    assert.equal(result.ok, false)
+    assert.match(result.stdout, /platform\.win32 must be a boolean/)
+  })
+
+  it('rejects a platform that is not an object', () => {
+    const result = withFixture('win32')
+
+    assert.equal(result.ok, false)
+    assert.match(result.stdout, /non-object "platform"/)
+  })
+})

--- a/scripts/validate-plugins.mjs
+++ b/scripts/validate-plugins.mjs
@@ -130,6 +130,63 @@ function checkDevLeakage(pluginName, dev, source) {
   return true
 }
 
+/**
+ * A manifest feature's `platform` must be `{ win32, darwin, linux }` booleans (#820).
+ *
+ * There are two platform shapes in this codebase and they are easy to confuse:
+ *
+ * - **manifest** — `{ win32: boolean, darwin: boolean, linux: boolean }`. All 20 manifests use
+ *   it, so it is the de-facto convention, and this is the one enforced here.
+ * - **runtime registration** — `{ win|darwin|linux: { enable, arch, os } }`, the `IPlatform` type,
+ *   which the host validates with `exactRecord` when a Prelude calls `features.addFeature`.
+ *
+ * `touch-browser-open` uses both — the manifest shape in `manifest.json` and the runtime shape in
+ * `index.js` — which is how you can hold them side by side and still write the wrong one.
+ *
+ * This pins the shape only. Nothing in the main process reads a manifest feature's `platform`, so
+ * the declarations are inert; whether they should gate registration is on #820.
+ *
+ * @returns true when the plugin should fail.
+ */
+function checkFeaturePlatformShape(pluginName, features) {
+  const MANIFEST_KEYS = ['win32', 'darwin', 'linux']
+  let failed = false
+
+  for (const feature of Array.isArray(features) ? features : []) {
+    const platform = feature?.platform
+    if (platform === undefined)
+      continue
+
+    const id = feature.id || feature.name || '<unnamed>'
+    if (platform === null || typeof platform !== 'object' || Array.isArray(platform)) {
+      logError(pluginName, `feature "${id}" has a non-object "platform"`)
+      failed = true
+      continue
+    }
+
+    const keys = Object.keys(platform).sort()
+    if (keys.join(',') !== [...MANIFEST_KEYS].sort().join(',')) {
+      const runtimeShaped = keys.includes('win') || keys.some(key => typeof platform[key] === 'object')
+      const hint = runtimeShaped ? ' — that is the runtime addFeature shape, which a manifest is not read as' : ''
+      logError(
+        pluginName,
+        `feature "${id}" declares platform keys [${keys.join(', ')}]; a manifest needs exactly [${MANIFEST_KEYS.join(', ')}]${hint}`,
+      )
+      failed = true
+      continue
+    }
+
+    for (const key of MANIFEST_KEYS) {
+      if (typeof platform[key] !== 'boolean') {
+        logError(pluginName, `feature "${id}" platform.${key} must be a boolean (received ${JSON.stringify(platform[key])})`)
+        failed = true
+      }
+    }
+  }
+
+  return failed
+}
+
 for (const pluginName of pluginDirs) {
   totalPlugins++
   const pluginPath = path.join(pluginsDir, pluginName)
@@ -177,6 +234,9 @@ for (const pluginName of pluginDirs) {
   }
 
   if (checkDevLeakage(pluginName, manifest?.dev, 'manifest.json'))
+    pluginHasError = true
+
+  if (checkFeaturePlatformShape(pluginName, manifest?.features))
     pluginHasError = true
 
   // 2. Required fields: id (or name), name, version


### PR DESCRIPTION
Refs #820 — does steps 1 and 2 of the suggested direction. Step 3, gating registration, is a behaviour change I have measured but not made; details below.

## Confirmed

**All 20 manifests** use `{ win32, darwin, linux }` booleans. This is not drift between plugins — it is a single de-facto convention that disagrees with the `IPlatform` type and with the host's own `addFeature` validator, which wants `{ win|darwin|linux: { enable, arch, os } }`.

`touch-browser-open` writes **both**: the manifest shape in `manifest.json`, the runtime shape in `index.js:125-133`. Having them side by side in one plugin is not enough to keep them apart.

The runtime never reads a manifest feature's `platform` — `plugin.ts:780` and `:1447` are pass-through assignments and nothing else. Verified with a positive control: `feature.commands` *is* validated, at `plugin-loaders.ts:459`, and the same query shape finds it.

## What this ships

`plugins:validate` now rejects a manifest feature `platform` that is not exactly three booleans, and names the runtime shape when it sees one — that is the mistake worth catching, since a plugin author who writes `{ win: { enable: true, … } }` into a manifest currently gets silence from the validator, the type checker and the runtime alike.

`scripts/validate-plugins.feature-platform.test.mjs` covers the runtime shape, a missing key, a non-boolean value, a non-object, plus two positive controls: the manifest shape passes, and a feature with **no** `platform` passes — 25 of the 30 shipped features declare nothing, so requiring it would fail the whole tree.

It runs under `pnpm test:scripts` in `PR Quality`, which blocks.

## What gating would cost, so you can decide

**Five features** across five plugins declare a restriction:

| plugin / feature | unavailable on |
|---|---|
| `touch-browser-open` / `browser-open` | linux |
| `touch-quick-actions` / `quick-actions` | linux |
| `touch-system-actions` / `system-actions` | linux |
| `touch-window-manager` / `window-app` | linux |
| `touch-window-presets` / `window-presets` | darwin, linux |

All five are genuinely OS-specific, and **all five preludes already self-check** — `currentPlatform()` appears 2–7 times in each. So gating would change the experience from *feature appears and reports it is unsupported* to *feature does not appear*.

That is probably what the declarations mean, and the gate would go next to the `commands` validation in `plugin-loaders.ts:459`. But it removes five features from the launcher on Linux for real users, which is a product call rather than a defect fix — so I have left it, and #820 stays open for it. Say the word and I will do it as its own change.
