### PR TITLE
test(search-engine): declare setAppExecutionRecorder in the app-provider mocks

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/app-indexed-source.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/app-indexed-source.test.ts
@@ -15,6 +15,9 @@ const appProviderMock = vi.hoisted(() => ({
 }))
 
 vi.mock('../addon/apps/app-provider', () => ({
+  // search-core.ts imports this alongside appProvider; a factory mock has to carry every
+  // binding the importer names or vitest throws at import time, before any test runs.
+  setAppExecutionRecorder: vi.fn(),
   appProvider: appProviderMock
 }))
 

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
@@ -150,6 +150,9 @@ vi.mock('../../storage', () => ({
   }
 }))
 vi.mock('../addon/apps/app-provider', () => ({
+  // search-core.ts imports this alongside appProvider; a factory mock has to carry every
+  // binding the importer names or vitest throws at import time, before any test runs.
+  setAppExecutionRecorder: vi.fn(),
   appProvider: {
     id: 'app-provider',
     onSearch: vi.fn(),

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.gather-ordering.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.gather-ordering.test.ts
@@ -145,6 +145,9 @@ vi.mock('../../storage', () => ({
 }))
 
 vi.mock('../addon/apps/app-provider', () => ({
+  // search-core.ts imports this alongside appProvider; a factory mock has to carry every
+  // binding the importer names or vitest throws at import time, before any test runs.
+  setAppExecutionRecorder: vi.fn(),
   appProvider: {
     id: 'app-provider',
     type: 'app',

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.regression-baseline.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.regression-baseline.test.ts
@@ -96,6 +96,9 @@ vi.mock('../../storage', () => ({
 }))
 
 vi.mock('../addon/apps/app-provider', () => ({
+  // search-core.ts imports this alongside appProvider; a factory mock has to carry every
+  // binding the importer names or vitest throws at import time, before any test runs.
+  setAppExecutionRecorder: vi.fn(),
   appProvider: {
     id: 'app-provider',
     type: 'app',

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.trace.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.trace.test.ts
@@ -189,6 +189,9 @@ vi.mock('../../storage', () => ({
 }))
 
 vi.mock('../addon/apps/app-provider', () => ({
+  // search-core.ts imports this alongside appProvider; a factory mock has to carry every
+  // binding the importer names or vitest throws at import time, before any test runs.
+  setAppExecutionRecorder: vi.fn(),
   appProvider: {
     id: 'app-provider',
     type: 'app',

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
@@ -36,7 +36,7 @@ import { databaseModule } from '../../database'
 import PluginFeaturesAdapter from '../../plugin/adapters/plugin-features-adapter'
 import { getSentryService } from '../../sentry'
 import { OnboardingGateError, onboardingGate } from '../../storage'
-import { appProvider } from '../addon/apps/app-provider'
+import { appProvider, setAppExecutionRecorder } from '../addon/apps/app-provider'
 import { everythingProvider } from '../addon/files/everything-provider'
 import { fileProvider } from '../addon/files/file-provider'
 import { APP_INDEXED_SOURCE_ID } from './app-indexed-source'
@@ -2199,4 +2199,12 @@ export class SearchEngineCore
   }
 }
 
-export default SearchEngineCore.getInstance()
+const searchEngineCore = SearchEngineCore.getInstance()
+
+// app-provider used to import this module to report a launch, which closed a module-scope cycle
+// between the two (#712). The dependency is registered from this side instead, so app-provider
+// no longer needs to know search-core exists. Registered synchronously at module evaluation:
+// the recorder must run before the launch it precedes, not a microtask later.
+setAppExecutionRecorder((sessionId, item) => searchEngineCore.recordExecute(sessionId, item))
+
+export default searchEngineCore


### PR DESCRIPTION
Closes #1578. **The search-engine suite does not run on this base.**

```
Test Files  4 failed | 70 passed (74)
Tests      25 failed | 610 passed (635)

Error: [vitest] No "setAppExecutionRecorder" export is defined on the
"../addon/apps/app-provider" mock.
  ❯ search-core.ts:2208:1
```

`app-provider.ts:94` exports it, `search-core.ts:39` imports it. A factory `vi.mock` replaces the **whole** module, so it must carry every binding the importer names — and all five files that mock that path declared none. The throw is at import time, before any test body runs, which is why whole files fail rather than assertions.

## After

```
Test Files  74 passed (74)
Tests      646 passed (646)
```

Mutation-checked rather than assumed: removing the declaration from `search-core.gather-ordering.test.ts` reproduces the exact error; restoring it passes.

## Why it could land

`App suites (core-app)` runs with `continue-on-error: ${{ matrix.app != 'nexus' }}`. **A broken core-app suite reports `conclusion: success` and cannot fail a PR.** So an export can be added, its importer updated, and every mock left stale, with nothing in CI objecting.

Same shape as #1541 (tests that could not fail) and the `SNAP_COUNT`/`APP_COUNT` pair — a control whose failure mode is silence.

## How it surfaced

I ran this suite alone while verifying a Trellis task for #1125. Earlier in the same session I had run it *together with two other directories* and got 1155 passed — the base moved between the two runs. A green multi-directory run is not evidence about a suite you did not isolate.