### PR TITLE
test(native): guard the two race windows #839/#840 fixed

### DIFF
--- a/packages/tuff-native/native-core/src/cancellation.rs
+++ b/packages/tuff-native/native-core/src/cancellation.rs
@@ -113,6 +113,8 @@ fn u8_to_reason(reason: u8) -> Option<CancelReason> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     #[tokio::test]
@@ -219,5 +221,48 @@ mod tests {
                 .is_err(),
             "cancelled() resolved without a cancel",
         );
+    }
+
+    /// #1541: the tests above cover the paths around the #840 window -- an already-parked
+    /// waiter, a waiter starting after the cancel, an uncancelled token, the reason/flag
+    /// pair -- but none of them races a cancel against a waiter's registration, which is
+    /// the defect itself. Restoring the pre-fix ordering left all five green on 3 of 3
+    /// runs.
+    ///
+    /// This hammers the window: a barrier releases eight waiters and the canceller
+    /// together so they all race the same cancel, and the timeout turns a parked waiter
+    /// into a failure rather than a hung suite. Calibrated against the defect deliberately
+    /// restored: 6 of 6 runs caught it, latest at iteration 4268, so the 20k bound carries
+    /// roughly a 5x margin. One waiter per iteration missed on one run in six, so the
+    /// eight-way concurrency is load-bearing rather than decorative.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn a_cancel_racing_a_waiters_registration_is_not_lost() {
+        const WAITERS: usize = 8;
+
+        for iteration in 0..20_000u32 {
+            let token = CancellationToken::new();
+            let barrier = Arc::new(std::sync::Barrier::new(WAITERS + 1));
+            let tasks = (0..WAITERS)
+                .map(|_| {
+                    let waiter = token.clone();
+                    let released = Arc::clone(&barrier);
+                    tokio::spawn(async move {
+                        released.wait();
+                        waiter.cancelled().await
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            barrier.wait();
+            token.cancel(CancelReason::Dispose);
+
+            for task in tasks {
+                let reason = tokio::time::timeout(Duration::from_secs(5), task)
+                    .await
+                    .unwrap_or_else(|_| panic!("cancelled() parked at iteration {iteration}"))
+                    .expect("the waiter task must not panic");
+                assert_eq!(reason, CancelReason::Dispose);
+            }
+        }
     }
 }

--- a/packages/tuff-native/native-screenshot/src/backend/macos/actor.rs
+++ b/packages/tuff-native/native-screenshot/src/backend/macos/actor.rs
@@ -1591,4 +1591,104 @@ mod tests {
         assert_eq!(parse_native_window_id(&zero), None);
         assert_eq!(parse_native_window_id(&descriptor_id), None);
     }
+
+    /// #839: `stop()` loaded `stopped` and only then built its `Notified`. tokio snapshots
+    /// the notify_waiters counter at construction and `stop_frames` notifies exactly once,
+    /// so a stop landing between the load and the construction was already accounted for:
+    /// the future registered as a waiter and parked with no wakeup left to come.
+    /// `invoke_stream` awaits this after `request_stop()`, so a lost notify means the
+    /// frames operation never emits its terminal frame and its entry stays in
+    /// NativeRuntime::streams until finish_dispose gives up with NATIVE_DISPOSE_TIMEOUT.
+    ///
+    /// #1536 fixed it with no test, so the window is currently unguarded. This hammers it:
+    /// a barrier releases eight waiters and the actor-side store together. `request_stop`
+    /// is idempotent (`stop_requested.swap`), so the eight `stop()` calls queue one
+    /// command, not eight. Calibrated against the defect deliberately restored on the
+    /// merged implementation: 6 of 6 runs caught it, latest at iteration 5821 against the
+    /// 20k bound.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn a_stop_landing_after_the_flag_read_is_not_lost() {
+        const WAITERS: usize = 8;
+
+        for iteration in 0..20_000u32 {
+            let (sender, _receiver) = sync_channel(ACTOR_QUEUE_CAPACITY);
+            let actor = Arc::new(ActorInner {
+                sender,
+                closed: AtomicBool::new(false),
+            });
+            let control = Arc::new(FrameControl {
+                slot: LatestFrameSlot::new(),
+                stopped: AtomicBool::new(false),
+                stop_requested: AtomicBool::new(false),
+                stop_notify: Notify::new(),
+            });
+            let source = MacFrameSource {
+                stream_id: 1,
+                actor,
+                control: Arc::clone(&control),
+            };
+
+            let barrier = Arc::new(std::sync::Barrier::new(WAITERS + 1));
+            let tasks = (0..WAITERS)
+                .map(|_| {
+                    let pending = source.stop();
+                    let released = Arc::clone(&barrier);
+                    tokio::spawn(async move {
+                        released.wait();
+                        pending.await
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            barrier.wait();
+            // What stop_frames does once the actor thread has torn the session down.
+            control.stopped.store(true, Ordering::Release);
+            control.stop_notify.notify_waiters();
+
+            for task in tasks {
+                tokio::time::timeout(std::time::Duration::from_secs(5), task)
+                    .await
+                    .unwrap_or_else(|_| panic!("stop() parked at iteration {iteration}"))
+                    .expect("the waiter task must not panic")
+                    .expect("stop must not fail");
+            }
+        }
+    }
+
+    /// The control for the test above: it only asserts that `stop()` *resolves*, which a
+    /// "return immediately" implementation would satisfy just as well. `stop()` must stay
+    /// pending until the actor actually reports the session torn down.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stop_stays_pending_until_the_actor_reports_stopped() {
+        let (sender, _receiver) = sync_channel(ACTOR_QUEUE_CAPACITY);
+        let control = Arc::new(FrameControl {
+            slot: LatestFrameSlot::new(),
+            stopped: AtomicBool::new(false),
+            stop_requested: AtomicBool::new(false),
+            stop_notify: Notify::new(),
+        });
+        let source = MacFrameSource {
+            stream_id: 1,
+            actor: Arc::new(ActorInner {
+                sender,
+                closed: AtomicBool::new(false),
+            }),
+            control: Arc::clone(&control),
+        };
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(250), source.stop())
+                .await
+                .is_err(),
+            "stop() resolved before the actor reported the session stopped"
+        );
+
+        control.stopped.store(true, Ordering::Release);
+        control.stop_notify.notify_waiters();
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), source.stop())
+            .await
+            .expect("stop() must resolve once the actor reports stopped")
+            .expect("stop must not fail");
+    }
 }


