### PR TITLE
fix(native-core): build the cancel Notified before reading the state

### DIFF
--- a/packages/tuff-native/native-core/src/cancellation.rs
+++ b/packages/tuff-native/native-core/src/cancellation.rs
@@ -169,6 +169,30 @@ mod tests {
         }
     }
 
+    /// The control for the test above: it only requires that `cancelled()` *resolves*, and
+    /// a "return immediately" implementation satisfies that too. A live token has to keep
+    /// it pending, or the race test would be measuring nothing.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_stays_pending_while_the_token_is_live() {
+        let token = CancellationToken::new();
+        let waiter = token.clone();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(250), waiter.cancelled())
+                .await
+                .is_err(),
+            "cancelled() resolved on a token that was never cancelled"
+        );
+
+        token.cancel(CancelReason::Caller);
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(5), token.cancelled())
+                .await
+                .expect("cancelled() must resolve once the token is cancelled"),
+            CancelReason::Caller
+        );
+    }
+
     // #840's second half -- `cancel` flipping a separate `cancelled` bool before storing
     // the reason, so a reader could see a cancelled token reporting `None` -- has no test
     // here on purpose. The window is two adjacent stores; a tight-spin observer on its own

--- a/packages/tuff-native/native-core/src/cancellation.rs
+++ b/packages/tuff-native/native-core/src/cancellation.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 
 use tokio::sync::Notify;
 
@@ -11,9 +11,12 @@ const REASON_CONSUMER_CLOSED: u8 = 2;
 const REASON_DEADLINE: u8 = 3;
 const REASON_DISPOSE: u8 = 4;
 
+/// `reason` doubles as the cancelled flag: `REASON_NONE` means live. Keeping them in
+/// one atomic is what makes "cancelled" and "which reason" indivisible -- with a
+/// separate bool, a reader could see the flag set while the reason was still
+/// `REASON_NONE` and report `None` from an already-cancelled token.
 #[derive(Debug)]
 struct CancellationState {
-    cancelled: AtomicBool,
     reason: AtomicU8,
     notify: Notify,
 }
