### PR TITLE
feat(plugin): honour a manifest feature's platform declaration [#820]

### DIFF
--- a/apps/core-app/src/main/modules/plugin/feature-platform.test.ts
+++ b/apps/core-app/src/main/modules/plugin/feature-platform.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { isFeatureUnavailableOnPlatform } from './feature-platform'
+
+describe('isFeatureUnavailableOnPlatform', () => {
+  it('excludes only on an explicit false for the running platform', () => {
+    const feature = { platform: { win32: true, darwin: false, linux: false } }
+
+    expect(isFeatureUnavailableOnPlatform(feature, 'darwin')).toBe(true)
+    expect(isFeatureUnavailableOnPlatform(feature, 'linux')).toBe(true)
+    expect(isFeatureUnavailableOnPlatform(feature, 'win32')).toBe(false)
+  })
+
+  it('leaves a feature that declares nothing available everywhere', () => {
+    // 25 of the 30 shipped features declare no platform. Treating undeclared as unavailable
+    // would empty the launcher (#820).
+    for (const platform of ['win32', 'darwin', 'linux'] as NodeJS.Platform[]) {
+      expect(isFeatureUnavailableOnPlatform({}, platform)).toBe(false)
+      expect(isFeatureUnavailableOnPlatform({ platform: undefined }, platform)).toBe(false)
+      expect(isFeatureUnavailableOnPlatform(undefined, platform)).toBe(false)
+    }
+  })
+
+  it('treats a platform the author did not mention as not ruled out', () => {
+    // Absence is "did not consider", not "excluded" — the difference matters on a platform
+    // outside the three the manifest schema knows about.
+    const feature = { platform: { win32: true, darwin: true, linux: true } }
+
+    expect(isFeatureUnavailableOnPlatform(feature, 'freebsd' as NodeJS.Platform)).toBe(false)
+  })
+
+  it('ignores a platform value that is not the manifest shape', () => {
+    // `plugins:validate` rejects these, but a hand-edited or older manifest can still reach
+    // the loader, and guessing at an unknown shape is worse than ignoring it.
+    expect(isFeatureUnavailableOnPlatform({ platform: 'linux' }, 'linux')).toBe(false)
+    expect(isFeatureUnavailableOnPlatform({ platform: ['linux'] }, 'linux')).toBe(false)
+    expect(isFeatureUnavailableOnPlatform({ platform: null }, 'linux')).toBe(false)
+    // The IPlatform runtime shape: `enable: false` is not the manifest's `false`.
+    expect(
+      isFeatureUnavailableOnPlatform({ platform: { linux: { enable: false } } }, 'linux')
+    ).toBe(false)
+  })
+
+  it('does not treat a falsy-but-not-false value as an exclusion', () => {
+    // `0`, `''` and `null` are all things a loose manifest could carry; only `false` means
+    // the author ruled the platform out.
+    for (const value of [0, '', null, 'false']) {
+      expect(isFeatureUnavailableOnPlatform({ platform: { linux: value } }, 'linux')).toBe(false)
+    }
+  })
+})

--- a/apps/core-app/src/main/modules/plugin/feature-platform.ts
+++ b/apps/core-app/src/main/modules/plugin/feature-platform.ts
@@ -1,0 +1,42 @@
+/**
+ * Manifest-declared platform availability for a plugin feature (#820).
+ *
+ * Every shipped manifest writes `feature.platform` as `{ win32, darwin, linux }` booleans —
+ * all 20 of them — and until now nothing read it. Five features declared themselves
+ * unavailable on Linux (one also on macOS) and registered there anyway; they only avoided
+ * misbehaving because each prelude re-checks `process.platform` itself, so the user saw the
+ * feature, triggered it, and was told it was unsupported.
+ *
+ * `plugins:validate` already rejects any other shape, including the `IPlatform`
+ * `{ win: { enable, arch, os } }` form that `addFeature` uses for *runtime*-registered
+ * features. That check is what makes reading a plain boolean here safe.
+ */
+
+/** The manifest shape, which is not `IPlatform` — see the module comment. */
+export interface ManifestFeaturePlatform {
+  win32?: unknown
+  darwin?: unknown
+  linux?: unknown
+}
+
+/**
+ * Whether the manifest says this feature does not belong on `platform`.
+ *
+ * Only an explicit `false` excludes, and that single rule covers three cases at once:
+ *
+ * - **no `platform` at all** — available everywhere. 25 of the 30 shipped features declare
+ *   nothing, so requiring a declaration would empty the launcher.
+ * - **a platform the object does not mention** — one the author did not consider, not one
+ *   they ruled out. `undefined === false` is already false, so no separate check earns its
+ *   keep here; a guard a test could only verify by grep is worse than none.
+ * - **a falsy-but-not-false value** (`0`, `''`, `null`) — not a declaration of anything.
+ */
+export function isFeatureUnavailableOnPlatform(
+  feature: { platform?: unknown } | null | undefined,
+  platform: NodeJS.Platform
+): boolean {
+  const declared = feature?.platform
+  if (!declared || typeof declared !== 'object' || Array.isArray(declared)) return false
+
+  return (declared as Record<string, unknown>)[platform] === false
+}

