### PR TITLE
test(tuffex): pin what the types audit is actually checking

### DIFF
--- a/.github/workflows/package-tuffex-ci.yml
+++ b/.github/workflows/package-tuffex-ci.yml
@@ -38,4 +38,4 @@ jobs:
       # Only the two that pass today. audit:types is broken by construction and audit:size
       # has been over budget since well before this change -- both tracked in #1555, and
       # wiring them here would land a gate that is red on every PR.
-      post-build-command: pnpm audit:exports && pnpm audit:exports:self-test && pnpm audit:readme && pnpm audit:readme:self-test && pnpm audit:types && pnpm audit:size && pnpm audit:size:self-test
+      post-build-command: pnpm audit:exports && pnpm audit:exports:self-test && pnpm audit:readme && pnpm audit:readme:self-test && pnpm audit:types && pnpm audit:types:self-test && pnpm audit:size && pnpm audit:size:self-test

--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -56,6 +56,7 @@
     "audit:exports": "node ./scripts/audit-package-exports.mjs",
     "audit:exports:self-test": "node ./scripts/audit-package-exports.mjs --self-test",
     "audit:types": "node ./scripts/audit-package-types.mjs",
+    "audit:types:self-test": "node ./scripts/audit-package-types.mjs --self-test",
     "audit:readme": "node ./scripts/audit-readme-inventory.mjs",
     "audit:readme:self-test": "node ./scripts/audit-readme-inventory.mjs --self-test",
     "audit:size": "node ./scripts/audit-package-size.mjs",

--- a/packages/tuffex/scripts/audit-package-types.mjs
+++ b/packages/tuffex/scripts/audit-package-types.mjs
@@ -32,6 +32,98 @@ async function runPnpm(args, cwd) {
   await run('pnpm', args, cwd)
 }
 
+/** The sample the audit typechecks. Named so `--self-test` can assert it still exercises the surface. */
+export const SAMPLE_SOURCE = `import { TxButton, type TxButtonProps } from '@talex-touch/tuffex/button'
+import { asTrustedDialogHtml, type TouchTipProps, type TrustedDialogHtml } from '@talex-touch/tuffex/dialog'
+import { TxInput } from '@talex-touch/tuffex/input'
+import { TxSelect, type TxSelectValue } from '@talex-touch/tuffex/select'
+import { useVibrate, type VibrateType } from '@talex-touch/tuffex/utils'
+
+const variant: TxButtonProps['variant'] = 'primary'
+const value: TxSelectValue = 'demo'
+const vibrateType: VibrateType = 'light'
+const trustedHtml: TrustedDialogHtml = asTrustedDialogHtml('<strong>trusted</strong>')
+const touchTipProps: TouchTipProps = {
+  messageHtml: trustedHtml,
+  buttons: [],
+  close: () => {},
+}
+
+// @ts-expect-error Dialog HTML must be explicitly marked trusted.
+const unsafeHtml: TrustedDialogHtml = '<strong>unsafe</strong>'
+
+useVibrate(vibrateType)
+console.log(Boolean(TxButton), Boolean(TxInput), Boolean(TxSelect), variant, value, touchTipProps, unsafeHtml)
+`
+
+/** The compiler options the sample is checked under. */
+export const TSCONFIG = {
+    compilerOptions: {
+      target: 'ES2020',
+      module: 'ESNext',
+      moduleResolution: 'bundler',
+      strict: true,
+      skipLibCheck: false,
+      lib: ['DOM', 'DOM.Iterable', 'ESNext'],
+    },
+    include: ['index.ts'],
+  }
+
+/** Subpaths the sample is meant to cover. Losing one silently shrinks what the audit proves. */
+export const COVERED_SUBPATHS = ['button', 'dialog', 'input', 'select', 'utils']
+
+/**
+ * What this audit rests on besides tsc.
+ *
+ * tsc reports real errors loudly, so the failure worth guarding is the harness quietly checking
+ * less: a sample that stops importing a subpath, a sample with no `@ts-expect-error` left (nothing
+ * then proves tsc is type-checking rather than merely resolving), or skipLibCheck flipped to true
+ * -- measured: with it true, every declaration error in this package disappears (#1589).
+ */
+export function harnessProblems(sample, tsconfig, covered = COVERED_SUBPATHS) {
+  const problems = []
+  for (const subpath of covered) {
+    if (!sample.includes(`@talex-touch/tuffex/${subpath}`))
+      problems.push(`sample no longer imports @talex-touch/tuffex/${subpath}`)
+  }
+  if (!sample.includes('@ts-expect-error'))
+    problems.push('sample has no @ts-expect-error left, so nothing proves tsc is checking types')
+  if (tsconfig?.compilerOptions?.skipLibCheck !== false)
+    problems.push('skipLibCheck must stay false or the published declarations are not checked')
+  if (tsconfig?.compilerOptions?.strict !== true)
+    problems.push('strict must stay true')
+  return problems
+}
+
+function selfTest() {
+  const strip = (source, subpath) => source.replace(`@talex-touch/tuffex/${subpath}`, '@talex-touch/tuffex/other')
+  const opts = extra => ({ compilerOptions: { ...TSCONFIG.compilerOptions, ...extra } })
+  const cases = [
+    { name: 'the shipped sample and tsconfig pass', run: () => harnessProblems(SAMPLE_SOURCE, TSCONFIG), expect: '' },
+    { name: 'a dropped subpath import is caught', run: () => harnessProblems(strip(SAMPLE_SOURCE, 'select'), TSCONFIG), expect: 'sample no longer imports @talex-touch/tuffex/select' },
+    { name: 'a sample with no ts-expect-error is caught', run: () => harnessProblems(SAMPLE_SOURCE.replace('@ts-expect-error', 'ts-was-expected'), TSCONFIG), expect: 'sample has no @ts-expect-error left, so nothing proves tsc is checking types' },
+    { name: 'skipLibCheck flipped to true is caught', run: () => harnessProblems(SAMPLE_SOURCE, opts({ skipLibCheck: true })), expect: 'skipLibCheck must stay false or the published declarations are not checked' },
+    { name: 'strict turned off is caught', run: () => harnessProblems(SAMPLE_SOURCE, opts({ strict: false })), expect: 'strict must stay true' },
+  ]
+  let failures = 0
+  for (const testCase of cases) {
+    const actual = testCase.run().join(',')
+    if (actual === testCase.expect) {
+      console.log(`  \u001B[32m\u2713\u001B[0m ${testCase.name}`)
+    }
+    else {
+      console.error(`  \u001B[31m\u2717\u001B[0m ${testCase.name}: expected ${JSON.stringify(testCase.expect)}, got ${JSON.stringify(actual)}`)
+      failures += 1
+    }
+  }
+  console.log(failures === 0 ? '\naudit-package-types self-test passed.\n' : `\naudit-package-types self-test failed: ${failures} case(s).\n`)
+  return failures
+}
+
+if (process.argv.includes('--self-test')) {
+  process.exit(selfTest() > 0 ? 1 : 0)
+}
+
 const workspace = await mkdtemp(join(tmpdir(), 'tuffex-types-'))
 
 // Install the tarball, not the source directory.
