### PR TITLE
chore(trellis): record what home-conversation and batch-settings-razor need

### DIFF
--- a/.trellis/tasks/08-04-batch-settings-razor/task.json
+++ b/.trellis/tasks/08-04-batch-settings-razor/task.json
@@ -22,5 +22,9 @@
   "parent": null,
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Get the planning artefacts reviewed. The task states its own gate: implementation may not start until the user has reviewed them and task.py start has been run.",
+    "blocker": "User review, by the task's own final criterion. This is a planning task whose output is documents - a settings inventory with code locations, a keep/merge/default/migrate/developer-visible/delete verdict per item, the credential-protection design, and contract updates to sensitive-data-inventory.json and the privacy spec. None of it can be closed by running anything.",
+    "evidence": "None to measure. Six criteria, all describing documents rather than behaviour, so there is no suite or check that can report on them."
+  }
 }

--- a/.trellis/tasks/08-04-home-conversation/task.json
+++ b/.trellis/tasks/08-04-home-conversation/task.json
@@ -22,5 +22,9 @@
   "parent": "08-03-app-shell-ai-redesign",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Cover the two halves of AC4 that pi-cli-runtime.test.ts does not: an abnormal exit of the pi child process, and cancellation. Its thirty cases already cover the NDJSON side (text delta out of message_update, requesting NDJSON in non-interactive mode, non-JSON stdout treated as skippable) and usage aggregation (four cases including dropping an all-zero block). The rest of the criteria need the app running with the pi CLI present.",
+    "blocker": "A running app with the pi CLI installed, for everything except AC4. Whether a streaming reply arrives with no cloud provider configured, whether the stop key leaves no orphan process, and whether an undetected pi produces actionable guidance rather than a bare error are all observations, not source facts.",
+    "evidence": "AC4 is 2 of 4 as of 2026-08-11. pi-cli-runtime.test.ts has 30 cases: NDJSON parsing and usage aggregation are covered; no case names an abnormal exit or a cancellation, and the file contains no exit, cancel or abort assertion."
+  }
 }


### PR DESCRIPTION
Toward #1125, continuing the per-task pass. Two tasks together because each one's verification is small.

## `08-04-home-conversation`

**AC4 is 2 of 4.** `pi-cli-runtime.test.ts` has thirty cases:

| AC4 requires | state |
|---|---|
| NDJSON incremental parsing | ✅ text delta out of `message_update`, requesting NDJSON in non-interactive mode, non-JSON stdout treated as skippable rather than fatal |
| usage aggregation | ✅ four cases, including dropping an all-zero block so it cannot overwrite a real reading |
| abnormal exit | ❌ no case, no assertion |
| cancellation | ❌ no case, no assertion |

Everything else needs the app running with the pi CLI present — whether a streaming reply arrives with no cloud provider configured, whether the stop key leaves no orphan process, whether an undetected `pi` produces actionable guidance. **Observations, not source facts.**

## `08-04-batch-settings-razor`

Blocked on **user review, by the task's own final criterion**: implementation may not start until the planning artefacts are reviewed and `task.py start` has been run.

It is a planning task whose output is documents — a settings inventory with code locations, a per-item keep/merge/default/migrate/developer-visible/delete verdict, the credential-protection design, and contract updates to `sensitive-data-inventory.json` and the privacy spec.

`evidence` says **there is nothing to measure** rather than inventing a number. No suite can report on any of it.

Verified per task by finding count: each goes **3 → 0**.