### PR TITLE
fix(tuffex): install the packed tarball in the types audit

### DIFF
--- a/packages/tuffex/scripts/audit-package-types.mjs
+++ b/packages/tuffex/scripts/audit-package-types.mjs
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from 'node:fs/promises'
+import { mkdtemp, readdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -34,12 +34,29 @@ async function runPnpm(args, cwd) {
 
 const workspace = await mkdtemp(join(tmpdir(), 'tuffex-types-'))
 
+// Install the tarball, not the source directory.
+//
+// `file:${root}` made pnpm read the raw package.json, workspace protocol and all, so the
+// install died on `@talex-touch/utils@workspace:^` -- unresolvable outside the monorepo.
+// That specifier was added after this script was written, which is when the audit stopped
+// running; nothing in CI ran it, so nothing said so (#1555). `pnpm pack` rewrites workspace
+// specifiers to the versions a published consumer resolves, which is also what this audit
+// is supposed to be checking.
+await runPnpm(['pack', '--pack-destination', workspace], root)
+const packed = (await readdir(workspace)).filter(entry => entry.endsWith('.tgz'))
+if (packed.length !== 1) {
+  throw new Error(
+    `[audit-package-types] expected exactly one tarball in the scratch workspace, found ${packed.length}`,
+  )
+}
+const tarball = join(workspace, packed[0])
+
 await writeFile(
   join(workspace, 'package.json'),
   JSON.stringify({
     type: 'module',
     dependencies: {
-      '@talex-touch/tuffex': `file:${root}`,
+      '@talex-touch/tuffex': `file:${tarball}`,
       typescript: '^5.9.3',
       vue: '^3.5.33',
     },


### PR DESCRIPTION
Part 2 of #1555. Makes `audit:types` runnable again. **Not wired into CI** — see the cost note.

## What was broken

It installed the package by `file:${root}`, which makes pnpm read the raw `package.json`, workspace protocol and all:

```
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  "@talex-touch/utils@workspace:^" is in the dependencies
but no package named "@talex-touch/utils" is present in the workspace
This error happened while installing the dependencies of @talex-touch/tuffex@0.3.9
```

That specifier was added **after** this script was written — at the commit that introduced the script, tuffex had no `@talex-touch/utils` dependency at all. So the audit has been dead since, and since no CI job runs it (#1555), nothing said so.

## The fix

`pnpm pack` rewrites workspace specifiers to the versions a published consumer resolves — which is exactly what this audit is meant to be checking. The tarball goes into the same scratch workspace and is located by `readdir` rather than by parsing `pack`'s stdout, and it goes through the existing `runPnpm` helper so the `npm_execpath` handling is not duplicated.

## Verified it can fail

A gate that passes proves nothing until it can fail. With the eight `@vue/reactivity` references in `dist/es/select/src/TxSelect.vue.d.ts` repointed at a package that does not exist:

```
RC=1    Cannot find module '@definitely/not-a-real-package'
```

Restored:

```
RC=0    [audit-package-types] package subpath declarations compile in an external project
```

Worth recording: my **first** attempt at that mutation silently matched nothing — I had counted `grep -c` lines (4) rather than occurrences (8). The count assertion caught it. Without it, that run would have read as "the audit passes with the defect in place", i.e. exactly the false-green this PR exists to prevent.

## Why not wired into CI

~4 minutes here, nearly all of it the install pulling tuffex's runtime tree (codemirror, shiki, mermaid, gsap) on a slow connection. That is a real cost for a gate, and choosing whether to pay it — or to trim what the scratch project installs — is a separate call. #1555 tracks it together with `audit:size`, whose budgets need a decision of their own.

`audit:exports` and `audit:readme` are already wired by #1556 and stay that way.
