### PR TITLE
test(tuffex): prove the package-exports audit can fail

### DIFF
--- a/.github/workflows/package-tuffex-ci.yml
+++ b/.github/workflows/package-tuffex-ci.yml
@@ -38,4 +38,4 @@ jobs:
       # Only the two that pass today. audit:types is broken by construction and audit:size
       # has been over budget since well before this change -- both tracked in #1555, and
       # wiring them here would land a gate that is red on every PR.
-      post-build-command: pnpm audit:exports && pnpm audit:readme && pnpm audit:readme:self-test && pnpm audit:types && pnpm audit:size
+      post-build-command: pnpm audit:exports && pnpm audit:exports:self-test && pnpm audit:readme && pnpm audit:readme:self-test && pnpm audit:types && pnpm audit:size

--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -54,6 +54,7 @@
     "test": "vitest run",
     "typecheck": "vue-tsc --noEmit -p tsconfig.json",
     "audit:exports": "node ./scripts/audit-package-exports.mjs",
+    "audit:exports:self-test": "node ./scripts/audit-package-exports.mjs --self-test",
     "audit:types": "node ./scripts/audit-package-types.mjs",
     "audit:readme": "node ./scripts/audit-readme-inventory.mjs",
     "audit:readme:self-test": "node ./scripts/audit-readme-inventory.mjs --self-test",

--- a/packages/tuffex/scripts/audit-package-exports.mjs
+++ b/packages/tuffex/scripts/audit-package-exports.mjs
@@ -6,6 +6,9 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const root = resolve(__dirname, '..')
 const componentSrcRoot = resolve(root, 'packages/components/src')
