### PR TITLE
ci(db): ratchet the drizzle snapshot gap while #1303 waits on a decision

### DIFF
--- a/scripts/check-drizzle-snapshot-drift.mjs
+++ b/scripts/check-drizzle-snapshot-drift.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Stops the drizzle snapshot chain drifting further from the journal (#1303).
+ *
+ * `drizzle-kit` diffs against the newest snapshot. The newest here is `0014`, written
+ * 2025-12-10, while the journal runs to `0037` — so `db:generate`'s first output re-emits
+ * every change from the 23 migrations in between, and cannot be committed.
+ *
+ * Repairing that is a migration-history decision (rebuild each intermediate state, or flatten
+ * to a new baseline) and belongs to the maintainer. What does not need a decision is that the
+ * gap should not get *bigger* while it waits: every hand-written migration added today widens
+ * it silently, and the only symptom is that the generator stays unusable.
+ *
+ * So this pins the known gap and fails when it grows. It is a ratchet, not a fix: the number
+ * below is a debt, and lowering it is the repair.
+ */
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const META = path.join(REPO_ROOT, 'apps/core-app/resources/db/migrations/meta')
+
+/**
+ * Journal indexes with no snapshot, as of 2026-08-11.
+ *
+ * `0011` and `0012` are not a later deletion — `git log --diff-filter=A` finds no commit that
+ * ever added them, and `--diff-filter=D` finds no snapshot deletion at all. The chain was
+ * never complete, so there is no lost history to recover before deciding what to do.
+ */
+export const KNOWN_MISSING_SNAPSHOTS = 25
+
+export function snapshotGap(metaDir = META) {
+  const journal = JSON.parse(readFileSync(path.join(metaDir, '_journal.json'), 'utf8'))
+  const snapshots = new Set(
+    readdirSync(metaDir)
+      .filter(name => name.endsWith('_snapshot.json'))
+      .map(name => name.slice(0, 4)),
+  )
+
+  const missing = journal.entries
+    .map(entry => String(entry.idx).padStart(4, '0'))
+    .filter(index => !snapshots.has(index))
+
+  return { journalEntries: journal.entries.length, snapshots: snapshots.size, missing }
+}
+
+function main() {
+  const { journalEntries, snapshots, missing } = snapshotGap()
+
+  if (missing.length > KNOWN_MISSING_SNAPSHOTS) {
+    console.error(
+      `[check-drizzle-snapshot-drift] ${missing.length} journal entries have no snapshot, up from ${KNOWN_MISSING_SNAPSHOTS}.\n`
+      + `  journal: ${journalEntries}  snapshots: ${snapshots}\n`
+      + `  newly unbacked: ${missing.slice(KNOWN_MISSING_SNAPSHOTS).join(', ')}\n\n`
+      + 'A migration was added by hand without advancing the snapshot chain, which pushes\n'
+      + 'drizzle-kit\'s diff baseline further from reality (#1303). Either write the snapshot\n'
+      + 'alongside the migration, or raise the pinned number deliberately and say why.',
+    )
+    process.exit(1)
+  }
+
+  if (missing.length < KNOWN_MISSING_SNAPSHOTS) {
+    console.error(
+      `[check-drizzle-snapshot-drift] only ${missing.length} entries lack a snapshot, down from ${KNOWN_MISSING_SNAPSHOTS}.\n`
+      + 'The debt shrank — lower KNOWN_MISSING_SNAPSHOTS so the ratchet holds the new floor.',
+    )
+    process.exit(1)
+  }
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href)
+  main()

--- a/scripts/check-drizzle-snapshot-drift.test.mjs
+++ b/scripts/check-drizzle-snapshot-drift.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, it } from 'vitest'
+
+import { KNOWN_MISSING_SNAPSHOTS, snapshotGap } from './check-drizzle-snapshot-drift.mjs'
+
+/**
+ * The ratchet that keeps the snapshot gap from widening while #1303 waits on a decision.
+ *
+ * The failure it guards is entirely silent: a hand-written migration lands, the journal grows,
+ * no snapshot is written, and nothing complains — the only symptom is that `db:generate`
+ * remains unusable, which nobody discovers until they next try to use it.
+ */
+
+function withMeta(entries, snapshots, run) {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'drizzle-meta-'))
+  try {
+    mkdirSync(root, { recursive: true })
+    writeFileSync(
+      path.join(root, '_journal.json'),
+      JSON.stringify({ entries: entries.map(idx => ({ idx })) }),
+    )
+    for (const index of snapshots)
+      writeFileSync(path.join(root, `${String(index).padStart(4, '0')}_snapshot.json`), '{}')
+    return run(root)
+  }
+  finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+describe('drizzle snapshot drift', () => {
+  it('counts journal entries that have no snapshot', () => {
+    withMeta([0, 1, 2, 3], [0, 1, 3], (meta) => {
+      const gap = snapshotGap(meta)
+
+      assert.equal(gap.journalEntries, 4)
+      assert.equal(gap.snapshots, 3)
+      assert.deepEqual(gap.missing, ['0002'])
+    })
+  })
+
+  it('reports a gap in the middle, not just a truncated tail', () => {
+    // 0011 and 0012 are missing while 0013 and 0014 exist. A check that only compared the
+    // highest snapshot against the highest journal entry would score this chain as sound up
+    // to 0014 and never notice.
+    withMeta([0, 1, 2, 3, 4], [0, 3, 4], (meta) => {
+      assert.deepEqual(snapshotGap(meta).missing, ['0001', '0002'])
+    })
+  })
+
+  it('is satisfied only by an exact match', () => {
+    withMeta([0, 1, 2], [0, 1, 2], (meta) => {
+      assert.deepEqual(snapshotGap(meta).missing, [])
+    })
+  })
+
+  it('measures the real migrations directory, and it still matches the pinned debt', () => {
+    // Positive control and the ratchet in one: if this drifts either way the script fails, and
+    // the direction tells you which — a widened gap is a new hand-written migration, a
+    // narrowed one is repair work that should lower the pin.
+    const gap = snapshotGap()
+
+    assert.ok(gap.journalEntries > 30, `journal looks wrong: ${gap.journalEntries}`)
+    assert.equal(gap.missing.length, KNOWN_MISSING_SNAPSHOTS)
+    // The two the chain never had, rather than a truncated tail — see the script's comment.
+    assert.ok(gap.missing.includes('0011'))
+    assert.ok(gap.missing.includes('0012'))
+  })
+})


