### PR TITLE
fix(voice): start the audio capture off the Electron main thread

### DIFF
--- a/apps/core-app/src/main/modules/voice/global-dictation.test.ts
+++ b/apps/core-app/src/main/modules/voice/global-dictation.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  registerMainShortcut: vi.fn(),
+  unregisterMainShortcut: vi.fn(),
+  beginCapture: vi.fn(),
+  endCapture: vi.fn(),
+  abortCapture: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  Notification: class {
+    static isSupported(): boolean {
+      return false
+    }
+
+    show(): void {}
+  }
+}))
+
+vi.mock('../global-shortcon', () => ({
+  shortcutModule: {
+    registerMainShortcut: mocks.registerMainShortcut,
+    unregisterMainShortcut: mocks.unregisterMainShortcut
+  }
+}))
+
+vi.mock('./voice-service', () => ({
+  voiceService: {
+    beginCapture: mocks.beginCapture,
+    endCapture: mocks.endCapture,
+    abortCapture: mocks.abortCapture
+  }
+}))
+
+import { GlobalDictationController } from './global-dictation'
+
+/**
+ * `beginCapture` became async in #841 so opening the input stream stops blocking the main thread.
+ * The session id it resolves to is then handed to `endCapture` / `abortCapture`, so a dropped
+ * `await` here does not fail loudly -- it stores a Promise and every later call receives one.
+ * Verified: mutating the await away leaves the whole voice suite green without these.
+ */
+function pressShortcut(): () => void {
+  const controller = new GlobalDictationController()
+  mocks.registerMainShortcut.mockReturnValue(true)
+  controller.register()
+  const handler = mocks.registerMainShortcut.mock.calls[0]?.[2] as () => void
+  expect(typeof handler).toBe('function')
+  return handler
+}
+
+describe('global dictation toggle', () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach((mock) => mock.mockReset())
+    mocks.beginCapture.mockResolvedValue('session-1')
+    mocks.endCapture.mockResolvedValue({ text: '', raw: '' })
+  })
+
+  it('把解析后的 session id 交给 endCapture,而不是一个 Promise', async () => {
+    const press = pressShortcut()
+
+    press()
+    await vi.waitFor(() => expect(mocks.beginCapture).toHaveBeenCalledTimes(1))
+
+    press()
+    await vi.waitFor(() => expect(mocks.endCapture).toHaveBeenCalledTimes(1))
+
+    const sessionId = mocks.endCapture.mock.calls[0]?.[0]
+    expect(sessionId).toBe('session-1')
+    expect(typeof sessionId).toBe('string')
+  })
+
+  it('第二次按下之前不会重复开启采集', async () => {
+    const press = pressShortcut()
+
+    press()
+    await vi.waitFor(() => expect(mocks.beginCapture).toHaveBeenCalledTimes(1))
+    press()
+    await vi.waitFor(() => expect(mocks.endCapture).toHaveBeenCalledTimes(1))
+
+    expect(mocks.beginCapture).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/core-app/src/main/modules/voice/global-dictation.ts
+++ b/apps/core-app/src/main/modules/voice/global-dictation.ts
@@ -64,7 +64,7 @@ export class GlobalDictationController {
       if (this.activeSessionId) {
         await this.finish(this.activeSessionId)
       } else {
-        this.activeSessionId = voiceService.beginCapture()
+        this.activeSessionId = await voiceService.beginCapture()
         this.notify('🎙️ 正在听写…', '再次按下快捷键停止并键入')
       }
     } catch (error) {

--- a/apps/core-app/src/main/modules/voice/voice-service.test.ts
+++ b/apps/core-app/src/main/modules/voice/voice-service.test.ts
@@ -36,6 +36,9 @@ import type { VoiceAsrStreamEvent } from '@talex-touch/utils/transport/sdk/domai
 import { VoiceService } from './voice-service'
 
 const support = nativeAudio.getNativeAudioSupport as unknown as ReturnType<typeof vi.fn>
+// Resolved rather than plain values: `startCapture` is async since #841, and a mock returning a
+// bare object lets a dropped `await` keep passing -- `const { sessionId } = promise` would just
+// hand every downstream call an undefined id.
 const startCapture = nativeAudio.startCapture as unknown as ReturnType<typeof vi.fn>
 const pollCapture = nativeAudio.pollCapture as unknown as ReturnType<typeof vi.fn>
 const snapshotCapture = nativeAudio.snapshotCapture as unknown as ReturnType<typeof vi.fn>
@@ -59,7 +62,7 @@ describe('VoiceService.dictate', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     support.mockReturnValue({ supported: true, platform: 'darwin' })
-    startCapture.mockReturnValue({ sessionId: 's1' })
+    startCapture.mockResolvedValue({ sessionId: 's1' })
     pollCapture.mockReturnValue({ active: false, durationMs: 1200, stoppedReason: 'silence' })
     stopCapture.mockReturnValue({
       audio: wav(),
@@ -171,7 +174,7 @@ describe('VoiceService.streamDictation', () => {
     vi.clearAllMocks()
     vi.useFakeTimers()
     support.mockReturnValue({ supported: true, platform: 'darwin' })
-    startCapture.mockReturnValue({ sessionId: 's1' })
+    startCapture.mockResolvedValue({ sessionId: 's1' })
     snapshotCapture.mockReturnValue({ audio: wav(), durationMs: 1000 })
     stopCapture.mockReturnValue({
       audio: wav(),
@@ -379,7 +382,7 @@ describe('VoiceService toggle capture', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     support.mockReturnValue({ supported: true, platform: 'darwin' })
-    startCapture.mockReturnValue({ sessionId: 't1' })
+    startCapture.mockResolvedValue({ sessionId: 't1' })
     stopCapture.mockReturnValue({
       audio: wav(),
       format: 'wav',
@@ -390,8 +393,8 @@ describe('VoiceService toggle capture', () => {
     })
   })
 
-  it('beginCapture starts native capture and returns a session id', () => {
-    const id = new VoiceService().beginCapture()
+  it('beginCapture starts native capture and returns a session id', async () => {
+    const id = await new VoiceService().beginCapture()
     expect(id).toBe('t1')
     expect(startCapture).toHaveBeenCalledTimes(1)
   })

--- a/apps/core-app/src/main/modules/voice/voice-service.ts
+++ b/apps/core-app/src/main/modules/voice/voice-service.ts
@@ -145,7 +145,7 @@ export class VoiceService {
     const maxDurationMs = payload.maxDurationMs ?? DEFAULT_MAX_DURATION_MS
     const silenceStopMs = payload.silenceStopMs ?? DEFAULT_SILENCE_STOP_MS
 
-    const { sessionId } = nativeAudio.startCapture({ maxDurationMs, silenceStopMs })
+    const { sessionId } = await nativeAudio.startCapture({ maxDurationMs, silenceStopMs })
     const cancelCapture = (): void => {
       try {
         nativeAudio.cancelCapture(sessionId)
@@ -254,10 +254,15 @@ export class VoiceService {
     }
   }
 
-  /** Begins a toggle-controlled capture (global hotkey). Returns the native session id. */
-  beginCapture(): string {
+  /**
+   * Begins a toggle-controlled capture (global hotkey). Resolves to the native session id.
+   *
+   * Async since #841: opening the input stream is what takes the time, and it used to take it on
+   * the main thread -- the global hotkey froze the app while CoreAudio came up.
+   */
+  async beginCapture(): Promise<string> {
     this.assertSupported()
-    const { sessionId } = nativeAudio.startCapture({
+    const { sessionId } = await nativeAudio.startCapture({
       maxDurationMs: TOGGLE_MAX_DURATION_MS,
       silenceStopMs: TOGGLE_SILENCE_STOP_MS
     })
@@ -361,7 +366,7 @@ export class VoiceService {
     caller = VOICE_CALLER
   ): AsyncGenerator<VoiceAsrStreamEvent> {
     const pollCapture = getPollCapture()
-    const { sessionId } = nativeAudio.startCapture({
+    const { sessionId } = await nativeAudio.startCapture({
       maxDurationMs: DEFAULT_MAX_DURATION_MS,
       silenceStopMs: DEFAULT_SILENCE_STOP_MS
     })
@@ -406,7 +411,7 @@ export class VoiceService {
     const snapshotCapture = getSnapshotCapture()
     const pollCapture = getPollCapture()
 
-    const { sessionId } = nativeAudio.startCapture({
+    const { sessionId } = await nativeAudio.startCapture({
       maxDurationMs: DEFAULT_MAX_DURATION_MS,
       silenceStopMs: DEFAULT_SILENCE_STOP_MS
     })

--- a/packages/tuff-native/audio.d.ts
+++ b/packages/tuff-native/audio.d.ts
@@ -70,7 +70,14 @@ export interface TypeTextResult {
 }
 
 export declare function getNativeAudioSupport(): NativeAudioSupport
-export declare function startCapture(options?: AudioCaptureOptions): AudioCaptureStart
+/**
+ * Opens the input stream and resolves once the capture thread confirms it is live.
+ *
+ * Asynchronous so the wait does not sit on the Electron main thread: opening a CoreAudio input can
+ * take seconds while a Bluetooth device reconnects, and on first use macOS raises the microphone
+ * consent sheet, which waits on a human (#841).
+ */
+export declare function startCapture(options?: AudioCaptureOptions): Promise<AudioCaptureStart>
 export declare function pollCapture(sessionId: string): AudioCaptureState
 export declare function snapshotCapture(sessionId: string): AudioSnapshot
 /** Returns only the NEW captured PCM since the last drain (raw 16-bit LE mono). Throws `session-not-found: <id>` for an unknown id. */

--- a/packages/tuff-native/native-audio/src/lib.rs
+++ b/packages/tuff-native/native-audio/src/lib.rs
@@ -7,8 +7,8 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use napi::bindgen_prelude::Buffer;
-use napi::{Error, Result};
+use napi::bindgen_prelude::{AsyncTask, Buffer};
+use napi::{Env, Error, Result, Task};
 use napi_derive::napi;
 
 /// Default hard cap on a capture session before it auto-stops.
@@ -99,8 +99,7 @@ pub fn get_native_audio_support() -> NativeAudioSupport {
     )
 }
 
-#[napi]
-pub fn start_capture(options: Option<AudioCaptureOptions>) -> Result<AudioCaptureStart> {
+fn start_capture_blocking(options: Option<AudioCaptureOptions>) -> Result<String> {
     if !platform_supported() {
         return Err(Error::from_reason("platform-not-supported"));
     }
@@ -173,7 +172,40 @@ pub fn start_capture(options: Option<AudioCaptureOptions>) -> Result<AudioCaptur
     };
     lock(sessions()).insert(session_id.clone(), handle);
 
-    Ok(AudioCaptureStart { session_id })
+    Ok(session_id)
+}
+
+/// Runs the blocking half on the libuv pool instead of the JS thread.
+///
+/// The wait itself is deliberate -- `start_capture` reports device failures rather than handing
+/// back a session that never produces audio -- but it was being served on the Electron main
+/// thread. `default_input_device()`, `build_input_stream()` and `stream.play()` on CoreAudio take
+/// seconds while a Bluetooth input is (re)connecting, and on first use macOS raises the microphone
+/// consent sheet before the AudioUnit starts, which waits on a human. Nothing in this repo asks
+/// for that permission ahead of time -- `assertSupported()` in voice-service.ts only checks
+/// `getNativeAudioSupport()` -- so the very first dictation blocks for as long as the user takes
+/// to click. A `recv_timeout` short enough to protect the event loop would have to be short enough
+/// to fail that (#841).
+pub struct StartCaptureTask {
+    options: Option<AudioCaptureOptions>,
+}
+
+impl Task for StartCaptureTask {
+    type Output = String;
+    type JsValue = AudioCaptureStart;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        start_capture_blocking(self.options.take())
+    }
+
+    fn resolve(&mut self, _env: Env, session_id: Self::Output) -> Result<Self::JsValue> {
+        Ok(AudioCaptureStart { session_id })
+    }
+}
+
+#[napi]
+pub fn start_capture(options: Option<AudioCaptureOptions>) -> AsyncTask<StartCaptureTask> {
+    AsyncTask::new(StartCaptureTask { options })
 }
 
 #[napi]


### PR DESCRIPTION
Closes #841

## Measured

On this machine, microphone already authorised, nothing reconnecting — the cheapest possible case:

```
before: startCapture blocked the JS thread for 157ms
after:  0ms, resolving at 162ms off-thread
```

The issue's scenario — a Bluetooth input reconnecting — scales that into seconds, during which the whole Electron event loop is frozen: no IPC, no repaint, no CoreBox shortcut.

## Why AsyncTask and not `recv_timeout`

The issue offers both. The timeout has a problem it does not mention: **nothing in this repo asks for microphone permission ahead of time.** `assertSupported()` in `voice-service.ts` only checks `getNativeAudioSupport()`, and the voice module's only permission wiring is the app's own `withPermission` channel guard, not the OS one. So on first use the macOS consent sheet is raised *inside* this call and waits on a human.

A timeout short enough to protect the event loop is short enough to fail the very first dictation, every time.

The wait itself is deliberate — `start_capture` reports device failures rather than handing back a session that never produces audio. It was the *thread* that was wrong, not the waiting. It now runs as a napi `AsyncTask` on the libuv pool. The cpal thread is untouched: its `Stream` is neither `Send` nor `Sync`, so it still owns the stream on its own OS thread.

## API change

`startCapture` returns `Promise<AudioCaptureStart>`. Four call sites, all already inside `async` functions. `beginCapture()` becomes `async` with it — its only caller is the global hotkey's `toggle()`, already `async` and already guarded by a `busy` flag, so no re-entrancy is introduced. That hotkey used to freeze the app while CoreAudio came up.

## Tests

Two things the existing suite could not have caught, both found by mutation:

- The `startCapture` mocks used `mockReturnValue`. `await` on a plain object also works, so a dropped `await` kept passing. Moved to `mockResolvedValue` — now dropping it in `dictate()` fails a test.
- `global-dictation.ts` had **no test file at all**, so dropping the `await` there left the entire voice suite green. The new `global-dictation.test.ts` drives the real path — register the shortcut, capture the handler, press twice — and asserts `endCapture` receives the resolved string rather than a Promise. Verified: it fails on that mutation and passes without it.

| mutation | result |
|---|---|
| `dictate()` drops the `await` | 1 failed |
| `toggle()` drops the `await` | 1 failed (was 0 before the new test) |

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (7 targets), `tsc --noEmit -p tsconfig.node.json --composite false`, eslint on the touched files (0 findings), and the voice suite (33 tests) all pass.

The Promise behaviour was checked against a real built addon, not just the types:

```
$ node -e "... require('./build/Release/tuff_native_audio.node').startCapture(...)"
returns a Promise: true
synchronous block: 0ms
resolved after: 162ms
```