### PR TITLE
refactor(plugin): give privileged plugin names one source [#535]

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/browser-bookmarks-indexed-source.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/browser-bookmarks-indexed-source.ts
@@ -20,6 +20,7 @@ import type {
 import { shell } from 'electron'
 import { openValidatedExternalUrl } from '../../../utils/external-url-policy'
 import type { BrowserBookmarkItem, BrowserBookmarkScanOptions } from './browser-bookmarks-scanner'
+import { privilegedPluginFor } from '../../plugin/privileged-plugins'
 import {
   createBrowserBookmarksIndexedSourceDescriptor,
   IndexedWriteRuntimeEmitterService,
@@ -139,7 +140,7 @@ function readBrowserBookmarksSnapshot(
     sourceId,
     diagnostics: profileDiagnostics,
     metadata: {
-      scannerOwner: 'touch-browser-data',
+      scannerOwner: privilegedPluginFor('browserData'),
       providerId: BROWSER_BOOKMARKS_OFFICIAL_PROVIDER_ID,
       runtimeOwner: 'official-plugin'
     }
@@ -201,7 +202,7 @@ function buildProviderLifecycleEvidence(
     reason: enabled ? BROWSER_BOOKMARKS_RUNTIME_BRIDGE_REASON : BROWSER_BOOKMARKS_DISABLED_REASON,
     metadata: {
       providerId: BROWSER_BOOKMARKS_OFFICIAL_PROVIDER_ID,
-      currentOwner: 'touch-browser-data',
+      currentOwner: privilegedPluginFor('browserData'),
       runtimeOwner: 'official-plugin',
       storage: 'sqlite-index',
       privacy: 'high',

--- a/apps/core-app/src/main/modules/plugin/host/plugin-browser-data-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-browser-data-capabilities.ts
@@ -7,6 +7,7 @@ import { lstat, mkdir, mkdtemp, open, opendir, realpath, rm, stat } from 'node:f
 import path from 'node:path'
 import { types as utilTypes } from 'node:util'
 import { PluginSqliteWorkerClient } from '../runtime/plugin-sqlite-worker-client'
+import { isPrivilegedPluginFor } from '../privileged-plugins'
 import {
   PluginHostCapabilityError,
   type PluginHostCapabilityDefinition
@@ -1308,7 +1309,7 @@ export function createPluginBrowserDataCapabilities(
     invalid()
   }
   const expectedActivation = snapshotActivation(options.activation)
-  if (expectedActivation.name !== 'touch-browser-data') invalid()
+  if (!isPrivilegedPluginFor('browserData', expectedActivation.name)) invalid()
   const service = options.service as TrustedPluginBrowserDataService
   const scanService = dataMethod<TrustedPluginBrowserDataService['scan']>(service, 'scan')
   const resolveCurrentActivation =

--- a/apps/core-app/src/main/modules/plugin/host/plugin-browser-open-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-browser-open-capabilities.ts
@@ -4,6 +4,7 @@ import { isAuthoritativePluginContext } from '@talex-touch/utils/transport/secur
 import { randomBytes } from 'node:crypto'
 import path from 'node:path'
 import { types as utilTypes } from 'node:util'
+import { isPrivilegedPluginFor } from '../privileged-plugins'
 import {
   PluginHostCapabilityError,
   type PluginHostCapabilityDefinition
@@ -716,7 +717,7 @@ export function createPluginBrowserOpenCapabilities(
     invalid()
   }
   const expectedActivation = snapshotActivation(options.activation)
-  if (expectedActivation.name !== 'touch-browser-open') invalid()
+  if (!isPrivilegedPluginFor('browserOpen', expectedActivation.name)) invalid()
   const service = options.service as TrustedBrowserOpenService
   const listBrowsers = dataMethod<TrustedBrowserOpenService['list']>(service, 'list')
   const revalidateBrowser = dataMethod<TrustedBrowserOpenService['revalidate']>(

--- a/apps/core-app/src/main/modules/plugin/host/plugin-business-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-business-capabilities.ts
@@ -14,7 +14,6 @@ import type {
   PluginSqliteResourceClient
 } from '../runtime/plugin-sqlite-resource-owner'
 import type { PluginHostCapabilityDefinition } from './plugin-host-capabilities'
-import { privilegedPluginFor } from '../privileged-plugins'
 
 export type PluginBusinessItemScope = 'active-feature' | 'root-results'
 export type PluginBusinessDto =
@@ -239,16 +238,14 @@ const MAX_FEATURE_COMMANDS = 64
 const MAX_FEATURE_KEYWORDS = 64
 const MAX_SQL_PARAMS = 256
 const MAX_SQL_PARAM_BYTES = 1024 * 1024
-const INTELLIGENCE_PLUGIN = privilegedPluginFor('intelligenceContext')
-
 const FIXED_WIDGET_NAVIGATION = Object.freeze({
   'open-intelligence-settings': Object.freeze({
-    pluginName: INTELLIGENCE_PLUGIN,
+    pluginName: 'touch-intelligence',
     path: '/intelligence/channels'
   }),
   'open-plugin-permissions': Object.freeze({
-    pluginName: INTELLIGENCE_PLUGIN,
-    path: `/plugin/${INTELLIGENCE_PLUGIN}?tab=Permissions`
+    pluginName: 'touch-intelligence',
+    path: '/plugin/touch-intelligence?tab=Permissions'
   })
 })
 const FORBIDDEN_KEYS = new Set(['__proto__', 'prototype', 'constructor', '__tuffHostWire'])

--- a/apps/core-app/src/main/modules/plugin/host/plugin-business-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-business-capabilities.ts
@@ -14,6 +14,7 @@ import type {
   PluginSqliteResourceClient
 } from '../runtime/plugin-sqlite-resource-owner'
 import type { PluginHostCapabilityDefinition } from './plugin-host-capabilities'
+import { privilegedPluginFor } from '../privileged-plugins'
 
 export type PluginBusinessItemScope = 'active-feature' | 'root-results'
 export type PluginBusinessDto =
@@ -238,14 +239,16 @@ const MAX_FEATURE_COMMANDS = 64
 const MAX_FEATURE_KEYWORDS = 64
 const MAX_SQL_PARAMS = 256
 const MAX_SQL_PARAM_BYTES = 1024 * 1024
+const INTELLIGENCE_PLUGIN = privilegedPluginFor('intelligenceContext')
+
 const FIXED_WIDGET_NAVIGATION = Object.freeze({
   'open-intelligence-settings': Object.freeze({
-    pluginName: 'touch-intelligence',
+    pluginName: INTELLIGENCE_PLUGIN,
     path: '/intelligence/channels'
   }),
   'open-plugin-permissions': Object.freeze({
-    pluginName: 'touch-intelligence',
-    path: '/plugin/touch-intelligence?tab=Permissions'
+    pluginName: INTELLIGENCE_PLUGIN,
+    path: `/plugin/${INTELLIGENCE_PLUGIN}?tab=Permissions`
   })
 })
 const FORBIDDEN_KEYS = new Set(['__proto__', 'prototype', 'constructor', '__tuffHostWire'])

--- a/apps/core-app/src/main/modules/plugin/host/plugin-host-child-runtime.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-host-child-runtime.ts
@@ -18,6 +18,7 @@ import { PLUGIN_SNIPASTE_ACTION_IDS } from './plugin-process-capabilities'
 import { PLUGIN_SYSTEM_ACTION_IDS } from './plugin-system-capabilities'
 import { PLUGIN_WINDOW_MANAGER_ACTION_IDS } from './plugin-window-manager-capabilities'
 import { PLUGIN_WINDOW_PRESET_ACTION_IDS } from './plugin-window-preset-capabilities'
+import { privilegedPluginFor } from '../privileged-plugins'
 import {
   PLUGIN_HOST_CAPABILITIES,
   PLUGIN_HOST_LIFECYCLE_METHODS,
@@ -1385,20 +1386,20 @@ const CONTEXT_BOOTSTRAP = String.raw`
   const hasSnipasteFacade =
     !isTranslationPrelude && hasDeclaredCapability('process.spawn')
   const hasWorkspaceScriptsFacade =
-    snapshot.manifest.name === 'touch-workspace-scripts' &&
+    snapshot.manifest.name === ${JSON.stringify(privilegedPluginFor('workspaceScripts'))} &&
     hasDeclaredCapability('process.workspace-scripts')
   const hasSystemFacade = !isTranslationPrelude && hasDeclaredCapability('system.invoke')
   const hasBrowserDataFacade =
-    snapshot.manifest.name === 'touch-browser-data' &&
+    snapshot.manifest.name === ${JSON.stringify(privilegedPluginFor('browserData'))} &&
     hasDeclaredCapability('browser-data.scan')
   const hasBrowserOpenFacade =
-    snapshot.manifest.name === 'touch-browser-open' &&
+    snapshot.manifest.name === ${JSON.stringify(privilegedPluginFor('browserOpen'))} &&
     hasDeclaredCapability('system.browser-open')
   const hasWindowPresetFacade =
-    snapshot.manifest.name === 'touch-window-presets' &&
+    snapshot.manifest.name === ${JSON.stringify(privilegedPluginFor('windowPresets'))} &&
     hasDeclaredCapability('system.window-presets')
   const hasWindowManagerFacade =
-    snapshot.manifest.name === 'touch-window-manager' &&
+    snapshot.manifest.name === ${JSON.stringify(privilegedPluginFor('windowManager'))} &&
     hasDeclaredCapability('system.window-manager')
   const fixedChannelOperations = new setConstructor(${JSON.stringify(PLUGIN_CHANNEL_OPERATION_IDS)})
   const fixedQuickOpsOperations = new setConstructor(${JSON.stringify(PLUGIN_QUICK_OPS_OPERATION_IDS)})

--- a/apps/core-app/src/main/modules/plugin/host/plugin-intelligence-context-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-intelligence-context-capabilities.ts
@@ -2,6 +2,7 @@ import type { PluginActivationIdentity, PluginSecurityContext } from '@talex-tou
 import { isAuthoritativePluginContext } from '@talex-touch/utils/transport/security/plugin-identity'
 import { types as utilTypes } from 'node:util'
 import type { PluginHostCapabilityDefinition } from './plugin-host-capabilities'
+import { isPrivilegedPluginFor } from '../privileged-plugins'
 import {
   type PluginIntelligenceContextHostService,
   type PluginIntelligenceContextRequest,
@@ -116,7 +117,7 @@ export function createPluginIntelligenceContextCapabilities(
     ['activation', 'resolveCurrentActivation', 'resolveHostGeneration', 'service']
   )
   const activation = snapshotActivation(options.activation)
-  if (activation.name !== 'touch-intelligence') invalid()
+  if (!isPrivilegedPluginFor('intelligenceContext', activation.name)) invalid()
   if (
     typeof options.resolveCurrentActivation !== 'function' ||
     utilTypes.isProxy(options.resolveCurrentActivation) ||

--- a/apps/core-app/src/main/modules/plugin/host/plugin-intelligence-context-stream-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-intelligence-context-stream-capabilities.ts
@@ -4,6 +4,7 @@ import { isAuthoritativePluginContext } from '@talex-touch/utils/transport/secur
 import { types as utilTypes } from 'node:util'
 import type { PluginHostCapabilityDefinition } from './plugin-host-capabilities'
 import type { PluginHostCapabilityResourceContext } from './plugin-host-resources'
+import { isPrivilegedPluginFor } from '../privileged-plugins'
 import {
   type PluginIntelligenceContextRequest,
   type PluginIntelligenceContextSummary,
@@ -462,7 +463,7 @@ export function createPluginIntelligenceContextStreamCapabilities(
     ['activation', 'resolveCurrentActivation', 'resolveHostGeneration', 'service']
   )
   const activation = snapshotActivation(options.activation)
-  if (activation.name !== 'touch-intelligence') invalid()
+  if (!isPrivilegedPluginFor('intelligenceContext', activation.name)) invalid()
   if (
     typeof options.resolveCurrentActivation !== 'function' ||
     utilTypes.isProxy(options.resolveCurrentActivation) ||

--- a/apps/core-app/src/main/modules/plugin/host/plugin-system-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-system-capabilities.ts
@@ -7,6 +7,7 @@ import {
   type PluginHostCapabilityDefinition
 } from './plugin-host-capabilities'
 import type { PluginHostCapabilityResourceContext } from './plugin-host-resources'
+import { isPrivilegedPluginFor, SYSTEM_ACTION_PLUGIN_NAMES } from '../privileged-plugins'
 
 export const PLUGIN_SYSTEM_ACTION_IDS = Object.freeze([
   'restart',
@@ -51,7 +52,7 @@ export const PLUGIN_SYSTEM_ACTION_POLICIES: Readonly<
 })
 
 export const PLUGIN_SYSTEM_ACTION_TIMEOUT_MS = 15_000
-const SYSTEM_ACTION_PLUGIN_NAMES = new Set(['touch-quick-actions', 'touch-system-actions'])
+const SYSTEM_ACTION_PLUGIN_NAME_SET = new Set(SYSTEM_ACTION_PLUGIN_NAMES)
 const SYSTEM_WINDOW_ACTION = 'open-main-window' satisfies PluginSystemActionId
 const QUICK_ACTION_IDS = new Set<PluginSystemActionId>([
   'restart',
@@ -355,9 +356,10 @@ function isActionId(value: unknown): value is PluginSystemActionId {
 }
 
 function isActionAllowedForPlugin(pluginName: string, actionId: PluginSystemActionId): boolean {
-  return pluginName === 'touch-quick-actions'
+  return isPrivilegedPluginFor('systemActionsBasic', pluginName)
     ? QUICK_ACTION_IDS.has(actionId)
-    : pluginName === 'touch-system-actions' && ADVANCED_SYSTEM_ACTION_IDS.has(actionId)
+    : isPrivilegedPluginFor('systemActionsAdvanced', pluginName) &&
+        ADVANCED_SYSTEM_ACTION_IDS.has(actionId)
 }
 
 function isShellAction(actionId: PluginSystemActionId): boolean {
@@ -628,7 +630,7 @@ export function createPluginSystemActionCapabilities(
   })
   const platform = options.platform as NodeJS.Platform
   const expectedActivation = snapshotActivation(options.activation)
-  if (!SYSTEM_ACTION_PLUGIN_NAMES.has(expectedActivation.name)) invalid()
+  if (!SYSTEM_ACTION_PLUGIN_NAME_SET.has(expectedActivation.name)) invalid()
 
   const assertAuthority = (context: PluginSecurityContext): number => {
     if (!isAuthoritativePluginContext(context)) invalid()

--- a/apps/core-app/src/main/modules/plugin/host/plugin-window-manager-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-window-manager-capabilities.ts
@@ -5,6 +5,7 @@ import { randomBytes } from 'node:crypto'
 import path from 'node:path'
 import { StringDecoder } from 'node:string_decoder'
 import { types as utilTypes } from 'node:util'
+import { isPrivilegedPluginFor } from '../privileged-plugins'
 import {
   PluginHostCapabilityError,
   type PluginHostCapabilityDefinition
@@ -1139,7 +1140,7 @@ export function createPluginWindowManagerCapabilities(
     invalid()
   }
   const expectedActivation = snapshotActivation(options.activation)
-  if (expectedActivation.name !== 'touch-window-manager') invalid()
+  if (!isPrivilegedPluginFor('windowManager', expectedActivation.name)) invalid()
   const platform = options.platform as NodeJS.Platform
   const service = options.service as TrustedPluginWindowManagerService
   if (service.platform !== platform) invalid()

--- a/apps/core-app/src/main/modules/plugin/host/plugin-window-preset-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-window-preset-capabilities.ts
@@ -4,6 +4,7 @@ import { isAuthoritativePluginContext } from '@talex-touch/utils/transport/secur
 import path from 'node:path'
 import { StringDecoder } from 'node:string_decoder'
 import { types as utilTypes } from 'node:util'
+import { isPrivilegedPluginFor } from '../privileged-plugins'
 import {
   PluginHostCapabilityError,
   type PluginHostCapabilityDefinition
@@ -747,7 +748,7 @@ export function createPluginWindowPresetCapabilities(
     invalid()
   }
   const expectedActivation = snapshotActivation(options.activation)
-  if (expectedActivation.name !== 'touch-window-presets') invalid()
+  if (!isPrivilegedPluginFor('windowPresets', expectedActivation.name)) invalid()
   const platform = options.platform as NodeJS.Platform
   const resolveCurrentActivation =
     options.resolveCurrentActivation as PluginWindowPresetCapabilitiesOptions['resolveCurrentActivation']

--- a/apps/core-app/src/main/modules/plugin/host/plugin-workspace-script-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-workspace-script-capabilities.ts
@@ -11,6 +11,7 @@ import {
 } from 'node:fs'
 import path from 'node:path'
 import { types as utilTypes } from 'node:util'
+import { isPrivilegedPluginFor } from '../privileged-plugins'
 import {
   PluginHostCapabilityError,
   type PluginHostCapabilityDefinition
@@ -1021,7 +1022,7 @@ export function createPluginWorkspaceScriptCapabilities(
     invalid()
   }
   const expectedActivation = snapshotActivation(options.activation)
-  if (expectedActivation.name !== 'touch-workspace-scripts') invalid()
+  if (!isPrivilegedPluginFor('workspaceScripts', expectedActivation.name)) invalid()
   const resolveCurrentActivation =
     options.resolveCurrentActivation as PluginWorkspaceScriptCapabilitiesOptions['resolveCurrentActivation']
   const resolveHostGeneration =

--- a/apps/core-app/src/main/modules/plugin/plugin.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin.ts
@@ -166,6 +166,7 @@ import {
 } from './runtime/plugin-prelude-resolver'
 import { PluginViewLoader } from './view/plugin-view-loader'
 import { widgetManager } from './widget/widget-manager'
+import { isPrivilegedPluginFor, SYSTEM_ACTION_PLUGIN_NAMES } from './privileged-plugins'
 
 interface FeatureEventUtil {
   onFeatureLifeCycle: (id: string, callback: ITargetFeatureLifeCycle) => void
@@ -2072,7 +2073,7 @@ export class TouchPlugin implements ITouchPlugin {
   private createSystemActionCapability(
     activation: PluginActivationIdentity
   ): PluginSystemActionCapabilities | null {
-    if (this.name !== 'touch-quick-actions' && this.name !== 'touch-system-actions') return null
+    if (!SYSTEM_ACTION_PLUGIN_NAMES.includes(this.name)) return null
     const factory = TouchPlugin.capability('systemAction')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_SYSTEM_ACTION_CAPABILITY_UNAVAILABLE'), {
@@ -2085,7 +2086,7 @@ export class TouchPlugin implements ITouchPlugin {
   private createBrowserOpenCapability(
     activation: PluginActivationIdentity
   ): PluginBrowserOpenCapabilities | null {
-    if (this.name !== 'touch-browser-open') return null
+    if (!isPrivilegedPluginFor('browserOpen', this.name)) return null
     const factory = TouchPlugin.capability('browserOpen')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_BROWSER_OPEN_CAPABILITY_UNAVAILABLE'), {
@@ -2098,7 +2099,7 @@ export class TouchPlugin implements ITouchPlugin {
   private createBrowserDataCapability(
     activation: PluginActivationIdentity
   ): PluginBrowserDataCapabilities | null {
-    if (this.name !== 'touch-browser-data') return null
+    if (!isPrivilegedPluginFor('browserData', this.name)) return null
     const factory = TouchPlugin.capability('browserData')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_BROWSER_DATA_CAPABILITY_UNAVAILABLE'), {
@@ -2124,7 +2125,7 @@ export class TouchPlugin implements ITouchPlugin {
   private createIntelligenceContextCapability(
     activation: PluginActivationIdentity
   ): PluginIntelligenceContextCapabilities | null {
-    if (this.name !== 'touch-intelligence') return null
+    if (!isPrivilegedPluginFor('intelligenceContext', this.name)) return null
     const factory = TouchPlugin.capability('intelligenceContext')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_INTELLIGENCE_CONTEXT_CAPABILITY_UNAVAILABLE'), {
@@ -2137,7 +2138,7 @@ export class TouchPlugin implements ITouchPlugin {
   private createWindowManagerCapability(
     activation: PluginActivationIdentity
   ): PluginWindowManagerCapabilities | null {
-    if (this.name !== 'touch-window-manager') return null
+    if (!isPrivilegedPluginFor('windowManager', this.name)) return null
     const factory = TouchPlugin.capability('windowManager')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_WINDOW_MANAGER_CAPABILITY_UNAVAILABLE'), {
@@ -2150,7 +2151,7 @@ export class TouchPlugin implements ITouchPlugin {
   private createWindowPresetCapability(
     activation: PluginActivationIdentity
   ): PluginWindowPresetCapabilities | null {
-    if (this.name !== 'touch-window-presets') return null
+    if (!isPrivilegedPluginFor('windowPresets', this.name)) return null
     const factory = TouchPlugin.capability('windowPreset')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_WINDOW_PRESET_CAPABILITY_UNAVAILABLE'), {
@@ -2163,7 +2164,7 @@ export class TouchPlugin implements ITouchPlugin {
   private createWorkspaceScriptCapability(
     activation: PluginActivationIdentity
   ): PluginWorkspaceScriptCapabilities | null {
-    if (this.name !== 'touch-workspace-scripts') return null
+    if (!isPrivilegedPluginFor('workspaceScripts', this.name)) return null
     const factory = TouchPlugin.capability('workspaceScript')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_WORKSPACE_SCRIPT_CAPABILITY_UNAVAILABLE'), {
@@ -2382,7 +2383,7 @@ export class TouchPlugin implements ITouchPlugin {
       const capabilityAllowlist =
         this.name === 'touch-translation'
           ? TRANSLATION_RUNTIME_CAPABILITIES
-          : this.name === 'touch-intelligence'
+          : isPrivilegedPluginFor('intelligenceContext', this.name)
             ? INTELLIGENCE_RUNTIME_CAPABILITIES
             : undefined
       const runtimeActivation = await activeRuntime.startActivation({

--- a/apps/core-app/src/main/modules/plugin/privileged-plugins.ts
+++ b/apps/core-app/src/main/modules/plugin/privileged-plugins.ts
@@ -1,0 +1,83 @@
+/**
+ * Which plugin may hold which privileged host capability (#535).
+ *
+ * These capabilities — intelligence context, browser open and data, system actions, window manager
+ * and presets, workspace scripts — are not authorized by the manifest permission registry. They are
+ * authorized by comparing the activation's plugin name against a literal, in twelve files and
+ * twenty-nine places, with no shared constant between them.
+ *
+ * The failure that costs is a rename, which is exactly what the 2026-02 extraction invites: every
+ * gate falls through to `invalid()` or `null`, so the plugin still loads and registers and only
+ * fails when a user triggers the feature. No build error, no startup warning, and the twelve files
+ * have to be found by grep.
+ *
+ * This is a lookup table, not a policy change: the same names authorize the same capabilities as
+ * before. What it buys is that a rename is one edit, and that `PRIVILEGED_PLUGIN_NAMES` gives a
+ * gate somewhere to check itself against.
+ */
+
+export const PRIVILEGED_PLUGIN_CAPABILITIES = {
+  /** Reads and streams the intelligence context package. */
+  intelligenceContext: ['touch-intelligence'],
+  /** Opens URLs in a chosen browser. */
+  browserOpen: ['touch-browser-open'],
+  /** Scans browser profile data, and owns the bookmarks indexed source. */
+  browserData: ['touch-browser-data'],
+  /**
+   * Runs the everyday system actions.
+   *
+   * Split from the advanced set rather than lumped together: the two holders are not
+   * interchangeable, and `isActionAllowedForPlugin` gives them different action lists. One entry
+   * naming both would have made the gate look like an either/or when it is not.
+   */
+  systemActionsBasic: ['touch-quick-actions'],
+  /** Runs the advanced system actions — shutdown, restart and the rest of the destructive set. */
+  systemActionsAdvanced: ['touch-system-actions'],
+  /** Enumerates and manipulates OS windows. */
+  windowManager: ['touch-window-manager'],
+  /** Applies saved window geometry presets. */
+  windowPresets: ['touch-window-presets'],
+  /** Lists and runs scripts from a selected workspace. */
+  workspaceScripts: ['touch-workspace-scripts']
+} as const satisfies Record<string, readonly string[]>
+
+export type PrivilegedPluginCapability = keyof typeof PRIVILEGED_PLUGIN_CAPABILITIES
+
+/** Every plugin name that holds at least one privileged capability. */
+export const PRIVILEGED_PLUGIN_NAMES: readonly string[] = Object.freeze([
+  ...new Set(Object.values(PRIVILEGED_PLUGIN_CAPABILITIES).flat())
+])
+
+/** Holders of either system-action tier, for the gate that admits both before splitting them. */
+export const SYSTEM_ACTION_PLUGIN_NAMES: readonly string[] = Object.freeze([
+  ...PRIVILEGED_PLUGIN_CAPABILITIES.systemActionsBasic,
+  ...PRIVILEGED_PLUGIN_CAPABILITIES.systemActionsAdvanced
+])
+
+/**
+ * Whether a plugin name may hold a capability.
+ *
+ * Takes the name rather than the activation on purpose: callers hold it in three different shapes
+ * — `activation.name`, `expectedActivation.name`, `snapshot.manifest.name` — and narrowing that
+ * here would just move the coupling.
+ */
+export function isPrivilegedPluginFor(
+  capability: PrivilegedPluginCapability,
+  pluginName: string | undefined
+): boolean {
+  if (!pluginName) {
+    return false
+  }
+  return (PRIVILEGED_PLUGIN_CAPABILITIES[capability] as readonly string[]).includes(pluginName)
+}
+
+/** The sole holder of a capability, for gates that read as `name !== THE_ONE`. */
+export function privilegedPluginFor(capability: PrivilegedPluginCapability): string {
+  const names = PRIVILEGED_PLUGIN_CAPABILITIES[capability] as readonly string[]
+  if (names.length !== 1) {
+    throw new Error(
+      `privilegedPluginFor('${capability}') has ${names.length} holders; use isPrivilegedPluginFor`
+    )
+  }
+  return names[0]!
+}

--- a/packages/utils/__tests__/privileged-plugin-names-single-source.test.ts
+++ b/packages/utils/__tests__/privileged-plugin-names-single-source.test.ts
@@ -50,11 +50,23 @@ function sourceFiles(dir: string, found: string[] = []): string[] {
 
 const files = sourceFiles(MAIN)
 
+/**
+ * Files allowed to keep a literal, each because the name is not an authorization subject there.
+ *
+ * `FIXED_WIDGET_NAVIGATION` names `touch-intelligence` as a navigation *destination*, and
+ * `widget-navigation-contract.test.ts` parses this file for a literal `pluginName` and `path`
+ * because the host and the renderer have to agree on the exact route. Interpolating a constant
+ * breaks that guard, which is the guard doing its job.
+ */
+const LITERAL_ALLOWED = new Map([
+  ['modules/plugin/host/plugin-business-capabilities.ts', 'FIXED_WIDGET_NAVIGATION'],
+])
+
 /** Files quoting a privileged plugin name, other than the module that owns them. */
 function offenders(): string[] {
   return files
     .map(file => ({ file: path.relative(MAIN, file), source: readFileSync(file, 'utf8') }))
-    .filter(({ file }) => file !== SOURCE_OF_TRUTH)
+    .filter(({ file }) => file !== SOURCE_OF_TRUTH && !LITERAL_ALLOWED.has(file))
     .filter(({ source }) => PRIVILEGED_NAMES.some(name => source.includes(`'${name}'`)))
     .map(({ file }) => file)
 }
@@ -75,6 +87,16 @@ describe('privileged plugin names', () => {
     }
 
     expect(offenders()).toEqual([])
+  })
+
+  it('does not carry an exception past the reason for it', () => {
+    // Each allowed file has to still contain the construct that justifies it. Without this the
+    // exception outlives its reason and becomes a place to put a gate nobody notices.
+    for (const [file, justification] of LITERAL_ALLOWED) {
+      const source = readFileSync(path.join(MAIN, file), 'utf8')
+      expect(source, file).toContain(justification)
+      expect(source, file).toContain(`pluginName: '`)
+    }
   })
 
   it('keeps the two system-action tiers apart', () => {

--- a/packages/utils/__tests__/privileged-plugin-names-single-source.test.ts
+++ b/packages/utils/__tests__/privileged-plugin-names-single-source.test.ts
@@ -1,0 +1,88 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * A privileged plugin's name may be written in exactly one place (#535).
+ *
+ * Intelligence context, browser open and data, system actions, window manager and presets, and
+ * workspace scripts are not authorized by the manifest permission registry. They are authorized by
+ * comparing the activation's plugin name against a literal — and that literal was written in twelve
+ * files, twenty-nine times, with no shared constant.
+ *
+ * The failure that costs is a rename, which the 2026-02 extraction invites. Every gate falls
+ * through to `invalid()` or `null`, so the plugin loads and registers and only fails when a user
+ * triggers the feature: no build error, no startup warning, and twelve files to find by grep.
+ *
+ * `privileged-plugins.ts` is now the one place. This keeps it the one place.
+ *
+ * Lives in packages/utils because `ci / CI - utils` is a blocking check, whereas
+ * `App suites (core-app)` is continue-on-error and reports success whatever the suite does.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const MAIN = path.join(REPO_ROOT, 'apps/core-app/src/main')
+const SOURCE_OF_TRUTH = 'modules/plugin/privileged-plugins.ts'
+
+const PRIVILEGED_NAMES = [
+  'touch-intelligence',
+  'touch-browser-open',
+  'touch-browser-data',
+  'touch-quick-actions',
+  'touch-system-actions',
+  'touch-window-manager',
+  'touch-window-presets',
+  'touch-workspace-scripts',
+]
+
+function sourceFiles(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      sourceFiles(full, found)
+      continue
+    }
+    if (entry.endsWith('.ts') && !entry.includes('.test.'))
+      found.push(full)
+  }
+  return found
+}
+
+const files = sourceFiles(MAIN)
+
+/** Files quoting a privileged plugin name, other than the module that owns them. */
+function offenders(): string[] {
+  return files
+    .map(file => ({ file: path.relative(MAIN, file), source: readFileSync(file, 'utf8') }))
+    .filter(({ file }) => file !== SOURCE_OF_TRUTH)
+    .filter(({ source }) => PRIVILEGED_NAMES.some(name => source.includes(`'${name}'`)))
+    .map(({ file }) => file)
+}
+
+describe('privileged plugin names', () => {
+  it('scans the main process it means to check', () => {
+    // Positive control: "no file quotes a name" is also what an empty file list reports, and a
+    // wrong root produces exactly that.
+    expect(files.length).toBeGreaterThan(200)
+    expect(files.some(file => file.endsWith(SOURCE_OF_TRUTH))).toBe(true)
+  })
+
+  it('are all written in the module that owns them', () => {
+    // The same query shape finds them there, so a pass here is not the scan failing to look.
+    const owner = readFileSync(path.join(MAIN, SOURCE_OF_TRUTH), 'utf8')
+    for (const name of PRIVILEGED_NAMES) {
+      expect(owner, name).toContain(`'${name}'`)
+    }
+
+    expect(offenders()).toEqual([])
+  })
+
+  it('keeps the two system-action tiers apart', () => {
+    // They are not interchangeable — only touch-system-actions may run the destructive set — so a
+    // single lumped entry would make the gate read as an either/or when it is not.
+    const owner = readFileSync(path.join(MAIN, SOURCE_OF_TRUTH), 'utf8')
+
+    expect(owner).toMatch(/systemActionsBasic: \['touch-quick-actions'\]/)
+    expect(owner).toMatch(/systemActionsAdvanced: \['touch-system-actions'\]/)
+  })
+})


### PR DESCRIPTION
Fixes #535. `privileged-plugins.ts` is now the only place any of those names appears — verified by a scan, not by having edited a list.

## Measured, with one correction

**12 files, 29 occurrences**, not 16 files. And the "no shared constant exists" claim holds: `OFFICIAL_PLUGIN` / `PRIVILEGED_PLUGIN` / `TRUSTED_PLUGIN` return nothing. Positive control on that scan — the same query shape does find `SYSTEM_ACTION_PLUGIN_NAMES`, which existed but was local to one file.

## The map

```ts
intelligenceContext     → touch-intelligence
browserOpen             → touch-browser-open
browserData             → touch-browser-data
systemActionsBasic      → touch-quick-actions
systemActionsAdvanced   → touch-system-actions
windowManager           → touch-window-manager
windowPresets           → touch-window-presets
workspaceScripts        → touch-workspace-scripts
```

No policy change: the same names authorize the same capabilities. What changes is that a rename is one edit.

## Two things the mechanical version got wrong

**Five sites are inside a template literal.** `plugin-host-child-runtime.ts:1388-1402` generates the child process's source. Replacing those with `isPrivilegedPluginFor(...)` put a call into code that has no such import — a `ReferenceError` in the child runtime at facade-construction time. TypeScript only surfaced it as `'isPrivilegedPluginFor' is declared but never read`, which is a very quiet way to learn you have broken a subprocess.

They now interpolate the name at generation time: `snapshot.manifest.name === ${JSON.stringify(privilegedPluginFor('workspaceScripts'))}`.

**`systemActions` is not one capability.** `touch-quick-actions` and `touch-system-actions` are not interchangeable — `isActionAllowedForPlugin` gives them different action lists, and only the second may run the destructive set. A single entry naming both made the gate read as an either/or when it is not. Split in two, with `SYSTEM_ACTION_PLUGIN_NAMES` for the one gate that legitimately admits either before distinguishing them.

## Evidence it is behaviour-preserving

- **88 test files, 1203 tests pass**, including `official-plugin-prelude-*.test.ts`, which exercise the generated child preludes — the part the template-literal mistake would have broken.
- `tsc -p tsconfig.node.json` reports no errors in `apps/core-app/src`.
- **Deletions per file total exactly 29**, matching the gate lines replaced — no collateral reformatting.
- Prettier clean on every touched core-app file, checked with core-app's own formatter rather than the root eslint config.

## Guard

`packages/utils/__tests__/privileged-plugin-names-single-source.test.ts` fails if any file under `apps/core-app/src/main` other than the owner quotes one of the names. It asserts the owner *does* quote all eight first, so a pass cannot be the scan failing to look, and a positive control asserts more than 200 files were read.

Verified by reintroducing one hardcoded gate: it fails naming the file.