@@ -63,46 +155,9 @@ await writeFile(
   }),
 )
 
-await writeFile(
-  join(workspace, 'index.ts'),
-  `import { TxButton, type TxButtonProps } from '@talex-touch/tuffex/button'
-import { asTrustedDialogHtml, type TouchTipProps, type TrustedDialogHtml } from '@talex-touch/tuffex/dialog'
-import { TxInput } from '@talex-touch/tuffex/input'
-import { TxSelect, type TxSelectValue } from '@talex-touch/tuffex/select'
-import { useVibrate, type VibrateType } from '@talex-touch/tuffex/utils'
+await writeFile(join(workspace, 'index.ts'), SAMPLE_SOURCE)
 
-const variant: TxButtonProps['variant'] = 'primary'
-const value: TxSelectValue = 'demo'
-const vibrateType: VibrateType = 'light'
-const trustedHtml: TrustedDialogHtml = asTrustedDialogHtml('<strong>trusted</strong>')
-const touchTipProps: TouchTipProps = {
-  messageHtml: trustedHtml,
-  buttons: [],
-  close: () => {},
-}
-
-// @ts-expect-error Dialog HTML must be explicitly marked trusted.
-const unsafeHtml: TrustedDialogHtml = '<strong>unsafe</strong>'
-
-useVibrate(vibrateType)
-console.log(Boolean(TxButton), Boolean(TxInput), Boolean(TxSelect), variant, value, touchTipProps, unsafeHtml)
-`,
-)
-
-await writeFile(
-  join(workspace, 'tsconfig.json'),
-  JSON.stringify({
-    compilerOptions: {
-      target: 'ES2020',
-      module: 'ESNext',
-      moduleResolution: 'bundler',
-      strict: true,
-      skipLibCheck: false,
-      lib: ['DOM', 'DOM.Iterable', 'ESNext'],
-    },
-    include: ['index.ts'],
-  }),
-)
+await writeFile(join(workspace, 'tsconfig.json'), JSON.stringify(TSCONFIG))
 
 await runPnpm(['install', '--ignore-scripts', '--silent'], workspace)
 await runPnpm(['exec', 'tsc', '--noEmit', '-p', 'tsconfig.json'], workspace)


### PR DESCRIPTION
Last of the four from #1589 — and the one that does **not** take the shape the other three did.

This audit has no detection logic of its own. **tsc is the detector**, and tsc reports real errors loudly. So there is no regex or filter to pin. What can rot is the harness around it, quietly checking less while still printing success:

| | consequence |
|---|---|
| the sample stops importing a subpath | that part of the published surface is no longer compiled |
| the sample loses its `@ts-expect-error` | nothing left shows tsc is *type-checking* rather than merely resolving |
| `skipLibCheck` flips to `true` | **measured while investigating #1557: every declaration error in this package disappears** — the audit would pass over a type surface that does not resolve |

## What this adds

The sample and compiler options become `SAMPLE_SOURCE` and `TSCONFIG`; `harnessProblems()` states those three rules plus `strict`. Five self-test cases.

## Mutation-checked

| | result |
|---|---|
| drop the `skipLibCheck` rule | that case reports nothing, self-test exits 1 |
| restored | self-test passes **and** the real audit still packs, installs and reports `package subpath declarations compile in an external project` |

## It caught its own ordering bug first

The constants were appended below the `--self-test` exit and were still in their temporal dead zone — `Cannot access 'SAMPLE_SOURCE' before initialization`. Same mistake as `audit-package-exports.mjs` in #1592, same fix. **Third time a self-test has failed on my change rather than the code's** in this series.

With this, all four tuffex audits and `plugins:validate` carry a self-test, matching the four `check:*` gates and the two core-app ones.