### PR TITLE
ci(release): keep the .app bundle the macOS cleanup claims to keep

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -830,8 +830,14 @@ jobs:
         if: matrix.os == 'macos-latest'
         shell: bash
         run: |
-          # Keep .dmg files, .zip files (contain .app), and .app directories
-          find apps/core-app/dist -type f ! -name "*.dmg" ! -name "*.zip" -delete 2>/dev/null || true
+          # Runs after Upload Artifacts; this only reclaims runner disk.
+          #
+          # `! -path "*.app/*"` is what makes the comment above true. A .app is a directory whose
+          # contents are files -- Contents/MacOS/tuff, Info.plist, the frameworks -- so without it
+          # this deletes the bundle's insides and leaves the skeleton. Harmless while the upload
+          # happens first; anyone who reorders these, or adds a second upload after this step, would
+          # otherwise ship an empty shell that still has the .app suffix and still counts (#1612).
+          find apps/core-app/dist -type f ! -path "*.app/*" ! -name "*.dmg" ! -name "*.zip" -delete 2>/dev/null || true
           find apps/core-app/dist -type d -name "mac-*" -prune -o -type d ! -name "*.app" -empty -delete 2>/dev/null || true
 
   create-release:


### PR DESCRIPTION
Closes #1612. **Latent, not live** — recorded and fixed because the failure it would cause is silent.

```bash
# Keep .dmg files, .zip files (contain .app), and .app directories
find apps/core-app/dist -type f ! -name "*.dmg" ! -name "*.zip" -delete
```

A `.app` is a **directory whose contents are files** — `Contents/MacOS/tuff`, `Info.plist`, the frameworks. Every one matches `-type f` and is neither a `.dmg` nor a `.zip`. Measured in a scratch tree, it leaves the bundle as an **empty skeleton**. The comment says the opposite.

## Why it is not a bug today

```
786  - name: Upload Artifacts
829  - name: Cleanup Artifacts for MacOS
```

Cleanup runs **after** the upload, so what ships is intact. This step only reclaims runner disk.

## Why fix it anyway

Anyone who moves this step earlier, or adds a second upload after it, gets macOS artifacts that are **empty shells** — directory present, `.app` suffix present, any count over them non-zero, nothing inside. That is exactly #1608's shape, one edit away from happening.

## Verified both ways

```
with    ! -path "*.app/*"   Info.plist + tuff survive; builder-effective-config.yaml still removed
without ! -path "*.app/*"   files left inside the .app: 0
```

`check:workflow-injection` and `check:action-pins` both pass.

The comment now says what the step is **for** (reclaim disk after upload) rather than what it keeps, so the two cannot drift apart again.