### PR TITLE
chore(trellis): record shell-chrome-resizable-sidebar's manual acceptance

### DIFF
--- a/.trellis/tasks/08-04-shell-chrome-resizable-sidebar/task.json
+++ b/.trellis/tasks/08-04-shell-chrome-resizable-sidebar/task.json
@@ -22,5 +22,9 @@
   "parent": null,
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Run the manual acceptance. Thirteen of the fifteen criteria are visual or interactive and need the app on the platform in question: traffic-light placement and a draggable top row on macOS, the self-drawn window controls on Windows and Linux, sidebar drag with the 220-360px clamp, the 180px snap to a 64px icon rail and the 110px restore, width persisting across restart, and light/dark/high-contrast. Also settle AC6: ShellTopBar is gone, but ShellBackRow.vue still exists and ShellSidebar.vue imports it, so either the criterion or the component needs updating.",
+    "blocker": "A running app on macOS, Windows and Linux. Nothing here is decidable from source: the criteria are about where the traffic lights land, whether the top row drags the window, and whether contrast holds in three themes.",
+    "evidence": "Machine-checkable parts, 2026-08-11. AC6 half met: ShellTopBar has zero files and zero references; ShellBackRow.vue is still present and imported by ShellSidebar.vue, which reads as repurposed rather than left behind. AC11 met: no flatNavBar.store key remains under apps/core-app. AC13: typecheck:node clean; typecheck:web reports 154 errors, none of them in a shell component - they are all under packages/tuffex/packages/components."
+  }
 }


### PR DESCRIPTION
Toward #1125, continuing the per-task pass.

Fifteen criteria, none ticked, and **thirteen of them are visual or interactive** — where the macOS traffic lights land, whether the top row drags the window, the self-drawn controls on Windows and Linux, the sidebar's 220–360px clamp, the 180px snap to a 64px icon rail and the 110px restore, width surviving a restart, contrast in light/dark/high-contrast.

None of that is decidable from source, so the blocker is **a running app on three platforms**.

## The two that are checkable, checked

| AC | result |
|---|---|
| **AC6** | **half met.** `ShellTopBar` has zero files and zero references. `ShellBackRow.vue` is **still present** and `ShellSidebar.vue` imports it |
| **AC11** | met — no `flatNavBar.store` key remains under `apps/core-app` |
| **AC13** | `typecheck:node` clean; `typecheck:web` reports 154 errors, **none in a shell component** — all under `packages/tuffex/packages/components` |

On AC6: the surviving `ShellBackRow` reads as **repurposed** rather than left behind, since the sidebar now imports it. I did not assume either way — `nextAction` says the criterion or the component wants updating, and leaves which to whoever knows the intent.

Verified by the per-task finding count: **3 → 0**.