### PR DESCRIPTION
Toward #1303. **Does not close it** — the rebuild-vs-flatten decision is still yours. This stops the gap growing while it waits, and settles one question I raised on the issue and could not answer there.

## The forensics: `0011`/`0012` were never written, not deleted

On the issue I said their absence "suggests the chain was hand-edited before — worth confirming when and why before rebuilding". That was wrong, and it was gating the decision:

```
git log --all --diff-filter=A -- meta/0011_snapshot.json   → nothing
git log --all --diff-filter=A -- meta/0012_snapshot.json   → nothing
git log --all --diff-filter=D -- meta/*_snapshot.json      → nothing
```

No commit ever added them, and no snapshot has ever been deleted. The migrations themselves came in as hand-written SQL:

| | added | commit |
|---|---|---|
| `0011_add_recommendation_tables.sql` | 2025-11-20 | `feat(db): add tables for recommendation engine` |
| `0012_app_update_records.sql` | 2025-11-22 | `feat: implement advanced update system…` |
| `0013_snapshot.json` | 2025-12-08 | generated properly |
| `0014_snapshot.json` | 2025-12-10 | generated properly |

**There is no lost history to recover before deciding.** The chain was never complete — the same hand-writing that produced the 0015–0037 tail also produced this earlier pair, three weeks before the generator was last used successfully.

It also means the gap is **two separate breaks**, not one truncated tail. A check comparing the highest snapshot against the highest journal entry would score this chain sound up to `0014` and never see it, so there is a test for exactly that shape.

## The ratchet

Current state, measured: **38 journal entries, 13 snapshots, 25 entries with no snapshot.**

`scripts/check-drizzle-snapshot-drift.mjs` pins 25 and fails in **both** directions:

- **wider** — names the newly unbacked indexes and says a migration skipped its snapshot
- **narrower** — says to lower the pin, so repair work moves the floor instead of leaving slack behind it

The number is a debt, not a target. Twenty-three migrations accumulated because the failure is completely silent: the journal advances, no snapshot is written, nothing complains, and the only symptom is that `db:generate` stays unusable — which nobody discovers until they next try to use it.

## Tests

Four, under `test:scripts` in **PR Quality** (blocking):

- counts entries with no snapshot
- **reports a gap in the middle, not just a truncated tail** — the `0011`/`0012` shape
- exact match is the only clean state
- the ratchet itself, against the real directory, doubling as a positive control

Verified both mutations: adding a journal entry exits 1 and names `0038`; adding a snapshot exits 1 and asks for the pin to be lowered.

## Still yours

Whether to reconstruct `0015`–`0037` individually (needs each intermediate state to be reproducible) or flatten to a new baseline (loses the ability to diff against earlier versions). That is a migration-history strategy, and it runs against users' databases.
