### PR TITLE
fix(ci): fail plugin validation when discovery finds nothing

### DIFF
--- a/scripts/validate-plugins.mjs
+++ b/scripts/validate-plugins.mjs
@@ -107,6 +107,15 @@ const pluginDirs = entries
 
 console.log(`\nValidating ${pluginDirs.length} plugins in plugins/\n`)
 
+// Discovery returning nothing is not a pass. Every rule below -- dev leakage, the manifest
+// feature.platform shape, search-provider migration -- applies per plugin, so an empty list
+// makes the run assert nothing while still printing success and exiting 0. A moved directory,
+// a bad path after a refactor, or a partial checkout all land here (#1586).
+if (pluginDirs.length === 0) {
+  console.error('\x1B[31mNo plugin directories found in plugins/ — validation would pass without checking anything.\x1B[0m\n')
+  process.exit(1)
+}
+
 /**
  * Fails a plugin that ships with its development loader switched on.
  *


### PR DESCRIPTION
Closes #1586

`validate-plugins.mjs` reads `plugins/`, prints how many directories it found, validates each, and exits 0 if none errored. **It never checks that it found any.**

```
$ node scripts/validate-plugins.mjs      # with plugins/ emptied
All plugins validated successfully.
RC=0
```

Twenty-four directories exist today. **Zero produces the same verdict as twenty-four.**

## Why it matters

The gate runs in `ci.yml`. Anything that makes discovery return nothing — a moved directory, a bad path after a refactor, a partial checkout — turns it into a green check that asserted nothing, and every manifest rule it carries (dev leakage, the `feature.platform` shape from #820, search-provider migration) silently stops applying.

Same class as the `APP_COUNT` / `SNAP_COUNT` pair in `build-and-release.yml`: **a control whose failure mode is silence.** That file already guards with `-gt 0`, so this follows the established shape.

## Verified in three directions

| | result |
|---|---|
| 24 plugins | RC=0, unchanged |
| empty `plugins/` | **RC=1**, naming the reason |
| guard removed, empty `plugins/` | RC=0 — the silent pass returns |

The third row is the one that makes this more than a change that happens to pass.

## Scope

A count *floor* would also catch partial discovery, but it needs maintenance on every plugin added or removed. This covers only the zero case, which needs no decision.