### PR TITLE
fix(transport): default-deny the plugin channel [#688]

### DIFF
--- a/packages/utils/__tests__/main-transport-identity.test.ts
+++ b/packages/utils/__tests__/main-transport-identity.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../transport/security/plugin-identity";
 import { TuffMainTransport } from "../transport/sdk/main-transport";
 import { defineRawEvent } from "../transport/event/builder";
+import { PluginEvents } from "../transport/events";
 import { describe, expect, it, vi } from "vitest";
 
 const { ipcHandle, browserWindowMock } = vi.hoisted(() => ({
@@ -24,10 +25,17 @@ vi.mock("electron", () => ({
   BrowserWindow: browserWindowMock,
 }));
 
+/**
+ * A real plugin-facing event, not a synthetic one.
+ *
+ * The plugin channel is default-deny since #688, so a `test:*` name is no longer bound to it
+ * — and a test asserting how a plugin-channel handler resolves identity has to use an event
+ * a plugin can actually reach, or it is asserting about a path that cannot happen.
+ */
 function identityEvent(suffix: string) {
-  return defineRawEvent<unknown, HandlerContext>(
-    `test:caller-identity:${suffix}`,
-  );
+  const source =
+    suffix === "channel" ? PluginEvents.storage.getStats : PluginEvents.storage.getTree;
+  return defineRawEvent<unknown, HandlerContext>(source.toEventName());
 }
 
 function activation(

--- a/packages/utils/__tests__/plugin-facing-events.test.ts
+++ b/packages/utils/__tests__/plugin-facing-events.test.ts
@@ -1,0 +1,201 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  isPluginFacingEvent,
+  pluginFacingEventNames,
+} from '../transport/security/plugin-facing-events'
+import { ClipboardEvents, PluginEvents, StorageEvents } from '../transport/events'
+import { TuffMainTransport } from '../transport/sdk/main-transport'
+
+const { ipcHandle, browserWindowMock } = vi.hoisted(() => ({
+  ipcHandle: vi.fn(),
+  browserWindowMock: {
+    getFocusedWindow: vi.fn(() => null),
+    getAllWindows: vi.fn(() => []),
+  },
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: ipcHandle },
+  MessageChannelMain: class {},
+  BrowserWindow: browserWindowMock,
+}))
+
+/** Records which `<channel>:<event>` pairs a transport actually binds. */
+function createHarness() {
+  const bound = new Set<string>()
+  const channel = {
+    regChannel: vi.fn((type: string, eventName: string) => {
+      bound.add(`${type}:${eventName}`)
+      return () => bound.delete(`${type}:${eventName}`)
+    }),
+    sendTo: vi.fn(),
+    send: vi.fn(),
+  }
+  const keyManager = {
+    requestKey: vi.fn(),
+    revokeKey: vi.fn(),
+    resolveKey: vi.fn(),
+    isValidKey: vi.fn(() => false),
+    resolveIdentity: vi.fn(),
+    resolveCurrentIdentity: vi.fn(),
+    resolveSenderIdentity: vi.fn(),
+  }
+  return {
+    bound,
+    transport: new TuffMainTransport(channel as never, keyManager as never),
+  }
+}
+
+/**
+ * The plugin channel's allowlist has to stay equal to what the plugin SDK actually sends (#688).
+ *
+ * `TuffMainTransport` binds a handler to `BRIDGE_CHANNEL.PLUGIN` only when its event is on that
+ * list. Getting the list wrong fails in one of two directions, and only one of them is loud:
+ *
+ * - **too short** — a plugin's call is simply never answered. No error, no log, no compile
+ *   failure, and no test here drives a real plugin view, so it would ship.
+ * - **too long** — a host-only handler is reachable from any plugin view again, which is the
+ *   defect this closed.
+ *
+ * So the list is not curated by hand: this re-derives it from `packages/utils/plugin/**`, the
+ * only path a plugin has to the transport, and fails on any difference in either direction.
+ */
+
+const UTILS_ROOT = path.resolve(__dirname, '..')
+/**
+ * Everything a plugin can import and reach the transport through.
+ *
+ * Deliberately just `plugin/`. `renderer/storage` looks like a peer but is renderer-only —
+ * neither the plugin SDK nor any plugin in this repo imports it — and including it silently
+ * added four `StorageEvents.app.*` entries to the allowlist, which is the "too long"
+ * direction above.
+ */
+const PLUGIN_SDK_ROOTS = ['plugin']
+/** How the SDK hands an event to the transport. */
+const SEND_SHAPES = /(?:\.send|\.sendStream|\.openStream|\.invoke|\.stream|\.on)\(\s*((?:[A-Z][A-Za-z0-9]*Events)\.[A-Za-z0-9_.]+)/g
+
+/**
+ * Transport infrastructure rather than SDK surface: a plugin upgrades to a MessagePort through
+ * these, so they are reachable by design and no `plugin/**` source names them.
+ */
+const PROTOCOL_EVENTS = [
+  'TransportEvents.port.upgrade',
+  'TransportEvents.port.confirm',
+  'TransportEvents.port.close',
+  'TransportEvents.port.error',
+]
+
+function sourceFiles(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry !== 'node_modules' && entry !== 'dist')
+        sourceFiles(full, found)
+      continue
+    }
+    if (entry.endsWith('.ts') && !entry.includes('.test.'))
+      found.push(full)
+  }
+  return found
+}
+
+/** The event constants the plugin SDK hands to the transport, as written. */
+function sdkSentConstants(): Set<string> {
+  const found = new Set(PROTOCOL_EVENTS)
+  for (const root of PLUGIN_SDK_ROOTS) {
+    for (const file of sourceFiles(path.join(UTILS_ROOT, root))) {
+      for (const [, constant] of readFileSync(file, 'utf8').matchAll(SEND_SHAPES))
+        found.add(constant)
+    }
+  }
+  return found
+}
+
+/** The same constants, as the allowlist module writes them. */
+function allowlistConstants(): Set<string> {
+  const source = readFileSync(
+    path.join(UTILS_ROOT, 'transport/security/plugin-facing-events.ts'),
+    'utf8',
+  )
+  const body = source.slice(
+    source.indexOf('export const PLUGIN_FACING_EVENTS'),
+    source.indexOf('] as const'),
+  )
+  return new Set(
+    [...body.matchAll(/^\s{2}([A-Z][A-Za-z0-9]*Events\.[A-Za-z0-9_.]+),$/gm)].map(
+      ([, constant]) => constant,
+    ),
+  )
+}
+
+describe('plugin-facing event allowlist', () => {
+  it('reads the sources it means to compare', () => {
+    // Positive control. Both halves of the comparison below are scans, and two equal empty
+    // sets pass. A wrong root, a renamed export, or a call shape the regex does not know
+    // would each produce exactly that.
+    expect(sdkSentConstants().size).toBeGreaterThan(80)
+    expect(allowlistConstants().size).toBeGreaterThan(80)
+    expect(pluginFacingEventNames().length).toBeGreaterThan(80)
+  })
+
+  it('lists exactly what the plugin SDK sends', () => {
+    const sent = sdkSentConstants()
+    const listed = allowlistConstants()
+
+    // Reported separately: one direction breaks plugins silently, the other reopens #688.
+    const missing = [...sent].filter(constant => !listed.has(constant)).sort()
+    const extra = [...listed].filter(constant => !sent.has(constant)).sort()
+
+    expect({ missing, extra }).toEqual({ missing: [], extra: [] })
+  })
+
+  it('every listed constant resolves to a real event name', () => {
+    // A typo'd path would be `undefined` at import and throw, but a *renamed* event would
+    // quietly resolve to something else. Names are what the transport actually matches on.
+    for (const name of pluginFacingEventNames()) {
+      expect(name).toMatch(/^[a-z][\w-]*(?::[\w-]+)+$/i)
+      expect(isPluginFacingEvent(name)).toBe(true)
+    }
+  })
+
+  it('refuses an event nothing declared', () => {
+    // The default-deny itself. Without this, an allowlist that returned true for everything
+    // would satisfy every assertion above.
+    expect(isPluginFacingEvent('plugin:definitely-not-declared')).toBe(false)
+    expect(isPluginFacingEvent('')).toBe(false)
+  })
+
+  it('binds on() to the plugin channel only for a listed event', () => {
+    const { bound, transport } = createHarness()
+
+    transport.on(PluginEvents.storage.getStats, async () => ({}) as never)
+    transport.on(StorageEvents.app.delete, async () => ({}) as never)
+
+    // Host binding is unconditional; the plugin one is the gate.
+    expect(bound.has(`main:${PluginEvents.storage.getStats.toEventName()}`)).toBe(true)
+    expect(bound.has(`main:${StorageEvents.app.delete.toEventName()}`)).toBe(true)
+
+    expect(bound.has(`plugin:${PluginEvents.storage.getStats.toEventName()}`)).toBe(true)
+    expect(bound.has(`plugin:${StorageEvents.app.delete.toEventName()}`)).toBe(false)
+  })
+
+  it('applies the same gate to onStream, both start and cancel', () => {
+    // Covering only `on()` would leave the entire stream surface bound — the half that is
+    // easy to miss, and the one a source-level assertion is most likely to wave through.
+    const { bound, transport } = createHarness()
+
+    transport.onStream(ClipboardEvents.change, () => {})
+    transport.onStream(StorageEvents.app.updated, () => {})
+
+    const listed = ClipboardEvents.change.toEventName()
+    const hostOnly = StorageEvents.app.updated.toEventName()
+
+    expect(bound.has(`plugin:${listed}:stream:start`)).toBe(true)
+    expect(bound.has(`plugin:${listed}:stream:cancel`)).toBe(true)
+    expect(bound.has(`plugin:${hostOnly}:stream:start`)).toBe(false)
+    expect(bound.has(`plugin:${hostOnly}:stream:cancel`)).toBe(false)
+    expect(bound.has(`main:${hostOnly}:stream:start`)).toBe(true)
+  })
+})

--- a/packages/utils/transport/sdk/main-transport.ts
+++ b/packages/utils/transport/sdk/main-transport.ts
@@ -29,6 +29,7 @@ import { randomUUID } from "node:crypto";
 import * as electron from "electron";
 import { assertTuffEvent } from "../event/builder";
 import { TransportEvents } from "../events";
+import { isPluginFacingEvent } from "../security/plugin-facing-events";
 import { isPortChannelEnabled } from "./port-policy";
 import { createServerStreamRuntime } from "./stream/server-runtime";
 import {
@@ -42,6 +43,8 @@ const BRIDGE_CHANNEL = {
   PLUGIN: "plugin",
 } as const;
 const BRIDGE_SUCCESS_CODE = 200;
+/** Stands in for a plugin-channel registration that default-deny refused to make (#688). */
+const NOOP_UNREGISTER = (): void => {};
 type BridgeChannelType = (typeof BRIDGE_CHANNEL)[keyof typeof BRIDGE_CHANNEL];
 type BridgeChannelCallback = (data: any) => unknown;
 type MainChannelBridge = {
@@ -737,11 +740,12 @@ export class TuffMainTransport implements ITuffTransportMain {
       eventName,
       channelHandler,
     );
-    const unregisterPlugin = this.channel.regChannel(
-      BRIDGE_CHANNEL.PLUGIN,
-      eventName,
-      channelHandler,
-    );
+    // Default-deny on the plugin channel. Binding every handler to it made the whole main
+    // process reachable from any plugin view, with each handler's own `context.plugin`
+    // check as the only thing between them (#688).
+    const unregisterPlugin = isPluginFacingEvent(eventName)
+      ? this.channel.regChannel(BRIDGE_CHANNEL.PLUGIN, eventName, channelHandler)
+      : NOOP_UNREGISTER;
     const unregisterInvoke = registerInvokeHandler(eventName, invokeHandler);
     const unregisterLocal = registerLocalHandler(eventName, localHandler);
 
@@ -902,16 +906,23 @@ export class TuffMainTransport implements ITuffTransportMain {
       cancelEventName,
       cancelHandler,
     );
-    const startCleanupPlugin = this.channel.regChannel(
-      BRIDGE_CHANNEL.PLUGIN,
-      startEventName,
-      startHandler,
-    );
-    const cancelCleanupPlugin = this.channel.regChannel(
-      BRIDGE_CHANNEL.PLUGIN,
-      cancelEventName,
-      cancelHandler,
-    );
+    // Same gate as `on()`. Covering only `on()` would leave the entire stream surface bound
+    // to the plugin channel, which is the half that is easy to miss (#688).
+    const pluginFacing = isPluginFacingEvent(eventName);
+    const startCleanupPlugin = pluginFacing
+      ? this.channel.regChannel(
+          BRIDGE_CHANNEL.PLUGIN,
+          startEventName,
+          startHandler,
+        )
+      : NOOP_UNREGISTER;
+    const cancelCleanupPlugin = pluginFacing
+      ? this.channel.regChannel(
+          BRIDGE_CHANNEL.PLUGIN,
+          cancelEventName,
+          cancelHandler,
+        )
+      : NOOP_UNREGISTER;
 
     return () => {
       startCleanupMain();

--- a/packages/utils/transport/security/plugin-facing-events.ts
+++ b/packages/utils/transport/security/plugin-facing-events.ts
@@ -1,0 +1,187 @@
+import {
+  AppEvents,
+  ClipboardEvents,
+  CoreBoxEvents,
+  DivisionBoxEvents,
+  FlowEvents,
+  MetaOverlayEvents,
+  PluginEvents,
+  QuickOpsEvents,
+  ScreenshotSessionEvents,
+  TransportEvents,
+} from '../events'
+
+/**
+ * Every event a plugin surface is allowed to reach on the main process.
+ *
+ * `TuffMainTransport.on()` and `onStream()` bind each handler to both
+ * `BRIDGE_CHANNEL.MAIN` and `BRIDGE_CHANNEL.PLUGIN`, and the plugin-view preload puts
+ * no filter on the event name a plugin's page may send. Every one of the ~414 handlers the
+ * main process registers was therefore reachable from any plugin view, and whether that
+ * mattered came down to whether the individual handler happened to inspect
+ * `context.plugin` — 67 of them did (#688).
+ *
+ * This is the default-deny half. A handler is bound to the plugin channel only if its event
+ * is named here; everything else is host-only, and a plugin asking for it gets no handler
+ * rather than an answer.
+ *
+ * **This list is derived, not curated.** It is exactly the set of events
+ * `packages/utils/plugin/**` sends — i.e. the plugin SDK's own surface, which is the only
+ * way a plugin reaches the transport. `plugin-facing-events.test.ts` re-derives it from
+ * those sources and fails if the two drift, so adding a plugin-facing handler means adding
+ * it here and nothing else does.
+ *
+ * Being on this list is not authorization. It decides whether a plugin can be *heard*, not
+ * whether it is *allowed* — the permission guard and each handler's own
+ * `context.plugin` checks still apply.
+ */
+export const PLUGIN_FACING_EVENTS = [
+  // AppEvents — 5
+  AppEvents.fileIndex.batteryLevel,
+  AppEvents.power.batteryStatus,
+  AppEvents.system.captureSelection,
+  AppEvents.system.getActiveApp,
+  AppEvents.window.show,
+
+  // ClipboardEvents — 15
+  ClipboardEvents.apply,
+  ClipboardEvents.change,
+  ClipboardEvents.clear,
+  ClipboardEvents.clearHistory,
+  ClipboardEvents.copyAndPaste,
+  ClipboardEvents.delete,
+  ClipboardEvents.getHistory,
+  ClipboardEvents.getImageUrl,
+  ClipboardEvents.getLatest,
+  ClipboardEvents.getStatus,
+  ClipboardEvents.read,
+  ClipboardEvents.readFiles,
+  ClipboardEvents.readImage,
+  ClipboardEvents.setFavorite,
+  ClipboardEvents.write,
+
+  // CoreBoxEvents — 16
+  CoreBoxEvents.clipboard.allow,
+  CoreBoxEvents.input.change,
+  CoreBoxEvents.input.clear,
+  CoreBoxEvents.input.get,
+  CoreBoxEvents.input.set,
+  CoreBoxEvents.inputMonitoring.allow,
+  CoreBoxEvents.item.clear,
+  CoreBoxEvents.layout.getBounds,
+  CoreBoxEvents.layout.setHeight,
+  CoreBoxEvents.layout.setPositionOffset,
+  CoreBoxEvents.metaOverlay.actionExecuted,
+  CoreBoxEvents.ui.expand,
+  CoreBoxEvents.ui.hide,
+  CoreBoxEvents.ui.hideInput,
+  CoreBoxEvents.ui.show,
+  CoreBoxEvents.ui.showInput,
+
+  // DivisionBoxEvents — 5
+  DivisionBoxEvents.close,
+  DivisionBoxEvents.getState,
+  DivisionBoxEvents.open,
+  DivisionBoxEvents.stateChanged,
+  DivisionBoxEvents.updateState,
+
+  // FlowEvents — 9
+  FlowEvents.acknowledge,
+  FlowEvents.cancel,
+  FlowEvents.deliver,
+  FlowEvents.dispatch,
+  FlowEvents.getTargets,
+  FlowEvents.nativeShare,
+  FlowEvents.reportError,
+  FlowEvents.sessionUpdate,
+  FlowEvents.setPluginHandler,
+
+  // MetaOverlayEvents — 2
+  MetaOverlayEvents.action.register,
+  MetaOverlayEvents.action.unregister,
+
+  // PluginEvents — 36
+  PluginEvents.communicate.index,
+  PluginEvents.i18n.getLocale,
+  PluginEvents.i18n.resolveText,
+  PluginEvents.lexicon.register,
+  PluginEvents.lexicon.resolve,
+  PluginEvents.lexicon.search,
+  PluginEvents.performance.getMetrics,
+  PluginEvents.performance.getPaths,
+  PluginEvents.service.handle,
+  PluginEvents.service.register,
+  PluginEvents.service.unregister,
+  PluginEvents.shortcut.register,
+  PluginEvents.shortcut.trigger,
+  PluginEvents.sqlite.execute,
+  PluginEvents.sqlite.query,
+  PluginEvents.sqlite.transaction,
+  PluginEvents.storage.clear,
+  PluginEvents.storage.deleteFile,
+  PluginEvents.storage.deleteSecret,
+  PluginEvents.storage.getFile,
+  PluginEvents.storage.getFileDetails,
+  PluginEvents.storage.getSecret,
+  PluginEvents.storage.getSecretHealth,
+  PluginEvents.storage.getStats,
+  PluginEvents.storage.getTree,
+  PluginEvents.storage.listFiles,
+  PluginEvents.storage.openFolder,
+  PluginEvents.storage.setFile,
+  PluginEvents.storage.setSecret,
+  PluginEvents.storage.setSecretBatch,
+  PluginEvents.storage.update,
+  PluginEvents.tempFile.create,
+  PluginEvents.tempFile.delete,
+  PluginEvents.window.command,
+  PluginEvents.window.new,
+  PluginEvents.window.visible,
+
+  // QuickOpsEvents — 21
+  QuickOpsEvents.audit.get,
+  QuickOpsEvents.batteryStatus.get,
+  QuickOpsEvents.capabilities.get,
+  QuickOpsEvents.commonDirectory.get,
+  QuickOpsEvents.developerPreview.get,
+  QuickOpsEvents.developerPreview.save,
+  QuickOpsEvents.directoryUsage.get,
+  QuickOpsEvents.diskSpace.get,
+  QuickOpsEvents.dnsQuery.get,
+  QuickOpsEvents.fileBase64.get,
+  QuickOpsEvents.fileHash.get,
+  QuickOpsEvents.formatText.get,
+  QuickOpsEvents.networkStatus.get,
+  QuickOpsEvents.pathFormat.get,
+  QuickOpsEvents.portStatus.get,
+  QuickOpsEvents.queryLocalIp.get,
+  QuickOpsEvents.recentDownload.get,
+  QuickOpsEvents.sessions.get,
+  QuickOpsEvents.systemInfo.get,
+  QuickOpsEvents.systemProxy.get,
+  QuickOpsEvents.tuffDiagnostics.get,
+
+  // ScreenshotSessionEvents — 2
+  ScreenshotSessionEvents.lifecycle.start,
+  ScreenshotSessionEvents.lifecycle.waitResult,
+
+  // TransportEvents — 4
+  TransportEvents.port.close,
+  TransportEvents.port.confirm,
+  TransportEvents.port.error,
+  TransportEvents.port.upgrade,
+] as const
+
+const PLUGIN_FACING_EVENT_NAMES: ReadonlySet<string> = new Set(
+  PLUGIN_FACING_EVENTS.map(event => event.toEventName()),
+)
+
+/** Whether a plugin surface may reach this event at all. */
+export function isPluginFacingEvent(eventName: string): boolean {
+  return PLUGIN_FACING_EVENT_NAMES.has(eventName)
+}
+
+/** Resolved names, for diagnostics and tests. */
+export function pluginFacingEventNames(): string[] {
+  return [...PLUGIN_FACING_EVENT_NAMES].sort()
+}


### PR DESCRIPTION
Fixes #688. Related: #838.

## Confirmed, and the numbers from my earlier comment still hold

`TuffMainTransport.on()` bound every handler to `BRIDGE_CHANNEL.PLUGIN` as well as `MAIN`; `onStream` did the same for its start **and** cancel pairs; and `plugin-view-channel.ts` puts no filter on the event name a plugin's page may send. All **414** handlers the main process registers were reachable from any plugin view, with each handler's own `context.plugin` check — present in **67** of them — as the only thing in between.

## A central list, not 96 call-site edits

My earlier comment measured the suggested direction at ~96 registrations to opt in. A single derived allowlist does the same job in one place, leaves all 414 call sites untouched, and puts the plugin-facing surface somewhere it can be read in one sitting.

`packages/utils/transport/security/plugin-facing-events.ts` holds **115** events. A handler binds to the plugin channel only if its event is listed; everything else is host-only, and a plugin asking for it gets *no handler* rather than an answer.

## The list is derived, not curated

It is exactly what `packages/utils/plugin/**` sends — the only path a plugin has to the transport. Verified rather than assumed: **no in-repo plugin** calls `$channel.send` directly (0 occurrences), references an `*Events` constant, or imports anything under `transport/` or `renderer/`. They import `@talex-touch/utils/plugin/sdk*` and `plugin/preload`, nothing else.

`plugin-facing-events.test.ts` re-derives the set and fails on a difference in **either** direction, because the two failure modes are not symmetric:

- **too long** → a host-only handler is reachable from a plugin view again; this issue reopens.
- **too short** → a plugin's call is simply never answered. No error, no log, no compile failure, and nothing here drives a real plugin view — it would ship.

## Getting the derivation right took two corrections, both caught by tests

1. My first scan looked only for `.send` / `.invoke` and missed `.stream`, dropping `ClipboardEvents.change`. It also missed the **port-handoff protocol** (`TransportEvents.port.*`), which no plugin source names but every plugin needs in order to upgrade to a MessagePort. Four existing transport tests failed — correctly.
2. I had included `renderer/storage` as a plugin root. It is renderer-only, and including it silently added four `StorageEvents.app.*` entries — the *too long* direction, caught by the new binding test.

Worth stating plainly: I would have shipped both without the tests.

## One existing test changed

`main-transport-identity.test.ts` asserted how a plugin-channel handler resolves identity using a `test:*` event name. That is a path that can no longer happen, so it now uses a real plugin-facing event — which is what it should have been asserting about.

## Mutations, each caught

| mutation | fails |
|---|---|
| allowlist drops an SDK event | `lists exactly what the plugin SDK sends` (reports it under `missing`) |
| allowlist gains a host-only event | same test (under `extra`) |
| `on()` gate removed | `binds on() to the plugin channel only for a listed event` |
| `onStream` gate removed | `applies the same gate to onStream, both start and cancel` |

The last two are **behavioural**, not source-level, and deliberately so: my first attempt asserted `transport.contains('isPluginFacingEvent(eventName)')`, which **passed against a removed `on()` gate** because the stream gate's line contains the same substring.

## Scope

Being on the list is not authorization. It decides whether a plugin can be *heard*, not whether it is *allowed* — the permission guard (now actually enforcing, #1559) and each handler's `context.plugin` checks still apply.

## Verified

184 utils test files / 1334 tests pass. core-app is unchanged at the **same 29 pre-existing failing files** as the base — measured by running the full suite on both. `lint:changed` (CI's own command, per-workspace config) OK; `typecheck:node` unchanged at 6 pre-existing errors.
