### PR TITLE
fix(native): repair ActorInner construction in the #839/#840 race tests

### DIFF
--- a/packages/tuff-native/native-screenshot/src/backend/macos/actor.rs
+++ b/packages/tuff-native/native-screenshot/src/backend/macos/actor.rs
@@ -1861,6 +1861,7 @@ mod tests {
             let actor = Arc::new(ActorInner {
                 sender,
                 closed: AtomicBool::new(false),
+                pending_stops: Mutex::new(Vec::new()),
             });
             let control = Arc::new(FrameControl {
                 slot: LatestFrameSlot::new(),
@@ -1918,6 +1919,7 @@ mod tests {
             actor: Arc::new(ActorInner {
                 sender,
                 closed: AtomicBool::new(false),
+                pending_stops: Mutex::new(Vec::new()),
             }),
             control: Arc::clone(&control),
         };


### PR DESCRIPTION
**`TalexDreamSoul/app-shell-v2` does not currently compile.** `cargo test --workspace` under `packages/tuff-native` fails with two `E0063`s:

```
error[E0063]: missing field `pending_stops` in initializer of `actor::ActorInner`
    --> native-screenshot/src/backend/macos/actor.rs:1861:34
    --> native-screenshot/src/backend/macos/actor.rs:1918:29
```

Every PR that touches `packages/tuff-native/**` will show a red `Protocol (*)` until this lands.

## How it happened

Neither PR was wrong:

- **#1544** added the two race tests that construct `ActorInner`.
- **#1545** added the `pending_stops` field to `ActorInner`.

Each was green against a base that did not yet contain the other. Git saw no conflict — the edits do not touch the same *lines*, only the same *struct* — so squash-merging both produced a base neither had been tested against.

That is my mistake in the merge, not theirs. I merged both with `--admin` minutes apart, so #1545's checks had already run by the time #1544 landed and nothing re-ran against the combined tree.

## The fix

`pending_stops: Mutex::new(Vec::new())` at both sites — the same initialiser the production constructor and the #851 tests already use.

Verified: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, all 7 crates green.