### PR TITLE
ci(tuffex): run the two audit scripts that pass

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -41,6 +41,11 @@ on:
         required: false
         type: string
         default: "pnpm test"
+      post-build-command:
+        description: "Package-specific checks to run after the build, e.g. audits that read dist/. Skipped when empty."
+        required: false
+        type: string
+        default: ""
       lint-command:
         description: "Custom lint command (default: pnpm lint)"
         required: false
@@ -96,6 +101,13 @@ jobs:
         if: ${{ inputs.run-build }}
         working-directory: ${{ inputs.package-path }}
         run: ${{ inputs.build-command }}
+
+      # After the build so an audit can read dist/, and before the artifact upload so a
+      # failure stops the run rather than publishing a dist nothing checked.
+      - name: Post-build checks
+        if: ${{ inputs.run-build && inputs.post-build-command != '' }}
+        working-directory: ${{ inputs.package-path }}
+        run: ${{ inputs.post-build-command }}
 
       - name: Upload Build Artifacts
         if: ${{ inputs.run-build }}

--- a/.github/workflows/package-tuffex-ci.yml
+++ b/.github/workflows/package-tuffex-ci.yml
@@ -35,3 +35,7 @@ jobs:
       run-test: true
       run-build: true
       build-command: pnpm build
+      # Only the two that pass today. audit:types is broken by construction and audit:size
+      # has been over budget since well before this change -- both tracked in #1555, and
+      # wiring them here would land a gate that is red on every PR.
+      post-build-command: pnpm audit:exports && pnpm audit:readme


### PR DESCRIPTION
Part 1 of #1555. Wires the audits that are green today; leaves the two that are not, with the reason.

## The gap

`packages/tuffex` defines four audit scripts. **None of them is run by any workflow:**

```
audit:exports  0 workflow files
audit:types    0 workflow files
audit:readme   0 workflow files
audit:size     0 workflow files
typecheck      9 workflow files      <- control, the scan works
```

`Tuffex Package CI` passes `run-typecheck`, `run-lint`, `run-test`, `run-build` to the shared `package-ci.yml` and nothing else.

## What is wired, and what is not

Measured against a fresh `pnpm build`:

| script | state | wired here |
|---|---|---|
| `audit:exports` | green, 0.2s | ✅ |
| `audit:readme` | green, 0.1s | ✅ |
| `audit:types` | broken by construction | ❌ |
| `audit:size` | base CSS 29.7 KiB vs 16.0; full 465.1 vs 330.0 | ❌ |

`audit:types` installs tuffex by `file:`, which reads the raw `package.json` and cannot resolve `@talex-touch/utils@workspace:^` outside the monorepo. `audit:size` has been over budget since long before this change. Wiring either would land a gate that is red on every PR — the failure mode #1125 is about. Both are written up in #1555 with the evidence.

## Shape

`package-ci.yml` grows an optional `post-build-command`, defaulting to `""` so the **six other callers are unchanged** (checked: none of them sets it). The step sits:

- **after** the build, so `audit:exports` can read `dist/`;
- **before** the artifact upload, so a failure stops the run rather than publishing a `dist` nothing checked.

## Verified it actually gates

Not just that it passes — that it can fail. With one assertion in `audit-package-exports.mjs` pointed at a file that does not exist:

```
COMBINED_RC=1     ELIFECYCLE  Command failed with exit code 1
```

Restored: `RC=0`.