### PR TITLE
chore(trellis): record settings-ia-primitives against what is in the tree

### DIFF
--- a/.trellis/tasks/08-04-settings-ia-primitives/task.json
+++ b/.trellis/tasks/08-04-settings-ia-primitives/task.json
@@ -22,5 +22,9 @@
   "parent": "08-03-app-shell-ai-redesign",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Run the visual acceptance against the boards - SettingRow padding [12,16], gap 16, title 13.5, description 12 at line-height 1.5; IdentityCard padding 16, gap 18, radius-lg, $bg with a 1px $border. Also settle two source-level points: the categories table has 11 entries where the criterion says 9, and AC6 names an AppMark component that does not exist under that name - so either the criteria or the code has moved since they were written.",
+    "blocker": "A running app, for the board measurements and the light/dark pass.",
+    "evidence": "Checked from source 2026-08-11. AC1 met in shape: one route per category driven by categories.ts, and /setting redirects to DEFAULT_SETTING_PATH, which is /setting/overview. AC2 met: LEGACY_SECTION_REDIRECTS maps the old ?section= links, with everything pointing at /setting/file-index. AC9: settings modules and views 122 passed / 21 files, including categories.smoke.test.ts. SettingRow and IdentityCard both exist; AppMark does not."
+  }
 }


### PR DESCRIPTION
Toward #1125, continuing the per-task pass.

Zero records, nine unticked criteria. Checking says most of the structure is there — **and two of the criteria have drifted from the code.**

| AC | result |
|---|---|
| **AC1** | met in shape — one route per category driven by `categories.ts`, `/setting` redirects to `DEFAULT_SETTING_PATH = '/setting/overview'`. **The criterion says nine categories; the table has eleven.** |
| **AC2** | met — `LEGACY_SECTION_REDIRECTS` maps the old `?section=` links, `everything` → `/setting/file-index` |
| **AC9** | settings modules and views: **122 passed / 21 files**, including `categories.smoke.test.ts` |
| **AC6** | names an **`AppMark`** component. Nothing in the repo is called that, while `SettingRow` and `IdentityCard` both exist. |

**Neither the eleven-vs-nine count nor the missing `AppMark` is asserted here to be a defect.** Both are stated as drift between criteria and code, for whoever knows which side moved — the categories may have grown deliberately, and `AppMark` may have been renamed.

The rest are board measurements — `SettingRow` padding [12,16], gap 16, title 13.5, description 12 at 1.5; `IdentityCard` padding 16, gap 18, `radius-lg`, `$bg` with a 1px `$border` — plus the light/dark pass. Those need the app.

Verified by the per-task finding count: **3 → 0**.