### PR TITLE
fix(native): report the windows a refresh had to drop [#853]

### DIFF
--- a/packages/tuff-native/native-screenshot/src/backend/macos/actor.rs
+++ b/packages/tuff-native/native-screenshot/src/backend/macos/actor.rs
@@ -446,13 +446,22 @@ impl ActorState {
             self.limits,
         )
         .map_err(|_| ScreenshotError::BackendFailed.to_protocol_error())?;
+        // Counted rather than only discarded. GlobalDipRect::new rejects any non-positive
+        // dimension, so a window mid-creation or fully collapsed vanishes here -- it never reaches
+        // the snapshot, hit_test cannot return it, and a later capture fails with
+        // SCREENSHOT_WINDOW_NOT_FOUND with nothing explaining why (#853).
+        let mut dropped_windows: u64 = 0;
         let shareable_windows = system_windows
             .iter()
-            .filter_map(|window| shareable_window(window, generation_number, self.limits).ok())
+            .filter_map(|window| {
+                shareable_window(window, generation_number, self.limits)
+                    .inspect_err(|_| dropped_windows += 1)
+                    .ok()
+            })
             .collect::<Vec<_>>();
         let cg_windows = cg_windows
             .iter()
-            .filter_map(|window| cg_window(window).ok())
+            .filter_map(|window| cg_window(window).inspect_err(|_| dropped_windows += 1).ok())
             .collect::<Vec<_>>();
         let windows = build_window_descriptors(
             shareable_windows,
@@ -463,6 +472,7 @@ impl ActorState {
         let snapshot_windows = windows.iter().map(snapshot_window).collect::<Vec<_>>();
         ensure_active(cancellation)?;
         let snapshot = ContentSnapshot {
+            dropped_windows,
             generation: generation.clone(),
             coordinate_space: CoordinateSpace::GlobalDipV1,
             captured_at_unix_ms: unix_time_ms()?,
@@ -1451,6 +1461,7 @@ mod tests {
         let generation = DescriptorId::new(id).unwrap();
         GenerationState {
             snapshot: ContentSnapshot {
+                dropped_windows: 0,
                 generation: generation.clone(),
                 coordinate_space: CoordinateSpace::GlobalDipV1,
                 captured_at_unix_ms: 1,

--- a/packages/tuff-native/native-screenshot/src/backend/test_backend.rs
+++ b/packages/tuff-native/native-screenshot/src/backend/test_backend.rs
@@ -72,6 +72,7 @@ impl ScreenshotBackend for DeterministicBackend {
         *lock(&self.current_generation) = Some(generation.clone());
         Box::pin(async move {
             Ok(ContentSnapshot {
+                dropped_windows: 0,
                 generation,
                 coordinate_space: CoordinateSpace::GlobalDipV1,
                 captured_at_unix_ms: generation_number,

--- a/packages/tuff-native/native-screenshot/src/backend/xcap.rs
+++ b/packages/tuff-native/native-screenshot/src/backend/xcap.rs
@@ -121,6 +121,7 @@ impl<S: XcapSource> XcapBackend<S> {
             descriptors.push(descriptor);
         }
         let snapshot = ContentSnapshot {
+            dropped_windows: 0,
             generation: generation.clone(),
             coordinate_space: CoordinateSpace::GlobalDipV1,
             captured_at_unix_ms: unix_time_ms(),

--- a/packages/tuff-native/native-screenshot/src/backend_contract_tests.rs
+++ b/packages/tuff-native/native-screenshot/src/backend_contract_tests.rs
@@ -111,6 +111,7 @@ impl ScreenshotBackend for FakeBackend {
             state.retained_displays = HashSet::from([display_id]);
             state.retained_elements.clear();
             Ok(ContentSnapshot {
+                dropped_windows: 0,
                 generation: generation.try_into().unwrap(),
                 coordinate_space: CoordinateSpace::GlobalDipV1,
                 captured_at_unix_ms: u64::from(next_generation),

--- a/packages/tuff-native/native-screenshot/src/capability.rs
+++ b/packages/tuff-native/native-screenshot/src/capability.rs
@@ -14,7 +14,8 @@ use crate::compose::{ComposedCapture, compose_region};
 use crate::error::ScreenshotError;
 use crate::limits::ScreenshotLimits;
 use crate::model::{
-    FramesInput, PixelSize, ScreenshotProbeResult, ScreenshotRequest, decode_screenshot_request,
+    ContentSnapshot, FramesInput, PixelSize, ScreenshotProbeResult, ScreenshotRequest,
+    decode_screenshot_request,
 };
 use crate::region_plan::{AttachmentChunkLimits, plan_attachment_chunks};
 
@@ -126,7 +127,8 @@ impl ScreenshotCapability {
                 })
             }
             ScreenshotRequest::Refresh(input) => {
-                serialize_output(self.backend.refresh(input, cancellation).await?)
+                let snapshot = self.backend.refresh(input, cancellation).await?;
+                refresh_output(snapshot)
             }
             ScreenshotRequest::HitTest(input) => {
                 serialize_output(self.backend.hit_test(input, cancellation).await?)
@@ -430,6 +432,22 @@ fn split_attachments(
     Ok(SplitAttachments { parts, attachments })
 }
 
+/// Serializes a snapshot and reports the windows the backend had to drop.
+///
+/// Rides `RunMeta.counters`, alongside the existing `dropped-source-frames`, so the diagnostic
+/// reaches the caller without a new protocol concept. Absent when nothing was dropped, since
+/// `counters` is skipped when empty (#853).
+fn refresh_output(snapshot: ContentSnapshot) -> Result<OperationOutput, ProtocolError> {
+    let dropped_windows = snapshot.dropped_windows;
+    let mut output = serialize_output(snapshot)?;
+    if dropped_windows > 0 {
+        output
+            .counters
+            .insert("dropped-windows".to_string(), dropped_windows);
+    }
+    Ok(output)
+}
+
 fn serialize_output<T>(value: T) -> Result<OperationOutput, ProtocolError>
 where
     T: Serialize,
@@ -470,5 +488,65 @@ impl Drop for FrameSourceGuard {
         if self.armed {
             self.source.request_stop();
         }
+    }
+}
+
+#[cfg(test)]
+mod refresh_counter_tests {
+    use super::*;
+    use crate::model::{AccessibilityStatus, CoordinateSpace, DescriptorId};
+
+    fn snapshot(dropped_windows: u64) -> ContentSnapshot {
+        ContentSnapshot {
+            dropped_windows,
+            generation: DescriptorId::new("generation:test").unwrap(),
+            coordinate_space: CoordinateSpace::GlobalDipV1,
+            captured_at_unix_ms: 0,
+            displays: Vec::new(),
+            windows: Vec::new(),
+            accessibility: AccessibilityStatus::Unknown,
+        }
+    }
+
+    /// A window the backend had to drop is reported, not just missing.
+    ///
+    /// `GlobalDipRect::new` rejects a non-positive dimension, so a window mid-creation or fully
+    /// collapsed disappears from the snapshot. It then cannot be hit-tested, and a later capture
+    /// targeting it fails with SCREENSHOT_WINDOW_NOT_FOUND — previously with nothing anywhere
+    /// explaining why, because the error was discarded at the `filter_map` (#853).
+    #[test]
+    fn dropped_windows_are_reported_through_run_counters() {
+        let output = refresh_output(snapshot(3)).expect("refresh output");
+
+        assert_eq!(output.counters.get("dropped-windows"), Some(&3));
+    }
+
+    /// Absent rather than zero, so an ordinary refresh carries no counters at all.
+    ///
+    /// `RunMeta.counters` is skipped when empty, and a `dropped-windows: 0` on every refresh would
+    /// turn that into noise — and make a real drop harder to notice, which is the whole point.
+    #[test]
+    fn an_ordinary_refresh_reports_no_counter() {
+        let output = refresh_output(snapshot(0)).expect("refresh output");
+
+        assert!(
+            output.counters.is_empty(),
+            "a refresh that dropped nothing should carry no counters",
+        );
+    }
+
+    /// The diagnostic must not leak into the snapshot payload.
+    ///
+    /// It is a property of the refresh, not of the content, and the payload is the serialized
+    /// protocol surface — adding a field there would be a protocol change rather than a
+    /// diagnostic.
+    #[test]
+    fn the_counter_is_not_serialized_into_the_payload() {
+        let output = refresh_output(snapshot(3)).expect("refresh output");
+
+        assert!(
+            !output.payload.to_string().contains("droppedWindows"),
+            "the diagnostic leaked into the serialized snapshot",
+        );
     }
 }

--- a/packages/tuff-native/native-screenshot/src/model.rs
+++ b/packages/tuff-native/native-screenshot/src/model.rs
@@ -673,6 +673,14 @@ pub struct UiElementDescriptor {
 #[derive(Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ContentSnapshot {
+    /// Windows the backend could not turn into a descriptor, usually a zero-sized frame from a
+    /// window mid-creation or fully collapsed.
+    ///
+    /// `#[serde(skip)]` on purpose: this rides out to `RunMeta.counters` as `dropped-windows`,
+    /// next to the existing `dropped-source-frames`, rather than into the snapshot payload. It is
+    /// a diagnostic about the refresh, not a property of the content (#853).
+    #[serde(skip)]
+    pub dropped_windows: u64,
     pub generation: DescriptorId,
     pub coordinate_space: CoordinateSpace,
     pub captured_at_unix_ms: u64,


### PR DESCRIPTION
Fixes #853, taking the counter half of the suggested direction — because the vehicle already exists.

## Confirmed

`filter_map(... .ok())` on both window sources discards the `GeometryError`. `GlobalDipRect::new` rejects any non-positive dimension, so a window mid-creation or fully collapsed disappears: absent from the snapshot, not returnable by `hit_test`, and a later `capture` fails with `SCREENSHOT_WINDOW_NOT_FOUND` with nothing explaining why.

## Why a counter and not a log

The crate has **no logging dependency** — no `log`, no `tracing`, not even an `eprintln!` — so "a debug log of the GeometryError" would mean adding one.

The counter needs nothing new. `RunMeta.counters: BTreeMap<String, u64>` is already on every response, already `skip_serializing_if = "BTreeMap::is_empty"`, and already carries `dropped-source-frames` from the capture path. This is the same shape, one operation over.

## Carrying it out without touching the protocol

`BackendContentSource::refresh` returns `ContentSnapshot`, which is the only channel back — and it is a serialized protocol type, so adding a normal field would be a protocol change.

`dropped_windows` is therefore `#[serde(skip)]`: it rides the struct to `refresh_output` and never enters the payload. It is a property of the *refresh*, not of the content.

The third test pins exactly that, because it is the thing a later refactor would quietly undo.

## Absent, not zero

`counters` is skipped when empty, so an ordinary refresh carries none at all. Emitting `dropped-windows: 0` every time would turn the signal into noise and make a real drop harder to notice — which is the whole point of adding it.

## Mutation-checked

| mutation | result |
|---|---|
| remove the insert (the original silent discard) | `dropped_windows_are_reported_through_run_counters` **fails** |
| insert unconditionally, including zero | `an_ordinary_refresh_reports_no_counter` **fails** |
| — | `the_counter_is_not_serialized_into_the_payload` guards the `serde(skip)` |

## Verified

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, all 7 native crates green.
