### PR TITLE
test(security): make the channel-key-is-not-a-credential rule blocking [#697]

### DIFF
--- a/packages/utils/__tests__/channel-key-is-not-a-credential.test.ts
+++ b/packages/utils/__tests__/channel-key-is-not-a-credential.test.ts
@@ -1,0 +1,90 @@
+import type { PluginActivationIdentity } from '../transport'
+import { describe, expect, it } from 'vitest'
+// Imported across the package boundary on purpose — see the note on blocking checks below.
+import { resolveChannelCallerIdentity } from '../../../apps/core-app/src/main/core/channel-caller-identity'
+
+/**
+ * Knowing a plugin's channel key must not, on its own, make you that plugin (#697, #698).
+ *
+ * The key travels as a renderer command-line argument (`additionalArguments`), so any process on
+ * the machine can read it out of the process table — `ps -ww`, or WMI on Windows. #697 filed that
+ * as a credential leak, and it was one until #698: `resolveChannelCallerIdentity` used to accept a
+ * self-declared key as an identity source when the sender was not a registered plugin webContents.
+ *
+ * #698 closed it — identity now comes only from the registration, and a declared key is a
+ * consistency check that can downgrade but never grant. That is what makes the exposure in #697
+ * inert today, so it is the invariant worth holding still.
+ *
+ * The core-app suite already covers this in `channel-caller-identity.test.ts`. It is mirrored here
+ * because `App suites (core-app)` runs with `continue-on-error: ${{ matrix.app != 'nexus' }}` — it
+ * reports success whatever the suite does, so those tests cannot fail a PR. An invariant that a
+ * security posture depends on should be enforceable, not merely observed.
+ */
+
+const REGISTRATION: PluginActivationIdentity = {
+  name: 'com.example.victim',
+  pluginInstanceId: 'instance-1',
+  activationGeneration: 3,
+  key: 'the-real-key',
+}
+
+describe('a channel key on its own', () => {
+  it('grants nothing to an unregistered sender, however valid it is', () => {
+    // The process-table reader's exact position: it has the real key and no registration.
+    const caller = resolveChannelCallerIdentity({
+      senderId: 99,
+      senderDestroyed: false,
+      declaredKey: REGISTRATION.key,
+      resolveIdentity: key => (key === REGISTRATION.key ? REGISTRATION : undefined),
+    })
+
+    expect(caller).toEqual({})
+  })
+
+  it('cannot name a plugin, which is what the handlers read', () => {
+    // pluginIdentity being empty is not enough on its own: #698 found that handlers reading only
+    // `data.plugin` were fooled by the name alone — storage namespacing, quota accounting,
+    // permission lookups. So the name must be absent too.
+    const caller = resolveChannelCallerIdentity({
+      senderId: 99,
+      senderDestroyed: false,
+      declaredKey: REGISTRATION.key,
+      resolveIdentity: () => REGISTRATION,
+    })
+
+    expect(caller.pluginName).toBeUndefined()
+    expect(caller.pluginIdentity).toBeUndefined()
+  })
+
+  it('cannot replace the identity of a sender that is registered as someone else', () => {
+    const other: PluginActivationIdentity = { ...REGISTRATION, name: 'com.example.attacker' }
+
+    const caller = resolveChannelCallerIdentity({
+      senderId: 7,
+      senderDestroyed: false,
+      declaredKey: REGISTRATION.key,
+      registration: { ...other, key: 'attacker-key' } as never,
+      resolveIdentity: () => REGISTRATION,
+    })
+
+    expect(caller.pluginName).toBe('com.example.attacker')
+    expect(caller.pluginIdentity).toBeUndefined()
+  })
+})
+
+describe('a registered sender', () => {
+  it('still resolves, so the rules above are not simply refusing everything', () => {
+    // Positive control. Every assertion above is satisfied by a resolver that returns {} always,
+    // which would break every plugin rather than secure anything.
+    const caller = resolveChannelCallerIdentity({
+      senderId: 7,
+      senderDestroyed: false,
+      declaredKey: REGISTRATION.key,
+      registration: REGISTRATION as never,
+      resolveIdentity: key => (key === REGISTRATION.key ? REGISTRATION : undefined),
+    })
+
+    expect(caller.pluginName).toBe(REGISTRATION.name)
+    expect(caller.pluginIdentity).toEqual(REGISTRATION)
+  })
+})


### PR DESCRIPTION
Refs #697. **The leak is real; the exploit it describes is not, as of #698.** This PR pins the invariant that makes it inert, and does not move the key off `additionalArguments` — I explain why that is a separate change below.

## What I verified

#697's failure scenario is: *"Because `resolveChannelCallerIdentity` accepts a self-declared `uniqueKey` as an identity source when the sender is not a registered plugin webContents, this key is a bearer credential."*

That is no longer what it does. Reading the resolver end to end:

- No registration → returns `{}`. No name, no identity, whatever the message declares.
- A registration whose key mismatches the declared one → downgraded to name-only.
- The declared key can only ever **downgrade**, never grant.

And nothing else trusts the key on its own: `isValidKey` has no callers outside the registry, and the `uniqueKey` echo at `channel-core.ts:314` is a reply field, not an authorisation. `caller.pluginName` and `caller.pluginIdentity` — the only two things handlers read — both come solely from the registration.

So a process that reads the key out of `ps -ww` gets a string it cannot exchange for anything. The exposure is hygiene, not a live vulnerability.

## Why that makes this the right change

The whole of #697's severity now rests on #698's fix holding. That invariant is covered — `channel-caller-identity.test.ts` has five tests — but `App suites (core-app)` runs `continue-on-error: ${{ matrix.app != 'nexus' }}`, so **those tests cannot fail a PR**. An invariant a security posture depends on should be enforceable, not merely observed.

This mirrors the rule into `packages/utils`, where `ci / CI - utils` blocks. It imports the real resolver across the package boundary rather than grepping source, so it tests behaviour, not phrasing — the module's only core-app imports are type-only, so it resolves cleanly.

Verified by reinstating the pre-#698 fallback: two of four fail with `expected { pluginName: 'com.example.victim' } to deeply equal {}`. The fourth is a positive control — a resolver that returns `{}` unconditionally satisfies the other three while breaking every plugin.

## Why not move the key off argv here

It is still worth doing, and the machinery exists — `installTransportPortHandoff` already transfers a `MessagePort` to plugin views. But the preload constructs the channel **synchronously** at preload time from `process.argv`:

```ts
const bootstrap = parsePluginViewBootstrapArgument(process.argv)
const channel = createPluginViewChannel(pluginViewRendererIpcAdapter, { uniqueKey: bootstrap.channelKey })
```

Moving the key to an async handoff means the channel cannot exist until the key arrives, so anything a plugin surface sends before that has to be queued or rejected. That is a sequencing change to plugin bootstrap with a real breakage mode, and it deserves its own PR rather than riding along with a test.

I have left #697 open for it and said so on the issue.
