### PR TITLE
chore(trellis): record where the two reco tasks actually stand

### DIFF
--- a/.trellis/tasks/08-05-reco-ranking-stats-fix/task.json
+++ b/.trellis/tasks/08-05-reco-ranking-stats-fix/task.json
@@ -22,5 +22,9 @@
   "parent": "08-05-search-audit-remediation",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Close the four AC1 assertions that have no test: scoring.final populated is asserted in recommendation-engine tests, and scored order across sources plus pinned truncation are covered, but nothing covers the type/id identity regression, the idempotent migration mapping all four known type->id pairs, or the snapshot taken before focus steal and consumed by the context provider. Then archive: AC2 and AC3 already hold.",
+    "blocker": "None. The remaining work is writing tests, not a decision.",
+    "evidence": "AC2 measured 2026-08-11: recommendation suite 99 passed / 7 files. AC3 met: the digest at .trellis/tasks/08-05-search-audit-remediation/research/audit-findings-digest.md records \"R1 fix-reco-ranking-and-stats - FIXED 2026-08-05\" and names P0-1, P0-2, P1-3 and P1-4. AC1 is partial - 2 of 6 assertions have matching tests."
+  }
 }

--- a/.trellis/tasks/08-05-reco-wire-existing-signals/task.json
+++ b/.trellis/tasks/08-05-reco-wire-existing-signals/task.json
@@ -22,5 +22,9 @@
   "parent": "08-05-search-audit-remediation",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Update the digest with what landed. The same file records R1 as \"FIXED 2026-08-05\" but lists R2 wire-existing-signals only as scope - hourDistribution, cache-key cardinality, cold start, incremental aggregation, selection-capture, timezone-change - with no status, so AC3 is open even though the hour-weighting and cache-key work is tested.",
+    "blocker": "None.",
+    "evidence": "AC2 measured 2026-08-11: recommendation suite 99 passed / 7 files, shared with the R1 task. AC1 has visible coverage - the hour weighting (current hour against busiest hour, uniform distribution as a full match, untouched score with no history, peak-hour item ranked above one peaking elsewhere) and the cache key including time slot and day type. AC3 not met: the digest carries no status line for R2."
+  }
 }


### PR DESCRIPTION
Toward #1125, continuing the per-task pass. Both share the recommendation suite, and **the digest is what tells them apart.**

## `08-05-reco-ranking-stats-fix`

**AC3 is met** — which I would have guessed wrong without opening the file. `audit-findings-digest.md` records:

> `R1 fix-reco-ranking-and-stats — FIXED 2026-08-05` … P0-1 … P0-2 … P1-3 … P1-4

**AC2 is met**: recommendation suite **99 passed / 7 files**.

**AC1 is 2 of 6.** Scored order across sources, pinned truncation and `scoring.final` have tests. Nothing covers the type/id identity regression, the idempotent migration mapping all four known `type→id` pairs, or the snapshot taken before focus steal.

I searched the **whole repo** rather than just the recommendation directory, with a negative control — a migration test would not live there, and concluding from one directory would have been wrong.

So this one is close to archivable, and `nextAction` says exactly what stands in the way.

## `08-05-reco-wire-existing-signals`

**Same digest, opposite verdict.** R2 appears there only as *scope* — hourDistribution, cache-key cardinality, cold start, incremental aggregation, selection-capture, timezone-change — with **no status line**. So AC3 is open even though the work it describes has tests: hour weighting against the busiest hour, a uniform distribution as a full match, an untouched score with no history, a peak-hour item outranking one that peaks elsewhere, and the cache key including time slot and day type.

Verified per task by finding count: each goes **3 → 0**.