### PR TITLE
chore(trellis): record the two tuffex-ai tasks against their suites

### DIFF
--- a/.trellis/tasks/08-05-tuffex-ai-elements-port/task.json
+++ b/.trellis/tasks/08-05-tuffex-ai-elements-port/task.json
@@ -22,5 +22,9 @@
   "parent": "08-05-ai-toolchain-suite",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Confirm the P0 five are all registered and exported with their four-state and streaming behaviour under mock data, then the theme and reduced-motion pass. The ai-elements suite is green, so what is open is the per-component checklist and the visual half.",
+    "blocker": "A running app for themes and reduced-motion.",
+    "evidence": "Measured 2026-08-11: ai-elements plus stream-markdown, 58 passed / 6 files, which covers the \"existing ai-elements tests stay green\" half of the parts-type criterion. The component directory carries its own tests (ai-elements.test.ts, ai-message-parts.test.ts) alongside the Vue sources."
+  }
 }

--- a/.trellis/tasks/08-05-tuffex-ai-stream-markdown/task.json
+++ b/.trellis/tasks/08-05-tuffex-ai-stream-markdown/task.json
@@ -22,5 +22,9 @@
   "parent": "08-05-tuffex-ai-suite",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Only the visual criteria are left: light and dark themes plus reduced-motion, and the zoom overlay behaviour by eye. The streaming, mermaid, code-block and sanitiser criteria all have tests.",
+    "blocker": "A running app for the theme and reduced-motion pass. Nothing else.",
+    "evidence": "Measured 2026-08-11: ai-elements plus stream-markdown, 58 passed / 6 files. Coverage maps to the criteria directly. Block identity: \"keeps settled block DOM nodes across streaming updates\", \"reuses settled block objects and only assigns fresh ids to new blocks\", \"keeps the tail id stable while a paragraph grows\". Cursor: \"marks a paragraph tail for the inline cursor while streaming\". Mermaid: skeleton with draft source while open, diagram once the fence closes under strict security, fallback to source with an alert when rendering fails. Sanitiser: nothing rendered before it resolves, sanitised markup once ready, unsanitised only when the flag is off. Code block: highlight after close, bare fences labelled text without asking shiki, stale highlights ignored."
+  }
 }


### PR DESCRIPTION
Toward #1125, picking up two of the five `in_progress` tasks my earlier survey missed — it was taken from a snapshot of the failing list, and tasks were created after it.

## `08-05-tuffex-ai-stream-markdown`

**Coverage maps to the criteria directly**, so what is left is only the visual pass:

| criterion | test |
|---|---|
| block node identity | `keeps settled block DOM nodes across streaming updates`; `reuses settled block objects and only assigns fresh ids to new blocks`; `keeps the tail id stable while a paragraph grows` |
| cursor | `marks a paragraph tail for the inline cursor while streaming` |
| mermaid | skeleton while open; diagram on close under strict security; fallback to source with an alert on failure |
| sanitiser | nothing before it resolves; sanitised once ready; unsanitised only when the flag is off |
| code blocks | highlight after close; bare fences labelled text without asking shiki; stale highlights ignored |

## `08-05-tuffex-ai-elements-port`

Suite green, which satisfies the *"existing ai-elements tests stay green"* half. Open: the per-component P0 checklist and the theme/reduced-motion pass.

Measured: **58 passed / 6 files**.

## How I nearly got this wrong

My first pass grepped the test directory for `identity`, `cursor` and `sanitize` and got **zero for three of four** — which reads as no coverage.

The path was relative to `packages/tuffex` while the grep ran from the repo root, so it matched nothing that exists. **A non-existent path and an uncovered criterion look identical without a positive control** — the same failure this pass keeps finding elsewhere. Reading the case names is what corrected it.

Verified per task by finding count: each goes **3 → 0**.