### PR TITLE
build(core-app): turn noImplicitAny on for the renderer [#548]

### DIFF
--- a/apps/core-app/src/renderer/src/modules/tuffex/index.ts
+++ b/apps/core-app/src/renderer/src/modules/tuffex/index.ts
@@ -60,7 +60,10 @@ const COMPONENT_IMPORTERS = {
  */
 export async function loadTuffexComponent(name: EnabledComponent) {
   try {
-    const module = await COMPONENT_IMPORTERS[name]()
+    // Annotated rather than inferred: `satisfies` above keeps the literal type, so the inferred
+    // result is a union of the concrete module shapes and `module[name]` indexes it implicitly as
+    // `any`. The satisfies clause already proves every importer meets this contract (#548).
+    const module: TuffexComponentModule = await COMPONENT_IMPORTERS[name]()
     return module[name] || null
   } catch (error) {
     tuffexLog.warn(`Failed to load component: ${name}`, error)
@@ -74,6 +77,20 @@ export async function loadTuffexComponent(name: EnabledComponent) {
  * @param app - Vue application instance
  * @param components - List of component names to register (defaults to all enabled)
  */
+/**
+ * Whether a component carries an `install`, and so may be handed to `app.use`.
+ *
+ * The runtime check was always here; what was missing is that it says something to the type
+ * system. `InstallableComponent` is `Component & Partial<Plugin>`, and `app.use` needs a whole
+ * `Plugin` — the implicit `any` on the loaded module was hiding that gap rather than closing it
+ * (#548).
+ */
+function isInstallable(
+  component: InstallableComponent
+): component is InstallableComponent & { install: (app: App) => void } {
+  return typeof component.install === 'function'
+}
+
 export async function registerTuffexComponents(
   app: App,
   components: EnabledComponent[] = [...ENABLED_COMPONENTS]
@@ -81,7 +98,7 @@ export async function registerTuffexComponents(
   try {
     for (const name of components) {
       const component = await loadTuffexComponent(name)
-      if (component && typeof component.install === 'function') {
+      if (component && isInstallable(component)) {
         app.use(component)
       } else if (component) {
         app.component(name, component)

--- a/apps/core-app/src/renderer/src/views/base/plugin/PluginNew.vue
+++ b/apps/core-app/src/renderer/src/views/base/plugin/PluginNew.vue
@@ -9,6 +9,7 @@ import { useTuffTransport } from '@talex-touch/utils/transport'
 import { defineRawEvent } from '@talex-touch/utils/transport/event/builder'
 import type { PluginInstallSourceResponse } from '@talex-touch/utils/transport/events/types/plugin'
 import { PluginEvents } from '@talex-touch/utils/transport/events'
+import type { ComputedRef, UnwrapNestedRefs } from 'vue'
 import { computed, createVNode, onMounted, reactive, ref, watch } from 'vue'
 
 import { useI18n } from 'vue-i18n'
@@ -219,8 +220,13 @@ interface EnvOptions {
   }
 }
 
-// Reactive plugin data object
-const plugin = reactive<Plugin>({
+// Reactive plugin data object.
+//
+// Annotated because `dev.enable` is a computed that reads `plugin.dev.address` — the object
+// references itself inside its own initializer, so inference gives up and the whole thing becomes
+// implicit `any` (#548). The annotation is the *unwrapped* type: reactive() turns the
+// ComputedRef<boolean> the interface declares into a plain boolean.
+const plugin: UnwrapNestedRefs<Plugin> = reactive<Plugin>({
   template: false,
   name: '',
   desc: '',

--- a/apps/core-app/tsconfig.web.json
+++ b/apps/core-app/tsconfig.web.json
@@ -1,6 +1,12 @@
 {
   "extends": "@electron-toolkit/tsconfig/tsconfig.web.json",
   "compilerOptions": {
+    // @electron-toolkit/tsconfig sets noImplicitAny: false alongside strict: true, and an
+    // explicit flag beats the strict-family default -- so every untyped parameter in the
+    // renderer was silently any, and a renamed field on a caller reached runtime with no
+    // compile error (#548). The renderer needed two files fixed to satisfy this; the main
+    // process needs 227 and is tracked on the issue.
+    "noImplicitAny": true,
     "composite": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
Refs #548. Turns the flag on for the **renderer**. The main process is quantified below and stays off — 227 errors is not one change.

## Confirmed

`@electron-toolkit/tsconfig` sets `noImplicitAny: false` alongside `strict: true`, and an explicit flag beats the strict-family default. Measured by running each project with and without `--noImplicitAny`:

| project | baseline errors | with the flag | implicit-any errors |
|---|---|---|---|
| `tsconfig.web.json` (renderer) | 10 | 13 | **3** |
| `tsconfig.node.json` (main) | 6 | 233 | **227** |

So the renderer costs two files. `typecheck:web` is now at the same 10 errors with the flag on as without it.

## Both fixes were the `any` hiding something

**`modules/tuffex/index.ts`.** The `satisfies` clause keeps the object's literal type, so `await COMPONENT_IMPORTERS[name]()` is a union of the concrete module shapes and `module[name]` indexes it implicitly as `any`. Annotating it to the declared `TuffexComponentModule` — which `satisfies` already proves every importer meets — then surfaced a **real** mismatch: `app.use()` wants a whole `Plugin`, and `InstallableComponent` is `Component & Partial<Plugin>`.

The runtime check `typeof component.install === 'function'` was always there. It is now a type predicate, so it tells the compiler what it already tells the reader, instead of the gap being papered over by `any`.

**`views/base/plugin/PluginNew.vue`.** `plugin` holds `dev.enable: computed(() => !!plugin.dev.address)` — the object references itself inside its own initializer, so inference gives up (TS7022) and the computed's return type follows (TS7024). Annotated with `UnwrapNestedRefs<Plugin>`, which is the honest type: `reactive()` turns the declared `ComputedRef<boolean>` into a plain `boolean`, so annotating it as `Plugin` would have been wrong.

## The main process, so the number is on record

**227 implicit-any errors.** That is not a per-file suppression job — it is a migration, and doing it in one commit would produce a diff nobody can review against a config change nobody can revert independently.

If you want it, the shape I would suggest is one PR per top-level module directory under `src/main/modules`, with the flag flipped last. Say the word and I will start; I have not, because a 227-error migration is a plan to agree on rather than a fix to slip in.

## Verified

- `typecheck:web`: 10 with the flag, 10 without.
- Tests near the changed files: 11 passing.
- Prettier clean on both touched files; `tsconfig.web.json` has 0 deletions, the two source files 2 each.
