### PR TITLE
test(core-box): catch the meta-overlay test up with the navigation policy

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/core-box/meta-overlay.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/core-box/meta-overlay.test.ts
@@ -1,5 +1,5 @@
 import type { TuffItem } from '@talex-touch/utils/core-box'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   sendTo: vi.fn(async (_target: unknown, _event: unknown, _payload: unknown) => undefined),
@@ -97,6 +97,10 @@ vi.mock('electron', () => ({
     webContents = {
       addListener: vi.fn(),
       on: vi.fn(),
+      // installAppViewNavigationPolicy, which init() now runs (#1465), denies window.open and
+      // rejects webview attachment through these. A mock without them throws before the test
+      // reaches what it is actually asserting.
+      setWindowOpenHandler: vi.fn(),
       isLoading: vi.fn(() => false),
       isDestroyed: vi.fn(() => false),
       close: vi.fn(),
@@ -123,8 +127,22 @@ const item = {
   meta: { app: { path: '/Applications/App.app' } }
 } as TuffItem
 
+// init() resolves the CoreBox renderer URL, and electron.app is mocked as unpackaged above, so it
+// takes the development branch and throws without one. Introduced by #1465, which gave app-profile
+// views the navigation guards plugin views have; this test was not updated with it.
+const previousRendererUrl = process.env.ELECTRON_RENDERER_URL
+
+afterAll(() => {
+  if (previousRendererUrl === undefined)
+    delete process.env.ELECTRON_RENDERER_URL
+  else
+    process.env.ELECTRON_RENDERER_URL = previousRendererUrl
+})
+
 describe('MetaOverlayManager action execution', () => {
-  beforeEach(() => {
+beforeEach(() => {
+  process.env.ELECTRON_RENDERER_URL = 'http://localhost:5173/'
+
     vi.clearAllMocks()
     metaOverlayManager.unregisterPluginActions('plugin-a')
     metaOverlayManager.destroy()


### PR DESCRIPTION
Two more of the ten in #1596.

**#1465** gave app-profile views the navigation guards plugin views already had. `MetaOverlayManager.init()` now resolves the CoreBox renderer URL and installs that policy — and the two tests that call `init()` have been failing since. The test was not updated with it.

## Two layers, one behind the other

```
ELECTRON_RENDERER_URL is not set in development mode
    electron.app is mocked as unpackaged, so the URL takes the dev branch

webContents.setWindowOpenHandler is not a function
    installAppViewNavigationPolicy denies window.open through it;
    the WebContentsView mock did not have the method
```

The second only appeared after the first was fixed — worth noting, because a single-error read would have called this done too early.

The env var is saved and restored around the suite rather than set globally, so it does not leak into other files sharing the worker.

## Mutation-checked separately

| mutation | result |
|---|---|
| drop the env line | first error returns |
| drop `setWindowOpenHandler` | second error returns |
| both in place | **6 passed** |

## Why it stayed invisible

`App suites (core-app)` runs with `continue-on-error`, so the step reports success whatever the tests do. A regression that arrived alongside a security fix sat on the base until someone parsed the JUnit artifact.