### PR TITLE
ci: pin the main process's implicit-any debt so it stops growing

### DIFF
--- a/scripts/check-implicit-any-debt.mjs
+++ b/scripts/check-implicit-any-debt.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Stops the Electron main process accumulating more implicit `any` (#548).
+ *
+ * `@electron-toolkit/tsconfig` sets `noImplicitAny: false` alongside `strict: true`, and
+ * `apps/core-app/tsconfig.node.json` inherits it. The renderer already overrides it back on
+ * (`tsconfig.web.json`), so this is a main-process-only debt now, whatever the issue title says.
+ *
+ * Turning it on outright is 227 errors across 49 files, concentrated in the plugin host and the
+ * privacy modules -- a real piece of work, and which of those to type first is a judgement about
+ * where the risk is. What does not need a judgement is that the number should not grow while that
+ * waits: every new untyped parameter lands silently today, because the flag that would name it is
+ * off.
+ *
+ * So this pins the count and fails when it grows. It is a ratchet, not a fix: the number below is
+ * a debt, and lowering it is the repair. It fails in both directions -- if the count drops, it
+ * says so and asks for the pin to come down, so repair work moves the floor instead of leaving
+ * slack for the next regression to hide in.
+ */
+import { execFile } from 'node:child_process'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const CORE_APP = path.join(REPO_ROOT, 'apps/core-app')
+
+/**
+ * Implicit-any diagnostics in the main process, as of the pin below.
+ *
+ * Measured with `tsc -p tsconfig.node.json --composite false --noImplicitAny`, counting TS7xxx
+ * only -- every error the flag produces is in that range, so a rise here is new untyped code and
+ * not some unrelated type break.
+ */
+export const KNOWN_IMPLICIT_ANY_ERRORS = 227
+
+/** Resolves the workspace's own tsc rather than trusting a .bin shim on PATH. */
+function resolveTsc() {
+  const require = createRequire(import.meta.url)
+  return require.resolve('typescript/bin/tsc', { paths: [REPO_ROOT] })
+}
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * Counts TS7xxx diagnostics the main-process project reports under `--noImplicitAny`.
+ *
+ * Async on purpose. The synchronous form blocked a vitest worker for the ~30s tsc takes on CI,
+ * which starved the reporter's RPC channel and failed the run with
+ * `[vitest-worker]: Timeout calling "onTaskUpdate"` while every assertion passed.
+ */
+export async function countImplicitAnyErrors() {
+  let output = ''
+  try {
+    const result = await execFileAsync(
+      process.execPath,
+      [
+        resolveTsc(),
+        '--noEmit',
+        '-p',
+        'tsconfig.node.json',
+        '--composite',
+        'false',
+        '--noImplicitAny',
+      ],
+      { cwd: CORE_APP, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
+    )
+    output = result.stdout ?? ''
+  }
+  catch (error) {
+    // tsc exits non-zero when it reports anything, which is the expected case here.
+    output = `${error.stdout ?? ''}${error.stderr ?? ''}`
+  }
+
+  const lines = output.split('\n').filter(line => /error TS7\d+:/.test(line))
+  return { count: lines.length, lines }
+}
+
+async function main() {
+  const { count } = await countImplicitAnyErrors()
+
+  if (count > KNOWN_IMPLICIT_ANY_ERRORS) {
+    process.stderr.write(
+      `[check-implicit-any-debt] ${count} implicit-any errors in the main process, up from `
+      + `${KNOWN_IMPLICIT_ANY_ERRORS}. Type the new parameters rather than widening the debt.\n`,
+    )
+    process.exit(1)
+  }
+
+  if (count < KNOWN_IMPLICIT_ANY_ERRORS) {
+    process.stderr.write(
+      `[check-implicit-any-debt] only ${count} implicit-any errors remain, down from `
+      + `${KNOWN_IMPLICIT_ANY_ERRORS}. Lower KNOWN_IMPLICIT_ANY_ERRORS to ${count} so the floor `
+      + `moves with the repair.\n`,
+    )
+    process.exit(1)
+  }
+
+  process.stdout.write(`[check-implicit-any-debt] main process holds at ${count} implicit-any errors\n`)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main()
+}

--- a/scripts/check-implicit-any-debt.test.mjs
+++ b/scripts/check-implicit-any-debt.test.mjs
@@ -1,0 +1,43 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import {
+  countImplicitAnyErrors,
+  KNOWN_IMPLICIT_ANY_ERRORS,
+} from './check-implicit-any-debt.mjs'
+
+/**
+ * The ratchet guarding #548. Runs against the real project, which is the point: a pin that only
+ * ever sees fixtures cannot tell you the debt moved.
+ *
+ * tsc runs once for all three assertions. Three separate runs cost ~90s on CI and, being three
+ * separate awaits inside one worker, gave the reporter that much longer to sit idle.
+ */
+describe('main-process implicit-any debt', () => {
+  let measured
+
+  beforeAll(async () => {
+    measured = await countImplicitAnyErrors()
+  }, 300_000)
+
+  it('still measures something, so the pin is not being compared against an empty run', () => {
+    // Positive control. A wrong project path, a tsc that failed to launch, or a changed
+    // diagnostic format would all return 0, and every assertion below would pass for the wrong
+    // reason -- silently declaring the debt repaired.
+    expect(measured.count).toBeGreaterThan(0)
+    expect(measured.lines[0]).toMatch(/error TS7\d+:/)
+  })
+
+  it('holds at the pinned count, in both directions', () => {
+    // Above the pin is new untyped code. Below it is repair work that did not move the floor,
+    // which leaves slack for the next regression to hide in.
+    expect(measured.count).toBe(KNOWN_IMPLICIT_ANY_ERRORS)
+  })
+
+  it('counts only implicit-any diagnostics, not every error the project can produce', () => {
+    // The pin means "untyped parameters", not "type errors". If an unrelated break were counted,
+    // fixing it would push the number below the pin and read as repair.
+    for (const line of measured.lines) {
+      expect(line).toMatch(/error TS7\d+:/)
+    }
+  })
+})


### PR DESCRIPTION
Refs #548. The part that needs no judgement call.

## The issue title is half stale

`@electron-toolkit/tsconfig` sets `noImplicitAny: false` alongside `strict: true`, and `apps/core-app/tsconfig.node.json` inherits it. But **the renderer half is already done** — `tsconfig.web.json:9` overrides the flag back on and the renderer typechecks clean under it.

So this is main-process-only now:

```
tsc -p tsconfig.node.json --composite false --noImplicitAny
  → 227 errors, all TS7xxx, across 49 files

  21  plugin/plugin-module.ts
  19  plugin/host/plugin-host-child-runtime.ts
  17  plugin/host/plugin-business-capabilities.ts
  16  plugin/host/plugin-runtime-service.ts
  14  privacy/privacy-secret-service.ts
```

## Why a ratchet rather than a fix

Typing 49 files is real work, and which to do first is a judgement about where the risk is. That judgement is not needed to stop the number *growing* — and right now a new untyped parameter lands silently, because the flag that would name it is off.

Same shape already used twice in this repo: the drizzle snapshot gap (#1303) and the CSS budgets (#1555).

**It fails in both directions.** Above the pin is new untyped code; below it is repair that did not move the floor, leaving slack for the next regression to hide in.

## Tests

Three, under `test:scripts` in the blocking **PR Quality** job.

The first is a positive control: a wrong project path, a tsc that failed to launch, or a changed diagnostic format would all return `0` — and every other assertion would pass for the wrong reason, silently reporting the debt as repaired. So the suite asserts it still *measures* something before it asserts the number.

| mutation | result |
|---|---|
| add an untyped callback parameter | **fails** |
| mis-state the pin (227 → 300) | **fails** |

Counting is restricted to `TS7xxx` deliberately: the pin means "untyped parameters", not "type errors". Otherwise fixing an unrelated break would push the count under the pin and read as repair.

## Cost

~11s. Resolves `tsc` through the workspace rather than a `.bin` shim, since those are stale in this checkout (#1564).

`test:scripts` full run: **222 tests, 22 files, all pass.** eslint clean on both new files.