### PR TITLE
fix(core-box): stub the renderer URL instead of assigning it

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/core-box/meta-overlay.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/core-box/meta-overlay.test.ts
@@ -130,18 +130,16 @@ const item = {
 // init() resolves the CoreBox renderer URL, and electron.app is mocked as unpackaged above, so it
 // takes the development branch and throws without one. Introduced by #1465, which gave app-profile
 // views the navigation guards plugin views have; this test was not updated with it.
-const previousRendererUrl = process.env.ELECTRON_RENDERER_URL
-
+// Set through vi.stubEnv rather than by assignment: electron-vite declares ELECTRON_RENDERER_URL
+// readonly, so writing it fails the main-process typecheck (TS2540/TS2704) even though the test
+// itself passes. vi.unstubAllEnvs also restores it, which the hand-rolled save/restore was for.
 afterAll(() => {
-  if (previousRendererUrl === undefined)
-    delete process.env.ELECTRON_RENDERER_URL
-  else
-    process.env.ELECTRON_RENDERER_URL = previousRendererUrl
+  vi.unstubAllEnvs()
 })
 
 describe('MetaOverlayManager action execution', () => {
-beforeEach(() => {
-  process.env.ELECTRON_RENDERER_URL = 'http://localhost:5173/'
+  beforeEach(() => {
+    vi.stubEnv('ELECTRON_RENDERER_URL', 'http://localhost:5173/')
 
     vi.clearAllMocks()
     metaOverlayManager.unregisterPluginActions('plugin-a')


### PR DESCRIPTION
**`TalexDreamSoul/app-shell-v2` does not typecheck right now.** Every PR opened against it inherits this.

```
meta-overlay.test.ts(137,12) error TS2704: The operand of a 'delete' operator cannot be a read-only property
meta-overlay.test.ts(139,17) error TS2540: Cannot assign to 'ELECTRON_RENDERER_URL' because it is read-only
meta-overlay.test.ts(144,15) error TS2540: same
```

## How it landed

`electron-vite` declares `ELECTRON_RENDERER_URL` readonly, and every other reader in the tree only *reads* it. #1600 was the first to write one, to give `init()` a URL to resolve.

**The tests pass either way** — which is exactly why it got through: `App suites (core-app)` is `continue-on-error`, so nothing in that PR reported it, and `Typecheck (workspace)` only sees the tree after the merge.

## The fix

`vi.stubEnv` — already the repo's idiom for this (`renderer-override-verification.test.ts`, `screenshot-service.test.ts`). It typechecks, and `vi.unstubAllEnvs` restores the value, which is what the hand-rolled save/restore around the assignment existed for, so that goes too.

Typecheck clean, the six meta-overlay tests pass, eslint clean.

## Note

Not my change and not a criticism of it — #1600 fixed two genuinely broken tests. This is the same class as #1547 earlier today: a PR that is green on its own breaks the base, because the job that would have caught it cannot fail a PR.