### PR TITLE
test(core-app): give the migration-backed suites room on a CI runner

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/query-completion-service.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/query-completion-service.test.ts
@@ -4,7 +4,13 @@ import { drizzle } from 'drizzle-orm/libsql'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+// This file drives a real libsql migration chain. It runs in 778ms here, but on a CI
+// runner -- fewer cores, the whole suite in parallel workers -- it went past vitest's 5s
+// default and timed out (#1596). Raised per file rather than globally so a genuine hang
+// elsewhere still fails fast.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 })
 import { QueryCompletionService } from './query-completion-service'
 
 /**

--- a/apps/core-app/src/main/modules/database/recommendation-exposure-schema.test.ts
+++ b/apps/core-app/src/main/modules/database/recommendation-exposure-schema.test.ts
@@ -14,7 +14,13 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// This file drives a real libsql migration chain. It runs in 325ms here, but on a CI
+// runner -- fewer cores, the whole suite in parallel workers -- it went past vitest's 5s
+// default and timed out (#1596). Raised per file rather than globally so a genuine hang
+// elsewhere still fails fast.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 })
 
 const testDir = dirname(fileURLToPath(import.meta.url))
 const migrationsFolder = resolve(testDir, '../../../../resources/db/migrations')

--- a/apps/core-app/src/main/modules/privacy/retention-migration.test.ts
+++ b/apps/core-app/src/main/modules/privacy/retention-migration.test.ts
@@ -3,7 +3,13 @@ import { migrate } from 'drizzle-orm/libsql/migrator'
 import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+// This file drives a real libsql migration chain. It runs in 549ms here, but on a CI
+// runner -- fewer cores, the whole suite in parallel workers -- it went past vitest's 5s
+// default and timed out (#1596). Raised per file rather than globally so a genuine hang
+// elsewhere still fails fast.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 })
 import {
   applyPrivacyMigrations,
   createPrivacyTestClient,


### PR DESCRIPTION
**Four of the ten in #1596 are the same failure, and none is a logic error:**

```
Test timed out in 5000ms
```

vitest's default, which core-app does not override. Measured locally:

| file | slowest case |
|---|---|
| `recommendation-exposure-schema.test.ts` | **325ms** |
| `retention-migration.test.ts` | **549ms** |
| `query-completion-service.test.ts` | **778ms** |

Under a second here, past five on CI — **more than ten times slower**. All three drive a real libsql migration chain, and the runner has fewer cores while the whole suite runs in parallel workers.

## Environment, not drift

Neither migration test file nor `resources/db/migrations` changed between the failing run (`917b9f87`) and now. Same code, two environments.

## Per file, not globally

A shared-config bump would also cover tests with no reason to be slow, and a genuine hang elsewhere should still fail fast. 30s leaves roughly 40x headroom over the local worst case while staying far below a hang.

## Verified the setting applies

A `vi.setConfig` in the wrong place fails silently — the same class of defect this issue is about. So:

```
testTimeout: 1     ->  Test timed out in 1ms
testTimeout: 30_000 -> 12 passed across the three files
```

With this and the five already merged, **nine of the ten are done**. The last one is `plugin-sqlite-worker`, which needs your call on #1596: build the worker in CI, or set `TUFF_SKIP_SQLITE_WORKER_TESTS=1` and leave its six sandbox tests dark.