### PR TITLE
fix(ocr): make each engine name itself when it recognizes nothing

### DIFF
--- a/packages/tuff-native/native/src/platform/macos/vision_ocr.mm
+++ b/packages/tuff-native/native/src/platform/macos/vision_ocr.mm
@@ -139,8 +139,10 @@ bool PerformPlatformOcr(const OcrOptions& options, OcrResult& result, OcrError& 
     CGImageRelease(image);
 
     if (lines.empty()) {
+      // See the note in winrt_ocr.cpp: both engines used to report this with the same words, so
+      // the message could not tell you which one had failed (#1517).
       error.code = "ERR_OCR_RECOGNIZE_FAILED";
-      error.message = "No text recognized from image";
+      error.message = "Apple Vision recognized no text in the image";
       return false;
     }
 

--- a/packages/tuff-native/native/src/platform/windows/winrt_ocr.cpp
+++ b/packages/tuff-native/native/src/platform/windows/winrt_ocr.cpp
@@ -172,8 +172,12 @@ bool PerformPlatformOcr(const OcrOptions& options, OcrResult& result, OcrError& 
     result.text = ToUtf8(ocrResult.Text());
 
     if (result.text.empty()) {
+      // Names the engine because the message alone used to be identical to the macOS one, and a
+      // failure surfaces without a `result` to read `engine` from -- so a CI log said only that
+      // *some* engine found nothing, on a fixture built and validated against the other one
+      // (#1517). The two neighbouring failures here already say "Windows OCR".
       error.code = "ERR_OCR_RECOGNIZE_FAILED";
-      error.message = "No text recognized from image";
+      error.message = "Windows OCR recognized no text in the image";
       return false;
     }
 


### PR DESCRIPTION
Refs #1517. Does not fix the Windows failure — makes the next report say which engine produced it.

## Both engines said the same thing

```
vision_ocr.mm:143   "No text recognized from image"
winrt_ocr.cpp:176   "No text recognized from image"
```

A failure surfaces **without** a `result`, so there is no `engine` field to read either. A CI log therefore said only that *some* engine had found nothing — on a fixture built and validated against the other one. Working out which took reading the source and reasoning about which platform the job had run on.

Now:

```
Apple Vision recognized no text in the image
Windows OCR recognized no text in the image
```

`ERR_OCR_RECOGNIZE_FAILED` is unchanged, so anything matching on the code is unaffected. **Nothing in the tree matches on the message** — checked before changing it. The Windows wording matches its two neighbouring failures, which already say "Windows OCR".

## Verified, not assumed

Rebuilt the addon and ran a blank white PNG through it:

```
code: ERR_OCR_RECOGNIZE_FAILED
message: Apple Vision recognized no text in the image
```

The Windows side compiles on its own runner — `node-gyp` runs from `pnpm install` there. `packages/test` OCR suite: 5 passed.

## Why this is worth a PR on its own

The triage on #1517 spent real time establishing that the failing engine was the Windows one and that the error came from the post-`CreateEngine` branch rather than a missing language pack. Half of that was reconstructing what a one-line log could have said.