### PR TITLE
ci: pin how many windows ship transparent with no background colour

### DIFF
--- a/scripts/check-transparent-window-debt.mjs
+++ b/scripts/check-transparent-window-debt.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Stops new transparent windows shipping without a background colour (#806).
+ *
+ * `touch-window.ts` branches `darwin` -> vibrancy, `win32` -> mica/acrylic, and falls through
+ * with no `else`. Linux is a shipped target -- `electron-builder.yml` builds AppImage and deb --
+ * so on a desktop without a compositor, or one that handles ARGB visuals differently, a
+ * `transparent: true` window with no `backgroundColor` renders black or invisible. There is no
+ * fallback to catch it, and nothing in the tree detects a compositor.
+ *
+ * Six of the eight window option sets are in that shape today. Fixing them is a rendering change
+ * on a platform this repo has no runner for, so it needs someone who can look at the result --
+ * that is the decision on #806. What needs no decision is that a seventh should not appear while
+ * that waits, because each one lands silently: it looks correct on macOS and Windows, which is
+ * where it gets reviewed.
+ *
+ * A ratchet, not a fix. The number below is a debt, and lowering it is the repair. It fails in
+ * both directions so a repair moves the floor with it.
+ */
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const WINDOW_CONFIG = path.join(REPO_ROOT, 'apps/core-app/src/main/config/default.ts')
+
+/** Window option sets that are transparent with no `backgroundColor`, as of the pin. */
+export const KNOWN_TRANSPARENT_WITHOUT_BACKGROUND = 6
+
+/** Every exported `*WindowOption` in the config, with the two fields that matter. */
+export function readWindowOptions() {
+  const source = readFileSync(WINDOW_CONFIG, 'utf8')
+  const blocks = source.split(/(?=^export const \w+WindowOption)/m)
+
+  return blocks
+    .map((block) => {
+      const name = /^export const (\w+WindowOption)/.exec(block)?.[1]
+      if (!name)
+        return null
+
+      const transparent = /^\s*transparent:\s*(true|false)/m.exec(block)?.[1]
+      return {
+        name,
+        transparent: transparent === 'true',
+        hasBackgroundColor: /^\s*backgroundColor:/m.test(block),
+      }
+    })
+    .filter(Boolean)
+}
+
+/** The subset with nothing to fall back to when the compositor does not cooperate. */
+export function transparentWithoutBackground(options = readWindowOptions()) {
+  return options.filter(option => option.transparent && !option.hasBackgroundColor)
+}
+
+function main() {
+  const options = readWindowOptions()
+  const risky = transparentWithoutBackground(options)
+
+  if (risky.length > KNOWN_TRANSPARENT_WITHOUT_BACKGROUND) {
+    process.stderr.write(
+      `[check-transparent-window-debt] ${risky.length} window options are transparent with no `
+      + `backgroundColor, up from ${KNOWN_TRANSPARENT_WITHOUT_BACKGROUND}: `
+      + `${risky.map(option => option.name).join(', ')}\n`,
+    )
+    process.exit(1)
+  }
+
+  if (risky.length < KNOWN_TRANSPARENT_WITHOUT_BACKGROUND) {
+    process.stderr.write(
+      `[check-transparent-window-debt] only ${risky.length} remain, down from `
+      + `${KNOWN_TRANSPARENT_WITHOUT_BACKGROUND}. Lower KNOWN_TRANSPARENT_WITHOUT_BACKGROUND to `
+      + `${risky.length} so the floor moves with the repair.\n`,
+    )
+    process.exit(1)
+  }
+
+  process.stdout.write(
+    `[check-transparent-window-debt] holds at ${risky.length} of ${options.length} window options\n`,
+  )
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main()
+}

--- a/scripts/check-transparent-window-debt.test.mjs
+++ b/scripts/check-transparent-window-debt.test.mjs
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  KNOWN_TRANSPARENT_WITHOUT_BACKGROUND,
+  readWindowOptions,
+  transparentWithoutBackground,
+} from './check-transparent-window-debt.mjs'
+
+/**
+ * The ratchet guarding #806. Reads the real config, so a restructure that defeats the parser has
+ * to fail loudly rather than quietly reporting zero.
+ */
+describe('transparent windows without a background colour', () => {
+  it('parses the config it means to measure', () => {
+    // Positive control. Regex over source is brittle by nature: renaming the exports, or moving
+    // them to another file, would return an empty list and read as "debt repaired".
+    const options = readWindowOptions()
+
+    expect(options.length).toBeGreaterThanOrEqual(8)
+    expect(options.map(option => option.name)).toContain('MainWindowOption')
+    expect(options.some(option => option.hasBackgroundColor)).toBe(true)
+    expect(options.some(option => !option.transparent)).toBe(true)
+  })
+
+  it('holds at the pinned count, in both directions', () => {
+    // Above the pin is a new window that renders black on a Linux desktop with no compositor and
+    // looks perfect wherever it gets reviewed. Below it is repair that did not move the floor.
+    expect(transparentWithoutBackground()).toHaveLength(KNOWN_TRANSPARENT_WITHOUT_BACKGROUND)
+  })
+
+  it('counts only the combination that has nothing to fall back to', () => {
+    // transparent with a backgroundColor is fine -- ScreenshotOverlay does exactly that -- and so
+    // is opaque without one. Only the pair is the problem, so only the pair is counted.
+    for (const option of transparentWithoutBackground()) {
+      expect(option.transparent).toBe(true)
+      expect(option.hasBackgroundColor).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
Refs #806. The part that needs no Linux runner.

## The shape

`touch-window.ts` branches `darwin` → vibrancy, `win32` → mica/acrylic, and falls through **with no `else`**. Linux is a shipped target — `electron-builder.yml` builds AppImage and deb.

Six of the eight window option sets are transparent with no `backgroundColor`:

| | transparent | backgroundColor |
|---|---|---|
| Main, Box, DivisionBox, AssistantFloatingBall, AssistantVoicePanel, OmniPanel | true | **none** |
| ScreenshotOverlay | true | `#00000000` |
| ScreenshotEditor | false | `#111315` |

So the pattern to copy already exists in the same file.

**Verified the absence is the whole story**: no `backgroundColor` is applied anywhere under `core/`, so nothing supplies a default later.

## Why a ratchet

Fixing the six is a rendering change on a platform this repo has no runner for — someone has to look at the result. That is the decision on #806.

A seventh appearing while that waits needs no decision to prevent, and each one lands **silently**: it looks correct on macOS and Windows, which is where it gets reviewed.

## Tests

Three under `test:scripts` in the blocking **PR Quality** job, same shape as #548 and #1303.

One is a positive control — regex over source is brittle by nature, and renaming or moving the exports would return an empty list and read as *"debt repaired"*. So the suite asserts it parsed 8 options, found `MainWindowOption`, and saw both a `backgroundColor` and a non-transparent window **before** it asserts the count.

| mutation | result |
|---|---|
| add a seventh transparent window with no colour | **fails** |
| give an existing one a `backgroundColor` without lowering the pin | **fails** |

`test:scripts` full run: 225 tests, 23 files, no errors. eslint clean on both files.