### PR TITLE
ci(core-app): declare the SQLite worker skip instead of failing on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,8 +345,16 @@ jobs:
         if: ${{ matrix.app == 'nexus' }}
         run: pnpm -C packages/tuffex build
 
+      # The plugin SQLite sandbox tests need out/main/plugin-sqlite-worker.js, which only
+      # electron-vite build produces and this job does not run. Their guard refuses to skip
+      # silently and fails instead, which is right -- but it was the last thing standing between
+      # this suite and a zero baseline. Skipping is declared here rather than discovered, and it
+      # costs no coverage: those six cases report `skipped` with or without this (#1596).
+      # Building the worker here would actually run them; that is the open half of #1596.
       - name: Run ${{ matrix.app }} suite
         continue-on-error: ${{ matrix.app != 'nexus' }}
+        env:
+          TUFF_SKIP_SQLITE_WORKER_TESTS: '1'
         run: >-
           pnpm -C "apps/${{ matrix.app }}" exec vitest run
           --reporter=default


### PR DESCRIPTION
Last of the ten in #1596 — **and the only one that was never a defect.**

`plugin-sqlite-worker.integration.test.ts` needs `out/main/plugin-sqlite-worker.js`. Only `electron-vite build` produces it, and this job does not run one. The test's guard refuses to skip silently and fails instead, which is the right design — but it was the last thing between this suite and a zero baseline.

## It costs no coverage

Measured both ways:

```
without the env var   1 failed | 6 skipped
with it               1 passed | 6 skipped
```

**The six sandbox cases are skipped either way**, because the artifact is absent either way. What changes is that the suite stops reporting a failure for a condition CI never intended to satisfy — the skip is now *declared* rather than discovered.

That measurement is what turned this from a judgement call into an obvious one: I had been treating "skip them" as losing six tests, and it loses nothing that runs today.

## What it does not do

Building the worker here would actually run those six. That is the open half of #1596 and needs a decision about paying a full `electron-vite build` on every PR — `electron-vite` has `--rendererOnly` but **no `--mainOnly`**, so there is no narrow path.

## Why continue-on-error is still here

Removing it is the whole point of reaching zero, and it is deliberately **not** in this PR.

The `Integration suite (packages/test)` took the same route — baseline to zero first, then the tolerance came off (#1255). Worth keeping that ordering when the alternative is every PR blocking on a suite whose green run I have seen exactly once. A few consecutive clean baselines first; I will open that PR when they are in.