### PR TITLE
fix(voice): cancel a capture that starts after the controller is torn down [#1552]

### DIFF
--- a/apps/core-app/src/main/modules/voice/global-dictation.test.ts
+++ b/apps/core-app/src/main/modules/voice/global-dictation.test.ts
@@ -41,13 +41,13 @@ import { GlobalDictationController } from './global-dictation'
  * `await` here does not fail loudly -- it stores a Promise and every later call receives one.
  * Verified: mutating the await away leaves the whole voice suite green without these.
  */
-function pressShortcut(): () => void {
+function pressShortcut(): { press: () => void; controller: GlobalDictationController } {
   const controller = new GlobalDictationController()
   mocks.registerMainShortcut.mockReturnValue(true)
   controller.register()
   const handler = mocks.registerMainShortcut.mock.calls[0]?.[2] as () => void
   expect(typeof handler).toBe('function')
-  return handler
+  return { press: handler, controller }
 }
 
 describe('global dictation toggle', () => {
@@ -58,7 +58,7 @@ describe('global dictation toggle', () => {
   })
 
   it('把解析后的 session id 交给 endCapture,而不是一个 Promise', async () => {
-    const press = pressShortcut()
+    const { press } = pressShortcut()
 
     press()
     await vi.waitFor(() => expect(mocks.beginCapture).toHaveBeenCalledTimes(1))
@@ -71,8 +71,30 @@ describe('global dictation toggle', () => {
     expect(typeof sessionId).toBe('string')
   })
 
+  it('拆除时正在启动的采集会被取消,而不是留在原生侧', async () => {
+    // beginCapture 是异步的,期间 activeSessionId 还是 null,unregister 无从取消。
+    // 落到一个已拆除的控制器上的 session id 是原生侧唯一的句柄,丢了就再也回收不了 (#1552)。
+    let resolveCapture!: (value: string) => void
+    mocks.beginCapture.mockImplementation(
+      async () =>
+        await new Promise<string>((resolve) => {
+          resolveCapture = resolve
+        })
+    )
+    const { press, controller } = pressShortcut()
+
+    press()
+    await vi.waitFor(() => expect(mocks.beginCapture).toHaveBeenCalledTimes(1))
+
+    controller.unregister()
+    expect(mocks.abortCapture).not.toHaveBeenCalled()
+
+    resolveCapture('session-late')
+    await vi.waitFor(() => expect(mocks.abortCapture).toHaveBeenCalledWith('session-late'))
+  })
+
   it('第二次按下之前不会重复开启采集', async () => {
-    const press = pressShortcut()
+    const { press } = pressShortcut()
 
     press()
     await vi.waitFor(() => expect(mocks.beginCapture).toHaveBeenCalledTimes(1))

--- a/apps/core-app/src/main/modules/voice/global-dictation.ts
+++ b/apps/core-app/src/main/modules/voice/global-dictation.ts
@@ -21,9 +21,19 @@ export class GlobalDictationController {
   private activeSessionId: string | null = null
   private busy = false
   private registered = false
+  /**
+   * Set by `unregister`, cleared by `register`.
+   *
+   * `beginCapture()` is async, so between the call and its resolution there is no
+   * session id anywhere for teardown to cancel. A capture that lands after this is
+   * set has nobody left to stop it, and the id is the only handle the native side
+   * has to that session (#1552).
+   */
+  private disposed = false
 
   register(): void {
     if (this.registered) return
+    this.disposed = false
     try {
       const ok = shortcutModule.registerMainShortcut(
         SHORTCUT_ID,
@@ -43,6 +53,7 @@ export class GlobalDictationController {
   }
 
   unregister(): void {
+    this.disposed = true
     if (this.registered) {
       try {
         shortcutModule.unregisterMainShortcut(SHORTCUT_ID)
@@ -64,7 +75,14 @@ export class GlobalDictationController {
       if (this.activeSessionId) {
         await this.finish(this.activeSessionId)
       } else {
-        this.activeSessionId = await voiceService.beginCapture()
+        const sessionId = await voiceService.beginCapture()
+        if (this.disposed) {
+          // Teardown ran while the native start was in flight. Nothing will toggle
+          // this controller again, so keeping the id here would strand the session.
+          voiceService.abortCapture(sessionId)
+          return
+        }
+        this.activeSessionId = sessionId
         this.notify('🎙️ 正在听写…', '再次按下快捷键停止并键入')
       }
     } catch (error) {


### PR DESCRIPTION
Fixes #1552. Native backstop for the same failure: #1553 (#842).

## Confirmed

`beginCapture()` became async in #1549. Between the call and its resolution, `this.activeSessionId` is still `null` — and that field is the only thing `unregister()` cancels through:

```ts
this.activeSessionId = await voiceService.beginCapture()   // ← null for the whole await
...
if (this.activeSessionId) { voiceService.abortCapture(this.activeSessionId) }
```

A teardown in that window aborts nothing, and the assignment then lands on a controller nobody will toggle again.

## The window is real

#1549 measured `startCapture` resolving at **162 ms** on an already-authorised mic with nothing reconnecting. The case it was made async *for* — a Bluetooth input reconnecting, or the first-use consent sheet — stretches that to seconds, waiting on a human.

## What it costs

Out of proportion to the window, because the id is the only handle the native side has: `SESSIONS` is keyed by it, every removal path needs one, and nothing enumerates the map. The interleaved buffer (~5.8 MB) plus the snapshot cache stay for the life of the process.

## Fix

`unregister()` marks the controller disposed; a start that resolves into a disposed controller aborts its own session rather than storing it. Same shape as the `busy` guard already there.

## Mutations, both caught

| mutation | result |
|---|---|
| guard removed (the defect restored) | new test fails |
| `unregister` no longer marks disposed | new test fails |

The test helper now returns the controller alongside the handler, so teardown can be driven mid-flight; the two existing tests destructure it and are otherwise untouched.

## Verified

34 voice tests pass, `prettier --check` clean on both files.