### PR TITLE
test(tuffex): prove the size audit's import scan still discriminates

### DIFF
--- a/.github/workflows/package-tuffex-ci.yml
+++ b/.github/workflows/package-tuffex-ci.yml
@@ -38,4 +38,4 @@ jobs:
       # Only the two that pass today. audit:types is broken by construction and audit:size
       # has been over budget since well before this change -- both tracked in #1555, and
       # wiring them here would land a gate that is red on every PR.
-      post-build-command: pnpm audit:exports && pnpm audit:exports:self-test && pnpm audit:readme && pnpm audit:readme:self-test && pnpm audit:types && pnpm audit:size
+      post-build-command: pnpm audit:exports && pnpm audit:exports:self-test && pnpm audit:readme && pnpm audit:readme:self-test && pnpm audit:types && pnpm audit:size && pnpm audit:size:self-test

--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -58,7 +58,8 @@
     "audit:types": "node ./scripts/audit-package-types.mjs",
     "audit:readme": "node ./scripts/audit-readme-inventory.mjs",
     "audit:readme:self-test": "node ./scripts/audit-readme-inventory.mjs --self-test",
-    "audit:size": "node ./scripts/audit-package-size.mjs"
+    "audit:size": "node ./scripts/audit-package-size.mjs",
+    "audit:size:self-test": "node ./scripts/audit-package-size.mjs --self-test"
   },
   "files": [
     "dist"

--- a/packages/tuffex/scripts/audit-package-size.mjs
+++ b/packages/tuffex/scripts/audit-package-size.mjs
@@ -417,6 +417,10 @@ async function auditDistSizes(errors) {
 
 const errors = []
 
+if (process.argv.includes('--self-test')) {
+  process.exit(selfTest() > 0 ? 1 : 0)
+}
+
 await auditDistSizes(errors)
 await auditOnDemandImports(errors)
 await auditRootImports(errors)
@@ -431,3 +435,88 @@ if (errors.length > 0) {
 }
 
 console.log('[audit-package-size] package size and Core App root import budgets are within limits')
+
+/**
+ * Proves the two functions the on-demand budget rests on still discriminate.
+ *
+ * `collectRuntimeSpecifiers` is a regex over emitted JS: if a change in output shape stops it
+ * matching, every on-demand entry reports an empty import graph and the budget passes over
+ * nothing. `resolveRuntimeSpecifier` decides what counts as an in-package runtime edge, so an
+ * over-eager filter has the same effect. Neither failure is visible from a green run (#1589).
+ */
+function selfTest() {
+  const inDist = file => `${distEs}/${file}`
+  const cases = [
+    {
+      name: 'a default import is collected',
+      run: () => collectRuntimeSpecifiers("import a from './a'"),
+      expect: './a',
+    },
+    {
+      name: 'a side-effect import is collected',
+      run: () => collectRuntimeSpecifiers("import './a.css'"),
+      expect: './a.css',
+    },
+    {
+      name: 'a re-export is collected',
+      run: () => collectRuntimeSpecifiers("export * from './b/index'"),
+      expect: './b/index',
+    },
+    {
+      name: 'a named re-export is collected',
+      run: () => collectRuntimeSpecifiers("export { x } from './c'"),
+      expect: './c',
+    },
+    {
+      name: 'several specifiers are all collected',
+      run: () => collectRuntimeSpecifiers("import a from './a'\nexport * from './b'\n"),
+      expect: './a,./b',
+    },
+    {
+      name: 'source with no imports collects nothing',
+      run: () => collectRuntimeSpecifiers('const x = 1'),
+      expect: '',
+    },
+    {
+      name: 'a relative sibling resolves to an in-package edge',
+      run: () => [resolveRuntimeSpecifier(inDist('button/index.js'), './style') ?? 'null'],
+      expect: `${distEs}/button/style`,
+    },
+    {
+      name: 'a bare specifier is not an in-package edge',
+      run: () => [resolveRuntimeSpecifier(inDist('button/index.js'), 'vue') ?? 'null'],
+      expect: 'null',
+    },
+    {
+      name: 'a css specifier is not a runtime edge',
+      run: () => [resolveRuntimeSpecifier(inDist('button/index.js'), './style.css') ?? 'null'],
+      expect: 'null',
+    },
+    {
+      name: 'an edge leaving dist/es is not followed',
+      run: () => [resolveRuntimeSpecifier(inDist('button/index.js'), '../../../outside') ?? 'null'],
+      expect: 'null',
+    },
+    {
+      name: 'a node_modules edge is not followed',
+      run: () => [resolveRuntimeSpecifier(inDist('button/index.js'), './node_modules/x') ?? 'null'],
+      expect: 'null',
+    },
+  ]
+
+  let failures = 0
+  for (const testCase of cases) {
+    const actual = testCase.run().join(',')
+    if (actual === testCase.expect) {
+      console.log(`  \u001B[32m\u2713\u001B[0m ${testCase.name}`)
+    }
+    else {
+      console.error(`  \u001B[31m\u2717\u001B[0m ${testCase.name}: expected ${JSON.stringify(testCase.expect)}, got ${JSON.stringify(actual)}`)
+      failures += 1
+    }
+  }
+  console.log(failures === 0
+    ? '\naudit-package-size self-test passed.\n'
+    : `\naudit-package-size self-test failed: ${failures} case(s).\n`)
+  return failures
+}


### PR DESCRIPTION
Third of the four from #1589.

The budget comparisons are plain `>` checks against measured bytes and fail loudly. The **on-demand import budget** rests on two functions that can stop discriminating with nothing looking wrong:

| | risk |
|---|---|
| `collectRuntimeSpecifiers` | a regex over emitted JS — if the output shape changes and it stops matching, every on-demand entry reports an **empty import graph** and the budget passes over nothing |
| `resolveRuntimeSpecifier` | decides what counts as an in-package runtime edge; an over-eager filter has the same effect |

Eleven self-test cases: the four import and re-export forms, a source with no imports, and the five specifier kinds that must or must not resolve to an in-package edge.

## Mutation-checked in both directions

| mutation | result |
|---|---|
| regex narrowed to `import` only | **3 cases fail** — both re-export forms and the multi-specifier case |
| `node_modules` exclusion removed | that case resolves instead of returning `null` |
| restored | self-test passes **and** the real audit still reports budgets within limits |

## A control I had to redo

My first attempt at the regex mutation had a quoting error in the patch script, so it never applied and the run reported `RC=0`. **That is a mutation that proves nothing, not a passing control.** Redone from a file with an assertion on the anchor count — which is how the second attempt caught all three cases.

Built on the base with #1592 already merged, so the `post-build-command` line carries all three self-tests rather than conflicting with it.