### PR TITLE
fix(permission): make the mapping gate see the wrappers most call sites use [#915]

### DIFF
--- a/apps/core-app/scripts/check-permission-api-mappings.mjs
+++ b/apps/core-app/scripts/check-permission-api-mappings.mjs
@@ -9,10 +9,15 @@
  * log for exactly that.
  *
  * This guards the other half, which needs no inventory: **every API name written at a call site
- * today must already be in the table.** It is currently true — all 19 literals reaching
- * `enforcePermission` match one of the 50 patterns — so the value is prospective: adding a call
- * site with an unmapped name stops being a silent allow discovered in production logs, and becomes
- * a red PR.
+ * today must already be in the table.** It is currently true — all 70 guarded call sites match one
+ * of the 50 patterns — so the value is prospective: adding a call site with an unmapped name stops
+ * being a silent allow discovered in production logs, and becomes a red PR.
+ *
+ * The first version of this scan read only literals written directly at `enforcePermission`, and
+ * found 19. Most guarded names are not written there: a module declares a local wrapper and passes
+ * the literal to *that*, which accounted for the other 51 call sites — so roughly two thirds of
+ * the guarded surface sat outside the gate, and an unmapped `enforce(context, 'flow:bus:new')`
+ * left it reporting a cheerful all-clear. The wrapper rule below closes that.
  *
  * Deliberately not a vitest file. The `App suites (core-app)` job is `continue-on-error`, so a
  * test there cannot fail a PR; `PR Quality` runs these scripts as gates.
@@ -37,6 +42,109 @@ const GUARD = path.join('modules', 'permission', 'permission-guard.ts')
  * directly and never consults the table, so it cannot have a mapping gap.
  */
 const ENFORCE_CALL = /enforcePermission\s*\(\s*[^,()]+,\s*'([^']+)'/g
+
+/**
+ * Most guarded names never appear at `enforcePermission` at all.
+ *
+ * A module declares a local wrapper that forwards one of its parameters:
+ *
+ *     const enforce = (context, eventName, sdkapi) => { ... perm.enforcePermission(pluginId, eventName, sdkapi) }
+ *     enforce(context, 'flow:bus:dispatch', payload)
+ *
+ * The literal is at the wrapper's call site, so the rule above cannot see it. That is not a corner
+ * case: 51 of the 70 guarded call sites reach the guard this way against 19 written directly, so
+ * most of the guarded surface sat outside a gate whose whole point is that nothing sits outside
+ * it. Adding `enforce(context, 'flow:bus:new-thing', payload)` with no mapping stayed green and
+ * silently allowed.
+ *
+ * One level of forwarding, within one file, is deliberate. It covers every wrapper in the tree and
+ * needs no type information; a general dataflow analysis would be a different tool, and a gate
+ * nobody can read is one nobody maintains.
+ */
+const WRAPPER_DECL = new RegExp(
+  [
+    // const enforce = (context, eventName, sdkapi) => …
+    /(?:const|let)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(([^)]*)\)\s*(?::[^=]+)?=>/.source,
+    // function enforceNativePermission(context, apiName): void { … }
+    /(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(([^)]*)\)/.source
+  ].join('|'),
+  'g'
+)
+
+/**
+ * Both entry points consult the table, so both can have a gap.
+ *
+ * `checkPermission` is not a softer case: `toPermissionState` reports `granted`/`denied` to the
+ * renderer from it, so an unmapped name there tells the UI a capability is granted that was never
+ * declared — the same silent allow, one layer further out.
+ */
+const FORWARDS_TO_GUARD =
+  /(?:enforcePermission|checkPermission)\s*\(\s*[^,()]+,\s*([A-Za-z_$][\w$]*)\s*[,)]/
+
+/**
+ * Split on commas that are not inside a generic, call, index or object.
+ *
+ * `function toPermissionState(context: Pick<HandlerContext, 'plugin'>, apiName: string)` has a
+ * comma inside the type argument. A naive split makes `apiName` parameter 2 instead of 1, the
+ * call-site argument at that index does not exist, and the whole `native:*` family — 18 names —
+ * drops out of the scan reporting a smaller number rather than an error.
+ */
+function splitTopLevel(text) {
+  const parts = []
+  let depth = 0
+  let current = ''
+  for (const character of text) {
+    if ('<([{'.includes(character)) depth += 1
+    else if ('>)]}'.includes(character)) depth -= 1
+
+    if (character === ',' && depth === 0) {
+      parts.push(current)
+      current = ''
+      continue
+    }
+    current += character
+  }
+  parts.push(current)
+  return parts
+}
+
+/** Which parameter of a wrapper is forwarded as the API name, or -1. */
+function forwardedParameterIndex(source, declIndex, parameters) {
+  const forwarded = FORWARDS_TO_GUARD.exec(source.slice(declIndex, declIndex + 1200))
+  if (!forwarded) return -1
+  return parameters.findIndex((parameter) => parameter === forwarded[1])
+}
+
+/** Literal API names passed to a local wrapper that forwards them to enforcePermission. */
+function collectWrappedNames(source, file) {
+  const found = []
+  for (const declaration of source.matchAll(WRAPPER_DECL)) {
+    // The alternation puts the arrow form in groups 1-2 and the function form in 3-4.
+    const name = declaration[1] ?? declaration[3]
+    const rawParameters = declaration[2] ?? declaration[4]
+    if (!name || rawParameters === undefined) continue
+    const parameters = splitTopLevel(rawParameters)
+      .map((parameter) => parameter.trim().split(/[:=]/)[0].trim())
+      .filter((parameter) => parameter.length > 0)
+
+    const index = forwardedParameterIndex(source, declaration.index, parameters)
+    if (index < 0) continue
+
+    // `name(a, b, c)` — take the argument in the forwarded position, literal only.
+    const callSite = new RegExp(`(?<![\\w$.])${name}\\s*\\(([^)]*)\\)`, 'g')
+    for (const call of source.matchAll(callSite)) {
+      const argument = splitTopLevel(call[1])[index]?.trim()
+      const literal = argument && /^'([^']+)'$/.exec(argument)
+      if (!literal) continue
+      found.push({
+        file,
+        line: source.slice(0, call.index).split('\n').length,
+        apiName: literal[1]
+      })
+    }
+  }
+  return found
+}
 
 /** Patterns as written in API_PERMISSION_MAPPINGS. `*` matches any remaining characters. */
 function readPatterns(source) {
@@ -68,7 +176,10 @@ function readFromDisk(file) {
   }
 }
 
