### PR TITLE
fix(permission): require a permission that a guard names directly [#915]

### DIFF
--- a/apps/core-app/src/main/modules/permission/permission-guard.test.ts
+++ b/apps/core-app/src/main/modules/permission/permission-guard.test.ts
@@ -156,6 +156,36 @@ describe('unmapped API inventory', () => {
     expect(guard.getUnmappedApis()).toEqual([])
   })
 
+  it('requires a permission that is named directly, rather than waving it through', () => {
+    // `withPermission({ permissionId: 'system.shell' })` hands channel-guard a permission
+    // id, and channel-guard passes it straight to check() as the apiName. No entry in
+    // API_PERMISSION_MAPPINGS contains a dot, so this fell off the end and returned
+    // allowed:true — the terminal gate was open to any plugin (#915).
+    const result = guard.check(TEST_PLUGIN_ID, 'system.shell', SDK_VERSION)
+
+    expect(result.allowed).toBe(false)
+    expect(result.permissionId).toBe('system.shell')
+    expect(guard.getUnmappedApis()).toEqual([])
+  })
+
+  it('still allows a directly-named permission once it is declared and granted', async () => {
+    // The other half: turning the gate on must not deny a plugin that did everything right.
+    store.setDeclaredPermissions(TEST_PLUGIN_ID, {
+      required: ['network.internet'],
+      optional: []
+    })
+    await store.grant(TEST_PLUGIN_ID, 'network.internet', 'user')
+
+    expect(guard.check(TEST_PLUGIN_ID, 'network.internet', SDK_VERSION).allowed).toBe(true)
+  })
+
+  it('resolves an API name through the table even when a permission shares its stem', () => {
+    // `clipboard:read` (API) and `clipboard.read` (permission) both exist. The table has to
+    // win for the API form, or the fallback would quietly bypass the mapping layer.
+    expect(guard.getRequiredPermissions('clipboard:read')).toEqual(['clipboard.read'])
+    expect(guard.getRequiredPermissions('clipboard.read')).toEqual(['clipboard.read'])
+  })
+
   it('orders the inventory by frequency, so the flip starts with the common names', () => {
     guard.check(TEST_PLUGIN_ID, 'unmapped:rare', SDK_VERSION)
     guard.check(TEST_PLUGIN_ID, 'unmapped:common', SDK_VERSION)

--- a/apps/core-app/src/main/modules/permission/permission-guard.ts
+++ b/apps/core-app/src/main/modules/permission/permission-guard.ts
@@ -164,11 +164,14 @@ export class PermissionGuard {
 
     if (requiredPermissions.length === 0) {
       // Unmapped names are allowed, which makes this an opt-in denylist keyed on a
-      // hand-maintained table rather than a default-deny gate (#915). Flipping the default
-      // needs an inventory of every name that legitimately reaches here — four call sites
-      // feed it, two of them with a caller-supplied string — and that inventory does not
-      // exist yet. Recording each one is how it gets built: an allow that leaves a trace is
-      // still a gap, but it is a countable gap rather than a silent one.
+      // hand-maintained table rather than a default-deny gate (#915). What still reaches
+      // here is a name that matches no API pattern AND is not a registered permission —
+      // i.e. one nothing in the permission model knows about at all. Every literal the
+      // main process passes today is one or the other, so this branch should be empty in
+      // practice; recording it is how a new one gets noticed.
+      //
+      // An allow that leaves a trace is still a gap, but it is a countable gap rather
+      // than a silent one.
       this.recordUnmappedApi(pluginId, apiName)
 
       const duration = performance.now() - startTime
@@ -325,6 +328,21 @@ export class PermissionGuard {
       if (this.matchPattern(pattern, apiName)) {
         return mapping.permissions.map((permissionId) => normalizePermissionId(permissionId))
       }
+    }
+
+    // Two vocabularies reach this function. `API_PERMISSION_MAPPINGS` is keyed on
+    // colon-separated *API names* (`clipboard:read`), but `withPermission` and
+    // `createProtectedRegister` name a dotted *permission id* directly
+    // (`system.shell`) — and channel-guard passes that straight through as the
+    // apiName. No pattern contains a dot, so every one of those fell off the end
+    // and was waved through: the terminal, network, plugin-window, localization
+    // and agent-execution gates were all allow-everything (#915).
+    //
+    // A name that is a registered permission is required as itself. There is no
+    // ambiguity to resolve — API names use colons and permission ids use dots.
+    const normalized = normalizePermissionId(apiName)
+    if (permissionRegistry.get(normalized)) {
+      return [normalized]
     }
 
     return []

--- a/packages/utils/__tests__/permission-id-vocabulary.test.ts
+++ b/packages/utils/__tests__/permission-id-vocabulary.test.ts
@@ -1,0 +1,131 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { PERMISSIONS } from '../permission/registry'
+
+/**
+ * Every name a guard is handed must resolve to a permission (#915).
+ *
+ * Two vocabularies feed `PermissionGuard.check()` through the same parameter:
+ *
+ * - `API_PERMISSION_MAPPINGS` is keyed on colon-separated **API names** — `clipboard:read`,
+ *   `native:file:stat` — which it maps to one or more permission ids.
+ * - `withPermission` / `createProtectedRegister` name a dotted **permission id** directly
+ *   (`{ permissionId: 'system.shell' }`), and `channel-guard.ts` passes that value straight
+ *   through as the `apiName` argument.
+ *
+ * No pattern in the table contains a dot, so for a long time every one of those fell off the
+ * end of the lookup and `check()` returned `allowed: true`. The terminal, network,
+ * plugin-window, localization and agent-execution gates were all allow-everything, and the
+ * only visible symptom was their absence: the code reads exactly like a working gate.
+ *
+ * That is why this test lives in `packages/utils` rather than beside the guard — `ci / CI -
+ * utils` blocks a PR, `App suites (core-app)` is continue-on-error and reports success
+ * whatever the suite does.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const MAIN = path.join(REPO_ROOT, 'apps/core-app/src/main')
+const GUARD = path.join(MAIN, 'modules/permission/permission-guard.ts')
+
+const REGISTERED = new Set(PERMISSIONS.map(permission => permission.id))
+
+/** The `pattern` side of API_PERMISSION_MAPPINGS. */
+function apiPatterns(): string[] {
+  const source = readFileSync(GUARD, 'utf8')
+  const table = source.slice(
+    source.indexOf('export const API_PERMISSION_MAPPINGS'),
+    source.indexOf('export class PermissionGuard'),
+  )
+  return [...table.matchAll(/pattern:\s*'([^']+)'/g)].map(([, pattern]) => pattern)
+}
+
+function matchesPattern(pattern: string, name: string): boolean {
+  if (pattern.endsWith('*'))
+    return name.startsWith(pattern.slice(0, -1))
+  if (pattern.includes('*'))
+    return new RegExp(`^${pattern.replace(/\*/g, '.*')}$`).test(name)
+  return pattern === name
+}
+
+function sourceFiles(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      sourceFiles(full, found)
+      continue
+    }
+    if (entry.endsWith('.ts') && !entry.includes('.test.'))
+      found.push(full)
+  }
+  return found
+}
+
+/**
+ * `permissionId: '<literal>'` in guard-option position.
+ *
+ * Skips the type-annotation form (`permissionId: 'fs.read' | 'fs.write'`) and the guard's own
+ * empty placeholder, neither of which is a value handed to a check.
+ */
+function declaredPermissionIds(): Map<string, string[]> {
+  const found = new Map<string, string[]>()
+  for (const file of sourceFiles(MAIN)) {
+    const source = readFileSync(file, 'utf8')
+    for (const match of source.matchAll(/permissionId:\s*'([^']*)'(\s*\|)?/g)) {
+      const [, name, isUnion] = match
+      if (isUnion || name === '')
+        continue
+      const line = source.slice(0, match.index).split('\n').length
+      const where = `${path.relative(MAIN, file)}:${line}`
+      found.set(name, [...(found.get(name) ?? []), where])
+    }
+  }
+  return found
+}
+
+describe('permission id vocabulary', () => {
+  it('reads the sources it means to check', () => {
+    // Positive control. "Nothing resolves to nothing" is also what an empty scan reports, and
+    // three separate mechanisms here can silently return empty: a wrong root, a renamed table,
+    // and a quoting change in the registry.
+    expect(REGISTERED.size).toBeGreaterThan(20)
+    expect(REGISTERED.has('system.shell')).toBe(true)
+    expect(apiPatterns().length).toBeGreaterThan(30)
+    expect(declaredPermissionIds().size).toBeGreaterThan(5)
+  })
+
+  it('names something the guard can resolve at every call site', () => {
+    const patterns = apiPatterns()
+    const unresolvable: string[] = []
+
+    for (const [name, sites] of declaredPermissionIds()) {
+      const resolves
+        = REGISTERED.has(name) || patterns.some(pattern => matchesPattern(pattern, name))
+      if (!resolves)
+        unresolvable.push(`${name} (${sites.join(', ')})`)
+    }
+
+    expect(unresolvable).toEqual([])
+  })
+
+  it('keeps the two vocabularies from colliding', () => {
+    // The fallback in getRequiredPermissions is only unambiguous because API names use colons
+    // and permission ids use dots. A registered permission that also matched an API pattern
+    // would make the lookup order load-bearing and silently mean different things.
+    const patterns = apiPatterns()
+    const ambiguous = [...REGISTERED].filter(id =>
+      patterns.some(pattern => matchesPattern(pattern, id)),
+    )
+
+    expect(ambiguous).toEqual([])
+  })
+
+  it('still resolves a directly-named permission in the guard itself', () => {
+    // The fix this file guards. Without the fallback, `permissionId: 'system.shell'` maps to
+    // no permission and the check returns allowed.
+    const source = readFileSync(GUARD, 'utf8')
+
+    expect(source).toContain('permissionRegistry.get(normalized)')
+    expect(source).toMatch(/return \[normalized\]/)
+  })
+})


### PR DESCRIPTION
Fixes #915. Related: #838 (the plugin → local execution chain this was supposed to be blocking).

## I was wrong earlier on this issue

My previous comment instrumented the gap instead of closing it, on the grounds that *"the set of names that legitimately arrive is not derivable by reading the code."* That was wrong. Three of the four call sites take their name from a literal, and the fourth **is** the `withPermission` option. Enumerating them statically turned "unmapped names are allowed" into a specific list of open gates.

## What the enumeration found

Two vocabularies reach `check()` through the same parameter:

- `API_PERMISSION_MAPPINGS` is keyed on colon-separated **API names** (`clipboard:read`) which it maps to permission ids.
- `withPermission` / `createProtectedRegister` name a dotted **permission id** directly (`{ permissionId: 'system.shell' }`), and `channel-guard.ts:161` passes that value straight through as `apiName`.

**No pattern in the table contains a dot.** Verified against the real matcher, not by reading:

```
MAPS   clipboard:read               -> ["clipboard.read"]
MAPS   native:screenshot:capture    -> ["window.capture"]
MAPS   storage:sqlite:query         -> ["storage.sqlite"]
...
UNMAP  system.shell                 -> []
UNMAP  network.internet             -> []
UNMAP  window.create                -> []
UNMAP  clipboard.read               -> []
UNMAP  i18n.read                    -> []
UNMAP  intelligence.agents          -> []
```

Every colon-named API maps. **Every dotted permission id does not** — so `requiredPermissions.length === 0` and `check()` returned `allowed: true`.

Nine gates were open to any plugin:

| permission | guarding |
|---|---|
| `system.shell` | terminal create / write / kill |
| `network.internet`, `network.local` | network module |
| `window.create` | plugin window transport |
| `clipboard.read` | system selection capture |
| `i18n.read`, `lexicon.read`, `lexicon.register` | localization channels |
| `intelligence.agents` | agent execution |

The code reads exactly like a working gate. Its only symptom was its absence.

## Fix

A name that is a registered permission is required as itself. No ambiguity to resolve — API names use colons, permission ids use dots — and the test asserts **no registered permission matches any pattern**, because the fallback is only unambiguous while that stays true.

## Blast radius: measured, not assumed

Every plugin in the repo that reaches one of these **already declares the matching permission**:

```
system.shell       touch-browser-open, touch-quick-actions, touch-snipaste,
                   touch-system-actions, touch-window-manager, touch-window-presets,
                   touch-workspace-scripts
network.internet   touch-browser-bookmarks, touch-browser-data, touch-browser-open,
                   touch-dev-toolbox, touch-snippets, touch-translation
clipboard.read     clipboard-history, touch-dictation, touch-snippets
```

So the gates start enforcing exactly what the manifests already say — which is also the strongest evidence they were meant to work.

- `window.create` is in `DEFAULT_PERMISSIONS`, auto-granted. No change.
- `i18n` / `lexicon` are touched only by `touch-image`, which ships no manifest at all (#813).
- Nothing shipped executes agents. The one grep hit was the string `agentExecute` inside an untracked `dist/` bundle of the inlined SDK, not a call.
- **Non-plugin callers were never gated** (`if (!pluginId) return callback(...)`) and still are not, so the app's own renderer is unaffected.

## Where the guard lives

`packages/utils/__tests__/permission-id-vocabulary.test.ts`, because `ci / CI - utils` blocks a PR and `App suites (core-app)` is `continue-on-error` and reports success whatever the suite does.

It has a positive control, because three separate mechanisms here can silently produce an empty scan: a wrong root, a renamed table, and a quoting change in the registry — the last of which actually bit me mid-investigation (`registry.ts` uses double quotes; my first scan reported 0 permissions).

## Mutations, both caught in both suites

| mutation | fails |
|---|---|
| fallback removed (the defect restored) | 2 core-app tests + `still resolves a directly-named permission in the guard itself` |
| a new call site names something unresolvable | `names something the guard can resolve at every call site`, naming the value **and its file:line** |

## Verified

1358 core-app tests (permission, terminal, network, plugin, channel), 1328 utils tests, `prettier --check` clean, root eslint clean on the new file, core-app eslint clean on both touched files, `typecheck:node` unchanged at 6 pre-existing errors.
