### PR TITLE
chore(trellis): record file-index-data-safety's residual and its evidence

### DIFF
--- a/.trellis/tasks/08-05-file-index-data-safety/task.json
+++ b/.trellis/tasks/08-05-file-index-data-safety/task.json
@@ -22,5 +22,9 @@
   "parent": "08-05-search-audit-remediation",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Decide what to do about the D4 residual its own check log records: normalizeFsPath stores NFC ids, which resolve only on normalisation-insensitive filesystems. Two candidates are already named there - platform-gate normalizeFsPath, or keep the raw path for filesystem access.",
+    "blocker": "None for the acceptance criteria. The D4 residual is a follow-up rather than a gate: it is recorded as such in check.jsonl and does not affect macOS, where the ids resolve.",
+    "evidence": "AC3 measured 2026-08-11: addon/files 322 passed / 48 files; packages/utils search + file-scan-utils 477 passed, 1 skipped / 48 files. check.jsonl records R1/R3/R4/R5 verified implemented and a second search-path deletion route found and closed during check - normalizeFileSearchItem -> cleanupStaleFileResult was deleting on an existsSync verdict, false for EACCES and offline volumes, now on the same ENOENT-only gate as cleanupStaleSearchCandidates, with a test."
+  }
 }


### PR DESCRIPTION
Toward #1125, continuing the per-task pass.

**The content comes from the task's own check log**, not from me reading the code and guessing. Two things were in there:

> R2 had a second search-path deletion route the implementation left open — `normalizeFileSearchItem -> cleanupStaleFileResult` removed rows on an `existsSync` verdict (false for EACCES/offline volumes). Fixed to the same ENOENT-only gate as `cleanupStaleSearchCandidates`, with a test. R1/R3/R4/R5 verified as implemented

> check pass **residual**: D4 stores NFC ids that only resolve on normalization-insensitive filesystems (macOS APFS/HFS+). On byte-exact filesystems (Linux ext4, NTFS) an NFD-named file is indexed under an NFC id whose stat returns ENOENT, so the ENOENT-gated cleanup deletes it after each scan — a follow-up candidate

That residual is now `nextAction`, with the two remedies it already names. `blocker` is **None** — a follow-up rather than a gate, and it does not affect macOS.

## Measured

```
addon/files                              322 passed / 48 files
packages/utils search + file-scan-utils  477 passed, 1 skipped / 48 files
```

## On the metric

Verified by the **per-task finding count**, not the total: this task goes **3 → 0**.

The total is not a usable control here — the shared worktree sits on a different commit than `origin` and the gate reads the working tree, so the aggregate moves for reasons unrelated to the change. I caught that when a fill that removed three findings left the total unchanged.