### PR TITLE
ci: run the plugin SQLite sandbox tests when that code changes

### DIFF
--- a/.github/workflows/plugin-sqlite-sandbox.yml
+++ b/.github/workflows/plugin-sqlite-sandbox.yml
@@ -1,0 +1,80 @@
+name: Plugin SQLite Sandbox
+
+# The six sandbox cases in plugin-sqlite-worker.integration.test.ts need
+# out/main/plugin-sqlite-worker.js, which only `electron-vite build` produces. The core-app
+# suite does not build, so those cases have never run in CI -- they report `skipped` there and,
+# since #1604, say so deliberately rather than failing (#1607).
+#
+# They are not incidental coverage: worker-side SQL policy, browser-history copies staying
+# query-only, row and byte limits, a database symlink inserted after host path validation,
+# timed-out workers terminating without a late write, and the per-plugin database cap.
+#
+# Run here rather than inside App suites (core-app) because the build costs ~182s on this runner
+# against that job's 71s total. Paying that on every PR would more than triple the feedback loop
+# for changes that cannot affect this. Path-filtered, so it is paid only when the sandbox, its
+# worker, or the toolchain that builds it actually changes.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/plugin-sqlite-sandbox.yml'
+      - 'apps/core-app/src/main/modules/plugin/runtime/**'
+      - 'apps/core-app/electron.vite.config.ts'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/plugin-sqlite-sandbox.yml'
+      - 'apps/core-app/src/main/modules/plugin/runtime/**'
+      - 'apps/core-app/electron.vite.config.ts'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: plugin-sqlite-sandbox-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sandbox:
+    name: Plugin SQLite sandbox
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The renderer imports @talex-touch/tuffex/icon/style.css, and tuffex's exports map resolves
+      # only into dist/, so without this the build dies on module resolution rather than on
+      # anything real. App suites (nexus) carries the same step for the same reason.
+      - name: Build tuffex
+        run: pnpm -C packages/tuffex build
+
+      # electron-vite has --rendererOnly but no --mainOnly, and the worker is a rollup input in
+      # the main build, so there is no narrower way to produce just this artifact.
+      - name: Build the main process
+        run: pnpm -C apps/core-app exec electron-vite build
+
+      # Deliberately without TUFF_SKIP_SQLITE_WORKER_TESTS. The guard in this file fails when the
+      # artifact is missing, which is what makes this job meaningful: if the build stops emitting
+      # the worker, this reports it instead of skipping six security cases quietly.
+      - name: Run the plugin SQLite sandbox tests
+        run: >-
+          pnpm -C apps/core-app exec vitest run
+          src/main/modules/plugin/runtime/plugin-sqlite-worker.integration.test.ts


### PR DESCRIPTION
Closes #1607.

Six cases in `plugin-sqlite-worker.integration.test.ts` need `out/main/plugin-sqlite-worker.js`, which only `electron-vite build` produces. The core-app suite does not build, so **they have never run in CI**. #1604 made that skip deliberate instead of a failure, which fixed the reporting and changed nothing about the coverage.

## They are not incidental

| |
|---|
| worker-side SQL policy and bounded CRUD |
| browser-history copies staying query-only, rejecting every non-fixed SQL shape |
| stable row and result byte limit errors |
| **a database symlink inserted after host path validation** |
| a timed-out worker terminating and recovering without a late write |
| the worker-owned database cap mapping to a stable quota error |

## Cost, measured not guessed

From the release workflow's own log — the span from `building client environment for production` to the last `built in`:

```
ubuntu-latest   182s
macos-latest    181s
windows-2022    197s
```

`App suites (core-app)` takes **71s** in total and **blocks a PR** as of #1605. Adding a build there would more than triple the feedback loop for every change, including ones that cannot affect this.

So this runs as its own **path-filtered** workflow — the shape  already uses. Paid when the sandbox, its worker, or the config that builds it changes; free otherwise.

## Deliberately no skip env var

The guard failing on a missing artifact is what makes the job meaningful. If the build stops emitting the worker, this reports it rather than quietly skipping six security cases — which is exactly the state #1607 describes.

## Validated

`check:action-pins` and `check:workflow-injection` both pass over 20 workflows with this file in place.

**This PR's own run is the test of whether those six pass.** They have never executed in CI, so if any of them fails on a Linux runner, it will show here before merge rather than after.