--- a/apps/core-app/src/main/modules/plugin/plugin-loaders.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-loaders.ts
@@ -16,6 +16,7 @@ import type {
   SearchProviderManifestDescriptor
 } from '@talex-touch/utils/search'
 import path from 'node:path'
+import { isFeatureUnavailableOnPlatform } from './feature-platform'
 import {
   isLocalizedList,
   isLocalizedText,
@@ -453,6 +454,19 @@ abstract class BasePluginLoader {
             },
             timestamp: Date.now()
           })
+        }
+
+        // C.1.5: Honour the manifest's platform declaration
+        if (isFeatureUnavailableOnPlatform(feature, process.platform)) {
+          this.touchPlugin.issues.push({
+            type: 'warning',
+            message: `Feature '${feature.name || feature.id}' is not registered: its manifest declares it unavailable on ${process.platform}.`,
+            source: `feature:${feature.id}`,
+            code: 'FEATURE_PLATFORM_EXCLUDED',
+            meta: { featureId: feature.id, platform: process.platform },
+            timestamp: Date.now()
+          })
+          return
         }
 
         // C.2: Validate feature commands structure

--- a/packages/utils/__tests__/feature-platform-gating.test.ts
+++ b/packages/utils/__tests__/feature-platform-gating.test.ts
@@ -1,0 +1,119 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * A manifest's `feature.platform` declaration has to actually gate registration (#820).
+ *
+ * Every shipped manifest writes `{ win32, darwin, linux }` booleans, and for a long time
+ * nothing read them: five features declared themselves unavailable on Linux and registered
+ * there anyway. They avoided misbehaving only because each prelude re-checks
+ * `process.platform` on its own, so the user saw the feature, triggered it, and was told it
+ * was unsupported.
+ *
+ * Two things can silently undo that, and they need different guards:
+ *
+ * - the gate is dropped from the loader — covered by the loader's own unit tests
+ * - the *declarations* change, so the gate stops covering the features it was written for —
+ *   covered here, against the real manifests
+ *
+ * Lives in `packages/utils` because `ci / CI - utils` blocks a PR, whereas
+ * `App suites (core-app)` is continue-on-error and reports success whatever the suite does.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const PLUGINS = path.join(REPO_ROOT, 'plugins')
+const GATE = path.join(
+  REPO_ROOT,
+  'apps/core-app/src/main/modules/plugin/feature-platform.ts',
+)
+const LOADER = path.join(
+  REPO_ROOT,
+  'apps/core-app/src/main/modules/plugin/plugin-loaders.ts',
+)
+
+/** The features that this gate actually removes, and where. */
+const EXCLUDED = new Map([
+  ['touch-browser-open/browser-open', ['linux']],
+  ['touch-quick-actions/quick-actions', ['linux']],
+  ['touch-system-actions/system-actions', ['linux']],
+  ['touch-window-manager/window-app', ['linux']],
+  ['touch-window-presets/window-presets', ['darwin', 'linux']],
+])
+
+interface ManifestFeature {
+  id?: string
+  platform?: Record<string, unknown>
+}
+
+function manifests(): Array<{ plugin: string, features: ManifestFeature[] }> {
+  const found: Array<{ plugin: string, features: ManifestFeature[] }> = []
+  for (const entry of readdirSync(PLUGINS)) {
+    const file = path.join(PLUGINS, entry, 'manifest.json')
+    if (!statSync(path.join(PLUGINS, entry)).isDirectory()) continue
+    try {
+      const parsed = JSON.parse(readFileSync(file, 'utf8'))
+      found.push({ plugin: entry, features: parsed.features ?? [] })
+    }
+    catch {
+      // No manifest, or an unreadable one — #813 / #814 track those.
+    }
+  }
+  return found
+}
+
+/** Every `<plugin>/<feature>` a manifest declares unavailable, and on which platforms. */
+function declaredExclusions(): Map<string, string[]> {
+  const found = new Map<string, string[]>()
+  for (const { plugin, features } of manifests()) {
+    for (const feature of features) {
+      const platform = feature.platform
+      if (!platform || typeof platform !== 'object') continue
+      const off = Object.entries(platform)
+        .filter(([, value]) => value === false)
+        .map(([key]) => key)
+        .sort()
+      if (off.length) found.set(`${plugin}/${feature.id}`, off)
+    }
+  }
+  return found
+}
+
+describe('manifest feature platform gating', () => {
+  it('reads the manifests it means to check', () => {
+    // Positive control: "no feature is excluded anywhere" is also what a wrong root reports.
+    const all = manifests()
+    expect(all.length).toBeGreaterThan(15)
+    expect(all.some(entry => entry.features.length > 0)).toBe(true)
+  })
+
+  it('is the exact set of features that stop appearing', () => {
+    // Written down deliberately: this is the user-visible half of #820. A new `false` here
+    // hides a feature from a whole platform, and that should be a decision, not a diff
+    // nobody noticed.
+    expect(Object.fromEntries([...declaredExclusions()].sort())).toEqual(
+      Object.fromEntries([...EXCLUDED].sort()),
+    )
+  })
+
+  it('only ever excludes on an explicit false', () => {
+    // 25 of the 30 shipped features declare no platform at all. Treating "undeclared" as
+    // "unavailable" would empty the launcher, so the gate has to be opt-out, not opt-in.
+    const source = readFileSync(GATE, 'utf8')
+
+    expect(source).toMatch(/\[platform\] === false/)
+  })
+
+  it('runs before the feature is registered, not after', () => {
+    // Reporting the exclusion but still calling addFeature would leave the defect in place
+    // with a log line on top.
+    const loader = readFileSync(LOADER, 'utf8')
+    const gateAt = loader.indexOf('isFeatureUnavailableOnPlatform(feature, process.platform)')
+    const addAt = loader.indexOf('this.touchPlugin.addFeature(pluginFeature)')
+
+    expect(gateAt).toBeGreaterThan(-1)
+    expect(addAt).toBeGreaterThan(gateAt)
+    // …and it has to leave the loop, not merely warn.
+    expect(loader.slice(gateAt, addAt)).toContain('return')
+  })
+})


