### PR TITLE
fix(release): let a channel's first release resolve a rollback target [#559]

### DIFF
--- a/packages/utils/__tests__/first-release-rollback-sentinel.test.ts
+++ b/packages/utils/__tests__/first-release-rollback-sentinel.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { isValidRollbackFromVersion, validateUpdateReleaseManifest } from '../types/update'
+
+/**
+ * A channel's first release has to produce a manifest that already-shipped clients accept (#559).
+ *
+ * `resolve-update-rollback-version.mjs` used to throw when no same-channel predecessor existed,
+ * failing the release job *after* all three platform builds had finished. It now emits a
+ * channel-matched zero instead.
+ *
+ * The obvious alternative — omit the field — is what this file rules out. `validateUpdateReleaseManifest`
+ * below is the validator running inside every installed client, and it requires
+ * `rollbackFromVersion` to be a **string**. An optional field would mean a first release
+ * publishes a manifest that existing users' clients reject, so they never see the update at
+ * all. That is a worse failure than the one being fixed, and an invisible one.
+ *
+ * So this test exists to keep the two ends of a cross-repo-boundary contract in agreement: the
+ * release script picks the sentinel, and the client has to accept it.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const RESOLVER = path.join(REPO_ROOT, 'scripts/resolve-update-rollback-version.mjs')
+
+/** The sentinel as the release script writes it, read from the script rather than restated. */
+function sentinels(): Record<'RELEASE' | 'BETA', string> {
+  const source = readFileSync(RESOLVER, 'utf8')
+  const block = source.slice(
+    source.indexOf('export const FIRST_RELEASE_ROLLBACK_VERSION'),
+    source.indexOf('function versionFromTag'),
+  )
+  const entries = [...block.matchAll(/(RELEASE|BETA):\s*'([^']+)'/g)].map(
+    ([, channel, version]) => [channel, version] as const,
+  )
+  return Object.fromEntries(entries) as Record<'RELEASE' | 'BETA', string>
+}
+
+describe('first-release rollback sentinel', () => {
+  it('reads the sentinel the release script actually uses', () => {
+    // Positive control: every assertion below is about values parsed out of that file, so a
+    // parse that silently returns nothing would make them all vacuous.
+    const found = sentinels()
+    expect(found.RELEASE).toMatch(/^\d+\.\d+\.\d+$/)
+    expect(found.BETA).toMatch(/^\d+\.\d+\.\d+-[a-z]+\.\d+$/)
+  })
+
+  it('is accepted by the validator running in already-shipped clients', () => {
+    const found = sentinels()
+
+    expect(isValidRollbackFromVersion('2.5.0', found.RELEASE, 'RELEASE')).toBe(true)
+    expect(isValidRollbackFromVersion('2.5.0-beta.1', found.BETA, 'BETA')).toBe(true)
+    // …and stays channel-correct, which is what a bare `0.0.0` would get wrong for BETA.
+    expect(isValidRollbackFromVersion('2.5.0-beta.1', found.RELEASE, 'BETA')).toBe(false)
+  })
+
+  it('cannot be omitted instead, because the shipped client requires a string', () => {
+    // The reason the sentinel exists rather than an optional field. If this ever starts
+    // passing, "no predecessor" can be modelled honestly and the sentinel can go.
+    const manifest = {
+      schemaVersion: 1,
+      release: {
+        tag: 'v2.5.0',
+        version: '2.5.0',
+        channel: 'RELEASE',
+        rollbackCompatible: false,
+      },
+      artifacts: [],
+    }
+
+    const result = validateUpdateReleaseManifest(manifest as never, {
+      tag: 'v2.5.0',
+      channel: 'RELEASE',
+    } as never)
+
+    expect(result.valid).toBe(false)
+  })
+})

