### PR TITLE
chore(trellis): record how much of shell-fixed-frame is already done

### DIFF
--- a/.trellis/tasks/08-04-shell-fixed-frame/task.json
+++ b/.trellis/tasks/08-04-shell-fixed-frame/task.json
@@ -22,5 +22,9 @@
   "parent": "08-03-app-shell-ai-redesign",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Run the visual acceptance. Six of the thirteen criteria are already met and checkable from source; the rest are measurements against the design boards - sidebar width 260 with a 1px right border, padding 14, gap 10, nav item padding [7,10], TopBar height 52 with padding [0,32], traffic lights unobstructed on macOS and absent on Windows, every existing route still rendering, and contrast in light and dark.",
+    "blocker": "A running app on macOS and Windows. Nothing in the remaining criteria is a source fact.",
+    "evidence": "Checked from source 2026-08-11, with AppShell as a positive control for the scan. AC1-AC3 met: zero files match LayoutShell, LayoutAtomProvider, FloatingNav, layouts-definition, useDynamicTuffLayout, DynamicLayout or LayoutPreview. LayoutSkeleton survives only as tuffex's TxLayoutSkeleton and two nexus demos, none of them under components/layout. AC5 met: coreBoxCanvasConfig is still reached from CoreBoxCanvasSection.vue, CoreBoxEditorOverlay.vue and useCoreBoxTheme.ts. AC6 met: no read or write of appSettingsData.layout remains in apps/core-app/src. AC13: typecheck:node clean, typecheck:web 154 errors, none of them in a shell or layout file - all under packages/tuffex/packages/components."
+  }
 }


### PR DESCRIPTION
Toward #1125, continuing the per-task pass.

**Zero records in either jsonl and thirteen unticked criteria — which reads as nothing having happened. Six of them are already met**, and are checkable from source rather than by eye.

| AC | result |
|---|---|
| **AC1–AC3** | zero files match `LayoutShell`, `LayoutAtomProvider`, `FloatingNav`, `layouts-definition`, `useDynamicTuffLayout`, `DynamicLayout`, `LayoutPreview`. `LayoutSkeleton` survives only as tuffex's `TxLayoutSkeleton` and two nexus demos — **none under `components/layout`** |
| **AC5** | `coreBoxCanvasConfig` still reachable from `CoreBoxCanvasSection.vue`, `CoreBoxEditorOverlay.vue`, `useCoreBoxTheme.ts` — the one thing the deletion could have taken with it |
| **AC6** | no read or write of `appSettingsData.layout` remains in `apps/core-app/src` |
| **AC13** | `typecheck:node` clean; `typecheck:web` 154 errors, **none in a shell or layout file** |

The scan used `AppShell` as a **positive control**, so "zero files" is a measurement rather than a broken grep.

## What is left

Measurement against the design boards — sidebar 260 wide with a 1px right border, TopBar 52 high, traffic lights unobstructed on macOS and absent on Windows, every route still rendering, contrast in both themes. That needs the app on two platforms.

Verified by the per-task finding count: **3 → 0**.