### PR TITLE
fix(native): fail the handshake once the runtime is disposed [#848]

### DIFF
--- a/packages/tuff-native/native-core/src/runtime.rs
+++ b/packages/tuff-native/native-core/src/runtime.rs
@@ -318,6 +318,15 @@ impl NativeRuntime {
         read(&self.registry).descriptors()
     }
 
+    /// Whether `begin_dispose` has run.
+    ///
+    /// Exposed so a carrier can refuse its handshake instead of reporting healthy and then failing
+    /// every invoke — the adapter lives in a process-wide `OnceLock` with no reset, so a runtime
+    /// disposed by a module teardown stays disposed for the life of the process (#848).
+    pub fn is_disposed(&self) -> bool {
+        self.disposed.load(Ordering::Acquire)
+    }
+
     pub fn health_payload(&self) -> Value {
         json!({
             "disposed": self.disposed.load(Ordering::Acquire),
@@ -1266,6 +1275,28 @@ mod tests {
             response_error_code(&packet.control),
             Some("TRANSPORT_DISPOSED")
         );
+    }
+
+    /// The terminal state has to be observable, not only felt through failing invokes.
+    ///
+    /// The adapter is a process-wide `OnceLock` with no reset, so a runtime disposed by a module
+    /// teardown stays disposed for the life of the process. A carrier built afterwards used to
+    /// report a healthy server_hello and then return a well-formed `ok=false` for every call,
+    /// which reads as a capability error rather than an unavailable carrier — so no fallback
+    /// fired and screenshots stayed broken until the app restarted (#848).
+    #[tokio::test]
+    async fn a_disposed_runtime_reports_itself_disposed() {
+        let runtime = NativeRuntime::new(registry(), ProtocolLimits::default());
+        assert!(
+            !runtime.is_disposed(),
+            "a fresh runtime must not be disposed"
+        );
+
+        assert!(runtime.begin_dispose());
+        assert!(runtime.is_disposed());
+
+        runtime.finish_dispose().await.expect("dispose");
+        assert!(runtime.is_disposed(), "disposal is terminal");
     }
 
     fn response_error_code(control: &Control) -> Option<&str> {

--- a/packages/tuff-native/native-napi/src/lib.rs
+++ b/packages/tuff-native/native-napi/src/lib.rs
@@ -38,6 +38,14 @@ impl NapiRuntimeAdapter {
 
     pub fn handshake(&self, env: &Env, encoded: String) -> Result<String> {
         self.ensure_cleanup(env)?;
+        // A disposed runtime cannot serve anything, and the adapter is a process-wide OnceLock
+        // with no reset path — so this state is terminal. Reporting a healthy server_hello here
+        // left every later invoke returning a well-formed ok=false response, which reads as a
+        // capability error rather than an unavailable carrier and never triggers the caller's
+        // fallback (#848). Failing the handshake is what marks the carrier unavailable.
+        if self.runtime.is_disposed() {
+            return Err(to_napi_error(ProtocolError::transport_disposed()));
+        }
         let hello = decode_control(&encoded).map_err(to_napi_error)?;
         let Control::ClientHello {
             protocol,


### PR DESCRIPTION
Fixes #848. Took the **second** suggested direction — rejecting the handshake — and the reason for not taking the first is the substantive part.

## Confirmed

`ADAPTER: OnceLock<NapiRuntimeAdapter>` has no reset path and `begin_dispose` sets `disposed` permanently. `handshake` never consulted it, so a carrier created after a module teardown reported a healthy `server_hello` advertising `screenshot.capture`, then returned `Ok(error_response(..., transport_disposed()))` for every invoke.

The issue's sharpest point is the one I checked first: that failure arrives as a **well-formed `ok=false` response**, which the caller reads as a capability error rather than an unavailable carrier — so no fallback fires.

## Why not "make the adapter re-creatable"

It changes lifecycle rather than reporting. The old runtime's actor threads may still hold ScreenCaptureKit sessions during a teardown — see #837, where a stream could keep compositing after an error — so a second runtime would overlap with the first while it drains. That is a real design question, and not one I can exercise from here.

## Why rejecting the handshake is enough

The path it needs already exists. `native-transport.ts:605` wraps `carrier.handshake()` in `try`/`catch`, disposes the carrier and returns `{ state: 'unavailable', … }`. So a rejected handshake produces exactly the degradation the issue says is not being reached — no new plumbing, and the failure becomes visible at the point that already knows how to handle it.

## Changes

- `NativeRuntime::is_disposed()` — public, because the terminal state has to be **observable**, not only felt through failing invokes.
- `handshake` returns `ProtocolError::transport_disposed()` when the runtime is disposed, before negotiating anything.

## Test

`a_disposed_runtime_reports_itself_disposed` asserts the state across both phases — false when fresh, true after `begin_dispose`, still true after `finish_dispose` — sitting next to the existing `dispose_is_idempotent_and_rejects_new_work`.

Mutation-checked: hardcoding `is_disposed()` to `false` fails it.

## Verified

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, and all 7 native crates' test suites pass.
