### PR TITLE
fix(tuffex): declare the @vue/reactivity its .d.ts imports

### DIFF
--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -85,6 +85,7 @@
     "@number-flow/vue": "^0.5.1",
     "@shikijs/engine-javascript": "^4.4.2",
     "@talex-touch/utils": "workspace:^",
+    "@vue/reactivity": "^3.5.27",
     "@vueuse/core": "^14.3.0",
     "dompurify": "^3.4.11",
     "gsap": "^3.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1132,6 +1132,9 @@ importers:
       '@talex-touch/utils':
         specifier: workspace:^
         version: link:../utils
+      '@vue/reactivity':
+        specifier: ^3.5.27
+        version: 3.5.39
       '@vueuse/core':
         specifier: ^14.3.0
         version: 14.3.0(vue@3.5.39(typescript@5.9.3))


### PR DESCRIPTION
Closes #1557

Eight shipped `.d.ts` files import from `@vue/reactivity`. The manifest declared it nowhere — not `dependencies`, not `peerDependencies`, not `devDependencies`.

Control: `@floating-ui/vue` is imported by a `.d.ts` too and **is** declared, so this is one specific omission, not a manifest that lists nothing.

## Correcting my own framing

I filed this as a live breakage and **that was wrong.** A faithful `pnpm install` of the packed tarball typechecks clean:

```
$ tsc --noEmit -p tsconfig.json        # skipLibCheck: false
TSC_RC=0    errors: 0

loaded tuffex files: 421   (including .../select/src/TxSelect.vue.d.ts)
deliberate type error  -> RC=2, error TS2322        <- positive control
installed manifest: dependencies[@vue/reactivity] = None   <- the pre-fix one
```

`--traceResolution` says why:

```
Module name '@vue/reactivity' was successfully resolved to
  node_modules/.pnpm/node_modules/@vue/reactivity/dist/reactivity.d.ts
unresolved: 0
```

pnpm's default `hoist-pattern` puts it in `node_modules/.pnpm/node_modules/` (189 packages there), which sits on the lookup path from tuffex's own `.d.ts`. npm and yarn flatten for the same effect.

My earlier reproduction had extracted the tarball into a plain `node_modules/@talex-touch/tuffex` **by hand**, bypassing every package manager's layout. That is what produced the TS2307, and it is not a layout anyone ships.

**So no consumer is broken today.** The issue is relabelled from `bug` accordingly.

## Why still fix it

An undeclared coupling: what a published type surface imports should be declared, rather than left to whether the consumer's package manager happens to hoist it. Cost is 3 lockfile lines.

## Not fixable at the source

The reference sits inside an inlined conditional type carrying Vue's `WatchCallback` shape:

```ts
(...args: any) => infer R ? (...args: [R, R, import('@vue/reactivity').OnCleanup]) => any : ...
```

vue-tsc emits it from the module that *declares* `OnCleanup`, and `vue` does not re-export it:

```
probe.ts(1,15): error TS2305: Module '"vue"' has no exported member 'OnCleanup'.
```

## `dependencies`, not `peerDependencies`

I wrote it as a peer first. This repo's own `.npmrc` sets `auto-install-peers=false`, so a peer would not be installed for consumers sharing that setting.

The usual argument against a plain dependency — a second copy giving two type identities — does not apply here: **all 32 references are to `OnCleanup`**, which is `(cleanupFn: () => void) => void`, a structural alias assignable across copies. pnpm resolved it to `3.5.39`, the version `vue` already pulls, so nothing is duplicated.

## Verification

| check | result |
|---|---|
| `pnpm typecheck` (tuffex) | 0 errors |
| `pnpm test` (tuffex) | 1114 passed / 145 files |
| `pnpm lint` (tuffex) | clean |
| core-app main-process `tsc` | 0 errors |
| packed manifest | carries `"@vue/reactivity": "^3.5.27"` |

`App suites (nexus)` failed on the first run at `Upload nexus test report` — a 404 from the artifact service. `Run nexus suite` itself passed; re-run requested.
