### PR TITLE
test(ci): prove the plugin validator's detectors fire

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
       # until #1099 removed it (#1128). If the declaration this commit adds is wrong, this
       # step is where it shows up rather than in whichever release script runs next.
       - name: Validate plugin manifests and package policy
-        run: pnpm plugins:validate
+        run: pnpm plugins:validate && pnpm plugins:validate:self-test
 
       # `pnpm lint` reaches plugins either as workspaces or through a hand-maintained brace
       # list, and touch-dictation was in neither (#562). The list is the kind that drifts

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "release:notes:prepare": "node scripts/release-notes-gateway.mjs prepare",
     "release:notes:verify": "node scripts/release-notes-gateway.mjs verify",
     "plugins:validate": "tsx scripts/validate-plugin-package-policy.ts && node scripts/validate-plugins.mjs",
+    "plugins:validate:self-test": "node scripts/validate-plugins.mjs --self-test",
     "plugins:release:audit": "tsx scripts/plugin-source-package-audit.ts",
     "publish:check": "node scripts/validate-publish-manifests.mjs",
     "publish:check:pack": "node scripts/validate-publish-manifests.mjs --pack",

--- a/scripts/validate-plugins.mjs
+++ b/scripts/validate-plugins.mjs
@@ -100,6 +100,10 @@ function logOk(pluginName, message) {
 }
 
 // Discover plugin directories
+if (process.argv.includes('--self-test')) {
+  process.exit(selfTest() > 0 ? 1 : 0)
+}
+
 const entries = fs.readdirSync(pluginsDir, { withFileTypes: true })
 const pluginDirs = entries
   .filter(e => e.isDirectory())
@@ -111,7 +115,7 @@ console.log(`\nValidating ${pluginDirs.length} plugins in plugins/\n`)
 // feature.platform shape, search-provider migration -- applies per plugin, so an empty list
 // makes the run assert nothing while still printing success and exiting 0. A moved directory,
 // a bad path after a refactor, or a partial checkout all land here (#1586).
-if (pluginDirs.length === 0) {
+if (discoveryFoundNothing(pluginDirs)) {
   console.error('\x1B[31mNo plugin directories found in plugins/ — validation would pass without checking anything.\x1B[0m\n')
   process.exit(1)
 }
@@ -385,4 +389,74 @@ if (hasErrors) {
 }
 else {
   console.log('\x1B[32mAll plugins validated successfully.\x1B[0m\n')
+}
+
+/**
+ * Discovery returning nothing is not a pass (#1586). Pulled out of the call site so `--self-test`
+ * can reach it: the rule it encodes is exactly the one that cannot be observed from a normal run,
+ * because a validator that checked nothing looks identical to one where nothing was wrong.
+ */
+export function discoveryFoundNothing(pluginDirs) {
+  return !Array.isArray(pluginDirs) || pluginDirs.length === 0
+}
+
+/**
+ * Proves the detectors fire. Every case here is a manifest this script must reject; if a refactor
+ * makes one of them pass, CI says so instead of reporting a clean sweep over inputs it stopped
+ * reading. Mirrors the shape used by check-plugin-lint-coverage.mjs and check-action-pins.mjs.
+ */
+function selfTest() {
+  const cases = [
+    {
+      name: 'discovery finding nothing fails rather than reporting success',
+      run: () => discoveryFoundNothing([]),
+      expect: true,
+    },
+    {
+      name: 'discovery finding plugins does not fail',
+      run: () => discoveryFoundNothing(['touch-snipaste']),
+      expect: false,
+    },
+    {
+      name: 'a committed dev.enable is caught',
+      run: () => checkDevLeakage('probe', { enable: true, address: 'http://localhost:3333/' }, 'manifest.json'),
+      expect: true,
+    },
+    {
+      name: 'dev.enable false is allowed',
+      run: () => checkDevLeakage('probe', { enable: false }, 'manifest.json'),
+      expect: false,
+    },
+    {
+      name: 'the runtime addFeature platform shape is rejected in a manifest',
+      run: () => checkFeaturePlatformShape('probe', [{ id: 'f', platform: { win: { enable: true, arch: [], os: [] } } }]),
+      expect: true,
+    },
+    {
+      name: 'a non-boolean manifest platform value is rejected',
+      run: () => checkFeaturePlatformShape('probe', [{ id: 'f', platform: { win32: 'yes', darwin: false, linux: false } }]),
+      expect: true,
+    },
+    {
+      name: 'the manifest platform shape is accepted',
+      run: () => checkFeaturePlatformShape('probe', [{ id: 'f', platform: { win32: true, darwin: false, linux: false } }]),
+      expect: false,
+    },
+  ]
+
+  let failures = 0
+  for (const testCase of cases) {
+    const actual = testCase.run()
+    if (actual === testCase.expect) {
+      console.log(`  \x1B[32m✓\x1B[0m ${testCase.name}`)
+    }
+    else {
+      console.error(`  \x1B[31m✗\x1B[0m ${testCase.name}: expected ${testCase.expect}, got ${actual}`)
+      failures += 1
+    }
+  }
+  console.log(failures === 0
+    ? '\n\x1B[32mvalidate-plugins self-test passed.\x1B[0m\n'
+    : `\n\x1B[31mvalidate-plugins self-test failed: ${failures} case(s).\x1B[0m\n`)
+  return failures
 }


### PR DESCRIPTION
Follows #1586 / #1587.

That PR fixed a validator reporting success over an empty `plugins/`. **Nothing would have caught it, and nothing would catch the next one** — a validator that checked nothing looks exactly like a validator that found nothing wrong.

## The repo already had the answer

Four checks carry a `--self-test` that builds failing inputs and asserts the detector fires:

```
check:doc-metadata:self-test
check:plugin-lint-coverage:self-test
check:action-pins:self-test
check:workflow-injection:self-test
```

`check-plugin-lint-coverage.mjs` even states the reason in its header: *"a coverage checker that matches nothing looks exactly like full coverage."*

**`plugins:validate` was missing from that set** — which is why the empty-directory hole survived.

## What this adds

Seven cases over `checkDevLeakage`, `checkFeaturePlatformShape`, and the zero-discovery rule from #1586. That rule becomes a function rather than an inline condition so `--self-test` can reach it — it is precisely the rule a normal run cannot demonstrate.

## Mutation-checked in both directions

| mutation | result |
|---|---|
| `checkFeaturePlatformShape` forced to `false` | **2 cases fail** |
| the zero-discovery rule forced to `false` | **1 case fails** |
| restored | self-test **and** the real run both pass |

Without that table this would be a test that cannot fail — the thing it exists to prevent.

CI runs it next to the check, matching how the other four are wired.