-/** Every literal API name passed to enforcePermission, with where it was written. */
+/**
+ * Every literal API name that reaches enforcePermission, with where it was written — both the
+ * ones passed to it directly and the ones passed to a local wrapper that forwards them.
+ */
 function collectGuardedNames(read, files) {
   const found = []
   for (const file of files) {
@@ -78,6 +189,7 @@ function collectGuardedNames(read, files) {
       const line = source.slice(0, match.index).split('\n').length
       found.push({ file, line, apiName: match[1] })
     }
+    found.push(...collectWrappedNames(source, file))
   }
   return found
 }
@@ -120,6 +232,70 @@ function selfTest() {
       files: ['modules/some/new-handler.ts'],
       read: () => "withPermission({ permissionId: 'system.shell' }, handler)\n",
       expectUnmapped: 0
+    },
+    {
+      name: 'an arrow wrapper forwarding its parameter is followed',
+      files: ['modules/some/new-handler.ts'],
+      read: () =>
+        [
+          'const enforce = (context, apiName, sdkapi) => {',
+          '  perm.enforcePermission(pluginId, apiName, sdkapi)',
+          '}',
+          "enforce(context, 'brand:new:capability', payload)"
+        ].join('\n'),
+      expectUnmapped: 1
+    },
+    {
+      name: 'a function-declaration wrapper is followed too',
+      files: ['modules/some/new-handler.ts'],
+      read: () =>
+        [
+          'function enforceNativePermission(context, apiName) {',
+          '  permissionModule.enforcePermission(plugin.name, apiName, plugin.sdkapi)',
+          '}',
+          "enforceNativePermission(context, 'brand:new:capability')"
+        ].join('\n'),
+      expectUnmapped: 1
+    },
+    {
+      name: 'a comma inside a generic does not shift the forwarded position',
+      // The failure this pins is silent: a shifted index finds no argument, so the whole family
+      // drops out of the scan and the gate reports a smaller number instead of an error.
+      files: ['modules/some/new-handler.ts'],
+      read: () =>
+        [
+          "function toPermissionState(context: Pick<HandlerContext, 'plugin'>, apiName: string) {",
+          '  return permissionModule.checkPermission(plugin.name, apiName, plugin.sdkapi).allowed',
+          '}',
+          "toPermissionState(context, 'brand:new:capability')"
+        ].join('\n'),
+      expectUnmapped: 1
+    },
+    {
+      name: 'a wrapper forwarding a mapped name is allowed',
+      // Positive control for the two above: they are also satisfied by a wrapper rule that flags
+      // everything it sees.
+      files: ['modules/some/new-handler.ts'],
+      read: () =>
+        [
+          'const enforce = (context, apiName, sdkapi) => {',
+          '  perm.enforcePermission(pluginId, apiName, sdkapi)',
+          '}',
+          "enforce(context, 'clipboard:read', payload)"
+        ].join('\n'),
+      expectUnmapped: 0
+    },
+    {
+      name: 'a wrapper that does not reach the guard is left alone',
+      files: ['modules/some/new-handler.ts'],
+      read: () =>
+        [
+          'const label = (context, apiName) => {',
+          '  return `${context.id}:${apiName}`',
+          '}',
+          "label(context, 'brand:new:capability')"
+        ].join('\n'),
+      expectUnmapped: 0
     }
   ]
 
