### PR TITLE
fix(intelligence): stop shipping a stale DEFAULT_PROVIDERS copy [#520]

### DIFF
--- a/packages/tuff-intelligence/src/types/intelligence.ts
+++ b/packages/tuff-intelligence/src/types/intelligence.ts
@@ -10,8 +10,10 @@
  * direction is settled and there is no second declaration left to drift.
  */
 
-import { DEFAULT_CAPABILITIES as SHARED_DEFAULT_CAPABILITIES } from "@talex-touch/utils/types/intelligence";
-import { NEXUS_BASE_URL } from "../env";
+import {
+  DEFAULT_CAPABILITIES as SHARED_DEFAULT_CAPABILITIES,
+  DEFAULT_PROVIDERS as SHARED_DEFAULT_PROVIDERS,
+} from "@talex-touch/utils/types/intelligence";
 /**
  * The IPC message shape, owned by @talex-touch/utils.
  *
@@ -2415,101 +2417,14 @@ export interface IntelligenceStorageData {
 /**
  * Default provider configurations.
  */
-export const DEFAULT_PROVIDERS: IntelligenceProviderConfig[] = [
-  {
-    id: "openai-default",
-    type: IntelligenceProviderType.OPENAI,
-    name: "OpenAI",
-    enabled: false,
-    priority: 1,
-    models: ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo"],
-    defaultModel: "gpt-4o-mini",
-    timeout: 30000,
-    rateLimit: {},
-  },
-  {
-    id: "anthropic-default",
-    type: IntelligenceProviderType.ANTHROPIC,
-    name: "Anthropic",
-    enabled: false,
-    priority: 2,
-    models: [
-      "claude-3-5-sonnet-20241022",
-      "claude-3-opus-20240229",
-      "claude-3-haiku-20240307",
-    ],
-    defaultModel: "claude-3-5-sonnet-20241022",
-    timeout: 30000,
-    rateLimit: {},
-  },
-  {
-    id: "deepseek-default",
-    type: IntelligenceProviderType.DEEPSEEK,
-    name: "DeepSeek",
-    enabled: false,
-    priority: 2,
-    models: ["deepseek-chat", "deepseek-coder"],
-    defaultModel: "deepseek-chat",
-    timeout: 30000,
-    rateLimit: {},
-  },
-  {
-    id: "siliconflow-default",
-    type: IntelligenceProviderType.SILICONFLOW,
-    name: "SiliconFlow",
-    enabled: false,
-    priority: 2,
-    baseUrl: "https://api.siliconflow.cn/v1",
-    models: [
-      "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
-      "tencent/Hunyuan-MT-7B",
-      "TeleAI/TeleSpeechASR",
-      "THUDM/GLM-4.1V-9B-Thinking",
-      "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
-      "BAAI/bge-reranker-v2-m3",
-      "netease-youdao/bce-embedding-base_v1",
-      "Kwai-Kolors/Kolors",
-      "BAAI/bge-m3",
-    ],
-    defaultModel: "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
-    timeout: 30000,
-    rateLimit: {},
-  },
-  {
-    id: "tuff-nexus-default",
-    type: IntelligenceProviderType.CUSTOM,
-    name: "Tuff Nexus",
-    enabled: false,
-    priority: 1,
-    baseUrl: `${NEXUS_BASE_URL}/v1`,
-    models: ["gpt-4o", "gpt-4o-mini"],
-    defaultModel: "gpt-4o-mini",
-    timeout: 30000,
-    rateLimit: {},
-    capabilities: [
-      "text.chat",
-      "text.translate",
-      "text.summarize",
-      "text.rewrite",
-      "vision.ocr",
-      "image.translate.e2e",
-    ],
-    metadata: {
-      origin: "tuff-nexus",
-    },
-  },
-  {
-    id: "local-default",
-    type: IntelligenceProviderType.LOCAL,
-    name: "Local Model",
-    enabled: false,
-    priority: 3,
-    models: [],
-    baseUrl: "http://localhost:11434",
-    timeout: 60000,
-    rateLimit: {},
-  },
-];
+/**
+ * Re-exported rather than copied. 7faea27bf consolidated DEFAULT_CAPABILITIES onto the shared
+ * declaration and left this one a literal, so utils gained FunAudioLLM/SenseVoiceSmall and
+ * fnlp/MOSS-TTSD-v0.5 while this copy kept TeleAI/TeleSpeechASR — and core-app imports this one,
+ * so the app has been shipping the stale set since 2026-07-14 (#520).
+ */
+export const DEFAULT_PROVIDERS: IntelligenceProviderConfig[] =
+  SHARED_DEFAULT_PROVIDERS;
 
 export const DEFAULT_GLOBAL_CONFIG: IntelligenceGlobalConfig = {
   defaultStrategy: "adaptive-default",

--- a/packages/utils/__tests__/intelligence-type-barrel-drift.test.ts
+++ b/packages/utils/__tests__/intelligence-type-barrel-drift.test.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * A type declared in both intelligence barrels must not drift apart (#520).
+ *
+ * `packages/utils/types/intelligence.ts` owns the shared surface. `tuff-intelligence` forwards 58
+ * names by hand and re-declares 146 more locally, so the two files hold ~146 declarations of the
+ * same names — and renderer components import from `@talex-touch/tuff-intelligence`, which is the
+ * copy that wins for them.
+ *
+ * That is the arrangement that produced the `IntelligenceMessage` fork (#519). It also produced a
+ * live one in *runtime data*: 7faea27bf consolidated `DEFAULT_CAPABILITIES` onto the shared
+ * declaration and left `DEFAULT_PROVIDERS` a literal, so utils gained two speech models while the
+ * copy kept a third — and `intelligence-config.ts` imports the copy, so the app shipped the stale
+ * set for four weeks with nothing failing.
+ *
+ * This does not stop the duplication; replacing it with `export type *` needs the 146 local
+ * declarations deleted first, and would drop 7 value exports that a type-only re-export cannot
+ * carry. What it does is make a divergence loud, which is the part that was missing.
+ *
+ * Lives in packages/utils because `ci / CI - utils` is a blocking check.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+
+const UTILS = readFileSync(path.join(REPO_ROOT, 'packages/utils/types/intelligence.ts'), 'utf8')
+const TUFF_INTELLIGENCE = readFileSync(
+  path.join(REPO_ROOT, 'packages/tuff-intelligence/src/types/intelligence.ts'),
+  'utf8',
+)
+
+/** Top-level exported declarations, keyed by name, with comments and whitespace normalised away. */
+function declarations(source: string): Map<string, string> {
+  const lines = source.split('\n')
+  const found = new Map<string, string>()
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = /^export (?:type|interface|enum|const) (\w+)/.exec(lines[index]!)
+    if (!match)
+      continue
+    let end = index + 1
+    while (end < lines.length && !(lines[end]!).startsWith('export ')) end += 1
+    found.set(
+      match[1]!,
+      lines
+        .slice(index, end)
+        .join('\n')
+        .replace(/\/\*\*[\s\S]*?\*\//g, '')
+        .replace(/\/\/.*$/gm, '')
+        .replace(/\s+/g, ' ')
+        .trim(),
+    )
+  }
+  return found
+}
+
+const utils = declarations(UTILS)
+const local = declarations(TUFF_INTELLIGENCE)
+const duplicated = [...local.keys()].filter(name => utils.has(name))
+
+describe('the intelligence type barrels', () => {
+  it('read the two files they mean to compare', () => {
+    // Positive control: "nothing has drifted" is also what two empty maps report, which is what a
+    // wrong path or a changed declaration style produces.
+    expect(utils.size).toBeGreaterThan(150)
+    expect(local.size).toBeGreaterThan(100)
+    expect(duplicated.length).toBeGreaterThan(100)
+  })
+
+  it('declare the duplicated names identically', () => {
+    // A name that delegates to the shared declaration is the *fixed* state, and its text differs
+    // from the original by definition — so it is excluded here and checked below instead. Matching
+    // on `SHARED_` rather than on a name list keeps that exclusion from becoming a place to hide.
+    const drifted = duplicated
+      .filter(name => !/=\s*SHARED_\w+/.test(local.get(name)!))
+      .filter(name => utils.get(name) !== local.get(name))
+
+    expect(drifted).toEqual([])
+  })
+
+  it('delegate the shared runtime constants rather than copying them', () => {
+    // Types drifting is a compile error somewhere eventually. A constant drifting is not — it
+    // ships. Both of these are values the app reads at startup, so they get named explicitly.
+    expect(TUFF_INTELLIGENCE).toMatch(/DEFAULT_CAPABILITIES[\s\S]{0,80}=\s*SHARED_DEFAULT_CAPABILITIES/)
+    expect(TUFF_INTELLIGENCE).toMatch(/DEFAULT_PROVIDERS[\s\S]{0,80}=\s*SHARED_DEFAULT_PROVIDERS/)
+  })
+})


### PR DESCRIPTION
Refs #520. Does not replace the manual barrel — it fixes the divergence that barrel had already produced, and makes the next one loud. The full `export type *` refactor needs a decision I have costed below.

## Measured

| | |
|---|---|
| symbols exported by `packages/utils/types/intelligence.ts` | **211** |
| forwarded by hand from `tuff-intelligence` | **58** |
| **re-declared locally that also exist in utils** | **146** |
| of those, textually identical | **144** |

So the duplication is not "forwards some and defines the rest" — it is a near-complete second copy of the shared surface.

## The one that had already gone wrong is a value, not a type

`7faea27bf` (2026-07-14) consolidated `DEFAULT_CAPABILITIES` onto the shared declaration — `= SHARED_DEFAULT_CAPABILITIES` — and left `DEFAULT_PROVIDERS` as a literal. The same commit added two speech models to utils. The copy never got them:

| | utils | tuff-intelligence |
|---|---|---|
| models | `FunAudioLLM/SenseVoiceSmall`, `fnlp/MOSS-TTSD-v0.5` | `TeleAI/TeleSpeechASR` |
| nexus id | `TUFF_NEXUS_PROVIDER_ID` | hardcoded `"tuff-nexus-default"` |

`apps/core-app/src/main/modules/ai/intelligence-config.ts:278` imports `DEFAULT_PROVIDERS` from `@talex-touch/tuff-intelligence` and clones it as the shipped default. **The app has been shipping the stale set for four weeks**, and nothing failed — because a type divergence eventually breaks a build somewhere, and a constant divergence just ships.

This PR makes it delegate, the way `DEFAULT_CAPABILITIES` already did. 96 lines of literal become two, and the now-unused `NEXUS_BASE_URL` import goes with them.

## Correcting the suggested direction

`export type * from "@talex-touch/utils/types/intelligence"` cannot be a drop-in:

1. It **collides** with the 146 local declarations — they have to be deleted first, so it is a 2,549-line file rewrite, not a one-line change.
2. It is **type-only**, and this file has **7 value exports** that also exist in utils: enums `IntelligenceProviderType`, `IntelligenceCapabilityType`, and consts `TUFF_INTELLIGENCE_PROVIDER_SYNC_SCHEMA_VERSION`, `TUFF_INTELLIGENCE_AGENT_TRACE_CONTRACT_VERSION`, `DEFAULT_PROVIDERS`, `DEFAULT_GLOBAL_CONFIG`, `DEFAULT_CAPABILITIES`. A type-only wildcard drops all seven and every consumer using them as values breaks.

The shape that works is a wildcard **plus** an explicit value re-export. I have not done it here because verifying a cross-package type change needs a faithful full-workspace typecheck, and this worktree's `node_modules` is a symlink — `@talex-touch/utils` resolves to a different checkout's source, so a local green would not mean anything. Happy to do it as its own PR and let CI adjudicate, if you want it.

## Guard

`packages/utils/__tests__/intelligence-type-barrel-drift.test.ts`:

- every duplicated declaration must be textually identical
- both shared constants must **delegate**, not copy

Two rules rather than one on purpose: a delegating constant is the *fixed* state and its text differs from the original by definition, so it is excluded from the identity rule — matched on `= SHARED_*` rather than a name list, so the exclusion cannot become a hiding place.

Mutation-tested: restoring the stale literal fails both rules; adding a field to `IntelligencePartEvent` in one copy fails the first. Positive control asserts all three maps are populated, since two empty maps also report "nothing has drifted".
