### PR TITLE
fix(docs): report an unreadable tracked file instead of throwing

### DIFF
--- a/scripts/docs/verify-docs.mjs
+++ b/scripts/docs/verify-docs.mjs
@@ -125,10 +125,27 @@ function linkDiagnostics(file, tree, scope) {
   return diagnostics
 }
 
+function readTrackedText(repoRoot, file, diagnostics) {
+  try {
+    return fs.readFileSync(path.join(repoRoot, file), 'utf8')
+  }
+  catch {
+    // The file list comes from `git ls-files`, i.e. the index, but the read is from the working
+    // tree. A directory move staged in halves, an interrupted rebase, or a deletion that has not
+    // been added yet puts those two out of step. Throwing here takes the whole run down and
+    // prints a Node stack instead of the findings, which reads as a broken tool rather than a
+    // tree mid-move. readTask already reports rather than throws; this matches it.
+    diagnostics.push(diagnostic('DOC-FILE-UNREADABLE', file, null, 'tracked file could not be read from the working tree'))
+    return undefined
+  }
+}
+
 export function checkMarkdownAndLinks(repoRoot, scope) {
   const diagnostics = []
   for (const file of scope.lintDocuments) {
-    const text = fs.readFileSync(path.join(repoRoot, file), 'utf8')
+    const text = readTrackedText(repoRoot, file, diagnostics)
+    if (text === undefined)
+      continue
     diagnostics.push(...markdownDiagnostics(file, text))
     try {
       const tree = unified().use(remarkParse).use(remarkMdc).parse(text)
@@ -339,7 +356,9 @@ function placeholderAllowed(file, token) {
 export function checkPlaceholders(repoRoot, scope) {
   const diagnostics = []
   for (const file of scope.activePrds) {
-    const text = fs.readFileSync(path.join(repoRoot, file), 'utf8')
+    const text = readTrackedText(repoRoot, file, diagnostics)
+    if (text === undefined)
+      continue
     let tree
     try {
       tree = unified().use(remarkParse).use(remarkMdc).parse(text)


### PR DESCRIPTION
Closes #1581

`verify-docs.mjs` takes its file list from `git ls-files` — the **index** — and reads each path from the **working tree**. When those disagree it threw:

```
Error: ENOENT: no such file or directory, open
  '.../.trellis/tasks/07-27-base-anchor-liquid-animation/prd.md'
    at checkPlaceholders (scripts/docs/verify-docs.mjs:342:21)
```

No diagnostics, no summary — **the other 119 findings that run had were never printed.** It reads as a broken tool rather than a tree caught between two states.

I hit it while archiving a task with the move staged in halves. An interrupted rebase, an unstaged deletion, or two agents sharing one worktree do the same.

## The file already had the convention

`readTask` catches and reports. Two readers did not — `checkMarkdownAndLinks:131` and `checkPlaceholders:342`. Both now go through a helper that follows `readTask`, emitting `DOC-FILE-UNREADABLE` and continuing.

## Verified in all three directions

| | result |
|---|---|
| fixed, file missing | `DOC-FILE-UNREADABLE=1` **and the other 113 findings still print** (114 total) |
| mutated back to a bare read, file missing | the same ENOENT stack returns |
| fixed, file restored | **113** — the untouched baseline |

The middle row is the one that matters: without it this would be a change that merely happens to pass.