### PR TITLE
chore(trellis): record that the search hot-path fix has landed

### DIFF
--- a/.trellis/tasks/08-05-search-hotpath-quadratic-fix/task.json
+++ b/.trellis/tasks/08-05-search-hotpath-quadratic-fix/task.json
@@ -22,5 +22,9 @@
   "parent": null,
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Archive it, or say what is left. The implementation has landed and both suites AC1 names pass; AC3 needs a check that the published surface of @talex-touch/utils is unchanged, and AC2 is a throwaway benchmark the task itself says is not committed, so it cannot be evidenced after the fact - worth rewording rather than leaving as an open box forever.",
+    "blocker": "None.",
+    "evidence": "The O(n^2) dedup is gone: addSearchToken in packages/utils/search/search-token-builder.ts now keys off a Set held in a WeakMap per token list, which is the O(n) replacement the goal describes. AC1 measured 2026-08-11: search-processing-service.test.ts 16 passed; packages/utils 1340 passed / 185 files, with one unrelated flake - nexus-provider.test.ts walked a temp directory a concurrent run had just deleted, and passes on its own."
+  }
 }


### PR DESCRIPTION
Toward #1125, continuing the per-task pass.

**This task had zero records in either jsonl, which reads as untouched. The work is in fact done.**

`addSearchToken` in `search-token-builder.ts` now keys off a `Set` held in a `WeakMap` per token list — exactly the O(n) replacement for the O(n²) `JSON.stringify` dedup the goal describes.

## Measured

```
search-processing-service.test.ts    16 passed
packages/utils                     1340 passed / 185 files
```

## Two things written down rather than smoothed over

**The one utils failure is unrelated.** `nexus-provider.test.ts` walked a temp directory a concurrent run had just deleted (`ENOENT` on `scan-utils-wide-uhmzwg`) and passes on its own. Shared worktree, not this task.

**AC2 cannot be evidenced.** It is a throwaway micro-benchmark the task itself says is *not committed*, so there is no artefact to point at after the fact. `nextAction` says to reword it rather than leave a box that can never be ticked.

Verified by the per-task finding count: **1 → 0** — this one was contributing a single finding, not three, because `assignee` was already set.