--- a/packages/utils/__tests__/first-release-rollback-sentinel.test.ts
+++ b/packages/utils/__tests__/first-release-rollback-sentinel.test.ts
@@ -1,7 +1,11 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { isValidRollbackFromVersion, validateUpdateReleaseManifest } from '../types/update'
+import {
+  AppPreviewChannel,
+  isValidRollbackFromVersion,
+  validateUpdateReleaseManifest,
+} from '../types/update'
 
 /**
  * A channel's first release has to produce a manifest that already-shipped clients accept (#559).
@@ -48,10 +52,16 @@ describe('first-release rollback sentinel', () => {
   it('is accepted by the validator running in already-shipped clients', () => {
     const found = sentinels()
 
-    expect(isValidRollbackFromVersion('2.5.0', found.RELEASE, 'RELEASE')).toBe(true)
-    expect(isValidRollbackFromVersion('2.5.0-beta.1', found.BETA, 'BETA')).toBe(true)
+    expect(
+      isValidRollbackFromVersion('2.5.0', found.RELEASE, AppPreviewChannel.RELEASE),
+    ).toBe(true)
+    expect(
+      isValidRollbackFromVersion('2.5.0-beta.1', found.BETA, AppPreviewChannel.BETA),
+    ).toBe(true)
     // …and stays channel-correct, which is what a bare `0.0.0` would get wrong for BETA.
-    expect(isValidRollbackFromVersion('2.5.0-beta.1', found.RELEASE, 'BETA')).toBe(false)
+    expect(
+      isValidRollbackFromVersion('2.5.0-beta.1', found.RELEASE, AppPreviewChannel.BETA),
+    ).toBe(false)
   })
 
   it('cannot be omitted instead, because the shipped client requires a string', () => {

--- a/scripts/resolve-update-rollback-version.mjs
+++ b/scripts/resolve-update-rollback-version.mjs
@@ -8,6 +8,27 @@ import {
   inferManifestChannel,
 } from './lib/update-rollback-contract.mjs'
 
+/**
+ * What a channel's first release names as its rollback target.
+ *
+ * "No predecessor" cannot be represented as an absent field: `prepare-release-assets.mjs`
+ * requires `--rollback-from-version`, `validateRollbackContract` requires a non-empty
+ * same-channel semver strictly older than the release, and — the one that decides it —
+ * `validateUpdateReleaseManifest` in every *already shipped* client rejects a manifest whose
+ * `rollbackFromVersion` is not a string. Making the field optional would mean the first
+ * release in a channel produced a manifest installed clients refuse, so they would never
+ * see the update at all.
+ *
+ * A channel-matched zero is the only shape the whole chain accepts, and it cannot mislead
+ * anyone: the client sets `rollbackCompatible` only when the manifest's rollback target
+ * equals the version the user is *currently running* (`update-system.ts`), and nobody is
+ * running 0.0.0. So a first release advertises no downgrade path rather than a false one.
+ */
+export const FIRST_RELEASE_ROLLBACK_VERSION = {
+  RELEASE: '0.0.0',
+  BETA: '0.0.0-beta.0',
+}
+
 function versionFromTag(tag) {
   return String(tag ?? '')
     .trim()
@@ -40,14 +61,24 @@ export function resolveSameChannelRollbackVersion({ tag, tags }) {
     })
 
   const previous = candidates[0]
-  if (!previous)
-    throw new Error(`No same-channel predecessor exists for ${tag}`)
+  if (!previous) {
+    // First release in this channel. Throwing here failed the release *after* all three
+    // platform builds had finished, with no way through short of editing the workflow (#559).
+    return {
+      channel,
+      rollbackFromVersion: FIRST_RELEASE_ROLLBACK_VERSION[channel],
+      rollbackTag: null,
+      targetVersion,
+      isFirstInChannel: true,
+    }
+  }
 
   return {
     channel,
     rollbackFromVersion: previous.version,
     rollbackTag: previous.tag,
     targetVersion,
+    isFirstInChannel: false,
   }
 }
 

