### PR TITLE
docs(channel): stop calling the plugin channel key encryption [#804]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,7 @@ send(type: ChannelType, eventName: string, arg: unknown): Promise<unknown>
 sendTo(win: Electron.BrowserWindow, type: ChannelType, eventName: string, arg: unknown): Promise<unknown>
 sendPlugin(pluginName: string, eventName: string, arg?: unknown): Promise<unknown>
 
-// Key management (encryption for plugin isolation)
+// Key management (per-activation capability tokens for plugin isolation)
 requestKey(name: string, activation?: Pick<PluginActivationIdentity, 'pluginInstanceId' | 'activationGeneration'>): string
 revokeKey(key: string): boolean
 ```
@@ -300,7 +300,7 @@ The two `regChannel` signatures are the trap: passing a `ChannelType` to the ren
 **Implementation Notes:**
 - Uses IPC listeners on `@main-process-message` and `@plugin-process-message`
 - Supports both sync and async request-response patterns
-- Plugin channels use encrypted keys for additional security
+- Plugin channels are addressed by a per-activation random capability token, not by plugin name
 
 ### Window Management
 - **Main Window**: Primary application interface with Vibrancy (macOS) or Mica (Windows) effects
@@ -428,7 +428,7 @@ await accountSDK.hasPrioritySupport()     // Priority support
 
 1. **Module Directory Pattern**: Each module requests an isolated directory for persistent storage without knowing the root path
 
-2. **Encryption for Plugin Isolation**: Plugin channels use encrypted keys instead of direct names for additional security
+2. **Capability Tokens for Plugin Isolation**: Plugin channels are addressed by a 16-byte random token minted per activation, not by plugin name. Nothing is encrypted — the token is a bearer capability, and its security comes from being unguessable, from rotating when a plugin re-activates, and from being revoked on disable, crash and failed activation.
 
 3. **Broadcast Storage Updates**: Storage module broadcasts updates to all windows to keep UI in sync across multiple renderer instances
 

--- a/apps/core-app/src/main/core/plugin-channel-key-registry.ts
+++ b/apps/core-app/src/main/core/plugin-channel-key-registry.ts
@@ -4,11 +4,19 @@ import { randomBytes } from 'node:crypto'
 /**
  * Per-plugin channel keys and the activation they belong to.
  *
- * This is the isolation CLAUDE.md describes as "plugin channels use encrypted keys instead of
- * direct names". It lived inside TouchChannel, where it could not be tested: constructing that
- * class pulls in Electron, Sentry, the perf monitor and most of the main process, so every
- * test that touched these methods replaced them with vi.fn() and the rotation logic itself had
- * never run (#929).
+ * The key is a **bearer capability token**, not encryption of anything: 16 random bytes minted per
+ * activation. CLAUDE.md described it as encryption until #804, which is worth stating plainly —
+ * a reviewer who reads that word assumes confidentiality and replay resistance and stops looking
+ * for the things that actually matter here, namely where the token travels and when it dies.
+ *
+ * What it does provide: it is unguessable, it rotates whenever the activation changes, and it is
+ * revoked on disable, on runtime crash and on failed activation. There is no TTL, because the
+ * token's lifetime is the activation's — a timer would expire a key out from under a live plugin
+ * without making a leaked one meaningfully less useful in the window before it fired.
+ *
+ * It lived inside TouchChannel, where it could not be tested: constructing that class pulls in
+ * Electron, Sentry, the perf monitor and most of the main process, so every test that touched
+ * these methods replaced them with vi.fn() and the rotation logic itself had never run (#929).
  *
  * It is pure state with no Electron dependency, so it belongs in its own unit — which is also
  * the shape a security boundary should have.

--- a/packages/utils/__tests__/plugin-channel-key-claims.test.ts
+++ b/packages/utils/__tests__/plugin-channel-key-claims.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The plugin channel key must not be described as encryption (#804).
+ *
+ * It is 16 random bytes minted per activation — a bearer capability token. CLAUDE.md called it
+ * "encrypted keys ... for additional security" in three places, and the registry's own doc comment
+ * quoted that phrasing back.
+ *
+ * The cost of the wrong word is specific: a reviewer who reads "encrypted" assumes confidentiality
+ * and replay resistance, and stops looking for where the token travels and when it dies — which is
+ * exactly where the real issues are (#697 has it passed through renderer command-line arguments,
+ * #698 had a self-declared identity accepted alongside it).
+ *
+ * The second half pins what the token *does* rely on, so the claim and the code cannot drift
+ * apart again: rotation on re-activation, and revocation on all three teardown paths.
+ *
+ * Lives in packages/utils because `ci / CI - utils` is a blocking check, whereas
+ * `App suites (core-app)` is continue-on-error and reports success whatever the suite does.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+
+const CLAUDE_MD = readFileSync(path.join(REPO_ROOT, 'CLAUDE.md'), 'utf8')
+const REGISTRY = readFileSync(
+  path.join(REPO_ROOT, 'apps/core-app/src/main/core/plugin-channel-key-registry.ts'),
+  'utf8',
+)
+const PLUGIN = readFileSync(
+  path.join(REPO_ROOT, 'apps/core-app/src/main/modules/plugin/plugin.ts'),
+  'utf8',
+)
+
+describe('plugin channel key documentation', () => {
+  it('reads the files it means to check', () => {
+    // Positive control: "no mention of encryption" is also what an unreadable file reports.
+    expect(CLAUDE_MD).toContain('Channel Communication')
+    expect(REGISTRY).toContain('PluginChannelKeyRegistry')
+    expect(PLUGIN).toContain('revokeActivationAuthority')
+  })
+
+  it('does not call the channel key encrypted', () => {
+    const offenders = [
+      ['CLAUDE.md', CLAUDE_MD],
+      ['plugin-channel-key-registry.ts', REGISTRY],
+    ].filter(([, source]) => /encrypt(?:ed|ion)\s+(?:key|for plugin)/i.test(source as string))
+
+    expect(offenders.map(([name]) => name)).toEqual([])
+  })
+
+  it('says what the token actually is', () => {
+    // Guards the rule above against being satisfied by deleting the description entirely.
+    expect(CLAUDE_MD).toMatch(/capability token/i)
+    expect(REGISTRY).toMatch(/bearer capability token/i)
+  })
+})
+
+describe('plugin channel key lifetime', () => {
+  it('mints 16 random bytes per activation', () => {
+    expect(REGISTRY).toContain('randomBytes(16).toString(\'hex\')')
+  })
+
+  it('rotates when the activation changes', () => {
+    // The three maps must move together; a key dropped from one and left in another is a live
+    // token with no owner.
+    expect(REGISTRY).toMatch(/keyToName\.delete\(existingKey\)/)
+    expect(REGISTRY).toMatch(/keyToIdentity\.delete\(existingKey\)/)
+    expect(REGISTRY).toMatch(/nameToKey\.delete\(name\)/)
+  })
+
+  it('revokes on every teardown path, not only the tidy one', () => {
+    // disable(), runtime crash and failed activation. A token that survives a crash is the one
+    // that matters, because nothing else about that plugin is still trustworthy.
+    const revocations = PLUGIN.match(/this\.revokeActivationAuthority\(activation\)/g) ?? []
+
+    expect(revocations.length).toBeGreaterThanOrEqual(3)
+    expect(PLUGIN).toMatch(/handleRuntimeCrash[\s\S]{0,400}revokeActivationAuthority/)
+    expect(PLUGIN).toMatch(/async disable\(\)[\s\S]{0,900}revokeActivationAuthority/)
+  })
+})


### PR DESCRIPTION
Fixes #804.

## The word

The channel key is `randomBytes(16).toString('hex')` minted per activation — a **bearer capability token**. Nothing is encrypted. `CLAUDE.md` claimed otherwise in three places, and `plugin-channel-key-registry.ts` quoted that phrasing back in its own doc comment, so the claim was self-reinforcing.

The cost is the one the issue names: a reviewer who reads "encrypted" assumes confidentiality and replay resistance, and stops looking at where the token travels and when it dies — which is precisely where the real problems are. #697 has it passed through renderer command-line arguments; #698 had a self-declared identity accepted alongside it.

## The two other asks

**"Confirm every plugin-deactivation path actually calls revokeKey."** Verified — three paths, all calling `revokeActivationAuthority(activation)`:

| path | site |
|---|---|
| normal disable | `plugin.ts` `async disable()` |
| runtime crash | `plugin.ts` `handleRuntimeCrash` |
| failed activation | `plugin.ts`, in the `enable()` catch |

Plus rotation: `requestKey` mints a new token when the activation differs, deleting the old one from all three maps first. The crash path is the one that matters most — a token that outlives a crash belongs to a plugin nothing else about is still trustworthy.

**"Add a TTL."** I did not, and the reasoning is now in the code rather than left as an open suggestion: the token's lifetime *is* the activation's. A timer would expire a key out from under a live plugin — the owner is a running process with no refresh path — while doing little for a leaked one, which is useful for whatever window the TTL allows. The leak paths in #697 are the thing worth fixing; a TTL would look like a mitigation for them without being one.

If you want a TTL anyway, say so and I will add it with a refresh handshake, but it needs that handshake to be safe.

## Guard

`packages/utils/__tests__/plugin-channel-key-claims.test.ts` pins both halves so the claim and the code cannot drift apart again: no "encrypted key" phrasing, a positive statement of what the token *is* (so the rule cannot be satisfied by deleting the description), the 16-byte mint, the three-map rotation, and revocation on all three teardown paths.

It caught my own first draft — I had quoted the old phrase in the new comment, and the rule flagged it. Reworded rather than loosening the regex.

In `packages/utils` because `ci / CI - utils` blocks, whereas `App suites (core-app)` is `continue-on-error`.

Verified by restoring the claim in `CLAUDE.md`: the rule fails. 6/6 here, 12/12 in the registry's own suite, lint clean.