+// Declared here rather than beside its use: declarationProblems runs from --self-test, which
+// exits before the filesystem work, so a const declared further down is still in its TDZ.
+const outsideUtilsPattern = /['"](?:\.\.\/)+utils(?:\/[\w.-]+)*['"]/
 const pkg = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf-8'))
 
 async function exists(relativePath) {
@@ -39,6 +42,17 @@ async function collectFiles(dir, predicate) {
 
 async function collectComponentSubpaths() {
   const dirents = await readdir(componentSrcRoot, { withFileTypes: true })
+  return publishableSubpaths(dirents)
+}
+
+/**
+ * Which directories under components/src are publishable subpaths.
+ *
+ * Pulled out so `--self-test` can pin it: this filter decides what the whole per-component
+ * existence sweep below even looks at, so a filter that quietly excludes too much reports a clean
+ * audit over a shrinking set -- indistinguishable from an audit that found nothing wrong (#1589).
+ */
+export function publishableSubpaths(dirents) {
   return dirents
     // Every directory under components/src is treated as a publishable component
     // subpath, so anything that is not one has to be excluded here. 'utils' is shared
@@ -49,6 +63,10 @@ async function collectComponentSubpaths() {
     .filter(dirent => dirent.isDirectory() && dirent.name !== 'utils' && !/^__.*__$/.test(dirent.name))
     .map(dirent => dirent.name)
     .sort()
+}
+
+if (process.argv.includes('--self-test')) {
+  process.exit(selfTest() > 0 ? 1 : 0)
 }
 
 const errors = []
@@ -76,21 +94,28 @@ for (const component of componentSubpaths) {
 }
 
 const declarationFiles = await collectFiles(resolve(root, 'dist/es'), filePath => filePath.endsWith('.d.ts'))
-const outsideUtilsPattern = /['"](?:\.\.\/)+utils(?:\/[\w.-]+)*['"]/
 for (const filePath of declarationFiles) {
   const source = await readFile(filePath, 'utf-8')
-  if (outsideUtilsPattern.test(source)) {
-    errors.push(`${filePath.replace(`${root}/`, './')} references package-external utils declarations`)
-  }
-  if (source.includes("import('vue').GlobalComponents")) {
-    errors.push(`${filePath.replace(`${root}/`, './')} references Vue GlobalComponents in emitted declarations`)
-  }
-  if (source.includes("import('vue').GlobalDirectives")) {
-    errors.push(`${filePath.replace(`${root}/`, './')} references Vue GlobalDirectives in emitted declarations`)
-  }
-  if (/\(\(event: "[^"]+", event:/.test(source)) {
-    errors.push(`${filePath.replace(`${root}/`, './')} contains duplicate event parameter names in emitted declarations`)
-  }
+  errors.push(...declarationProblems(filePath.replace(`${root}/`, './'), source))
+}
+
+/**
+ * The four content rules over emitted declarations. Text in, problems out.
+ *
+ * Three of them are plain `includes`, so a change in how vue-tsc emits these constructs would stop
+ * them matching and the audit would keep reporting success. `--self-test` is what notices.
+ */
+export function declarationProblems(label, source) {
+  const problems = []
+  if (outsideUtilsPattern.test(source))
+    problems.push(`${label} references package-external utils declarations`)
+  if (source.includes("import('vue').GlobalComponents"))
+    problems.push(`${label} references Vue GlobalComponents in emitted declarations`)
+  if (source.includes("import('vue').GlobalDirectives"))
+    problems.push(`${label} references Vue GlobalDirectives in emitted declarations`)
+  if (/\(\(event: "[^"]+", event:/.test(source))
+    problems.push(`${label} contains duplicate event parameter names in emitted declarations`)
+  return problems
 }
 
 if (errors.length > 0) {
@@ -102,3 +127,74 @@ if (errors.length > 0) {
 }
 
 console.log('[audit-package-exports] package exports are backed by dist files')
+
+/**
+ * Every case is an input the audit must reject, plus the clean ones it must accept. Same shape as
+ * audit-readme-inventory.mjs, validate-plugins.mjs and the four check:* gates.
+ */
+function selfTest() {
+  const dirent = (name, isDir = true) => ({ name, isDirectory: () => isDir })
+  const cases = [
+    {
+      name: 'a component directory is publishable',
+      run: () => publishableSubpaths([dirent('button'), dirent('input')]),
+      expect: 'button,input',
+    },
+    {
+      name: 'utils is not a publishable subpath',
+      run: () => publishableSubpaths([dirent('button'), dirent('utils')]),
+      expect: 'button',
+    },
+    {
+      name: '__tests__ is not a publishable subpath',
+      run: () => publishableSubpaths([dirent('button'), dirent('__tests__')]),
+      expect: 'button',
+    },
+    {
+      name: 'a file is not a publishable subpath',
+      run: () => publishableSubpaths([dirent('button'), dirent('index.ts', false)]),
+      expect: 'button',
+    },
+    {
+      name: 'a clean declaration is accepted',
+      run: () => declarationProblems('d.ts', "import type { Foo } from './types'\n"),
+      expect: '',
+    },
+    {
+      name: 'a package-external utils reference is caught',
+      run: () => declarationProblems('d.ts', "import type { X } from '../../utils/vibrate'\n"),
+      expect: 'd.ts references package-external utils declarations',
+    },
+    {
+      name: 'a Vue GlobalComponents reference is caught',
+      run: () => declarationProblems('d.ts', "declare module 'vue' { interface X extends import('vue').GlobalComponents {} }"),
+      expect: 'd.ts references Vue GlobalComponents in emitted declarations',
+    },
+    {
+      name: 'a Vue GlobalDirectives reference is caught',
+      run: () => declarationProblems('d.ts', "type X = import('vue').GlobalDirectives"),
+      expect: 'd.ts references Vue GlobalDirectives in emitted declarations',
+    },
+    {
+      name: 'duplicate event parameter names are caught',
+      run: () => declarationProblems('d.ts', 'declare const e: ((event: "change", event: string) => void)'),
+      expect: 'd.ts contains duplicate event parameter names in emitted declarations',
+    },
+  ]
+
+  let failures = 0
+  for (const testCase of cases) {
+    const actual = testCase.run().join(',')
+    if (actual === testCase.expect) {
+      console.log(`  \u001B[32m\u2713\u001B[0m ${testCase.name}`)
+    }
+    else {
+      console.error(`  \u001B[31m\u2717\u001B[0m ${testCase.name}: expected ${JSON.stringify(testCase.expect)}, got ${JSON.stringify(actual)}`)
+      failures += 1
+    }
+  }
+  console.log(failures === 0
+    ? '\naudit-package-exports self-test passed.\n'
+    : `\naudit-package-exports self-test failed: ${failures} case(s).\n`)
+  return failures
+}


### PR DESCRIPTION
Second of the four from #1589.

This audit carries two kinds of rule and only one of them is obviously safe.

The **existence** checks fail loudly when a declared export has no file — I mutation-checked that when wiring the audit into CI (#1556). The **four content rules over emitted declarations** are the exposed half: three are plain `includes`, so a change in how vue-tsc emits `GlobalComponents`, `GlobalDirectives` or duplicated event parameters would stop them matching and the audit would keep reporting success.

## Two seams, both pure

- `publishableSubpaths(dirents)` — decides what the per-component sweep even looks at. A filter that quietly excludes too much reports a clean audit over a shrinking set.
- `declarationProblems(label, source)` — the four content rules, text in, problems out.

Nine self-test cases across them.

## It caught my own bug first

`outsideUtilsPattern` was declared beside its use, below the `--self-test` exit. The first self-test run died with `Cannot access 'outsideUtilsPattern' before initialization` — a TDZ error that would have shipped. It moves up with the other constants, with a comment saying why.

## Mutation-checked

| | result |
|---|---|
| drop the `GlobalDirectives` rule | that case reports nothing, self-test exits 1 |
| restored | self-test passes **and** the real audit still reports `package exports are backed by dist files` against the built dist |

## One note on how this was assembled

My first push of this branch silently **reverted** #1590's `audit:readme:self-test` wiring. I had restored `ci.yml` with `git checkout --` in a worktree whose HEAD is on another agent's branch, predating that merge, then hashed that stale file into the commit. Rebuilt from `origin` content instead and force-updated the branch; the workflow line now carries both self-tests.