--- a/scripts/resolve-update-rollback-version.test.mjs
+++ b/scripts/resolve-update-rollback-version.test.mjs
@@ -1,7 +1,14 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'vitest'
 
-import { resolveSameChannelRollbackVersion } from './resolve-update-rollback-version.mjs'
+import {
+  compareRollbackVersions,
+  validateRollbackContract,
+} from './lib/update-rollback-contract.mjs'
+import {
+  FIRST_RELEASE_ROLLBACK_VERSION,
+  resolveSameChannelRollbackVersion,
+} from './resolve-update-rollback-version.mjs'
 
 describe('resolveSameChannelRollbackVersion', () => {
   it('selects the highest lower same-channel version from unsorted tags when the current tag is absent', () => {
@@ -15,6 +22,7 @@ describe('resolveSameChannelRollbackVersion', () => {
       rollbackFromVersion: '2.4.12',
       rollbackTag: 'v2.4.12',
       targetVersion: '2.4.13',
+      isFirstInChannel: false,
     })
   })
 
@@ -43,14 +51,73 @@ describe('resolveSameChannelRollbackVersion', () => {
     assert.equal(result.rollbackFromVersion, '2.4.12-alpha.2')
   })
 
-  it('fails rather than selecting a cross-channel or newer rollback target', () => {
+  it('never selects a cross-channel or newer rollback target', () => {
+    // Same guard as before; it no longer throws, because "nothing older in this channel" is
+    // exactly the first-release case (#559). What must not happen is picking one of these.
+    const result = resolveSameChannelRollbackVersion({
+      tag: 'v2.4.12-beta.1',
+      tags: ['v2.4.12', 'v2.4.12-beta.2', 'v2.4.11'],
+    })
+
+    assert.equal(result.rollbackFromVersion, FIRST_RELEASE_ROLLBACK_VERSION.BETA)
+    assert.equal(result.rollbackTag, null)
+    for (const wrong of ['2.4.12', '2.4.12-beta.2', '2.4.11'])
+      assert.notEqual(result.rollbackFromVersion, wrong)
+  })
+
+  it('resolves a channel first release instead of failing the whole publish', () => {
+    // The throw landed in the release job, after all three platform builds had finished.
+    for (const [tag, channel] of [
+      ['v2.5.0', 'RELEASE'],
+      ['v2.5.0-beta.1', 'BETA'],
+      ['v2.5.0-snapshot.20260811', 'BETA'],
+    ]) {
+      const result = resolveSameChannelRollbackVersion({ tag, tags: [] })
+
+      assert.equal(result.channel, channel)
+      assert.equal(result.rollbackFromVersion, FIRST_RELEASE_ROLLBACK_VERSION[channel])
+      assert.equal(result.isFirstInChannel, true)
+      assert.equal(result.rollbackTag, null)
+    }
+  })
+
+  it('produces a sentinel the release contract accepts', () => {
+    // The reason absence is not an option: prepare-release-assets requires the field, and so
+    // does every already-shipped client. This has to pass the same validator a real
+    // predecessor does, or the fix just moves the failure one step later.
+    for (const [version, channel] of [
+      ['2.5.0', 'RELEASE'],
+      ['2.5.0-beta.1', 'BETA'],
+    ]) {
+      const issues = validateRollbackContract({
+        version,
+        channel,
+        rollbackFromVersion: FIRST_RELEASE_ROLLBACK_VERSION[channel],
+        rollbackCompatible: false,
+        expectedRollbackFromVersion: FIRST_RELEASE_ROLLBACK_VERSION[channel],
+      })
+
+      assert.deepEqual(issues, [], `${channel}: ${JSON.stringify(issues)}`)
+    }
+  })
+
+  it('is strictly older than anything that could be installed', () => {
+    // What makes the sentinel safe rather than a lie. The client marks an update
+    // rollback-compatible only when the manifest's target equals the version the user is
+    // running, so a target older than every real version can never advertise a downgrade.
+    for (const real of ['0.0.1', '1.0.0', '2.4.9', '2.5.0']) {
+      assert.equal(compareRollbackVersions(FIRST_RELEASE_ROLLBACK_VERSION.RELEASE, real), -1, real)
+    }
+    for (const real of ['0.0.1-beta.1', '2.4.9-beta.7', '2.5.0-beta.1']) {
+      assert.equal(compareRollbackVersions(FIRST_RELEASE_ROLLBACK_VERSION.BETA, real), -1, real)
+    }
+  })
+
+  it('still refuses a tag with no usable version', () => {
+    // Being total about missing predecessors must not make it total about garbage input.
     assert.throws(
-      () =>
-        resolveSameChannelRollbackVersion({
-          tag: 'v2.4.12-beta.1',
-          tags: ['v2.4.12', 'v2.4.12-beta.2', 'v2.4.11'],
-        }),
-      /No same-channel predecessor exists/,
+      () => resolveSameChannelRollbackVersion({ tag: 'manual-build-20260811', tags: [] }),
+      /must contain a supported semantic version/,
     )
   })
 })


### PR DESCRIPTION
Fixes #559.

## I asked you to choose between three options. Checking instead of assuming removed the choice.

My earlier comment offered a zero sentinel, an optional field, or seeding channels by hand, and said I'd pick the optional field "if the client is yours to change". Both premises behind that were wrong:

**1. The sentinel's stated cost does not exist.** I wrote that a first release "advertises a downgrade path to a version nobody can install". It cannot. `update-system.ts` computes:

```ts
const rollbackCompatible =
  candidate.manifest.release.rollbackCompatible &&
  candidate.manifest.release.rollbackFromVersion === this.currentVersion.raw...
```

`rollbackCompatible` is true only when the manifest's target equals the version the user is **currently running**. Nobody is running `0.0.0`, so a first release offers no downgrade path rather than a false one.

**2. The "honest" option breaks every installed client.** `validateUpdateReleaseManifest` in `packages/utils/types/update.ts:596` — the validator running inside already-shipped clients — requires:

```ts
typeof releaseRecord.rollbackFromVersion !== 'string'   // → manifest-rollback-invalid
```

So making the field optional means the first release in a channel publishes a manifest existing users' clients **reject**. They would never see the update at all: a worse failure than the one being fixed, and a silent one.

A channel-matched zero is therefore not a compromise, it is the only shape the whole chain accepts.

## The change

`resolveSameChannelRollbackVersion` returns `0.0.0` (RELEASE) / `0.0.0-beta.0` (BETA) instead of throwing, plus `isFirstInChannel` and a null `rollbackTag`. The workflow reads only `.rollbackFromVersion` and `.channel` through `jq -er`, both still strings.

## One existing test changed

`fails rather than selecting a cross-channel or newer rollback target` asserted the throw. That scenario **is** the first-release case — nothing older exists in that channel — so it now asserts the same guard positively: the result is the sentinel, and specifically not `2.4.12`, `2.4.12-beta.2` or `2.4.11`. The property it was written to protect is unchanged.

## Mutations, each caught

| mutation | fails |
|---|---|
| restore the throw | 2 resolver tests |
| BETA sentinel loses its channel suffix | contract test + both cross-package tests |
| sentinel not older than everything installable | `is strictly older than anything that could be installed` |

The cross-package test **reads the sentinel out of the release script** rather than restating it, so the two ends of the contract cannot drift apart, and it has a positive control since every assertion depends on that parse.

It also pins the reason the sentinel exists: a test asserting the shipped client *rejects* a manifest with the field absent. If that ever starts failing, "no predecessor" can be modelled honestly and the sentinel can go.

## Verified

Script suite and 186 utils test files pass, with the same four pre-existing failures as the base (measured on both). `lint:changed` OK.