### PR DESCRIPTION
Fixes #820 — step 3. Steps 1 and 2 landed in #1521.

## The behaviour change, stated first

This removes five features from the launcher on platforms their own manifests rule out:

| plugin / feature | disappears on |
|---|---|
| `touch-browser-open` / `browser-open` | linux |
| `touch-quick-actions` / `quick-actions` | linux |
| `touch-system-actions` / `system-actions` | linux |
| `touch-window-manager` / `window-app` | linux |
| `touch-window-presets` / `window-presets` | darwin, linux |

**No capability is lost.** Every one of those preludes already refuses on those platforms — `currentPlatform()` appears 2–7 times in each. What changes is that the user stops seeing a feature that only exists to tell them it is unsupported.

I flagged this as a product decision twice and did not act on it; with the instruction to keep working the issue, I am taking the declaration at face value, since both readings agree the feature does not work there and only the presentation differs. Revert is a one-line change if you disagree.

## The rule

Only an explicit `false` excludes. That one rule covers three cases:

- **no `platform` at all** — 25 of the 30 shipped features. Opt-in would empty the launcher.
- **a platform the object does not mention** — one the author did not consider, not one they ruled out.
- **a falsy-but-not-false value** (`0`, `''`, `null`) — not a declaration of anything.

I wrote a separate `platform in record` guard for the second case first. It is unreachable — `undefined === false` is already `false` — so the only way a test could check it was by grepping for the line. A guard verifiable only that way is worse than none, so it is gone and the comment explains why.

## Where the guards live

- `feature-platform.test.ts` (core-app) covers the predicate.
- `feature-platform-gating.test.ts` (**packages/utils**, because `ci / CI - utils` blocks and `App suites (core-app)` is continue-on-error) pins **the excluded set against the real manifests**. A new `false` hides a feature from a whole platform; that should be a decision, not a diff nobody noticed. It also checks the gate runs *before* `addFeature` and actually returns — reporting the exclusion and registering anyway would leave the defect with a log line on top.

## Mutations, each caught

| mutation | fails |
|---|---|
| exclude on any falsy value | `does not treat a falsy-but-not-false value as an exclusion` |
| a manifest silently gains an exclusion | `is the exact set of features that stop appearing` |
| warn but do not skip | `runs before the feature is registered, not after` |
| gate placed after `addFeature` | same |

## Verified

185 utils test files (1338 tests) and 89 core-app plugin test files (1208 tests) pass. `lint:changed` OK, `prettier --check` clean, `typecheck:node` unchanged at 6 pre-existing errors.
