### PR TITLE
fix(intelligence): stop the bare input rule stretching checkboxes

### DIFF
--- a/apps/core-app/src/renderer/src/views/base/intelligence/IntelligenceWorkflowPage.vue
+++ b/apps/core-app/src/renderer/src/views/base/intelligence/IntelligenceWorkflowPage.vue
@@ -1327,7 +1327,11 @@ onMounted(async () => {
   letter-spacing: 0.08em;
 }
 
-input,
+// Excludes checkboxes deliberately. Chromium honours width, border, background and padding on
+// them, so the bare `input` selector rendered all 7 on this page as stretched rounded boxes
+// rather than squares -- wrong against the old dark panels too, just less visible there than on
+// a white card (#1023).
+input:not([type='checkbox']),
 select,
 textarea {
   width: 100%;


### PR DESCRIPTION
Part 1 of #1023.

## The rule

```scss
input,          // ← matched all 7 type="checkbox" too
select,
textarea {
  width: 100%;
  border: 1px solid rgba(255, 255, 255, 0.1);
  border-radius: 12px;
  background: rgba(5, 9, 14, 0.5);
  padding: 10px 12px;
}
```

Chromium honours `width`, `border`, `background` and `padding` on a checkbox, so each of the 7 rendered as a stretched rounded box rather than a square.

Pre-existing, as the issue says — equally wrong against the old dark panels, just far less visible there than on the white card the page now sits on.

## The change

`input:not([type='checkbox'])`. Counted what the page actually contains before narrowing it:

| `type=` | count | after |
|---|---|---|
| `text` | 9 | unchanged |
| `checkbox` | 7 | **excluded** |
| `button` | 1 | unchanged |

So only the checkboxes drop out; nothing else in the page changes.

## Not in this PR

The second half of #1023 — the layout overflowing a very narrow settings column — is untouched. Judging it needs the page rendered at width, and this change touches no box model that would affect it.

`vue-tsc` reports the same 2 pre-existing `@xterm/*` module errors as the baseline; the page has no test file.