### PR TITLE
security(csp): report the narrow policy so the wildcards can be closed [#689]

### DIFF
--- a/apps/core-app/src/renderer/index.html
+++ b/apps/core-app/src/renderer/index.html
@@ -42,6 +42,37 @@
   "
     />
 
+    <!--
+      The candidate narrow policy, in report-only mode. It blocks nothing; it exists to produce
+      the runtime inventory that narrowing `default-src` and `connect-src` for real has been
+      waiting on (#689).
+
+      Reading the renderer statically says those wildcards are close to unused. There are three
+      `fetch`/`axios` matches in the whole renderer and two of them are comments in i18n.ts; the
+      only real one is `attachment-payload.ts`, which reads `blob:` URLs and already refuses any
+      other scheme. `nexus-store-provider.ts` resolves a user-configurable base URL but does not
+      fetch it — that request is made in main. There is no `new WebSocket` and no `EventSource`,
+      and the widget sandbox denies `sendBeacon` outright. What genuinely remains is Sentry, which
+      is initialised in the renderer, and the dev server.
+
+      Static reading is exactly what cannot settle this, though: a dependency may reach for
+      something at runtime that no literal in the tree mentions. So this reports rather than
+      enforces, `securitypolicyviolation` is logged from the renderer entry, and the wildcards
+      above stay until that log is empty in real use.
+    -->
+    <meta
+      http-equiv="Content-Security-Policy-Report-Only"
+      content="
+    default-src 'self' blob: data: tfile: remix:;
+    connect-src 'self' https://o4508024637620224.ingest.us.sentry.io blob: data: tfile: ws://localhost:* http://localhost:*;
+    img-src 'self' data: blob: tfile: file: remix:;
+    font-src 'self' data: blob:;
+    style-src 'self' 'unsafe-inline' blob: data:;
+    style-src-elem 'self' 'unsafe-inline' blob: data:;
+    media-src 'self' blob: data: tfile:;
+  "
+    />
+
     <title>Tuff</title>
   </head>
 

--- a/apps/core-app/src/renderer/src/main.ts
+++ b/apps/core-app/src/renderer/src/main.ts
@@ -50,6 +50,34 @@ let lifecycleEventsRegistered = false
 registerNotificationHub(transport)
 registerMainWindowSideEffects()
 registerLifecycleEvents()
+reportContentSecurityPolicyViolations()
+
+/**
+ * Logs violations of the report-only CSP in index.html (#689).
+ *
+ * `default-src` and `connect-src` are still wildcards because narrowing them needs to know what the
+ * renderer actually reaches, and a static reading cannot produce that — a dependency can ask for
+ * something at runtime that no literal in the tree mentions. The report-only policy names the
+ * candidate, blocks nothing, and this turns each would-be block into a line naming the directive
+ * and the origin.
+ *
+ * When this stays quiet in real use, the candidate becomes the enforcing policy and the wildcards
+ * go. Until then it is the only honest way to get from here to there.
+ */
+function reportContentSecurityPolicyViolations(): void {
+  document.addEventListener('securitypolicyviolation', (event) => {
+    // The enforcing policy blocks nothing here, so anything reaching this listener is a request
+    // the narrow candidate would have refused — a finding, not an error.
+    mainLog.warn(
+      `[csp-report-only] ${event.effectiveDirective} would block ${event.blockedURI || '<inline>'}`,
+      {
+        documentURI: event.documentURI,
+        sourceFile: event.sourceFile,
+        line: event.lineNumber
+      }
+    )
+  })
+}
 
 function registerRouterEvents(instance: Router): void {
   if (routerEventsRegistered) {

--- a/packages/utils/__tests__/renderer-csp.test.ts
+++ b/packages/utils/__tests__/renderer-csp.test.ts
@@ -22,19 +22,37 @@ import { describe, expect, it } from 'vitest'
 
 const INDEX_HTML = readFileSync(
   path.resolve(__dirname, '../../../apps/core-app/src/renderer/index.html'),
-  'utf8'
+  'utf8',
 )
 
-const csp = (() => {
-  const match = /http-equiv="Content-Security-Policy"\s*\n?\s*content="([\s\S]*?)"/.exec(INDEX_HTML)
+const RENDERER_MAIN = readFileSync(
+  path.resolve(__dirname, '../../../apps/core-app/src/renderer/src/main.ts'),
+  'utf8',
+)
+
+function policyFor(httpEquiv: string): string {
+  const match = new RegExp(
+    `http-equiv="${httpEquiv}"\\s*\\n?\\s*content="([\\s\\S]*?)"`,
+  ).exec(INDEX_HTML)
   return (match?.[1] ?? '').replace(/\s+/g, ' ').trim()
-})()
+}
+
+const csp = policyFor('Content-Security-Policy')
+const reportOnly = policyFor('Content-Security-Policy-Report-Only')
+
+function find(policy: string, name: string): string | undefined {
+  return policy
+    .split(';')
+    .map(part => part.trim())
+    .find(part => part === name || part.startsWith(`${name} `))
+}
 
 function directive(name: string): string | undefined {
-  return csp
-    .split(';')
-    .map((part) => part.trim())
-    .find((part) => part === name || part.startsWith(`${name} `))
+  return find(csp, name)
+}
+
+function reportOnlyDirective(name: string): string | undefined {
+  return find(reportOnly, name)
 }
 
 describe('renderer Content-Security-Policy', () => {
@@ -52,29 +70,60 @@ describe('renderer Content-Security-Policy', () => {
 
     expect(scriptSrc).not.toMatch(/(^|\s)\*/)
     expect(scriptSrc).not.toContain('unsafe-inline')
-    expect(scriptSrc).toContain("'self'")
+    expect(scriptSrc).toContain('\'self\'')
   })
 
-  it("still allows 'unsafe-eval', which the widget runtime needs", () => {
+  it('still allows \'unsafe-eval\', which the widget runtime needs', () => {
     // Stated as a requirement rather than left implicit: widget-registry.ts runs widget code through
     // `new Function`. Dropping this is a product change, not a hardening.
-    expect(directive('script-src')).toContain("'unsafe-eval'")
+    expect(directive('script-src')).toContain('\'unsafe-eval\'')
   })
 
   it('closes the directives nothing uses instead of letting them fall through', () => {
     // Without these three, `default-src *` governs them — and the renderer has no <object>,
     // <embed>, <iframe> or `new Worker` to justify that.
-    expect(directive('object-src')).toBe("object-src 'none'")
-    expect(directive('frame-src')).toBe("frame-src 'none'")
-    expect(directive('worker-src')).toBe("worker-src 'self' blob:")
+    expect(directive('object-src')).toBe('object-src \'none\'')
+    expect(directive('frame-src')).toBe('frame-src \'none\'')
+    expect(directive('worker-src')).toBe('worker-src \'self\' blob:')
   })
 
   it('records that default-src and connect-src are still open', () => {
-    // Not an endorsement — an acknowledgement. Narrowing connect-src needs the set of origins the
-    // renderer actually reaches, and users configure arbitrary AI provider base URLs, so it cannot
-    // be derived by reading the source. If someone does narrow it, this test should be updated
-    // rather than deleted, so the change is deliberate.
+    // Not an endorsement — an acknowledgement. Narrowing them needs the set of origins the
+    // renderer actually reaches at runtime, which reading the source cannot settle. The
+    // report-only policy below is how that set is being collected. If someone does narrow these,
+    // this test should be updated rather than deleted, so the change is deliberate.
     expect(directive('connect-src')).toContain('*')
     expect(directive('default-src')).toContain('*')
+  })
+})
+
+describe('the report-only candidate policy', () => {
+  it('is present, and is the narrow one', () => {
+    // Positive control first: an empty match would satisfy "contains no wildcard" trivially.
+    expect(reportOnly.length).toBeGreaterThan(80)
+    expect(reportOnlyDirective('default-src')).toBe('default-src \'self\' blob: data: tfile: remix:')
+  })
+
+  it('drops the wildcards the enforcing policy still carries', () => {
+    // The whole point of it. A report-only copy of the enforcing policy would report nothing and
+    // look like a clean bill of health.
+    for (const name of ['default-src', 'connect-src', 'img-src', 'font-src', 'media-src']) {
+      expect(reportOnlyDirective(name), name).not.toContain('*;')
+      expect(reportOnlyDirective(name), name).not.toMatch(/\s\*\s|\s\*$/)
+    }
+  })
+
+  it('keeps the origins the renderer is known to need', () => {
+    // Sentry is initialised in the renderer (sentry-renderer.ts), and the dev server plus its
+    // websocket would otherwise fill the log with noise that is not a finding.
+    expect(reportOnlyDirective('connect-src')).toContain('ingest.us.sentry.io')
+    expect(reportOnlyDirective('connect-src')).toContain('ws://localhost:*')
+  })
+
+  it('is reported rather than enforced, and the report is listened for', () => {
+    // A report-only policy nobody listens to is decoration. The listener is what turns it into
+    // the inventory that unblocks narrowing the real policy.
+    expect(INDEX_HTML).toContain('Content-Security-Policy-Report-Only')
+    expect(RENDERER_MAIN).toContain('addEventListener(\'securitypolicyviolation\'')
   })
 })


### PR DESCRIPTION
Refs #689. `script-src` was fixed in #913; this is about the two wildcards that were left, and it does **not** flip them — it builds the evidence that flipping them needs.

## The recorded blocker does not apply

The note left on the enforcing policy says narrowing `connect-src` needs "an inventory of what the renderer actually reaches at runtime (user-configured AI provider origins, the Vite dev server and its websocket)".

The AI-provider half is not true of the **renderer**. Measured:

| | |
|---|---|
| `fetch` / `axios` matches in the whole renderer | **3** — two are comments in `i18n.ts` |
| the one real call | `attachment-payload.ts`, reads `blob:` URLs and explicitly refuses any other scheme |
| `nexus-store-provider.ts` | resolves a user-configurable base URL but **does not fetch it** — that request is made in main |
| `new WebSocket` / `EventSource` | none |
| `sendBeacon` | denied outright by the widget sandbox policy |
| genuinely needed | Sentry (`sentry-renderer.ts` initialises it in the renderer) and the dev server |

So the renderer's own `connect-src` looks like a short allowlist, not a wildcard.

## Which is still not enough to flip it

A dependency can reach for something at runtime that no literal in the tree mentions, and a blocked request in a shipped desktop app is a silent feature failure. So this adds the candidate as **`Content-Security-Policy-Report-Only`** and logs `securitypolicyviolation` from the renderer entry.

It blocks nothing — report-only never does — so the change cannot break anything. What it produces is the runtime inventory that has been the blocker, as lines naming the directive and the origin. When that log stays empty in real use, the candidate becomes the enforcing policy and the wildcards go.

`ws://localhost:*` and `http://localhost:*` are in the candidate deliberately, so the dev server does not fill the log with entries that are not findings.

## Guard

Four new cases in `renderer-csp.test.ts`, and two of them are the ones that matter:

- **the report-only policy is not a copy of the enforcing one.** A copy reports nothing and reads as a clean bill of health — the failure mode that would make this whole change decorative.
- **something listens.** A report-only policy nobody reads is decoration too.

Mutation-tested on both: replacing the candidate with the enforcing policy fails 3 of 9; removing the listener fails 1.

## Not touched

`'unsafe-eval'`. `widget-registry.ts:1633` executes plugin widget code through `new Function` inside a `with (sandboxScope)` proxy. Removing the directive deletes plugin widgets; replacing that executor — a separate isolated renderer, or precompiled widget modules — is its own change and its own risk.

Note on local verification: `vue-tsc -p tsconfig.web.json` reports an unrelated `IntelligencePartEvent` mismatch here, and the paths in it point at the *main* checkout — this worktree's `node_modules` is a symlink, so workspace imports resolve to that checkout's source rather than the branch. CI typechecks against the branch.
