### PR TITLE
ci(release): give a manual build a tag the rollback resolver accepts [#727]

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1039,9 +1039,26 @@ jobs:
           else
             # 手动触发：创建 draft release，使用时间戳作为临时标签
             # 标签会被 release action 自动创建，但因为是 draft，不会正式发布
+            #
+            # The tag has to be semver-shaped. The next step feeds it to
+            # resolve-update-rollback-version.mjs, which calls inferManifestChannel and throws on
+            # anything that is not MAJOR.MINOR.PATCH[-label.x] -- manual-build-<timestamp> is not,
+            # so every manual run died after the full three-platform build (#727).
+            #
+            # The label picks the channel, and only these work: snapshot/beta/alpha map to BETA,
+            # master maps to RELEASE; manual, release and rc all return null. The base version is
+            # used rather than the package version because inferManifestChannel reads the *first*
+            # prerelease identifier -- appending to 2.4.14-beta.2 keeps resolving to BETA even for
+            # a release-type build.
             TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+            BASE_VERSION=$(node -p "require('./package.json').version.split('-')[0]")
+            case "$RELEASE_TYPE" in
+              snapshot) CHANNEL_LABEL=snapshot ;;
+              beta) CHANNEL_LABEL=beta ;;
+              *) CHANNEL_LABEL=master ;;
+            esac
             echo "type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
-            echo "tag=manual-build-$TIMESTAMP" >> $GITHUB_OUTPUT
+            echo "tag=v${BASE_VERSION}-${CHANNEL_LABEL}.${TIMESTAMP}" >> $GITHUB_OUTPUT
             echo "name=Manual Build ($RELEASE_TYPE) - $TIMESTAMP" >> $GITHUB_OUTPUT
             echo "target_ref=$TARGET_SHA" >> $GITHUB_OUTPUT
             if [ "$RELEASE_TYPE" = "snapshot" ] || [ "$RELEASE_TYPE" = "beta" ]; then

--- a/scripts/manual-build-tag.test.mjs
+++ b/scripts/manual-build-tag.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it } from 'vitest'
+import { inferManifestChannel } from './lib/update-rollback-contract.mjs'
+
+/**
+ * A manual build's synthesised tag must be one the rollback resolver accepts (#727).
+ *
+ * `workflow_dispatch` without a `sync_tag` used to synthesise `manual-build-<timestamp>`, and the
+ * next step feeds that to `resolve-update-rollback-version.mjs`, which calls
+ * `inferManifestChannel` and throws on anything that is not `MAJOR.MINOR.PATCH[-label.x]`.
+ *
+ * The cost is the shape of it: the throw happens in the *release* job, after all three platform
+ * builds have finished. A manual build burned the full matrix and then died at the last step, every
+ * time, and the workflow is not one anybody runs by accident to find out.
+ *
+ * Two things this pins that are easy to get wrong:
+ *
+ * - the label decides the channel, and the accepting set is narrow — `manual`, `release` and `rc`
+ *   all return `null`, which is what made the obvious fix (`-manual.<ts>`) wrong too.
+ * - the **base** version has to be used. `inferManifestChannel` reads the *first* prerelease
+ *   identifier, so appending to `2.4.14-beta.2` keeps resolving to BETA even for a release-type
+ *   build — the channel would silently be wrong rather than the run failing.
+ */
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const WORKFLOW = readFileSync(path.join(REPO_ROOT, '.github/workflows/build-and-release.yml'), 'utf8')
+const VERSION = JSON.parse(readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8')).version
+
+/** What the workflow's shell would produce for a given release_type. */
+function synthesisedTag(releaseType) {
+  const base = String(VERSION).split('-')[0]
+  const label = releaseType === 'snapshot' ? 'snapshot' : releaseType === 'beta' ? 'beta' : 'master'
+  return `v${base}-${label}.20260805-120000`
+}
+
+describe('manual build tag', () => {
+  it('is the shape the workflow actually writes', () => {
+    // Positive control: every assertion below is about a string this test builds, so it is only
+    // worth anything if the workflow builds the same one.
+    assert.match(WORKFLOW, /BASE_VERSION=\$\(node -p "require\('\.\/package\.json'\)\.version\.split\('-'\)\[0\]"\)/)
+    assert.match(WORKFLOW, /tag=v\$\{BASE_VERSION\}-\$\{CHANNEL_LABEL\}\.\$\{TIMESTAMP\}/)
+    assert.match(WORKFLOW, /snapshot\) CHANNEL_LABEL=snapshot ;;/)
+    assert.match(WORKFLOW, /beta\) CHANNEL_LABEL=beta ;;/)
+    assert.match(WORKFLOW, /\*\) CHANNEL_LABEL=master ;;/)
+  })
+
+  it('no longer synthesises the tag that could not be resolved', () => {
+    assert.doesNotMatch(WORKFLOW, /tag=manual-build-/)
+  })
+
+  it('resolves to a channel for every release_type the dispatch offers', () => {
+    // The three values the workflow's own prerelease branch distinguishes.
+    for (const releaseType of ['snapshot', 'beta', 'release']) {
+      const tag = synthesisedTag(releaseType)
+      const channel = inferManifestChannel(tag.replace(/^v/i, ''))
+      assert.ok(channel, `${releaseType} -> ${tag} resolved to ${channel}`)
+    }
+  })
+
+  it('puts a release-type build on RELEASE and the others on BETA', () => {
+    // The half that would fail silently rather than loudly: a wrong channel still resolves, it
+    // just publishes the build to the wrong update stream.
+    assert.equal(inferManifestChannel(synthesisedTag('release').replace(/^v/i, '')), 'RELEASE')
+    assert.equal(inferManifestChannel(synthesisedTag('beta').replace(/^v/i, '')), 'BETA')
+    assert.equal(inferManifestChannel(synthesisedTag('snapshot').replace(/^v/i, '')), 'BETA')
+  })
+
+  it('would have resolved to nothing under the labels that look reasonable', () => {
+    // Negative control, and the reason the base version matters. Without these the test above
+    // passes against a resolver that accepts everything.
+    const base = String(VERSION).split('-')[0]
+    for (const label of ['manual', 'release', 'rc']) {
+      assert.equal(inferManifestChannel(`${base}-${label}.20260805-120000`), null, label)
+    }
+    assert.equal(inferManifestChannel('manual-build-20260805-120000'), null)
+    // Appending to the full version keeps the first identifier, so the channel stays BETA.
+    assert.equal(inferManifestChannel(`${VERSION}-master.20260805-120000`), 'BETA')
+  })
+})


