### PR TITLE
fix(native): register the stop waiter before reading the flag [#839]

### DIFF
--- a/packages/tuff-native/native-screenshot/src/backend/macos/actor.rs
+++ b/packages/tuff-native/native-screenshot/src/backend/macos/actor.rs
@@ -164,10 +164,30 @@ impl BackendFrameSource for MacFrameSource {
         self.request_stop();
         let control = Arc::clone(&self.control);
         Box::pin(async move {
-            while !control.stopped.load(Ordering::Acquire) {
-                control.stop_notify.notified().await;
+            // The Notified is registered before `stopped` is read.
+            //
+            // `notify_waiters()` only reaches waiters that are already registered, and the actor
+            // thread calls it exactly once per stream. Reading the flag first left a window where
+            // the store and the notify both landed before this future registered, so it parked
+            // with no further wakeup coming: `stop()` never resolved, the frames operation never
+            // emitted its terminal frame, and `finish_dispose()` timed out with the entry still in
+            // `NativeRuntime::streams` (#839).
+            //
+            // `native-core/src/stream.rs`, `native-core/src/runtime.rs` and `backend/mod.rs` all
+            // build the Notified before checking their state; this is the same shape, with
+            // `enable()` making the registration explicit rather than resting on when the future
+            // happens to be first polled.
+            loop {
+                let notified = control.stop_notify.notified();
+                tokio::pin!(notified);
+                notified.as_mut().enable();
+
+                if control.stopped.load(Ordering::Acquire) {
+                    return Ok(());
+                }
+
+                notified.await;
             }
-            Ok(())
         })
     }
 }


### PR DESCRIPTION
Fixes #839. Same class as #840 (#1535); this is the `native-screenshot` half.

## Confirmed

`MacFrameSource::stop()` read `stopped` and only then constructed the `Notified`. `notify_waiters()` reaches only waiters that are already registered, and `stop_frames` calls it exactly once per stream, so a `store(true)` + `notify_waiters()` landing in that window left the future parked with nothing further coming.

The consequence chain holds: `stop()` never resolves → the frames operation never emits its terminal frame → the entry stays in `NativeRuntime::streams` → `finish_dispose()` fails with `NATIVE_DISPOSE_TIMEOUT`.

## The fix, and the positive control that came with the issue

The issue names three sites in the same crate that get this right — `native-core/src/stream.rs`, `native-core/src/runtime.rs:597` and `backend/mod.rs:314` — and they do: each builds the `Notified` before checking state. That is a useful control, because it means the codebase already agrees on the correct shape and this was the one place that diverged.

The fix matches them, with `enable()` making the registration explicit rather than resting on when the future happens to be first polled.

A repo-wide scan for `notified().await` now finds one remaining site — `cancellation.rs:75` — which is #840, fixed in #1535.

## No regression test, and why

The window is a few instructions wide. I established this concretely on #840: I wrote a stress test for exactly this race, ran it at **2,000 iterations against the unfixed order, and it passed every time**. Shipping one here would be a test that cannot fail under a name saying it can.

`MacFrameSource` also needs a live ScreenCaptureKit session to construct, so there is no cheap unit-level seam either.

What the fix rests on is structural, and it is written where the next reader will find it: the `Notified` is registered before the flag is read, so either it is registered when `notify_waiters()` fires, or the read that follows sees `stopped == true`. Neither order can drop the wakeup.

Proving the interleaving's absence needs `loom` — a dependency decision, raised on both issues.

## Verified

`cargo fmt --check`, `cargo clippy -p tuff-native-screenshot --all-targets -D warnings`, and the full native workspace suite (`--workspace`) all pass.
