### PR TITLE
fix(hooks): name the stale .bin instead of failing with a path nobody recognises [#1564]

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -20,4 +20,8 @@ elif ! git diff --quiet -- "$CORE_PKG" 2>/dev/null; then
   echo "[pre-commit] silently include your other changes. Stage it yourself when ready."
 fi
 
+# Fails with an actionable message instead of a MODULE_NOT_FOUND naming a path nobody
+# recognises, when node_modules/.bin belongs to a checkout at a different depth (#1564).
+node scripts/check-bin-shims.mjs || exit 1
+
 pnpm lint:staged

--- a/scripts/check-bin-shims.mjs
+++ b/scripts/check-bin-shims.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Detects a `node_modules/.bin` whose shims point outside this checkout (#1564).
+ *
+ * pnpm writes each shim's exec target as a path *relative to the shim*, and `sh` resolves
+ * `../..` lexically rather than through symlinks. So a `pnpm install` run from a git worktree
+ * whose `node_modules` is a symlink to another checkout writes paths computed at the
+ * worktree's depth into the `.bin` both checkouts share. They then resolve correctly from
+ * whichever depth they were written for, and one directory too shallow from the other.
+ *
+ * What that looks like in practice is every tool failing at once — `lint-staged`, `eslint`,
+ * `prettier` — with a `Cannot find module` naming a path nobody recognises:
+ *
+ *   Cannot find module '/Users/.../Workspace/talex-touch/node_modules/lint-staged/bin/...'
+ *                                       ^^^^^^^^^^^^ one level above the real checkout
+ *
+ * Nothing in the repository is wrong, which is exactly why it costs so much to work out:
+ * a clean clone never reproduces it, and the same commit succeeds from the other checkout.
+ *
+ * This turns that into one line naming the remedy. It is a *detector*, not a fix — the fix
+ * is `pnpm install` from the checkout you are committing in, and not sharing one
+ * `node_modules` between checkouts at different depths.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+/** Tools the commit hook cannot run without. */
+const REQUIRED = ['lint-staged', 'eslint', 'prettier']
+
+/**
+ * The file a shim would hand to node, resolved the way `sh` does it: lexically from the
+ * shim's own directory, without following symlinks.
+ */
+export function shimTarget(shimPath, contents) {
+  const match = contents.match(/exec (?:"\$basedir\/node"|node)\s+"\$basedir\/([^"]+)"/)
+  if (!match)
+    return null
+  return path.resolve(path.dirname(shimPath), match[1])
+}
+
+/** Every required shim whose target does not exist. */
+export function brokenShims(binDir, required = REQUIRED) {
+  const broken = []
+  for (const name of required) {
+    const shimPath = path.join(binDir, name)
+    if (!existsSync(shimPath))
+      continue
+
+    const target = shimTarget(shimPath, readFileSync(shimPath, 'utf8'))
+    if (target && !existsSync(target))
+      broken.push({ name, target })
+  }
+  return broken
+}
+
+function main() {
+  const binDir = path.join(REPO_ROOT, 'node_modules', '.bin')
+  if (!existsSync(binDir)) {
+    console.error('[check-bin-shims] node_modules/.bin is missing — run `pnpm install`.')
+    process.exit(1)
+  }
+
+  const broken = brokenShims(binDir)
+  if (!broken.length)
+    return
+
+  console.error(
+    `[check-bin-shims] ${broken.length} of ${REQUIRED.length} required tools resolve outside this checkout:\n`,
+  )
+  for (const { name, target } of broken) console.error(`  ${name} -> ${target}`)
+  console.error(`
+This is a local install, not the repository. The shims carry paths relative to the depth of
+whichever checkout last ran \`pnpm install\`, and \`sh\` resolves them lexically — so a shared
+node_modules cannot serve two checkouts at different depths.
+
+  Fix:  pnpm install        (from ${REPO_ROOT})
+  And:  give each git worktree its own node_modules rather than symlinking another checkout's.
+
+Skipping the hook with HUSKY=0 leaves the next commit to hit the same wall.`)
+  process.exit(1)
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href)
+  main()

--- a/scripts/check-bin-shims.test.mjs
+++ b/scripts/check-bin-shims.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, it } from 'vitest'
+
+import { brokenShims, shimTarget } from './check-bin-shims.mjs'
+
+/**
+ * The detector for a `.bin` whose shims resolve outside the checkout (#1564).
+ *
+ * The failure it names cost a whole commit gate and read as a corrupt install: every tool
+ * failing at once with `Cannot find module` pointing at a directory that does not exist.
+ * Nothing in the repository was wrong, which is why it was expensive — a clean clone cannot
+ * reproduce it, and the same commit succeeds from a checkout at a different depth.
+ */
+
+function shim(target) {
+  return [
+    '#!/bin/sh',
+    'basedir=$(dirname "$(echo "$0" | sed -e \'s,\\\\,/,g\')")',
+    'if [ -x "$basedir/node" ]; then',
+    `  exec "$basedir/node"  "$basedir/${target}" "$@"`,
+    'else',
+    `  exec node  "$basedir/${target}" "$@"`,
+    'fi',
+  ].join('\n')
+}
+
+function withBinDir(run) {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'bin-shims-'))
+  try {
+    return run(root)
+  }
+  finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+describe('check-bin-shims', () => {
+  it('resolves a shim target lexically, the way sh does', () => {
+    // The whole defect lives here: `sh` does not follow symlinks when collapsing `../..`, so
+    // the same relative path means different files from checkouts at different depths.
+    const target = shimTarget(
+      '/repo/node_modules/.bin/lint-staged',
+      shim('../../../../other/node_modules/lint-staged/bin/lint-staged.js'),
+    )
+
+    assert.equal(target, '/other/node_modules/lint-staged/bin/lint-staged.js')
+  })
+
+  it('reports a shim whose target does not exist', () => {
+    withBinDir((root) => {
+      const bin = path.join(root, '.bin')
+      const real = path.join(root, 'real.js')
+      writeFileSync(real, '')
+      mkdirSync(bin, { recursive: true })
+
+      writeFileSync(path.join(bin, 'eslint'), shim('../real.js'))
+      writeFileSync(path.join(bin, 'prettier'), shim('../../gone/nope.js'))
+
+      const broken = brokenShims(bin, ['eslint', 'prettier'])
+
+      assert.deepEqual(
+        broken.map(entry => entry.name),
+        ['prettier'],
+      )
+      assert.match(broken[0].target, /gone\/nope\.js$/)
+    })
+  })
+
+  it('says nothing when every required shim resolves', () => {
+    // Positive control for the case that has to stay silent: this runs on every commit, so a
+    // detector that cries wolf is worse than none.
+    withBinDir((root) => {
+      const bin = path.join(root, '.bin')
+      writeFileSync(path.join(root, 'real.js'), '')
+      mkdirSync(bin, { recursive: true })
+      writeFileSync(path.join(bin, 'eslint'), shim('../real.js'))
+
+      assert.deepEqual(brokenShims(bin, ['eslint']), [])
+    })
+  })
+
+  it('ignores a name that has no shim at all', () => {
+    // A tool that is simply not installed is a different problem, and not this one's to guess
+    // at — reporting it here would point at the wrong remedy.
+    withBinDir((root) => {
+      const bin = path.join(root, '.bin')
+      mkdirSync(bin, { recursive: true })
+
+      assert.deepEqual(brokenShims(bin, ['never-installed']), [])
+    })
+  })
+})


