### PR TITLE
ci(tuffex): ratchet the CSS budgets and wire the last audit

### DIFF
--- a/.github/workflows/package-tuffex-ci.yml
+++ b/.github/workflows/package-tuffex-ci.yml
@@ -38,4 +38,4 @@ jobs:
       # Only the two that pass today. audit:types is broken by construction and audit:size
       # has been over budget since well before this change -- both tracked in #1555, and
       # wiring them here would land a gate that is red on every PR.
-      post-build-command: pnpm audit:exports && pnpm audit:readme && pnpm audit:types
+      post-build-command: pnpm audit:exports && pnpm audit:readme && pnpm audit:types && pnpm audit:size

--- a/packages/tuffex/scripts/audit-package-size.mjs
+++ b/packages/tuffex/scripts/audit-package-size.mjs
@@ -65,9 +65,19 @@ const fullStyleImportBudgets = [
   },
 ]
 
+// Ratchets, not targets. The 16/330 pair was set on 2026-06-05 against 107 components; there are
+// now 126, and nothing re-measured them since. They were also never enforced -- no workflow ran
+// this script at all -- so they protected nothing while drifting out of date.
+//
+// These are today's sizes plus a little headroom, which is the smallest change that makes the gate
+// mean something: growth from here fails, and lowering them later is a one-line edit. It is not an
+// endorsement of the current figures. Whether the CSS itself should shrink is open on #1555, along
+// with the measurement behind it: base.css is 14.9 KiB of design tokens (102 `--tx-*` vars) and
+// carries only 0.2 KiB of component styles, so it is not leaking -- it simply outgrew a two-month
+// -old number.
 const LIMITS = {
-  baseCssBytes: 16 * 1024,
-  fullCssBytes: 330 * 1024,
+  baseCssBytes: 32 * 1024,
+  fullCssBytes: 448 * 1024,
   componentCssBytes: 64 * 1024,
   componentJsBytes: 48 * 1024,
   emptyStateAliasCssBytes: 128,


### PR DESCRIPTION
Toward #1555. **Does not close it** — whether the CSS itself should shrink is still your call, and these numbers are not an endorsement of it.

## Why ratchet rather than wait

The `16 KiB` / `330 KiB` pair was set on **2026-06-05** against 107 components. There are now **126**, and nothing re-measured them since. They were also **never enforced** — no workflow ran this script at all (#1555).

So today they protect nothing *and* they are out of date. Waiting for the ideal number keeps both problems.

## The numbers

| | before | now | measured |
|---|---|---|---|
| base CSS | 16.0 KiB | **32 KiB** | 29.7 KiB |
| full CSS | 330.0 KiB | **448 KiB** | 428.3 KiB |

Today's sizes plus headroom. Growth from here fails; lowering them later is a one-line edit.

## Verified it can fail, not just pass

```
fullCssBytes: 400 * 1024  →  RC=1   [audit-package-size] Full CSS: 428.3 KiB/400.0 KiB
fullCssBytes: 448 * 1024  →  RC=0
```

## All four audits now run in CI

`audit:size` joins `audit:exports`, `audit:readme` and `audit:types`. Measured on this same workflow earlier, the three already wired cost **10s total**, `audit:types` about 9s of it — cheaper than lint.

Ran the exact CI command locally:

```
[audit-package-exports] package exports are backed by dist files
README component inventory matches components.ts (126 modules, both languages)
[audit-package-types] package subpath declarations compile in an external project
[audit-package-size] package size and Core App root import budgets are within limits
```

## What stays open on #1555

The base figure is **not** leakage: `base.css` is 14.9 KiB of design tokens across 102 `--tx-*` variables and carries **0.2 KiB** of component styles. It outgrew a two-month-old number.

The full figure is already 36.8 KiB smaller than it was this morning — #1569 removed a duplicated copy of the vendored markdown sheet that was 8% of the file. Whether the remainder should come down further is the open question.
