### PR TITLE
ci(core-app): build the main process so the SQLite sandbox tests run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,15 +346,27 @@ jobs:
         if: ${{ matrix.app == 'nexus' }}
         run: pnpm -C packages/tuffex build
 
-      # The plugin SQLite sandbox tests need out/main/plugin-sqlite-worker.js, which only
-      # electron-vite build produces and this job does not run. Their guard refuses to skip
-      # silently and fails instead, which is right -- but it was the last thing standing between
-      # this suite and a zero baseline. Skipping is declared here rather than discovered, and it
-      # costs no coverage: those six cases report `skipped` with or without this (#1596).
-      # Building the worker here would actually run them; that is the open half of #1596.
+      # The plugin SQLite sandbox tests need out/main/plugin-sqlite-worker.js, and only
+      # electron-vite build produces it: the worker is a rollup input in the main-process build
+      # and the CLI has --rendererOnly but no --mainOnly, so this is the whole build. Their guard
+      # refuses to skip silently, so until now the job declared the skip and six sandbox cases
+      # had never run in CI (#1596, #1607).
+      #
+      # Main process only, via a config that takes `main` straight from electron.vite.config.ts
+      # -- derived rather than restated, so the two cannot drift. A full `electron-vite build`
+      # also does the renderer, which is what pulls in tuffex's dist and most of the time: 58s
+      # plus a 29s tuffex build on this runner, against 6s locally for main alone. Nothing here
+      # needs the renderer.
+      #
+      # The whole out/main is needed, not the one file -- the worker is code-split and loads
+      # siblings from out/main/chunks (50 of them). Copying only plugin-sqlite-worker.js fails
+      # all six with `Cannot find module './chunks/plugin-sqlite-worker-protocol-*.js'`, which
+      # reads exactly like a real defect.
+      - name: Build core-app main process
+        if: ${{ matrix.app == 'core-app' }}
+        run: pnpm -C apps/core-app exec electron-vite build -c electron.vite.ci-main.config.ts
+
       - name: Run ${{ matrix.app }} suite
-        env:
-          TUFF_SKIP_SQLITE_WORKER_TESTS: '1'
         run: >-
           pnpm -C "apps/${{ matrix.app }}" exec vitest run
           --reporter=default

--- a/apps/core-app/electron.vite.ci-main.config.ts
+++ b/apps/core-app/electron.vite.ci-main.config.ts
@@ -1,0 +1,14 @@
+/**
+ * Builds only the main process, for jobs that need out/main artifacts and nothing else.
+ *
+ * Derived from the real config rather than restating it: `main` is taken straight from
+ * electron.vite.config.ts, so a change there is picked up here and the two cannot drift.
+ * The renderer half is what pulls in tuffex's dist and most of the build time, and a job that
+ * only needs the plugin SQLite worker has no use for it.
+ */
+import { defineConfig } from 'electron-vite'
+import full from './electron.vite.config'
+
+const resolved = typeof full === 'function' ? full({ command: 'build', mode: 'production' }) : full
+
+export default defineConfig({ main: (resolved as { main: unknown }).main as never })


### PR DESCRIPTION
Closes #1607.

Six plugin SQLite sandbox cases had never run in CI. They need `out/main/plugin-sqlite-worker.js`; only `electron-vite build` produces it; this job did not run one. #1604 declared the skip rather than leaving it to be discovered — which cost nothing and gained nothing.

## The cost was the open question. Measured.

Cold, with any existing `out/` moved aside first:

```
electron-vite build                 22s
out/main/plugin-sqlite-worker.js    12,686 bytes
```

Against **~90s** for the suite itself and **~34s** for the install in this same job. And with the artifact present:

```
Tests  7 passed (7)     ← was 6 skipped + 1 guard
```

## One trap, recorded in the comment because I fell into it

**The whole `out/main` is required, not the one file.** The worker is code-split and loads siblings from `out/main/chunks` — 50 of them. Copying only `plugin-sqlite-worker.js` fails all six with

```
Cannot find module './chunks/plugin-sqlite-worker-protocol-DOuRtMyk.js'
```

which reads exactly like six real defects. I reported that to myself first and had to spend the next step ruling it out. Anyone who later caches this artifact between jobs, or trims it, will hit the same thing.

## Note on the measurement environment

Built in the main checkout, not this worktree — `electron-vite build` cannot run here (`@iconify-json/carbon` unresolvable, 33 top-level packages against 1684). That is an incomplete install in the worktree, **not** a missing declaration: the import has been there since 2025-11-12 and the 2026-08-03 release built fine. Same class as #1564; written up on #1607 so the next person does not re-diagnose it as a phantom dependency.

The build wrote only gitignored `out/`; the main checkout's dirty file count was 43 before and 43 after.