@@ -142,6 +318,22 @@ function selfTest() {
   if (!reaches) {
     failures += 1
     console.log(`     ${realPatterns.length} pattern(s), ${realNames.length} guarded name(s)`)
+  }
+
+  // A floor, not an equality: new guarded call sites are expected, silent shrinkage is not.
+  // The wrapper rule is the fragile part — a parameter-position mistake makes a whole family
+  // vanish from the scan and the gate still prints a cheerful all-clear, which is how the
+  // direct-literals-only version passed for months while missing two thirds of the surface.
+  const FLOOR = 60
+  const covers = realNames.length >= FLOOR
+  console.log(
+    `${covers ? 'ok  ' : 'FAIL'} the scan still covers at least ${FLOOR} guarded call sites`
+  )
+  if (!covers) {
+    failures += 1
+    console.log(
+      `     found ${realNames.length}; a drop means the detector stopped seeing a family, not that the code shrank`
+    )
   }
   return failures
 }


### PR DESCRIPTION
Refs #915. The gate that #1484 built was covering **19 of 70** guarded call sites. This widens it to all 70.

## What was wrong with the gate

It read only literals written directly at `enforcePermission`:

```js
const ENFORCE_CALL = /enforcePermission\s*\(\s*[^,()]+,\s*'([^']+)'/g
```

Most guarded names are not written there. A module declares a local wrapper and passes the literal to *that*:

```js
const enforce = (context, eventName, sdkapi) => { … perm.enforcePermission(pluginId, eventName, sdkapi) }
enforce(context, 'flow:bus:dispatch', payload)
```

**51 of the 70** guarded call sites are that shape — `flow-bus/ipc.ts` (6), `flow-bus/module.ts` (5), `division-box/ipc.ts` (10), `native-capabilities/index.ts` (18), and others. So most of the guarded surface sat outside a gate whose whole point is that nothing sits outside it, and `enforce(context, 'flow:bus:new-thing', payload)` with no mapping left it green.

## Negative control on the real tree

Renaming one wrapper call to an unmapped name:

| | result |
|---|---|
| old gate | `19 guarded API name(s) all match one of 50 mapping pattern(s)`, **exit 0** |
| this gate | `modules/flow-bus/ipc.ts:196 enforces "zzz:brand:new"`, **exit 1** |

My first attempt at this control used `flow:bus:brand-new`, which the gate correctly *passed* — `flow:*` is a wildcard in the table. Worth stating, because a control that cannot fail proves nothing.

## Also covered

- **Function declarations**, not just arrow consts — `native-capabilities` uses `function enforceNativePermission(context, apiName)`.
- **`checkPermission`**, not just `enforcePermission`. `toPermissionState` reports `granted`/`denied` to the renderer from it, so an unmapped name there tells the UI a capability is granted that was never declared — the same silent allow, one layer out.
- **Top-level comma splitting.** `function toPermissionState(context: Pick<HandlerContext, 'plugin'>, apiName: string)` has a comma inside a type argument; a naive split makes `apiName` parameter 2, the call-site argument at that index does not exist, and the whole `native:*` family — 18 names — drops out **reporting a smaller number rather than an error**. I hit exactly this while building it: the count went 19 → 40 and looked like success until I diffed it against a manual scan.

## Nothing is ungated today

All 70 match one of the 50 patterns, so this is prospective hardening, same as the original. No live silent-allow was found.

## Self-test

Five new cases — arrow wrapper, function wrapper, the generic-comma position, a wrapper forwarding a *mapped* name (positive control, since the first two are also satisfied by a rule that flags everything), and a wrapper that never reaches the guard — plus a **coverage floor of 60**. The floor matters because the failure mode here is under-reporting: a parameter-position mistake makes a family vanish and the gate still prints a cheerful all-clear.

`--self-test` 12/12, gate exit 0, eslint clean.

## Still open on #915

The default-deny flip. #1484 said it needs an inventory only production traffic can build, and that is still true for names arriving from plugins at runtime — but the repo-side inventory is now enumerable and complete, which is a precondition it did not have before.