### PR DESCRIPTION
Closes #1541

Test-only. **No implementation changes** — #1535 and #1536 fixed both defects correctly. Neither is covered by a test that fails on the defect it fixed.

## The gap, measured

Restore the pre-#1535 ordering in `cancelled()` — read the state, then build the `Notified` — and run the five tests #1535 added:

```
run1: test result: ok. 5 passed; 0 failed
run2: test result: ok. 5 passed; 0 failed
run3: test result: ok. 5 passed; 0 failed
```

Those five cover the paths *around* the window: an already-parked waiter, a waiter starting after the cancel, an uncancelled token staying pending, and the reason/flag pair. None races a cancel against a waiter's **registration**, which is the whole defect.

`#1536` added 23 lines and zero tests, so the same holds there by inspection.

## What these add

Each test hammers its window: a barrier releases **eight** waiters and the canceller (or the actor-side store) together, and a timeout turns a parked waiter into a failure rather than a hung suite.

Calibrated against each defect deliberately restored **on the merged implementation**:

| site | detection | latest hit |
|---|---|---|
| `cancelled()` | 6 of 6 runs | iteration 4268 |
| `MacFrameSource::stop()` | 6 of 6 runs | iteration 5821 |

against a 20k bound. One waiter per iteration missed on one run in six, so the eight-way concurrency is load-bearing rather than decorative. ~1.5s per test.

`request_stop` is idempotent (`stop_requested.swap`), so the eight `stop()` calls queue one command, not eight.

## Control

`stop()` also gets `stop_stays_pending_until_the_actor_reports_stopped`. Without it a `stop()` mutated to **return immediately** passes the race test — verified, it does. `cancelled()` already has that guard from #1535's `an_uncancelled_token_does_not_resolve`.

## Deliberately not covered

The torn `cancelled`/`reason` pair from #840's second half. Its window is two adjacent stores; a tight-spin observer on its own OS thread — 2,000 rounds x 200,000 loads, defect restored — never landed inside it. The single atomic #1535 introduced removes the state rather than narrowing it, which is a construction-level guarantee, not an observable one. A test there would be claiming coverage that does not exist.

## Platform note

The `stop()` tests live in `backend/macos/actor.rs`, which is `#[cfg(target_os = "macos")]` — they run only on the macOS leg of `native-protocol.yml`. That leg is green and has no `continue-on-error`.

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` all pass.