### PR TITLE
chore(trellis): record the two home tasks as live-runtime acceptance

### DIFF
--- a/.trellis/tasks/08-05-home-chat-tuffex-ai-fusion/task.json
+++ b/.trellis/tasks/08-05-home-chat-tuffex-ai-fusion/task.json
@@ -22,5 +22,9 @@
   "parent": "08-05-tuffex-ai-suite",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Run the manual acceptance with a real streaming reply: long text with code blocks and a mermaid diagram fading in block by block, the cursor, the diagram closing, and no full-page reflow while scrolling. Then 500 injected history entries for scroll smoothness and a bounded DOM, image paste and drag with preview and delete, the behaviour non-regression checklist item by item, and both themes.",
+    "blocker": "A running app with a live model. Every criterion here is an observation of rendering under a real stream - fade-in, cursor, reflow, scroll smoothness, DOM bounds - none of which a test run can report on.",
+    "evidence": "The unit half of AC4 measured 2026-08-11: ai modules plus the home views, 559 passed, 1 skipped / 58 files. The rest is unmeasured by design."
+  }
 }

--- a/.trellis/tasks/08-05-home-tool-loop/task.json
+++ b/.trellis/tasks/08-05-home-tool-loop/task.json
@@ -22,5 +22,9 @@
   "parent": "08-05-ai-toolchain-suite",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Run the end-to-end acceptance against a real pi: the four-state tool card streaming through to a table, a widget tool returning an interactive chart in the sandbox with controlled dimensions, a tuff plugin feature round-tripping through the extension bridge, and a denied confirmation leaving the session alive while stop terminates the loop without orphans.",
+    "blocker": "A real pi runtime. Four of the five criteria are end-to-end behaviours of a live tool loop.",
+    "evidence": "AC5, the tools-disabled path, has the closest thing to coverage: pi-cli-runtime.test.ts asserts that --no-tools is kept without an allowlist and that exactly the allowlisted tools are enabled, and the ai suites hold the governance side - an allowed stable tool ID routed while a worker-confirmed cancellation is rejected, a single-use approval fingerprint, sensitive tool output redacted and capped before crossing the worker boundary, and a started but uncompleted call surfaced as interrupted rather than executed. Measured: 559 passed, 1 skipped / 58 files."
+  }
 }


### PR DESCRIPTION
Toward #1125. **These are the last two `in_progress` tasks in the pass.**

Both are end-to-end by construction, and the records now say so rather than leaving three empty fields that read as *nobody looked*.

## `08-05-home-chat-tuffex-ai-fusion`

Every criterion is an observation of rendering under a real stream — long text with code blocks and a mermaid diagram fading in block by block, the cursor, the diagram closing, no full-page reflow while scrolling, 500 injected history entries staying smooth with a bounded DOM, image paste and drag with preview and delete. **No test run reports on any of that.**

The unit half of AC4 is measured: ai modules plus home views, **559 passed, 1 skipped / 58 files**.

## `08-05-home-tool-loop`

Four of five criteria need a real `pi`. **AC5 — the tools-disabled path — already has the closest thing to coverage:**

- `pi-cli-runtime.test.ts`: `--no-tools` kept without an allowlist; exactly the allowlisted tools enabled
- the ai suites: a single-use approval fingerprint, sensitive tool output redacted and capped before crossing the worker boundary, a started but uncompleted call surfaced as **interrupted** rather than executed

Verified per task by finding count: each goes **3 → 0**.

## Where this leaves #1125

With these, **every `in_progress` task in the failing set has a record.** What remains is the 17 `planning` tasks — the part that wants a rule decision rather than more of this, because filling `evidence` on work that has not started means writing the same empty sentence 17 times.