### PR TITLE
fix(native): stop the SCStream even after an extraction error [#837]

### DIFF
--- a/packages/tuff-native/native-screenshot/src/backend/macos/system/stream.rs
+++ b/packages/tuff-native/native-screenshot/src/backend/macos/system/stream.rs
@@ -116,6 +116,13 @@ pub struct MacStreamSession {
     output: Retained<StreamOutput>,
     _queue: DispatchRetained<DispatchQueue>,
     callbacks: Arc<CallbackState>,
+    /// Whether `stopCaptureWithCompletionHandler` has been issued.
+    ///
+    /// Separate from `callbacks.closed`, which is the *callback* latch: the frame-output callback
+    /// sets that on any extraction error, and while `stop()` and `Drop` shared it, a single
+    /// oversized frame made both of them skip the stop. ScreenCaptureKit then kept compositing for
+    /// the rest of the process lifetime with the screen-recording indicator lit (#837).
+    stopped: AtomicBool,
 }
 
 pub fn start_stream<Started, Frame, Failed>(
@@ -202,6 +209,7 @@ where
             output,
             _queue: queue,
             callbacks,
+            stopped: AtomicBool::new(false),
         })
     })
 }
@@ -211,10 +219,13 @@ impl MacStreamSession {
     where
         F: FnOnce(Result<(), MacSystemError>) + Send + 'static,
     {
-        if self.callbacks.closed.swap(true, Ordering::AcqRel) {
+        if self.stopped.swap(true, Ordering::AcqRel) {
             completion(Ok(()));
             return;
         }
+        // Latched here rather than used as the guard: it silences further frames and errors, and
+        // an extraction error may already have set it without any stop having been issued.
+        self.callbacks.closed.store(true, Ordering::Release);
         let output = ProtocolObject::from_ref(&*self.output);
         // SAFETY: The output was added to this exact stream and remains retained by the session.
         let remove_result = unsafe {
@@ -244,7 +255,8 @@ impl MacStreamSession {
 
 impl Drop for MacStreamSession {
     fn drop(&mut self) {
-        if !self.callbacks.closed.swap(true, Ordering::AcqRel) {
+        self.callbacks.closed.store(true, Ordering::Release);
+        if !self.stopped.swap(true, Ordering::AcqRel) {
             // SAFETY: Best-effort asynchronous stop; the stream retains internal state until stop.
             unsafe { self.stream.stopCaptureWithCompletionHandler(None) };
         }


### PR DESCRIPTION
Fixes #837.

## Confirmed

`callbacks.closed` carried two jobs at once:

1. **callback latch** — stop delivering frames and errors (lines 73, 85, 97)
2. **stop-once guard** — for `stop()` and `Drop` (lines 214, 247)

The frame-output callback latches it on any extraction error, which then silently disabled (2). `stop()` returned `completion(Ok(()))` without calling `stopCaptureWithCompletionHandler`, and `Drop` skipped it for the same reason.

## The leak is reachable both ways, which is the part worth stating

`capture_single_frame` calls `session.stop(...)` explicitly — but on the error path it returns early through `?` at `wait_for_stream_frame(...)` and never reaches that call. So it falls back to `Drop`.

And `Drop` was gated on the same flag. So an extraction error leaked the stream whether the consumer stopped it or dropped it: there was no path left that issued `stopCapture`.

## Fix

`MacStreamSession` owns a separate `stopped: AtomicBool` as the stop-once guard. `closed` keeps its callback-latch job and is now `store`d rather than `swap`ped at both sites, so an error that already latched it no longer suppresses the stop.

The error path's `on_error` delivery is unchanged — it still swaps `closed` and fires exactly once.

## No unit test, and why

`MacStreamSession` needs a live ScreenCaptureKit session to construct, and both flags are private to it, so there is no seam that tests the wiring rather than a one-line helper. Extracting one would test the extraction, not the fix.

The invariant is documented at the field, where anyone reusing `closed` as a guard will read it.

Unlike #839 and #840, this is **not** a race — it is a deterministic consequence of an extraction error, so a reader can follow it end to end from the issue's repro (`maxFrameBytes` below one frame's size on any 1080p display).

## Verified

`cargo fmt --check`, `cargo clippy -p tuff-native-screenshot --all-targets -D warnings`, and the full native workspace suite all pass.
