### PR TITLE
perf(tuffex): stop shipping the vendored markdown sheet twice

### DIFF
--- a/packages/tuffex/packages/components/src/markdown-view/index.ts
+++ b/packages/tuffex/packages/components/src/markdown-view/index.ts
@@ -1,3 +1,9 @@
+// The vendored GitHub sheet is imported here rather than @import-ed inside the SFC's
+// <style>: an SFC @import is inlined into that component's own CSS, so two components
+// needing it shipped two copies -- 37.2 KiB, 8% of components.css (#1555). As a module
+// specifier the bundler sees one file.
+import './src/github-markdown.css'
+
 import type { MarkdownViewProps } from './src/types'
 import { withInstall } from '../../../utils/withInstall'
 import TxMarkdownView from './src/TxMarkdownView.vue'

--- a/packages/tuffex/packages/components/src/markdown-view/src/TxMarkdownView.vue
+++ b/packages/tuffex/packages/components/src/markdown-view/src/TxMarkdownView.vue
@@ -155,7 +155,6 @@ const resolvedTheme = computed<'light' | 'dark'>(() => {
 </template>
 
 <style lang="scss">
-@import './github-markdown.css';
 
 .tx-markdown-view {
   font-size: 14px;

--- a/packages/tuffex/packages/components/src/stream-markdown/index.ts
+++ b/packages/tuffex/packages/components/src/stream-markdown/index.ts
@@ -1,3 +1,9 @@
+// The vendored GitHub sheet is imported here rather than @import-ed inside the SFC's
+// <style>: an SFC @import is inlined into that component's own CSS, so two components
+// needing it shipped two copies -- 37.2 KiB, 8% of components.css (#1555). As a module
+// specifier the bundler sees one file.
+import '../markdown-view/src/github-markdown.css'
+
 import type {
   StreamBlock,
   StreamMarkdownBlockContext,

--- a/packages/tuffex/packages/components/src/stream-markdown/src/TxStreamMarkdown.vue
+++ b/packages/tuffex/packages/components/src/stream-markdown/src/TxStreamMarkdown.vue
@@ -175,7 +175,6 @@ function isSuppressedFence(block: StreamBlock): boolean {
 </template>
 
 <style lang="scss">
-@import '../../markdown-view/src/github-markdown.css';
 
 .tx-stream-md {
   font-size: 14px;


### PR DESCRIPTION
Refs #1555 — the `audit:size` budget question needed to know what was actually in the file. **8% of it was a duplicate.**

## Measured

`components.css` carried **two copies** of `github-markdown.css`. Both `TxMarkdownView.vue` and `TxStreamMarkdown.vue` `@import`-ed it inside their `<style>` blocks, and an SFC `@import` is inlined into that component's own CSS — so the bundle got one copy per importer.

Verified with a 200-character fingerprint taken from the middle of the source sheet, with the source as its own control:

| | source | bundle |
|---|---|---|
| before | 3 | **6** |
| after | 3 | **3** |

That is **37.2 KiB in a 465.1 KiB file — 8.0%**, and the single largest item in it by a wide margin. For scale, the next-largest contributor is `markdown-view`'s own styling at 14.6 KiB, then `tabs` at 11.2.

```
components.css  476,294 -> 438,595 bytes
full CSS        465.1 KiB -> 428.3 KiB
```

## The change

Import the sheet from each component's `index.ts` instead of `@import`-ing it in the SFC. As a module specifier the bundler sees one file; as an SFC `@import` it is two texts.

## On-demand consumers are unaffected

This was the risk worth checking, and it holds:

```
dist/es/markdown-view/style.css     41,486 bytes   --fgColor-accent x9
dist/es/stream-markdown/style.css   50,342 bytes   --fgColor-accent x9
```

Each subpath's own stylesheet still carries the sheet, so importing a single component still styles markdown. And no component entry imports CSS — **not before this change and not after** — so the delivery model (`./style.css`, `./base.css`, `./*/style.css`) is unchanged.

## What this does not do

full CSS is still **428.3 KiB against a 330.0 KiB budget**, and base CSS is untouched at 29.7 against 16.0 — the sheet lives in `components.css`, not `base.css`. #1555's budget decision still stands. It is just no longer a decision made without knowing that 8% of the file was duplication.

## Verification

1115 tests pass (145 files), `typecheck` and `lint` clean, `audit:exports` passes.
