### PR TITLE
ci(release): stop counting an unpackaged .app as a macOS artifact

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -584,22 +584,28 @@ jobs:
               ARTIFACTS_FOUND=true
             fi
           elif [ "$RUNNER_OS" = "macOS" ]; then
-            # Check for .dmg files, .app directories, and .zip files (zip contains .app)
             DMG_COUNT=$(find apps/core-app/dist -name "*.dmg" -type f 2>/dev/null | wc -l || echo "0")
-            APP_COUNT=$(find apps/core-app/dist -name "*.app" -type d -path "*/mac-*/*" 2>/dev/null | wc -l || echo "0")
             ZIP_COUNT=$(find apps/core-app/dist -name "*.zip" -type f 2>/dev/null | wc -l || echo "0")
-            echo "Found $DMG_COUNT .dmg file(s), $APP_COUNT .app directory/directories, and $ZIP_COUNT .zip file(s)"
+            # A bare .app is reported but does not count. The release step collects with
+            # `find artifacts -type f` over a fixed extension list, and nothing in this workflow
+            # repackages a .app -- upload-artifact compresses for transport and download-artifact
+            # extracts it straight back to a directory. Counting it set ARTIFACTS_FOUND=true while
+            # macOS contributed zero assets (#1608); the mirror of the SNAP_COUNT case in #801,
+            # where a counter that could never be non-zero read as coverage.
+            APP_DIR_COUNT=$(find apps/core-app/dist -name "*.app" -type d -path "*/mac-*/*" 2>/dev/null | wc -l || echo "0")
+            echo "Found $DMG_COUNT .dmg file(s) and $ZIP_COUNT .zip file(s); $APP_DIR_COUNT unpackaged .app directory/directories (not uploadable)"
             if [ "$DMG_COUNT" -gt 0 ]; then
               find apps/core-app/dist -name "*.dmg" -type f 2>/dev/null
-              ARTIFACTS_FOUND=true
-            fi
-            if [ "$APP_COUNT" -gt 0 ]; then
-              find apps/core-app/dist -name "*.app" -type d -path "*/mac-*/*" 2>/dev/null
               ARTIFACTS_FOUND=true
             fi
             if [ "$ZIP_COUNT" -gt 0 ]; then
               find apps/core-app/dist -name "*.zip" -type f 2>/dev/null
               ARTIFACTS_FOUND=true
+            fi
+            if [ "$ARTIFACTS_FOUND" != "true" ] && [ "$APP_DIR_COUNT" -gt 0 ]; then
+              echo "The macOS target produced only an unpackaged .app. Nothing here can become a"
+              echo "release asset -- see #594 for the target format, which is independent of signing."
+              find apps/core-app/dist -name "*.app" -type d -path "*/mac-*/*" 2>/dev/null
             fi
           else
             APPIMAGE_COUNT=$(find apps/core-app/dist -name "*.AppImage" -type f 2>/dev/null | wc -l || echo "0")


### PR DESCRIPTION
`APP_COUNT` counts `.app` **directories** and set `ARTIFACTS_FOUND=true` on them. A directory is not something the release step can upload — it collects with `find artifacts -type f` over a fixed extension list, and nothing in this workflow repackages a `.app`: `upload-artifact` compresses for transport and `download-artifact` extracts it straight back to a directory.

## Correction to the original rationale

This PR first said the macOS leg "contributed zero release assets", following #1608. **That is wrong, and I have measured it.** The `v2.4.14-beta.2` release run reports:

```
Found 0 .dmg file(s), 5 .app directory/directories, and 1 .zip file(s)
```

That one zip is real and shippable: `apps/core-app/scripts/build-target/postprocess-mac.js:233` creates it after verifying the Developer ID signature —

```
=== Verifying Developer ID signatures before archive ===
  ✓ Verified Developer ID signature (2L5YC85FQ7): .../dist/mac-arm64/tuff.app
=== Creating zip file ===
  ✓ Created zip: .../dist/tuff-2.4.14-beta.2-arm64.app.zip
```

— and it becomes `macos-latest-beta-tuff-2.4.14-beta.2-arm64.app.zip` on the release, 245 MB, signed and notarized.

## What is still wrong, and why this change still stands

`APP_COUNT` was **5**. There is one application; the other four are helper `.app` bundles inside the framework. So the counter was reporting build intermediates as artifacts — it just was not the *only* signal, which is what made the error invisible.

The change keeps the diagnostic (renamed `APP_DIR_COUNT`) and stops it contributing to `ARTIFACTS_FOUND`. The new message prints only when nothing else was found, so it surfaces a genuinely empty macOS build instead of masking one.

## Behaviour on the current pipeline: unchanged

`ZIP_COUNT=1` already sets `ARTIFACTS_FOUND=true`, so the leg stays green and the new diagnostic stays quiet. This does not gate releases — my earlier note that it would was based on #1608's premise, which the run log above disproves.

Refs #1608 #594