@@ -33,7 +36,6 @@ impl CancellationToken {
     pub fn new() -> Self {
         Self {
             state: Arc::new(CancellationState {
-                cancelled: AtomicBool::new(false),
                 reason: AtomicU8::new(REASON_NONE),
                 notify: Notify::new(),
             }),
@@ -41,38 +43,45 @@ impl CancellationToken {
     }
 
     pub fn cancel(&self, reason: CancelReason) -> bool {
+        // One compare-exchange publishes the reason and the cancelled state together,
+        // so no reader can land between them.
         if self
             .state
-            .cancelled
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .reason
+            .compare_exchange(
+                REASON_NONE,
+                reason_to_u8(reason),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
             .is_err()
         {
             return false;
         }
-        self.state
-            .reason
-            .store(reason_to_u8(reason), Ordering::Release);
         self.state.notify.notify_waiters();
         true
     }
 
     pub fn is_cancelled(&self) -> bool {
-        self.state.cancelled.load(Ordering::Acquire)
+        self.state.reason.load(Ordering::Acquire) != REASON_NONE
     }
 
     pub fn reason(&self) -> Option<CancelReason> {
-        if !self.is_cancelled() {
-            return None;
-        }
         u8_to_reason(self.state.reason.load(Ordering::Acquire))
     }
 
     pub async fn cancelled(&self) -> CancelReason {
         loop {
+            // Built before the state is read, not after. `Notified` snapshots the
+            // notify_waiters counter when it is constructed, and `cancel` notifies
+            // exactly once -- so a cancel landing between the read and the await is
+            // accounted for by this future rather than lost, and it resolves instead
+            // of parking forever. Same shape as stream.rs and runtime.rs.
+            let notified = self.state.notify.notified();
             if let Some(reason) = self.reason() {
                 return reason;
             }
-            self.state.notify.notified().await;
+            notified.await;
         }
     }
 }
@@ -98,6 +107,8 @@ fn u8_to_reason(reason: u8) -> Option<CancelReason> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     #[tokio::test]
@@ -114,4 +125,54 @@ mod tests {
         );
         assert_eq!(token.reason(), Some(CancelReason::Deadline));
     }
+
+    /// #840: the wait loop read the state first and only then built its `Notified`.
+    /// tokio snapshots the notify_waiters counter at construction and `cancel` notifies
+    /// exactly once, so a cancel landing in that window was already accounted for and
+    /// the waiter parked with no wakeup left to come. `cancelled()` is awaited in
+    /// `tokio::select!` arms across the screenshot backend, so a lost cancel there
+    /// strands the stream entry in NativeRuntime::streams until dispose times out.
+    ///
+    /// The window is a few instructions wide, so this hammers it: a barrier releases
+    /// eight waiters and the canceller together so they all race the same cancel, and the
+    /// timeout turns a parked waiter into a failure rather than a hung suite. Calibrated
+    /// against the defect deliberately restored: 6 of 6 runs caught it, latest at
+    /// iteration 4268, so the 20k bound carries roughly a 5x margin. One waiter per
+    /// iteration was measurably worse -- it missed on one run in six.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn a_cancel_racing_the_state_read_is_not_lost() {
+        const WAITERS: usize = 8;
+        for iteration in 0..20_000u32 {
+            let token = CancellationToken::new();
+            let barrier = Arc::new(std::sync::Barrier::new(WAITERS + 1));
+            let tasks = (0..WAITERS)
+                .map(|_| {
+                    let waiter = token.clone();
+                    let released = barrier.clone();
+                    tokio::spawn(async move {
+                        released.wait();
+                        waiter.cancelled().await
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            barrier.wait();
+            token.cancel(CancelReason::Dispose);
+
+            for task in tasks {
+                let reason = tokio::time::timeout(Duration::from_secs(5), task)
+                    .await
+                    .unwrap_or_else(|_| panic!("cancelled() parked at iteration {iteration}"))
+                    .expect("the waiter task must not panic");
+                assert_eq!(reason, CancelReason::Dispose);
+            }
+        }
+    }
+
+    // #840's second half -- `cancel` flipping a separate `cancelled` bool before storing
+    // the reason, so a reader could see a cancelled token reporting `None` -- has no test
+    // here on purpose. The window is two adjacent stores; a tight-spin observer on its own
+    // thread (2,000 rounds x 200,000 loads, against the defect deliberately restored)
+    // never landed inside it. The single atomic removes the state rather than narrowing
+    // it, which is a construction-level guarantee, not an observable one.
 }


### PR DESCRIPTION
Closes #840

## What was wrong

`cancelled()` read `reason()` first and only then constructed its `Notified`:

```rust
loop {
    if let Some(reason) = self.reason() { return reason; }
    self.state.notify.notified().await;   // built after the read
}
```

tokio snapshots the `notify_waiters` counter when a `Notified` is **constructed**, and `cancel()` notifies exactly once. A cancel landing between the read and the construction is therefore already accounted for by the snapshot: the future registers as a waiter and parks, with no wakeup left to come.

`cancelled()` is awaited in `tokio::select!` arms across the screenshot backend (`backend/mod.rs:332`, `macos/actor.rs:278`, `macos/ax_actor.rs:109/129`, `xcap.rs:246/265`), so a lost cancel there leaves the stream entry in `NativeRuntime::streams` until `finish_dispose` gives up with `NATIVE_DISPOSE_TIMEOUT`.

The same crate already gets this right in `native-core/src/stream.rs:53`, `runtime.rs:597` and `backend/mod.rs:314` — all build the `Notified` first.

## Second half

`cancel()` flipped a separate `cancelled: AtomicBool` **before** storing the reason, so a reader could observe `is_cancelled() == true` with `reason() == None`. `reason` now doubles as the flag — `REASON_NONE` means live — so one compare-exchange publishes both. `is_cancelled()`, `reason()`, `cancel()` keep their signatures and semantics; only the internal representation changed.

## Test

The window is a few instructions wide, so the test hammers it: a barrier releases **eight** waiters and the canceller together so they all race the same cancel, and a timeout turns a parked waiter into a failure rather than a hung suite.

Calibrated against the defect deliberately restored:

| configuration | detection |
|---|---|
| 8 waiters/iteration, 20k iterations | **6 of 6 runs**, latest at iteration 4268 |
| 1 waiter/iteration, 20k iterations | 5 of 6 runs — **missed once** |

So the 20k bound carries roughly a 5x margin, and the concurrency is load-bearing rather than decorative. Runtime on the fixed code: 1.5s, stable across 5 runs.

Mutations, each applied through a patch asserting it matched exactly once:

| mutation | result |
|---|---|
| `Notified` built after the state read | the race test parks and fails |
| drop the first-cancel-wins gate | the pre-existing reason test fails |
| `reason()` always `Some` | both tests fail |

## Not covered by a test

The second half has none, deliberately. Its window is two adjacent stores; a tight-spin observer on its own OS thread — 2,000 rounds x 200,000 loads, with the defect restored — never landed inside it. The single atomic **removes** the intermediate state rather than narrowing it, which is a construction-level guarantee, not an observable one. Claiming a test for it would be claiming coverage that does not exist.

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` all pass.