### PR DESCRIPTION
Fixes #1564 — as far as a repository can. The actual remedy is an environment one, and the diagnosis is the substance of this PR.

## Reproduced, and the reason it looked machine-specific

pnpm writes each `.bin` shim's exec target as a path **relative to the shim**, and `sh` collapses `../..` **lexically** — it does not follow symlinks. A `pnpm install` run from a git worktree whose `node_modules` is a symlink to another checkout therefore writes paths computed at *the worktree's* depth into the `.bin` both checkouts share:

```sh
exec node "$basedir/../../../../talex-touch/node_modules/lint-staged/bin/lint-staged.js"
```

| invoked from | `../../../../talex-touch/…` resolves to | result |
|---|---|---|
| `…/Projects/talex-touch-worktrees/tx/node_modules/.bin` | `…/Projects/talex-touch/…` | ✅ works |
| `…/Projects/talex-touch/node_modules/.bin` | `…/Workspace/talex-touch/…` | ❌ **the path in the issue** |

Measured: **163 shims** carry that path. From the main checkout, `lint-staged`, `eslint` and `prettier` all fail — via `pnpm exec` *and* via bare PATH. From the worktree, all three succeed. That is why the hook ran clean for me and not for the reporter.

## Nothing in the repository is wrong, and that is the expensive part

A clean clone cannot reproduce it. The same commit succeeds from the other checkout. Every tool breaks at once, with a `MODULE_NOT_FOUND` naming a directory that does not exist and that nobody recognises. Nothing points at the cause.

## What this changes

The hook runs a detector before `lint:staged`:

```
[check-bin-shims] 3 of 3 required tools resolve outside this checkout:

  lint-staged -> /Users/…/Workspace/talex-touch/node_modules/lint-staged/bin/lint-staged.js
  eslint      -> /Users/…/Workspace/talex-touch/node_modules/eslint/bin/eslint.js
  prettier    -> /Users/…/Workspace/talex-touch/node_modules/prettier/bin/prettier.cjs

This is a local install, not the repository. …

  Fix:  pnpm install        (from <repo root>)
  And:  give each git worktree its own node_modules rather than symlinking another checkout's.

Skipping the hook with HUSKY=0 leaves the next commit to hit the same wall.
```

It exits non-zero, so the gate stays a gate. It is a detector, not a workaround — the issue explicitly rules out `HUSKY=0` as durable, and this makes ignoring it harder rather than easier.

## Tests

Four, in `scripts/*.test.mjs` (runs under `test:scripts` in **PR Quality**, which blocks):

- lexical resolution asserted directly, since that *is* the defect
- a broken target is reported, an existing one is not
- **a name with no shim at all is ignored** — "not installed" is a different problem and pointing at the wrong remedy is worse than silence
- the positive control that matters most here: silence when everything resolves. This runs on every commit, so a detector that cries wolf is worse than none

## What I did not do

I have not run `pnpm install` against the main checkout to repair its shims. It rewrites a `node_modules` another session is actively working in, and that is not mine to disrupt. Running it there fixes the reporter's blocker immediately — and note the shims cannot be correct for both checkouts at once while one symlinks the other's `node_modules`.

## Closure criteria

- *A normal `git commit` invokes lint-staged without a module-resolution error* — true in a checkout with its own install; from the shared one it now fails **with the reason and the fix** instead of a loader stack.
- *A negative staged-file control fails for the intended lint reason* — verified: the hook runs to completion and `lint-staged` reports normally.
