### PR TITLE
fix(docs): stop sharing one /g regex between test and matchAll

### DIFF
--- a/scripts/docs/verify-docs.mjs
+++ b/scripts/docs/verify-docs.mjs
@@ -322,6 +322,12 @@ export function checkTasks(repoRoot, scope) {
 }
 
 const PLACEHOLDER = /\b(?:TBD|TODO\s*:\s*(?:fill|complete|determine)|to be determined|\[placeholder\])\b|<evidence>|待定|待填写|待补充|占位符|请填写/gi
+// `matchAll` requires the global flag; `test` is broken by it. A /g regex advances lastIndex on
+// every `test`, so the same string alternates true/false across calls -- a section whose only
+// content is TBD reads as substantive on the second look. Worse, `matchAll` inherits whatever
+// lastIndex the previous `test` left behind, so it can skip the first placeholder in a string.
+// One source, two objects, no shared cursor.
+const PLACEHOLDER_TEST = new RegExp(PLACEHOLDER.source, 'i')
 const REQUIRED_PRD_SECTION = /^(?:goal|objective|acceptance criteria|evidence|目标|验收标准|证据)$/i
 function sectionHasSubstantiveContent(nodes) {
   return nodes.some((node) => {
@@ -329,7 +335,7 @@ function sectionHasSubstantiveContent(nodes) {
       return false
     let substantive = false
     walk(node, (child) => {
-      if (child.type === 'text' && /[\p{L}\p{N}]/u.test(child.value) && !PLACEHOLDER.test(child.value))
+      if (child.type === 'text' && /[\p{L}\p{N}]/u.test(child.value) && !PLACEHOLDER_TEST.test(child.value))
         substantive = true
     })
     return substantive
@@ -370,7 +376,7 @@ export function checkPlaceholders(repoRoot, scope) {
     walk(tree, (node) => {
       if (node.type !== 'text' && node.type !== 'html')
         return
-      for (const match of node.value.matchAll(PLACEHOLDER)) {
+      for (const match of node.value.matchAll(new RegExp(PLACEHOLDER.source, 'gi'))) {
         const token = match[0]
         if (!placeholderAllowed(file, token))
           diagnostics.push(diagnostic('DOC-PRD-PLACEHOLDER', file, node.position?.start, `unresolved placeholder ${token}`))


### PR DESCRIPTION
Closes #1583

`PLACEHOLDER` is used two ways. `matchAll` **requires** the global flag; `.test()` is **broken** by it.

## Two consequences, both measured

**`test` on a `/g` regex is stateful** — the same input alternates `true`/`false`, so `!PLACEHOLDER.test(value)` reports *substantive* on every second call.

**`matchAll` inherits the leftover `lastIndex`** — it starts mid-string and skips the first placeholder:

```
test('TBD and TBD')          -> true, lastIndex=3
matchAll same string         -> one match at index 8     <- index 0 skipped
without the preceding test   -> matches at 0 and 8
```

## The rule was firing zero times

| | total | `DOC-PRD-PLACEHOLDER` |
|---|---|---|
| today | 113 | **absent** |
| with this change | **123** | **10** |
| both parts reverted | 113 | absent |

Ten real `- TBD` placeholders sit in tracked PRDs unreported. Spot-checked: `.trellis/tasks/08-05-reco-behavior-learning/prd.md:9` is literally `- TBD`.

**The count going up is the rule starting to work, not a regression.**

## A control I got wrong first

Reverting either part alone does **not** reproduce the bug — either one is enough to break the shared cursor. I ran both single-part reverts, saw 123 twice, and briefly concluded the ten findings were unrelated to my change. Measuring the untouched base (113) is what caught it. The mutation that matters reverts **both**.