### PR TITLE
chore(trellis): record what search-sort-reaches-ui still needs

### DIFF
--- a/.trellis/tasks/08-05-search-sort-reaches-ui/task.json
+++ b/.trellis/tasks/08-05-search-sort-reaches-ui/task.json
@@ -22,5 +22,9 @@
   "parent": "08-05-search-audit-remediation",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Write the two AC1 scenarios that have no test: the completion cache containing deferred items, and a single publish per batch. The other four are covered in useSearch.rank.test.ts (deferred outranks fast, pinned tops, per-source floor above the render cap, selection preserved across a re-rank).",
+    "blocker": "None. The two missing tests need writing, not a decision.",
+    "evidence": "AC2 measured 2026-08-11: renderer box adapter + main search-engine suites 736 passed / 86 files; typecheck:node 0 errors. typecheck:web reports 154 errors, all under packages/tuffex/packages/components and none touching useSearch or the box adapter, so the AC2 wording \"for touched files\" holds. AC1 is 4 of 6 scenarios covered; AC3 (D1-D7) not independently verified."
+  }
 }


### PR DESCRIPTION
Toward #1125, continuing the per-task pass the concurrent session pointed at in its last comment there (#1575, #1577).

This task is genuinely still in progress, and checking says **where**.

| AC | state |
|---|---|
| **AC1** | **4 of 6 scenarios covered.** `useSearch.rank.test.ts` has deferred outranking fast, pinned on top, the per-source floor above the render cap, and selection preserved across a re-rank. **Nothing covers** the completion cache containing deferred items, or a single publish per batch. |
| **AC2** | measured green — renderer box adapter + main search-engine, **736 passed / 86 files**, `typecheck:node` 0 errors |
| **AC3** | D1–D7 **not independently verified**. Said so rather than implying it. |

## On the web typecheck

`typecheck:web` reports 154 errors. Every one is under `packages/tuffex/packages/components`, and **none touches `useSearch` or the box adapter** — so AC2's own wording, *"for touched files"*, holds. Worth stating explicitly rather than quoting a green number that isn't.

`blocker` is **None**: the two missing tests need writing, not a decision.

```
docs:verify   123 -> 120
DOC-TASK-META 108 -> 105
```

No rule changed.