### PR TITLE
build(utils): publish the subpaths plugins actually import

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -50,7 +50,7 @@
     "node": ">=24.15.0"
   },
   "scripts": {
-    "build": "tsup index.ts --format esm --dts --target node24 --platform neutral --clean --out-dir dist --tsconfig tsconfig.build.json",
+    "build": "tsup core-box/index.ts index.ts network/index.ts plugin/index.ts plugin/preload.ts plugin/sdk/box-sdk.ts plugin/sdk/clipboard.ts plugin/sdk/index.ts plugin/sdk/service/index.ts plugin/sdk/storage.ts plugin/sdk/system.ts plugin/sdk/types.ts service/protocol/index.ts transport/events/types/index.ts --format esm --dts --target node24 --platform neutral --clean --out-dir dist --tsconfig tsconfig.build.json",
     "benchmark:preview": "vitest run \"__tests__/core-box/preview-sdk.benchmark.test.ts\" --reporter verbose",
     "lint": "pnpm exec eslint --cache .",
     "lint:fix": "pnpm exec eslint --cache --fix .",
@@ -85,6 +85,79 @@
     "access": "public",
     "main": "./dist/index.mjs",
     "module": "./dist/index.mjs",
-    "types": "./dist/index.d.mts"
+    "types": "./dist/index.d.mts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      },
+      "./core-box": {
+        "types": "./dist/core-box/index.d.mts",
+        "import": "./dist/core-box/index.mjs",
+        "default": "./dist/core-box/index.mjs"
+      },
+      "./network": {
+        "types": "./dist/network/index.d.mts",
+        "import": "./dist/network/index.mjs",
+        "default": "./dist/network/index.mjs"
+      },
+      "./plugin": {
+        "types": "./dist/plugin/index.d.mts",
+        "import": "./dist/plugin/index.mjs",
+        "default": "./dist/plugin/index.mjs"
+      },
+      "./plugin/preload": {
+        "types": "./dist/plugin/preload.d.mts",
+        "import": "./dist/plugin/preload.mjs",
+        "default": "./dist/plugin/preload.mjs"
+      },
+      "./plugin/sdk": {
+        "types": "./dist/plugin/sdk/index.d.mts",
+        "import": "./dist/plugin/sdk/index.mjs",
+        "default": "./dist/plugin/sdk/index.mjs"
+      },
+      "./plugin/sdk/box-sdk": {
+        "types": "./dist/plugin/sdk/box-sdk.d.mts",
+        "import": "./dist/plugin/sdk/box-sdk.mjs",
+        "default": "./dist/plugin/sdk/box-sdk.mjs"
+      },
+      "./plugin/sdk/clipboard": {
+        "types": "./dist/plugin/sdk/clipboard.d.mts",
+        "import": "./dist/plugin/sdk/clipboard.mjs",
+        "default": "./dist/plugin/sdk/clipboard.mjs"
+      },
+      "./plugin/sdk/service": {
+        "types": "./dist/plugin/sdk/service/index.d.mts",
+        "import": "./dist/plugin/sdk/service/index.mjs",
+        "default": "./dist/plugin/sdk/service/index.mjs"
+      },
+      "./plugin/sdk/storage": {
+        "types": "./dist/plugin/sdk/storage.d.mts",
+        "import": "./dist/plugin/sdk/storage.mjs",
+        "default": "./dist/plugin/sdk/storage.mjs"
+      },
+      "./plugin/sdk/system": {
+        "types": "./dist/plugin/sdk/system.d.mts",
+        "import": "./dist/plugin/sdk/system.mjs",
+        "default": "./dist/plugin/sdk/system.mjs"
+      },
+      "./plugin/sdk/types": {
+        "types": "./dist/plugin/sdk/types.d.mts",
+        "import": "./dist/plugin/sdk/types.mjs",
+        "default": "./dist/plugin/sdk/types.mjs"
+      },
+      "./service/protocol": {
+        "types": "./dist/service/protocol/index.d.mts",
+        "import": "./dist/service/protocol/index.mjs",
+        "default": "./dist/service/protocol/index.mjs"
+      },
+      "./transport/events/types": {
+        "types": "./dist/transport/events/types/index.d.mts",
+        "import": "./dist/transport/events/types/index.mjs",
+        "default": "./dist/transport/events/types/index.mjs"
+      },
+      "./package.json": "./package.json"
+    }
   }
 }


### PR DESCRIPTION
Refs #699 — the remaining half. The root entry was fixed by #1398; **every subpath still resolved into the raw TypeScript.**

## The defect, measured against a packed tarball

Importing a subpath is not a syntax error later — Node cannot resolve it at all:

```
without exports:  ERR_UNSUPPORTED_DIR_IMPORT
                  Directory import '.../@talex-touch/utils/network'

with exports:     resolves to dist/network/index.mjs, executes, and only then
                  reports 'Cannot find package path-browserify' — its own
                  dependency, absent because that probe did not install them
```

That difference is the whole proof: with the map, the module is **found and run**; without it, resolution never reaches a file.

## Why this is 14 subpaths and not 135

The earlier analysis priced this at ~135 subpaths and left it as a decision. That number came from the **147 subpaths this monorepo imports** — which resolve through the workspace and never touch the published package.

The consumers that do touch it are the plugins. Scanned across `from` / `import()` / `require()` with a negative control:

```
14 distinct subpaths, 4 plugins declaring the dependency
depth: 1 root, 3 at depth 1, 3 at depth 2, 7 at depth 3
renderer/*: 0
```

**None of them is under `renderer/`** — the one directory that genuinely cannot be built, because it imports `.vue` SFCs. So the blocker in the earlier analysis does not apply to the surface that is actually consumed.

## What this does

Builds those 14 entries and enumerates them in `publishConfig.exports`.

Verified that **pnpm applies `publishConfig.exports` at pack time** — the repo had no precedent for it, so it was worth checking rather than assuming:

```
packed manifest exports: 15 entries
tarball contains: dist/plugin/sdk/index.mjs, dist/transport/events/types/index.mjs, dist/network/index.mjs
```

All 14 resolve to their built `.mjs` in a real consumer layout.

## In-repo resolution is unchanged, deliberately

`main`/`module` still point at `index.ts`. Pointing them at `dist` would make the app bundle a prebuilt copy beside the sources it already compiles — two instances of every singleton. Only `publishConfig` is remapped, which is the existing pattern from #1398.

## Not covered, and worth saying plainly

Anything outside these 14 is still bundler-only. A plugin importing, say, `@talex-touch/utils/search/foo` gets the same `ERR_UNSUPPORTED_DIR_IMPORT` as before. Extending the map is a one-line addition per entry; wildcards are not an option — the earlier analysis measured that every `"./*"` form breaks part of the tree, because subpath patterns resolve to exact files and neither Node nor esbuild falls through a fallback array.

1341 tests pass.
