### PR TITLE
ci(tuffex): run the types audit too — it costs 9s

### DIFF
--- a/.github/workflows/package-tuffex-ci.yml
+++ b/.github/workflows/package-tuffex-ci.yml
@@ -38,4 +38,4 @@ jobs:
       # Only the two that pass today. audit:types is broken by construction and audit:size
       # has been over budget since well before this change -- both tracked in #1555, and
       # wiring them here would land a gate that is red on every PR.
-      post-build-command: pnpm audit:exports && pnpm audit:readme
+      post-build-command: pnpm audit:exports && pnpm audit:readme && pnpm audit:types


### PR DESCRIPTION
Closes the CI half of #1555. **The measurement is in, and there is no decision to make.**

I opened this as an experiment because the only figure I had was ~4 minutes locally. That number was entirely my network — the runner already has tuffex's whole dependency tree in the pnpm store from the monorepo install, so the scratch install is hardlinks, not fetches.

Measured on this branch's run:

```
[audit-package-types] package subpath declarations compile in an external project
```

| step | duration |
|---|---|
| Run Tests | 53s |
| Install Dependencies | 34s |
| Run Build | 30s |
| Run Lint | 12s |
| **Post-build checks** (all three audits) | **10s** |
| Run Typecheck | 9s |

`audit:types` accounts for ~9s of that 10s — cheaper than lint, cheaper than typecheck. Verified it actually ran rather than being skipped: the command line in the log is `pnpm audit:exports && pnpm audit:readme && pnpm audit:types`, and the audit printed its success line at `07:59:41`.

`audit:size` stays out. Its budgets have been over since well before this change and need a decision first — the base/full breakdown is on #1555.
