### PR TITLE
test(core-box): install a vue-i18n stub for ActivatedProviders

### DIFF
--- a/apps/core-app/src/renderer/src/views/box/ActivatedProviders.test.ts
+++ b/apps/core-app/src/renderer/src/views/box/ActivatedProviders.test.ts
@@ -4,6 +4,14 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import ActivatedProviders from './ActivatedProviders.vue'
 
+// The component calls useI18n() in setup for the close control's accessible name, so mounting it
+// without vue-i18n installed throws `Need to install with \`app.use\` function` before a single
+// assertion runs. Mocked rather than installed: these cases are about icon colour mode, and the
+// translated string is not what they check. Same shape as WhatsChangedDialog.test.ts.
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key })
+}))
+
 vi.mock('@talex-touch/tuffex/icon', () => ({
   TxIcon: {
     name: 'TxIcon',


### PR DESCRIPTION
Two of the ten failures in #1596.

`ActivatedProviders.vue` calls `useI18n()` in setup for the close control's accessible name (#510). The test mounts it **without vue-i18n installed**, so both cases threw before a single assertion ran:

```
SyntaxError: Need to install with `app.use` function
  ❯ useI18n  vue-i18n.mjs
  ❯ setup    ActivatedProviders.vue:38:15
```

Deterministic, not flaky — it reproduces locally on the first try.

## Mocked rather than installed

These two cases are about **icon colour mode** — monochrome tinting and colourful assets passing through. The translated string is not what they assert, so a stub `t` keeps the test about its subject. Same shape as `WhatsChangedDialog.test.ts`, which mocks `vue-i18n` for the same reason.

## Mutation-checked

Removing the mock brings both failures straight back; with it, `Tests 2 passed`.

## Why nobody saw it

`App suites (core-app)` runs with `continue-on-error`, so the step reports success whatever the tests do. These were only visible by downloading the JUnit artifact and parsing it — which is what #1596 is about.