### PR TITLE
chore(trellis): record what realtime-index-freshness is actually waiting on

### DIFF
--- a/.trellis/tasks/08-05-realtime-index-freshness/task.json
+++ b/.trellis/tasks/08-05-realtime-index-freshness/task.json
@@ -22,5 +22,9 @@
   "parent": "08-05-search-audit-remediation",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Add the two missing F1/F4 unit tests AC1 asks for: the dead-letter sweep lifecycle (including timer release when the set drains) and the health-probe mismatch -> backfill trigger. Both are implemented but no test file references them. Testing F1 in place means reaching private state on app-provider.ts, so extract the sweep scheduling first (see #712).",
+    "blocker": "AC3 is a manual acceptance the task itself assigns to the user post-restart (install an app -> searchable within 10s). It cannot be produced from a test run, so this task cannot reach a terminal state without that session.",
+    "evidence": "AC2 measured 2026-08-11: addon/apps + search-engine + addon/files 1155 passed / 140 files; typecheck:node 0 errors. F2 coalescing and F5 lastIndexedAt are covered (14 and 15 test files reference them). F1 dead-letter and F4 health probe are implemented in app-provider.ts but have 0 referencing test files, so AC1 is partial. AC3 not run."
+  }
 }


### PR DESCRIPTION
Toward #1125 — the **other** case from #1575.

That one archived a task that was finished. This one is a task genuinely still in progress, where the three meta fields turn out to have real answers once someone actually checks.

## What checking found

| feature | test files referencing it |
|---|---|
| F2 coalescing | 14 |
| F5 `lastIndexedAt` | 15 |
| **F1 dead-letter** | **0** — implemented, untested |
| **F4 health probe → backfill** | **0** — implemented, untested |

So **AC1 is partial**, not done. AC2 measured green: `addon/apps` + `search-engine` + `addon/files` → **1155 passed / 140 files**, `typecheck:node` 0 errors.

**AC3 the task assigns to the user post-restart** — install an app, expect it searchable within 10s. No test run can produce that, so this task cannot reach a terminal state without that session. That is the blocker, and it is now written down instead of implied by silence.

`nextAction` names the two missing tests. Testing F1 in place means reaching private state on `app-provider.ts` — the 4540-line class #712 is about — so the note says to extract the sweep scheduling first rather than pretending it is a quick test.

## Result

```
docs:verify   116 -> 113
DOC-TASK-META 111 -> 108
```

No rule changed. The fields were fillable; they had just never been filled.