### PR TITLE
fix(screenshot): build the stop Notified before reading the flag

### DIFF
--- a/packages/tuff-native/native-screenshot/src/backend/macos/actor.rs
+++ b/packages/tuff-native/native-screenshot/src/backend/macos/actor.rs
@@ -164,10 +164,19 @@ impl BackendFrameSource for MacFrameSource {
         self.request_stop();
         let control = Arc::clone(&self.control);
         Box::pin(async move {
-            while !control.stopped.load(Ordering::Acquire) {
-                control.stop_notify.notified().await;
+            loop {
+                // Built before the flag is read, not after. `Notified` snapshots the
+                // notify_waiters counter at construction and the actor notifies exactly
+                // once in stop_frames, so a stop landing between the load and the await
+                // is accounted for by this future rather than lost -- it resolves instead
+                // of parking with no wakeup left to come. Same shape as
+                // native-core/src/stream.rs:53 and backend/mod.rs:314.
+                let notified = control.stop_notify.notified();
+                if control.stopped.load(Ordering::Acquire) {
+                    return Ok(());
+                }
+                notified.await;
             }
-            Ok(())
         })
     }
 }
@@ -1570,5 +1579,102 @@ mod tests {
         assert_eq!(parse_native_window_id(&valid), Some(7001));
         assert_eq!(parse_native_window_id(&zero), None);
         assert_eq!(parse_native_window_id(&descriptor_id), None);
+    }
+
+    /// #839: `stop()` loaded `stopped` and only then built its `Notified`. tokio snapshots
+    /// the notify_waiters counter at construction and `stop_frames` notifies exactly once,
+    /// so a stop landing between the load and the construction was already accounted for:
+    /// the future registered as a waiter and parked with no wakeup left to come.
+    /// `invoke_stream` awaits this after `request_stop()`, so a lost notify means the
+    /// frames operation never emits its terminal frame and its entry stays in
+    /// NativeRuntime::streams until finish_dispose gives up with NATIVE_DISPOSE_TIMEOUT.
+    ///
+    /// The window is a few instructions wide, so this hammers it: a barrier releases eight
+    /// waiters and the actor-side store together. `request_stop` is idempotent
+    /// (`stop_requested.swap`), so the eight `stop()` calls queue one command, not eight.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn a_stop_landing_after_the_flag_read_is_not_lost() {
+        const WAITERS: usize = 8;
+
+        for iteration in 0..20_000u32 {
+            let (sender, _receiver) = sync_channel(ACTOR_QUEUE_CAPACITY);
+            let actor = Arc::new(ActorInner {
+                sender,
+                closed: AtomicBool::new(false),
+            });
+            let control = Arc::new(FrameControl {
+                slot: LatestFrameSlot::new(),
+                stopped: AtomicBool::new(false),
+                stop_requested: AtomicBool::new(false),
+                stop_notify: Notify::new(),
+            });
+            let source = MacFrameSource {
+                stream_id: 1,
+                actor,
+                control: Arc::clone(&control),
+            };
+
+            let barrier = Arc::new(std::sync::Barrier::new(WAITERS + 1));
+            let tasks = (0..WAITERS)
+                .map(|_| {
+                    let pending = source.stop();
+                    let released = Arc::clone(&barrier);
+                    tokio::spawn(async move {
+                        released.wait();
+                        pending.await
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            barrier.wait();
+            // What stop_frames does once the actor thread has torn the session down.
+            control.stopped.store(true, Ordering::Release);
+            control.stop_notify.notify_waiters();
+
+            for task in tasks {
+                tokio::time::timeout(std::time::Duration::from_secs(5), task)
+                    .await
+                    .unwrap_or_else(|_| panic!("stop() parked at iteration {iteration}"))
+                    .expect("the waiter task must not panic")
+                    .expect("stop must not fail");
+            }
+        }
+    }
+
+    /// The control for the test above: it only asserts that `stop()` *resolves*, which a
+    /// "return immediately" implementation would satisfy just as well. `stop()` must stay
+    /// pending until the actor actually reports the session torn down.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stop_stays_pending_until_the_actor_reports_stopped() {
+        let (sender, _receiver) = sync_channel(ACTOR_QUEUE_CAPACITY);
+        let control = Arc::new(FrameControl {
+            slot: LatestFrameSlot::new(),
+            stopped: AtomicBool::new(false),
+            stop_requested: AtomicBool::new(false),
+            stop_notify: Notify::new(),
+        });
+        let source = MacFrameSource {
+            stream_id: 1,
+            actor: Arc::new(ActorInner {
+                sender,
+                closed: AtomicBool::new(false),
+            }),
+            control: Arc::clone(&control),
+        };
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(250), source.stop())
+                .await
+                .is_err(),
+            "stop() resolved before the actor reported the session stopped"
+        );
+
+        control.stopped.store(true, Ordering::Release);
+        control.stop_notify.notify_waiters();
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), source.stop())
+            .await
+            .expect("stop() must resolve once the actor reports stopped")
+            .expect("stop must not fail");
     }
 }


### PR DESCRIPTION
Closes #839

Same defect shape as #840, different file.

## What was wrong

```rust
while !control.stopped.load(Ordering::Acquire) {
    control.stop_notify.notified().await;   // built after the load
}
```

tokio snapshots the `notify_waiters` counter when a `Notified` is **constructed**, and `stop_frames` notifies exactly once (`actor.rs:889`). A stop landing between the load and the construction is therefore already accounted for by the snapshot: the future registers as a waiter and parks, with no wakeup left to come.

`ScreenshotCapability::invoke_stream` awaits this right after `request_stop()`, so a lost notify means the frames operation never emits its terminal frame, its entry stays in `NativeRuntime::streams`, and `finish_dispose` eventually fails with `NATIVE_DISPOSE_TIMEOUT`.

`native-core/src/stream.rs:53` and `backend/mod.rs:314` already build theirs first.

## Tests

| test | covers |
|---|---|
| `a_stop_landing_after_the_flag_read_is_not_lost` | the race — a barrier releases 8 waiters and the actor-side store together |
| `stop_stays_pending_until_the_actor_reports_stopped` | the control — `stop()` must not resolve early |

The second one exists because the race test alone is satisfied by a `stop()` that returns immediately. `request_stop` is idempotent (`stop_requested.swap`), so the eight `stop()` calls queue one command rather than eight.

Calibrated against the defect deliberately restored: **6 of 6 runs** caught it, latest at iteration **2916** against the 20k bound — roughly 7x margin.

Mutations, each applied through a patch asserting it matched exactly once:

| mutation | result |
|---|---|
| `Notified` built after the flag read | race test parks and fails |
| resolve without ever awaiting | control test fails |
| `request_stop` marks it stopped itself | control test fails |

## Platform note

`backend/macos/actor.rs` is `#[cfg(target_os = "macos")]`, so these tests only compile and run on the macOS leg of `native-protocol.yml`. That leg is green and has no `continue-on-error`, so the gate is real — but a Linux/Windows-only run will not exercise this.

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` all pass.