### PR DESCRIPTION
Fixes #727.

## Confirmed

`workflow_dispatch` without a `sync_tag` synthesised `manual-build-<timestamp>`, and the next step feeds that straight to `resolve-update-rollback-version.mjs` → `inferManifestChannel`, which returns `null` for anything that is not `MAJOR.MINOR.PATCH[-label.x]` and makes the resolver throw.

The shape of the failure is what makes it high severity: the throw is in the **release** job, after all three platform builds have finished. A manual run burned the full matrix and then died at the last step, every time.

## The fix, and two ways it could have been got wrong

The tag is now `v${BASE_VERSION}-${CHANNEL_LABEL}.${TIMESTAMP}`.

**The label set is narrower than it looks.** From `update-rollback-contract.mjs`:

| label | channel |
|---|---|
| `snapshot`, `beta`, `alpha` | BETA |
| `master` | RELEASE |
| `manual`, `release`, `rc` | **null — throws** |

So the obvious fix, `-manual.<ts>`, fails exactly the way the old tag did. The workflow maps its own `release_type` values onto the accepting set: `snapshot`→`snapshot`, `beta`→`beta`, anything else→`master`.

**The base version has to be used, not the package version.** `inferManifestChannel` reads the *first* prerelease identifier, so `2.4.14-beta.2-master.<ts>` still resolves to **BETA**. A release-type manual build would have published to the beta update stream — resolving fine, and wrong. Confirmed by running it:

```
2.4.14-beta.2-master.20260805-120000  →  BETA
2.4.14-master.20260805-120000         →  RELEASE
```

## Verified end to end

Ran the real resolver against the tag the workflow now produces:

```
resolveSameChannelRollbackVersion({ tag: 'v2.4.14-snapshot.20260805-120000', tags: [...] })
→ { channel: 'BETA', rollbackFromVersion: '2.4.14-beta.2', rollbackTag: 'v2.4.14-beta.2', … }
```

Nothing else in the repo consumed the `manual-build-` prefix — the only match was the line being replaced.

`scripts/manual-build-tag.test.mjs` runs under `pnpm test:scripts` in `PR Quality`, which blocks. It pins the shell the workflow writes, that the old prefix is gone, the channel for each `release_type`, and — as a negative control — that `manual`/`release`/`rc` and the append-to-full-version form still resolve to the wrong thing. Without those the channel assertions would pass against a resolver that accepts anything.

Mutation-tested: restoring `tag=manual-build-$TIMESTAMP` fails 2 of 5.

## Not fixed here

With **no prior tag in the channel** the resolver still throws `No same-channel predecessor exists`. That is #559, and it is a contract question — what should `rollbackFromVersion` be for the first release in a channel — rather than a shape mistake. Left alone deliberately.
