### PR TITLE
docs(native): record why writeDarwinAppIcon blocks, and what not to try

### DIFF
--- a/packages/tuff-native/index.d.ts
+++ b/packages/tuff-native/index.d.ts
@@ -47,6 +47,11 @@ export interface DarwinAppIconWriteResult {
   height: number
 }
 
+/**
+ * Resolves a Promise, but blocks the calling thread while it works: the underlying AppKit call
+ * must run on the main thread, which in Electron is the JS thread. ~28 ms p50 per app on a cold
+ * index. See the note in index.js and #857.
+ */
 export declare function writeDarwinAppIcon(
   options: DarwinAppIconWriteOptions,
 ): Promise<DarwinAppIconWriteResult>

--- a/packages/tuff-native/index.js
+++ b/packages/tuff-native/index.js
@@ -66,6 +66,24 @@ async function recognizeImageText(options) {
   return nativeBinding.recognizeImageText(options)
 }
 
+/**
+ * Writes a macOS app icon. `async` in signature only -- the work runs on the calling thread.
+ *
+ * `iconForFile:` is AppKit, and AppKit here means the main thread: app_icon.mm:140 rejects any
+ * other with `ERR_DARWIN_APP_ICON_WRONG_THREAD`. In Electron the main thread *is* the JS thread,
+ * so there is nowhere to move it to. An AsyncWorker version was written, compiled, and threw that
+ * error on the first call (#857) -- worth knowing before writing it a second time.
+ *
+ * The `setImmediate` below defers when the block starts, not that it blocks. Measured cost is
+ * ~28 ms p50 per app on a cold index; of that only ~6 ms is AppKit work
+ * (fetch 1.0 / draw 3.6 / encode 1.4 warm) and the rest is bundle icon I/O happening *inside*
+ * `iconForFile:`, which cannot leave the main thread either. Moving just the PNG encode and the
+ * file write off-thread would save single digits of the 28.
+ *
+ * The alternative is ImageIO, which is ~50x kinder to the event loop and returns the wrong asset:
+ * it hands back the light-paper icon where AppKit returns the dark-paper one, so on a dark-mode
+ * system essentially every modern app gets the wrong icon. That trade is open on #857.
+ */
 async function writeDarwinAppIcon(options) {
   if (
     !nativeBinding


### PR DESCRIPTION
Refs #857. The half of it that needs no decision.

## The signature lies

```js
async function writeDarwinAppIcon(options) {
  …
  await new Promise(resolve => setImmediate(resolve))
  return nativeBinding.writeDarwinAppIconSync(options)
}
```

`async`, a yield, and then a **Sync** call. The `setImmediate` defers *when* the block starts, not *that* it blocks — ~28 ms p50 per app on a cold index, on the JS thread.

## And it cannot be moved

`iconForFile:` is AppKit; `app_icon.mm:140` rejects any non-main thread with `ERR_DARWIN_APP_ICON_WRONG_THREAD`; in Electron the main thread **is** the JS thread.

An AsyncWorker version was written, compiled, and threw exactly that on its first call. That is the part worth having in the file: an `async` signature over blocking work is an open invitation to reach for a worker, and the next person would spend the same afternoon finding out it is impossible.

## Where the 28 ms goes

Only ~6 ms is AppKit work — `fetch 1.0 / draw 3.6 / encode 1.4` warm. The rest is bundle icon I/O happening *inside* `iconForFile:`, which cannot leave the main thread either. So moving just the PNG encode and the file write off-thread would save single digits of the 28, which is worth knowing before someone tries that as a compromise.

## Not decided here

The ImageIO alternative — ~50× kinder to the event loop, and returns the light-paper icon where AppKit returns the dark-paper one, so dark-mode users get the wrong asset for essentially every modern app — stays open on #857. This PR only records the constraint and the measurements.

Comments only. Runtime load, `index.d.ts` syntax, and core-app main-process typecheck all verified unchanged.