### PR TITLE
fix(screenshot): let window selection use the configured limits

### DIFF
--- a/packages/tuff-native/native-screenshot/src/backend/macos/actor.rs
+++ b/packages/tuff-native/native-screenshot/src/backend/macos/actor.rs
@@ -413,6 +413,7 @@ impl ActorState {
             self_process_ids,
             input.self_context.bundle_ids,
             self_native_ids,
+            self.limits,
         )
         .map_err(|_| ScreenshotError::BackendFailed.to_protocol_error())?;
         let selection_policy = WindowSelectionPolicy::new(
@@ -422,11 +423,12 @@ impl ActorState {
                 .iter()
                 .map(|value| (*value).to_string())
                 .collect(),
+            self.limits,
         )
         .map_err(|_| ScreenshotError::BackendFailed.to_protocol_error())?;
         let shareable_windows = system_windows
             .iter()
-            .filter_map(|window| shareable_window(window, generation_number).ok())
+            .filter_map(|window| shareable_window(window, generation_number, self.limits).ok())
             .collect::<Vec<_>>();
         let cg_windows = cg_windows
             .iter()
@@ -492,7 +494,7 @@ impl ActorState {
         let windows = hit_test_windows(
             &current.windows,
             input.point,
-            WindowHitTestOptions::new(input.include_panels, input.max_candidates),
+            WindowHitTestOptions::new(input.include_panels, input.max_candidates, self.limits),
         );
         let candidates = windows
             .iter()
@@ -1249,6 +1251,7 @@ fn encode_png(image: &MacCapturedImage) -> Result<Vec<u8>, ProtocolError> {
 fn shareable_window(
     window: &MacSystemWindow,
     generation_number: u64,
+    limits: ScreenshotLimits,
 ) -> Result<ShareableWindow, ProtocolError> {
     ShareableWindow::new(
         descriptor(format!(
@@ -1260,6 +1263,7 @@ fn shareable_window(
             window.process_id,
             window.bundle_id.clone(),
             window.application_name.clone(),
+            limits,
         )
         .map_err(|_| ScreenshotError::BackendFailed.to_protocol_error())?,
         window.title.clone(),
@@ -1268,6 +1272,7 @@ fn shareable_window(
         window.on_screen,
         Some(window.active),
         true,
+        limits,
     )
     .map_err(|_| ScreenshotError::BackendFailed.to_protocol_error())
 }

--- a/packages/tuff-native/native-screenshot/src/limits.rs
+++ b/packages/tuff-native/native-screenshot/src/limits.rs
@@ -134,6 +134,23 @@ impl ScreenshotLimits {
         self
     }
 
+    /// Raises the hit-test candidate ceiling above the default, so a test can tell a
+    /// configured limit apart from the hardcoded one.
+    #[cfg(test)]
+    pub(crate) fn with_window_candidates_for_test(mut self, max_candidates: usize) -> Self {
+        assert!(max_candidates > 0);
+        self.max_window_candidates = max_candidates;
+        self
+    }
+
+    /// Tightens the bundle id ceiling below the default, for the same reason.
+    #[cfg(test)]
+    pub(crate) fn with_bundle_id_bytes_for_test(mut self, max_bytes: usize) -> Self {
+        assert!(max_bytes > 0);
+        self.max_bundle_id_bytes = max_bytes;
+        self
+    }
+
     pub fn public(self) -> ScreenshotLimitsPublic {
         ScreenshotLimitsPublic {
             max_displays: self.max_displays,

--- a/packages/tuff-native/native-screenshot/src/window_candidates.rs
+++ b/packages/tuff-native/native-screenshot/src/window_candidates.rs
@@ -20,11 +20,11 @@ impl WindowOwner {
         process_id: u32,
         bundle_id: Option<String>,
         application_name: Option<String>,
+        limits: ScreenshotLimits,
     ) -> Result<Self, GeometryError> {
         if process_id == 0 {
             return Err(GeometryError::new("window process id must be positive"));
         }
-        let limits = ScreenshotLimits::default();
         validate_optional_text(bundle_id.as_deref(), limits.max_bundle_id_bytes())?;
         validate_optional_text(
             application_name.as_deref(),
@@ -75,11 +75,11 @@ impl ShareableWindow {
         on_screen: bool,
         active: Option<bool>,
         capturable: bool,
+        limits: ScreenshotLimits,
     ) -> Result<Self, GeometryError> {
         if native_id == 0 {
             return Err(GeometryError::new("native window id must be positive"));
         }
-        let limits = ScreenshotLimits::default();
         if title
             .as_deref()
             .is_some_and(|value| value.chars().count() > limits.max_title_scalars())
@@ -159,13 +159,13 @@ impl SelfWindowPolicy {
         process_ids: Vec<u32>,
         bundle_ids: Vec<String>,
         native_window_ids: Vec<u32>,
+        limits: ScreenshotLimits,
     ) -> Result<Self, GeometryError> {
         if process_ids.contains(&0) || native_window_ids.contains(&0) {
             return Err(GeometryError::new(
                 "self window identifiers must be positive",
             ));
         }
-        let limits = ScreenshotLimits::default();
         for bundle_id in &bundle_ids {
             validate_text(bundle_id, limits.max_bundle_id_bytes())?;
         }
@@ -199,11 +199,11 @@ impl WindowSelectionPolicy {
         minimum_size: f64,
         self_windows: SelfWindowPolicy,
         system_bundle_ids: Vec<String>,
+        limits: ScreenshotLimits,
     ) -> Result<Self, GeometryError> {
         if !minimum_size.is_finite() || minimum_size <= 0.0 {
             return Err(GeometryError::new("window minimum size must be positive"));
         }
-        let limits = ScreenshotLimits::default();
         for bundle_id in &system_bundle_ids {
             validate_text(bundle_id, limits.max_bundle_id_bytes())?;
         }
@@ -312,8 +312,7 @@ pub struct WindowHitTestOptions {
 }
 
 impl WindowHitTestOptions {
-    pub fn new(include_panels: bool, max_candidates: usize) -> Self {
-        let limits = ScreenshotLimits::default();
+    pub fn new(include_panels: bool, max_candidates: usize, limits: ScreenshotLimits) -> Self {
         Self {
             include_panels,
             max_candidates: max_candidates.clamp(1, limits.max_window_candidates()),

--- a/packages/tuff-native/native-screenshot/src/window_candidates_contract_tests.rs
+++ b/packages/tuff-native/native-screenshot/src/window_candidates_contract_tests.rs
@@ -1,4 +1,5 @@
 use crate::geometry::DisplayGeometry;
+use crate::limits::ScreenshotLimits;
 use crate::model::{DescriptorId, GlobalDipPoint, GlobalDipRect, PixelSize, Rotation};
 use crate::region_plan::RegionDisplay;
 use crate::test_fixtures::fixture;
@@ -16,6 +17,7 @@ fn owner(process_id: u32, bundle_id: &str) -> WindowOwner {
         process_id,
         Some(bundle_id.to_string()),
         Some("Shared Owner Name".to_string()),
+        ScreenshotLimits::default(),
     )
     .expect("valid owner")
 }
@@ -38,6 +40,7 @@ fn shareable(
         true,
         None,
         true,
+        ScreenshotLimits::default(),
     )
     .expect("valid shareable window")
 }
@@ -58,12 +61,18 @@ fn cg(native_id: u32, process_id: u32, frame: GlobalDipRect, layer: i32) -> CgWi
 fn selection_policy() -> WindowSelectionPolicy {
     WindowSelectionPolicy::new(
         8.0,
-        SelfWindowPolicy::new(vec![700], vec!["com.talex.touch".to_string()], vec![7000])
-            .expect("valid self policy"),
+        SelfWindowPolicy::new(
+            vec![700],
+            vec!["com.talex.touch".to_string()],
+            vec![7000],
+            ScreenshotLimits::default(),
+        )
+        .expect("valid self policy"),
         vec![
             "com.apple.dock".to_string(),
             "com.apple.systemuiserver".to_string(),
         ],
+        ScreenshotLimits::default(),
     )
     .expect("valid selection policy")
 }
@@ -187,6 +196,7 @@ fn off_screen_and_protected_windows_do_not_become_default_candidates() {
         false,
         None,
         true,
+        ScreenshotLimits::default(),
     )
     .unwrap();
     let protected = ShareableWindow::new(
@@ -199,6 +209,7 @@ fn off_screen_and_protected_windows_do_not_become_default_candidates() {
         true,
         None,
         false,
+        ScreenshotLimits::default(),
     )
     .unwrap();
     let descriptors = build_window_descriptors(
@@ -215,7 +226,7 @@ fn off_screen_and_protected_windows_do_not_become_default_candidates() {
         hit_test_windows(
             &descriptors,
             GlobalDipPoint::new(10.0, 10.0).unwrap(),
-            WindowHitTestOptions::new(false, 16),
+            WindowHitTestOptions::new(false, 16, ScreenshotLimits::default()),
         )
         .is_empty()
     );
@@ -296,7 +307,7 @@ fn sharing_alpha_size_system_and_self_rules_fail_closed() {
     let hits = hit_test_windows(
         &descriptors,
         GlobalDipPoint::new(10.0, 10.0).unwrap(),
-        WindowHitTestOptions::new(false, 16),
+        WindowHitTestOptions::new(false, 16, ScreenshotLimits::default()),
     );
     assert!(hits.is_empty());
     assert!(GlobalDipRect::new(0.0, 0.0, 0.0, 10.0).is_err());
@@ -328,7 +339,11 @@ fn panels_are_opt_in_transients_are_excluded_and_candidates_are_truncated() {
     assert_eq!(descriptors[2].kind(), WindowKind::Transient);
 
     let point = GlobalDipPoint::new(10.0, 10.0).unwrap();
-    let default_hits = hit_test_windows(&descriptors, point, WindowHitTestOptions::new(false, 16));
+    let default_hits = hit_test_windows(
+        &descriptors,
+        point,
+        WindowHitTestOptions::new(false, 16, ScreenshotLimits::default()),
+    );
     assert_eq!(
         default_hits
             .iter()
@@ -336,7 +351,11 @@ fn panels_are_opt_in_transients_are_excluded_and_candidates_are_truncated() {
             .collect::<Vec<_>>(),
         vec![1, 4]
     );
-    let panel_hits = hit_test_windows(&descriptors, point, WindowHitTestOptions::new(true, 2));
+    let panel_hits = hit_test_windows(
+        &descriptors,
+        point,
+        WindowHitTestOptions::new(true, 2, ScreenshotLimits::default()),
+    );
     assert_eq!(
         panel_hits
             .iter()
@@ -406,5 +425,85 @@ fn cross_display_windows_report_all_coverage_and_maximum_scale() {
     assert_eq!(
         descriptor.maximum_scale(),
         Some(window.expected_maximum_scale)
+    );
+}
+
+/// #854: every constructor in window_candidates.rs used to build its own
+/// `ScreenshotLimits::default()`, so a capability configured with anything else had
+/// its window-selection limits silently replaced by the hardcoded ones. Both tests
+/// below pick a limit that *differs* from the default in the direction that matters
+/// -- with the default value they would pass against the old code too.
+#[test]
+fn hit_test_honours_a_candidate_ceiling_above_the_default() {
+    let frame = rect(0.0, 0.0, 400.0, 300.0);
+    let default_ceiling = ScreenshotLimits::default().max_window_candidates();
+    let wanted = default_ceiling + 4;
+
+    let windows = (0..wanted)
+        .map(|index| {
+            shareable(
+                &format!("window:stack-{index}"),
+                index as u32 + 1,
+                101,
+                "com.example",
+                frame,
+                0,
+            )
+        })
+        .collect::<Vec<_>>();
+    let metadata = (0..wanted)
+        .map(|index| cg(index as u32 + 1, 101, frame, 0))
+        .collect::<Vec<_>>();
+    let descriptors = build_window_descriptors(
+        windows,
+        metadata,
+        &[display("display:main", frame, 1)],
+        &selection_policy(),
+    );
+    let point = GlobalDipPoint::new(10.0, 10.0).unwrap();
+
+    let configured = ScreenshotLimits::default().with_window_candidates_for_test(wanted);
+    let hits = hit_test_windows(
+        &descriptors,
+        point,
+        WindowHitTestOptions::new(false, wanted, configured),
+    );
+    assert_eq!(hits.len(), wanted);
+
+    // The default still clamps, so this is a ceiling being honoured rather than removed.
+    let clamped = hit_test_windows(
+        &descriptors,
+        point,
+        WindowHitTestOptions::new(false, wanted, ScreenshotLimits::default()),
+    );
+    assert_eq!(clamped.len(), default_ceiling);
+}
+
+#[test]
+fn window_owner_honours_a_bundle_id_ceiling_below_the_default() {
+    let bundle_id = "c".repeat(64);
+    let configured = ScreenshotLimits::default().with_bundle_id_bytes_for_test(32);
+
+    assert!(
+        bundle_id.len() < ScreenshotLimits::default().max_bundle_id_bytes(),
+        "the default must accept this id, or the test proves nothing"
+    );
+    assert!(
+        WindowOwner::new(
+            101,
+            Some(bundle_id.clone()),
+            Some("Shared Owner Name".to_string()),
+            ScreenshotLimits::default(),
+        )
+        .is_ok()
+    );
+    assert!(
+        WindowOwner::new(
+            101,
+            Some(bundle_id),
+            Some("Shared Owner Name".to_string()),
+            configured,
+        )
+        .is_err()
     );
 }


### PR DESCRIPTION
Closes #854

## What was wrong

Every constructor in `window_candidates.rs` built its own `ScreenshotLimits::default()` rather than taking the limits the capability was constructed with. `ScreenshotCapability::new(backend, limits)` and `platform_backend(limits)` both accept a `ScreenshotLimits`, and the rest of the crate threads it through, so the two layers disagreed:

- `decode_hit_test` clamps `max_candidates` against the **configured** ceiling
- `WindowHitTestOptions::new` then re-clamped it against the **hardcoded** 16

Same shape for `max_bundle_id_bytes` / `max_application_name_bytes` / `max_title_scalars` in `WindowOwner::new`, `ShareableWindow::new`, `SelfWindowPolicy::new` and `WindowSelectionPolicy::new`.

The five constructors now take `limits`; `backend/macos/actor.rs` hands over the `self.limits` it already holds. `shareable_window` grew the parameter to reach the two constructors it calls.

## Tests

The existing 63 tests could not have caught this — every one of them uses `ScreenshotLimits::default()`, so the old and new code behave identically under them. Both new tests deliberately pick a limit that **differs from the default in the direction that matters**:

| test | limit | why that direction |
|---|---|---|
| `hit_test_honours_a_candidate_ceiling_above_the_default` | `default + 4` | a *looser* ceiling is the case the hardcoded 16 silently overrode |
| `window_owner_honours_a_bundle_id_ceiling_below_the_default` | 32 vs default 512 | a *tighter* ceiling is the case the hardcoded 512 silently ignored |

The candidate test also asserts the default **still clamps**, so this reads as a ceiling being honoured, not removed.

Mutations, each applied through a patch asserting it matched exactly once:

| mutation | result |
|---|---|
| hit test ignores the passed limits | candidate test fails |
| `WindowOwner` ignores the passed limits | bundle id test fails |
| no clamping at all | candidate test fails |

Restored: 65 passed, 0 failed. `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all pass.

## Note

`max_window_candidates` was in fact being enforced — by `decode_hit_test`, against the configured value. The defect is the **second**, hardcoded clamp downstream of it, which is why the failure only shows up when the configured limits differ from the defaults.