### PR TITLE
chore(trellis): record the last three in_progress tasks

### DIFF
--- a/.trellis/tasks/08-05-semantic-catalog-token-boundary/task.json
+++ b/.trellis/tasks/08-05-semantic-catalog-token-boundary/task.json
@@ -22,5 +22,9 @@
   "parent": "08-05-search-audit-remediation",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Confirm AC3 - that the diff stayed inside the two catalog files, the shared matcher util and the tests - and then archive. AC1 and AC2 are met.",
+    "blocker": "None.",
+    "evidence": "AC1 met: app-semantic-catalog.test.ts asserts \"requires token boundaries so short needles cannot attach through substrings\", and carries both fixtures the criterion names - Telegram with aliases im/telegram/tg, and Postgres with bundleId com.postgresapp.Postgres2. It also keeps ambiguous Illustrator away from the AI alias. AC2 measured 2026-08-11: addon/apps 188 passed / 18 files."
+  }
 }

--- a/.trellis/tasks/08-05-tuffex-ai-attachments-toolcards/task.json
+++ b/.trellis/tasks/08-05-tuffex-ai-attachments-toolcards/task.json
@@ -22,5 +22,9 @@
   "parent": "08-05-tuffex-ai-suite",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Cover the two criteria with no tests: the composer dispatching attachment-add on paste and drop with the drop highlight and no Enter/IME regression, and TxToolCallCard walking all four states from a mock event sequence with a retry from the error state. The parts model and the attachment tray are already covered.",
+    "blocker": "None for the two open criteria - they need tests written, not a decision. The animation smoothness half of the tool-card criterion needs an eye.",
+    "evidence": "Measured 2026-08-11: attachment-tray plus ai-elements, 19 passed / 3 files. The parts model is covered - each part type rendered in order, only the last text part marked streaming, the legacy content path kept when parts are absent, parts-only messages with an empty content summary. The tray is covered - images split into thumbs and files into chips, the viewer opening at the clicked image, file chips emitting open, remove replaced by cancel with a progress ring while uploading, and a placeholder when a thumbnail fails."
+  }
 }

--- a/.trellis/tasks/08-05-tuffex-ai-conversation-stream/task.json
+++ b/.trellis/tasks/08-05-tuffex-ai-conversation-stream/task.json
@@ -22,5 +22,9 @@
   "parent": "08-05-tuffex-ai-suite",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Implement it. TxAiConversation.vue is 91 lines and contains no virtualisation, no stick-to-bottom, no loadOlder and no hasMore, so none of the four criteria has an implementation to test yet.",
+    "blocker": "None. This is unstarted work rather than blocked work.",
+    "evidence": "Checked 2026-08-11 against the criteria rather than the suite: the ai-elements tests that pass cover message rendering, not the scroller. TxAiConversation.vue has zero occurrences of virtual, windowed, visibleRange, stickToBottom, loadOlder or hasMore."
+  }
 }


### PR DESCRIPTION
Toward #1125. The remaining three from the recount — **and one of them turns out not to be in progress at all.**

## `08-05-semantic-catalog-token-boundary`

**AC1 met.** `app-semantic-catalog.test.ts` asserts *"requires token boundaries so short needles cannot attach through substrings"* and carries both fixtures the criterion names — Telegram with aliases `im`/`telegram`/`tg`, and Postgres with bundleId `com.postgresapp.Postgres2`.

**AC2 measured**: addon/apps **188 passed / 18 files**. Only AC3 — that the diff stayed inside the two catalog files — is left.

## `08-05-tuffex-ai-attachments-toolcards`

Covered: each part type rendered in order, only the last text part marked streaming, the legacy `content` path kept when parts are absent, images split into thumbs and files into chips, the viewer opening at the clicked image, remove replaced by cancel with a progress ring while uploading.

**Two criteria have no tests** — the composer dispatching `attachment-add` on paste and drop, and `TxToolCallCard` walking four states with a retry from error.

## `08-05-tuffex-ai-conversation-stream` — not started

`TxAiConversation.vue` is **91 lines with zero occurrences** of `virtual`, `windowed`, `visibleRange`, `stickToBottom`, `loadOlder` or `hasMore`. None of its four criteria has an implementation to test.

The ai-elements suite passes — **but it covers message rendering, not the scroller.** "Suite green" would have been exactly the wrong thing to look at here, and checking the criteria against the source is what separated the two.

`blocker` says **None**: this is unstarted, not blocked.

Verified per task by finding count: each goes **3 → 0**. With these, **every `in_progress` task in the tree carries a record.**