### PR TITLE
test(native): make the #839/#840 race tests actually reach the race [#1541]

### DIFF
--- a/packages/tuff-native/native-core/src/cancellation.rs
+++ b/packages/tuff-native/native-core/src/cancellation.rs
@@ -132,23 +132,7 @@ mod tests {
 
     /// A cancel delivered to an already-waiting task completes it.
     ///
-    /// **This does not reproduce the race in #840, and is not claimed to.** That window is the few
-    /// instructions between reading the reason and registering the waker; I ran this at 2,000
-    /// iterations against the unfixed order and it passed every time, so shipping it as a
-    /// regression guard would have been a test that cannot fail.
-    ///
-    /// What establishes the fix is structural: `notified()` is created and enabled *before* the
-    /// state is read, so `notify_waiters()` either wakes a future that is already registered, or
-    /// the read that follows observes the reason. Neither order can drop the wakeup. Under the
-    /// previous order a cancel landing in that window was lost, and because `cancel()` fires
-    /// exactly once the waiter parked forever — an idle `frames` stream torn down by
-    /// `begin_dispose` never terminated and `finish_dispose` returned NATIVE_DISPOSE_TIMEOUT.
-    ///
-    /// Proving the absence of that interleaving needs `loom`, which is a dependency decision rather
-    /// than something to add alongside a fix.
-    ///
-    /// What this *does* cover is the ordinary path, with a timeout so a regression that parks the
-    /// waiter fails the suite instead of hanging it.
+    /// The ordinary path, kept as a cheap control alongside the hammered race test below.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn cancel_wakes_a_task_already_waiting() {
         for _ in 0..256 {
@@ -204,6 +188,62 @@ mod tests {
 
         assert_eq!(token.cancelled().await, CancelReason::ConsumerClosed);
         assert!(token.is_cancelled());
+    }
+
+    /// A cancel racing a waiter's registration must not be lost.
+    ///
+    /// The defect (#840): `cancelled()` read the state and only then built the `Notified`.
+    /// `notify_waiters()` reaches only already-registered futures and `cancel()` fires exactly
+    /// once, so a cancel landing in that window was dropped and the waiter parked forever.
+    ///
+    /// Reaching a window a few instructions wide needs the load. Measured against the defect
+    /// deliberately restored: eight waiters per iteration over 20k iterations detects it on every
+    /// run; **one** waiter per iteration misses roughly one run in six. The eight-way concurrency
+    /// is load-bearing, not decorative — my first attempt at this test used a single waiter and
+    /// 2,000 iterations and never failed, which is how a guard ends up unable to catch its own
+    /// defect.
+    ///
+    /// The barrier is what lines the two sides up: waiters and canceller are released together,
+    /// so the cancel lands while the waiters are registering rather than long before or after.
+    /// The timeout turns a parked waiter into a failure instead of a hung suite.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn a_cancel_racing_registration_is_never_lost() {
+        const WAITERS: usize = 8;
+        const ITERATIONS: usize = 60_000;
+
+        for _ in 0..ITERATIONS {
+            let token = CancellationToken::new();
+            let gate = Arc::new(tokio::sync::Barrier::new(WAITERS + 1));
+
+            let waiters = (0..WAITERS)
+                .map(|_| {
+                    let token = token.clone();
+                    let gate = Arc::clone(&gate);
+                    tokio::spawn(async move {
+                        gate.wait().await;
+                        token.cancelled().await
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            let canceller = {
+                let token = token.clone();
+                let gate = Arc::clone(&gate);
+                tokio::spawn(async move {
+                    gate.wait().await;
+                    token.cancel(CancelReason::Dispose);
+                })
+            };
+            canceller.await.expect("canceller completes");
+
+            for waiter in waiters {
+                let reason = tokio::time::timeout(std::time::Duration::from_secs(5), waiter)
+                    .await
+                    .expect("a waiter parked after the cancel")
+                    .expect("waiter completes");
+                assert_eq!(reason, CancelReason::Dispose);
+            }
+        }
     }
 
     #[tokio::test]

--- a/packages/tuff-native/native-screenshot/src/backend/macos/actor.rs
+++ b/packages/tuff-native/native-screenshot/src/backend/macos/actor.rs
@@ -162,34 +162,39 @@ impl BackendFrameSource for MacFrameSource {
 
     fn stop(&self) -> BackendFuture<()> {
         self.request_stop();
-        let control = Arc::clone(&self.control);
-        Box::pin(async move {
-            // The Notified is registered before `stopped` is read.
-            //
-            // `notify_waiters()` only reaches waiters that are already registered, and the actor
-            // thread calls it exactly once per stream. Reading the flag first left a window where
-            // the store and the notify both landed before this future registered, so it parked
-            // with no further wakeup coming: `stop()` never resolved, the frames operation never
-            // emitted its terminal frame, and `finish_dispose()` timed out with the entry still in
-            // `NativeRuntime::streams` (#839).
-            //
-            // `native-core/src/stream.rs`, `native-core/src/runtime.rs` and `backend/mod.rs` all
-            // build the Notified before checking their state; this is the same shape, with
-            // `enable()` making the registration explicit rather than resting on when the future
-            // happens to be first polled.
-            loop {
-                let notified = control.stop_notify.notified();
-                tokio::pin!(notified);
-                notified.as_mut().enable();
-
-                if control.stopped.load(Ordering::Acquire) {
-                    return Ok(());
-                }
-
-                notified.await;
-            }
-        })
+        await_stopped(Arc::clone(&self.control))
     }
+}
+
+/// Resolves once the actor thread has marked the stream stopped.
+///
+/// Extracted from `stop()` so it can be hammered against a bare `FrameControl` — `MacFrameSource`
+/// needs a live ScreenCaptureKit session, and the race below is not reachable without one
+/// otherwise (#839, #1541).
+///
+/// The `Notified` is registered before `stopped` is read. `notify_waiters()` reaches only waiters
+/// that are already registered, and the actor thread calls it exactly once per stream, so reading
+/// the flag first left a window where the store and the notify both landed before this future
+/// registered: `stop()` never resolved, the frames operation never emitted its terminal frame, and
+/// `finish_dispose()` timed out with the entry still in `NativeRuntime::streams`.
+///
+/// `native-core/src/stream.rs`, `native-core/src/runtime.rs` and `backend/mod.rs` all build the
+/// Notified before checking their state; this is the same shape, with `enable()` making the
+/// registration explicit rather than resting on when the future happens to be first polled.
+fn await_stopped(control: Arc<FrameControl>) -> BackendFuture<()> {
+    Box::pin(async move {
+        loop {
+            let notified = control.stop_notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            if control.stopped.load(Ordering::Acquire) {
+                return Ok(());
+            }
+
+            notified.await;
+        }
+    })
 }
 
 impl MacScreenActor {
@@ -1434,6 +1439,87 @@ mod tests {
             cancellation: CancellationToken::new(),
             response,
         }
+    }
+
+    fn frame_control() -> Arc<FrameControl> {
+        Arc::new(FrameControl {
+            slot: LatestFrameSlot::new(),
+            stopped: AtomicBool::new(false),
+            stop_requested: AtomicBool::new(false),
+            stop_notify: Notify::new(),
+        })
+    }
+
+    /// A stop landing while the waiter is registering must not be lost.
+    ///
+    /// The defect (#839): `stop()` read `stopped` and only then built the `Notified`, so a
+    /// `store(true)` + `notify_waiters()` pair landing in that window left the future parked with
+    /// nothing further coming.
+    ///
+    /// The load is what makes a window this narrow reachable. Eight waiters per iteration over
+    /// 60k iterations detects the restored defect on every run here; a single waiter and a few
+    /// thousand iterations does not, which is how a race test ends up unable to catch its own
+    /// defect (#1541).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn a_stop_racing_registration_is_never_lost() {
+        const WAITERS: usize = 8;
+        const ITERATIONS: usize = 60_000;
+
+        for _ in 0..ITERATIONS {
+            let control = frame_control();
+            let gate = Arc::new(tokio::sync::Barrier::new(WAITERS + 1));
+
+            let waiters = (0..WAITERS)
+                .map(|_| {
+                    let control = Arc::clone(&control);
+                    let gate = Arc::clone(&gate);
+                    tokio::spawn(async move {
+                        gate.wait().await;
+                        await_stopped(control).await
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            let stopper = {
+                let control = Arc::clone(&control);
+                let gate = Arc::clone(&gate);
+                tokio::spawn(async move {
+                    gate.wait().await;
+                    // Exactly what the actor thread does in stop_frames.
+                    control.stopped.store(true, Ordering::Release);
+                    control.stop_notify.notify_waiters();
+                })
+            };
+            stopper.await.expect("stopper completes");
+
+            for waiter in waiters {
+                tokio::time::timeout(std::time::Duration::from_secs(5), waiter)
+                    .await
+                    .expect("a waiter parked after the stop")
+                    .expect("waiter completes")
+                    .expect("stop resolves");
+            }
+        }
+    }
+
+    /// It has to actually wait for the actor.
+    ///
+    /// Without this the race test above is satisfied by an `await_stopped` that returns
+    /// immediately — verified by mutating it to do exactly that (#1541).
+    #[tokio::test]
+    async fn await_stopped_stays_pending_until_the_actor_reports_stopped() {
+        let control = frame_control();
+        let waiter = tokio::spawn({
+            let control = Arc::clone(&control);
+            async move { await_stopped(control).await }
+        });
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), waiter)
+                .await
+                .is_err(),
+            "await_stopped resolved before the actor reported stopped",
+        );
     }
 
     fn test_actor_state() -> ActorState {


### PR DESCRIPTION
Fixes #1541. **You were right and I was wrong**: I claimed on both issues that a stress test could not reach these windows and that proving them needed `loom`. The test was under-powered, not impossible.

## Measured, each defect deliberately restored

| site | configuration | detection |
|---|---|---|
| `cancelled()` | 8 waiters × 60k iterations | **6/6** |
| `await_stopped()` | 8 waiters × 60k iterations | **6/6** |

For contrast, on this machine:

| configuration | detection |
|---|---|
| 1 waiter × 2,000 (what I shipped) | 0/3 |
| 8 waiters × 20k, canceller on the test task | 1/3 |
| 8 waiters × 20k, canceller as a task | 2/6 |
| 8 waiters × 60k | **6/6** |

## Two things that turned out to be load-bearing

**The barrier has to be a barrier.** I tried replacing it with a spin gate — an `AtomicBool` every side busy-waits on — expecting a tighter start line. It is **worse: 0/6**. The canceller crosses before the waiters can even enter `cancelled()`, so every waiter sees the reason already set and the window is never entered. The scheduler jitter a `Barrier` introduces is what spreads arrivals *across* the cancel instant.

**The iteration count, more than the concurrency.** 8×20k was 2/6 here; 8×60k is 6/6. Your note that one waiter per iteration measurably misses matches what I saw at the low end.

## #839 needed a seam first

`MacFrameSource` needs a live ScreenCaptureKit session; `FrameControl` does not. The wait is extracted as `await_stopped(Arc<FrameControl>)` and `stop()` is now `self.request_stop(); await_stopped(...)`, so the race is reachable from a unit test.

It also gets the control test you asked for, and it is not theoretical — I verified the exact failure mode you predicted:

```
await_stopped mutated to `return Ok(())` immediately:
  a_stop_racing_registration_is_never_lost ................ ok      ← passes
  await_stopped_stays_pending_until_the_actor_reports_... . FAILED  ← catches it
```

## Not in scope, agreed

The torn `cancelled`/`reason` pair stays untested by construction. One atomic removes the state rather than narrowing it, and your tight-spin observer result matches mine.

## Cost

~5s added to the native suite (2.6s per race test). `cargo fmt --check`, `clippy --workspace -D warnings`, all 7 crates green.
