### PR TITLE
refactor(core-app): break the app-provider/search-core module cycle

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider-test-harness.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider-test-harness.ts
@@ -302,12 +302,6 @@ vi.mock('../../file-system-watcher', () => ({
   }
 }))
 
-vi.mock('../../search-engine/search-core', () => ({
-  default: {
-    recordExecute: searchRecordExecuteMock
-  }
-}))
-
 vi.mock('./app-scanner', () => ({
   appScanner: {
     getApps: getAppsMock,
@@ -461,6 +455,9 @@ export async function withTimeout<T>(
 
 export async function loadSubject() {
   const subject = await import('./app-provider')
+  // app-provider no longer imports search-core (#712), so mocking that module would sit inert.
+  // The recorder is registered through the same seam search-core uses in production.
+  subject.setAppExecutionRecorder(searchRecordExecuteMock)
   subject.appProvider.setIndexedSourceRuntimeDelegate({
     scan: appRuntimeScanMock,
     reconcile: appRuntimeReconcileMock,

--- a/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises'
 import os from 'node:os'
+import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import type { IExecuteArgs, TuffItem } from '@talex-touch/utils'
 import type { IndexedSourceRecordBatch } from '@talex-touch/utils/search'
@@ -676,6 +677,12 @@ describe('appProvider rebuild maintenance', () => {
     } as IExecuteArgs)
 
     expect(searchRecordExecuteMock).toHaveBeenCalledWith('search-session-42', item)
+    // "before" has to be asserted, not implied by the await: awaiting onExecute drains the
+    // microtask queue, so a recorder deferred by a Promise.resolve().then() still ends up
+    // called by the time these run. Invocation order is what actually pins it (#712).
+    expect(searchRecordExecuteMock.mock.invocationCallOrder[0]).toBeLessThan(
+      scheduleAppLaunchMock.mock.invocationCallOrder[0]
+    )
     expect(scheduleAppLaunchMock).toHaveBeenCalledWith({
       name: 'Recorded App',
       path: '/Applications/Recorded.app',
@@ -685,6 +692,25 @@ describe('appProvider rebuild maintenance', () => {
       workingDirectory: undefined,
       sourceItemId: 'recorded-app'
     })
+  })
+
+  it('has search-core register the recorder, since nothing else can', async () => {
+    // The seam defaults to a no-op. If search-core stops registering, app launches simply stop
+    // being recorded -- no error, no failing assertion anywhere else, because every other test
+    // registers the mock itself. Read from source: importing search-core here would drag in the
+    // whole engine, and the thing worth pinning is that the call site exists at all (#712).
+    const here = path.dirname(fileURLToPath(import.meta.url))
+    const searchCore = await fs.readFile(
+      path.resolve(here, '../../search-engine/search-core.ts'),
+      'utf-8'
+    )
+
+    expect(searchCore).toContain('setAppExecutionRecorder(')
+    expect(searchCore).toMatch(/setAppExecutionRecorder\(\s*\(sessionId, item\) =>/)
+
+    // And app-provider must not reach back, or the cycle returns.
+    const provider = await fs.readFile(path.resolve(here, './app-provider.ts'), 'utf-8')
+    expect(provider).not.toMatch(/^import .*search-engine\/search-core/m)
   })
 
   it('requests a runtime reset for public rebuilds', async () => {

--- a/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.ts
@@ -40,6 +40,7 @@ import { completeTiming, sleep, startTiming, StorageList, timingLogger } from '@
 import { normalizeFsPath } from '@talex-touch/utils/common/file-scan-utils'
 import { getLogger } from '@talex-touch/utils/common/logger'
 import { pollingService } from '@talex-touch/utils/common/utils/polling'
+import type { TuffItem } from '@talex-touch/utils'
 import { TuffInputType, TuffSearchResultBuilder } from '@talex-touch/utils/core-box'
 import {
   IndexedSourceGroupedEvidenceService,
@@ -74,7 +75,27 @@ import { iconService } from '../../../../service/icon-service'
 import { getMainConfig, saveMainConfig } from '../../../storage'
 import { operationalErrorService } from '../../../observability'
 import FileSystemWatcher from '../../file-system-watcher'
-import searchEngineCore from '../../search-engine/search-core'
+/**
+ * How a launched app reports itself back to the search engine.
+ *
+ * This used to be a direct `import searchEngineCore from '../../search-engine/search-core'`,
+ * and search-core imports `appProvider` back, so the two modules instantiated each other at
+ * module scope. That only worked because AppProvider's constructor is a single log call --
+ * promoting any of its methods into constructor-time work would have dereferenced
+ * `searchEngineCore` mid-evaluation and failed at boot rather than at the call site (#712).
+ *
+ * The recorder is invoked **synchronously**; a lazy `await import()` was tried first and broke
+ * `records a session-scoped usage event before handing the app to the launch boundary`, because
+ * deferring by a microtask puts the record after the launch it is supposed to precede.
+ */
+export type AppExecutionRecorder = (sessionId: string, item: TuffItem) => Promise<void>
+
+let recordAppExecution: AppExecutionRecorder = async () => {}
+
+export function setAppExecutionRecorder(recorder: AppExecutionRecorder): void {
+  recordAppExecution = recorder
+}
+
 import { appScanner, type AppScannerSourceScanResult } from './app-scanner'
 import { scheduleAppLaunch } from './app-launcher'
 import { AppProviderSourceScanner } from './app-provider-source-scanner'
@@ -3438,7 +3459,7 @@ class AppProvider implements ISearchProvider<ProviderContext> {
     const sessionId = searchResult?.sessionId
     if (sessionId) {
       logApp(`Recording app execution: ${chalk.cyan(item.id)}`, LogStyle.info)
-      searchEngineCore.recordExecute(sessionId, item).catch((err) => {
+      recordAppExecution(sessionId, item).catch((err) => {
         logApp(`Failed to record execution: ${chalk.red(err.message)}`, LogStyle.error)
       })
     }

--- a/apps/core-app/src/main/modules/box-tool/search-engine/app-indexed-source.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/app-indexed-source.test.ts
@@ -15,6 +15,9 @@ const appProviderMock = vi.hoisted(() => ({
 }))
 
 vi.mock('../addon/apps/app-provider', () => ({
+  // search-core.ts imports this alongside appProvider; a factory mock has to carry every
+  // binding the importer names or vitest throws at import time, before any test runs.
+  setAppExecutionRecorder: vi.fn(),
   appProvider: appProviderMock
 }))
 

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
@@ -150,6 +150,9 @@ vi.mock('../../storage', () => ({
   }
 }))
 vi.mock('../addon/apps/app-provider', () => ({
+  // search-core.ts imports this alongside appProvider; a factory mock has to carry every
+  // binding the importer names or vitest throws at import time, before any test runs.
+  setAppExecutionRecorder: vi.fn(),
   appProvider: {
     id: 'app-provider',
     onSearch: vi.fn(),

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.gather-ordering.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.gather-ordering.test.ts
@@ -145,6 +145,9 @@ vi.mock('../../storage', () => ({
 }))
 
 vi.mock('../addon/apps/app-provider', () => ({
+  // search-core.ts imports this alongside appProvider; a factory mock has to carry every
+  // binding the importer names or vitest throws at import time, before any test runs.
+  setAppExecutionRecorder: vi.fn(),
   appProvider: {
     id: 'app-provider',
     type: 'app',

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.regression-baseline.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.regression-baseline.test.ts
@@ -96,6 +96,9 @@ vi.mock('../../storage', () => ({
 }))
 
 vi.mock('../addon/apps/app-provider', () => ({
+  // search-core.ts imports this alongside appProvider; a factory mock has to carry every
+  // binding the importer names or vitest throws at import time, before any test runs.
+  setAppExecutionRecorder: vi.fn(),
   appProvider: {
     id: 'app-provider',
     type: 'app',

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.trace.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.trace.test.ts
@@ -189,6 +189,9 @@ vi.mock('../../storage', () => ({
 }))
 
 vi.mock('../addon/apps/app-provider', () => ({
+  // search-core.ts imports this alongside appProvider; a factory mock has to carry every
+  // binding the importer names or vitest throws at import time, before any test runs.
+  setAppExecutionRecorder: vi.fn(),
   appProvider: {
     id: 'app-provider',
     type: 'app',

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
@@ -36,7 +36,7 @@ import { databaseModule } from '../../database'
 import PluginFeaturesAdapter from '../../plugin/adapters/plugin-features-adapter'
 import { getSentryService } from '../../sentry'
 import { OnboardingGateError, onboardingGate } from '../../storage'
-import { appProvider } from '../addon/apps/app-provider'
+import { appProvider, setAppExecutionRecorder } from '../addon/apps/app-provider'
 import { everythingProvider } from '../addon/files/everything-provider'
 import { fileProvider } from '../addon/files/file-provider'
 import { APP_INDEXED_SOURCE_ID } from './app-indexed-source'
@@ -2199,4 +2199,12 @@ export class SearchEngineCore
   }
 }
 
-export default SearchEngineCore.getInstance()
+const searchEngineCore = SearchEngineCore.getInstance()
+
+// app-provider used to import this module to report a launch, which closed a module-scope cycle
+// between the two (#712). The dependency is registered from this side instead, so app-provider
+// no longer needs to know search-core exists. Registered synchronously at module evaluation:
+// the recorder must run before the launch it precedes, not a microtask later.
+setAppExecutionRecorder((sessionId, item) => searchEngineCore.recordExecute(sessionId, item))
+
+export default searchEngineCore


### PR DESCRIPTION
Closes #712 — the cycle half. The 4540-line split is untouched.

## The cycle

`app-provider` imported `search-core`; `search-core` imported `appProvider` back; both instantiate at module scope. It only worked because `AppProvider`'s constructor is a single log call — promoting any of its 142 methods into constructor-time work would have dereferenced `searchEngineCore` mid-evaluation and failed at **boot**, not at the call site.

The back edge was **one fire-and-forget call**. It is now a registered recorder:

- `app-provider` exposes `setAppExecutionRecorder`, default no-op
- `search-core` registers its `recordExecute` at module evaluation
- `app-provider` no longer names `search-core` at all

## The call stays synchronous, on purpose

An earlier attempt used a lazy `await import()` and broke *"records a session-scoped usage event **before** handing the app to the launch boundary"* — a microtask of deferral puts the record after the launch it is supposed to precede.

## That test did not assert what it is named for

Awaiting `onExecute` drains the microtask queue, so a recorder wrapped in `Promise.resolve().then()` **still passed it** — measured, 67/67 green with the deferral in place. The dynamic-import version failed it only because module loading is slower than a microtask; the protection was incidental.

It now compares `invocationCallOrder`:

| mutation | before | after |
|---|---|---|
| defer the recorder by a microtask | passes | **fails** |

## Registration cannot silently go missing

Nothing else can perform it, every other test registers its own mock, and the default is a no-op — so deleting the line in `search-core` would stop recording launches with **no error anywhere**. A guard reads both files:

| mutation | result |
|---|---|
| remove `setAppExecutionRecorder(...)` from search-core | **fails** |
| re-add the static import to app-provider (cycle returns) | **fails** |

Worth recording: `onExecute` has exactly one caller in the tree — `search-core.ts:1995` — so search-core is necessarily loaded before an app can be executed. There is no path where the recorder is still the no-op.

## Verification

- app-provider suite: **68 passed**
- search-engine suite: **646 passed**, and 646 with my four files restored to base — identical
- main-process typecheck: 0 errors; eslint clean on every touched file
- `meta-overlay.test.ts` fails 2 tests **both with and without** this change — pre-existing, verified by restoring the four files to their base versions

## Note on the branch

`de2bf5053` is not mine: a concurrent session picked up my uncommitted `search-core.ts` edit and added the `setAppExecutionRecorder` declaration to five search-engine test mocks — work this change genuinely required. Both commits are needed and coherent together.
