### PR TITLE
chore(trellis): record the five planning tasks that produced something

### DIFF
--- a/.trellis/tasks/07-28-rust-screenshot-mvp/task.json
+++ b/.trellis/tasks/07-28-rust-screenshot-mvp/task.json
@@ -30,5 +30,9 @@
   "parent": "07-28-rust-native-protocol-screenshot",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Start the children in its delivery map, or fold the map into whichever child now leads. The research it produced is done.",
+    "blocker": "None recorded. This is a parent whose scope is carried by child tasks.",
+    "evidence": "research/pixpin-scrollsnap-feature-audit.md is the produced artefact - a feature audit of the reference implementation. The prd carries a Confirmed Facts section and a Child Delivery Map rather than implementation criteria."
+  }
 }

--- a/.trellis/tasks/07-30-docs-roadmap-consolidation-cleanup/task.json
+++ b/.trellis/tasks/07-30-docs-roadmap-consolidation-cleanup/task.json
@@ -22,5 +22,9 @@
   "parent": null,
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Act on the three inventories, or close the task if the cleanup is no longer wanted. Nothing has been changed yet - the inventory itself says it is read-only analysis.",
+    "blocker": "None recorded.",
+    "evidence": "Three research artefacts exist and are substantive: research/docs-inventory.md is a full sweep of 125 markdown files under docs/ with per-file last-commit dates and an explicit note that docs/design/ holds no markdown at all; plus roadmap-factcheck.md and root-clutter.md. The inventory states it modified no docs file."
+  }
 }

--- a/.trellis/tasks/08-03-app-shell-ai-redesign/task.json
+++ b/.trellis/tasks/08-03-app-shell-ai-redesign/task.json
@@ -27,5 +27,9 @@
   "parent": null,
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Continue through its children. Two of them - 08-04-shell-fixed-frame and 08-04-settings-ia-primitives - are in progress with their own records, and their remaining criteria are board measurements needing a running app.",
+    "blocker": "The same running app its children need, for the visual acceptance.",
+    "evidence": "design.md is the produced artefact and is measured rather than estimated: it states the values come from the design boards iqbKR (settings v2) and JVvAr (home v2) in docs/design/corebox/v2.5.0.pen, not from estimation."
+  }
 }

--- a/.trellis/tasks/08-04-settings-rewrite/task.json
+++ b/.trellis/tasks/08-04-settings-rewrite/task.json
@@ -22,5 +22,9 @@
   "parent": "08-03-app-shell-ai-redesign",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Reconcile with 08-04-settings-ia-primitives, which is in progress and already carries the route table and row primitives. This task narrowed its scope on 2026-08-05 by user confirmation, so what is left of it may already be covered there.",
+    "blocker": "None recorded.",
+    "evidence": "design.md exists, and the prd opens with a scope reduction dated 2026-08-05 marked as user confirmed - so the narrowing is a decision on record rather than drift."
+  }
 }

--- a/.trellis/tasks/08-05-search-audit-remediation/task.json
+++ b/.trellis/tasks/08-05-search-audit-remediation/task.json
@@ -35,5 +35,9 @@
   "parent": null,
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "nextAction": "Keep landing the child batches. Its own criterion is that each child lands with its gates green, and R1 is already marked FIXED in the digest while R2 is not.",
+    "blocker": "None. It is a tracking parent, and its progress is its children.",
+    "evidence": "Four research artefacts, and they are load-bearing rather than notes: research/audit-findings-digest.md is what records R1 fix-reco-ranking-and-stats as FIXED 2026-08-05 with P0-1, P0-2, P1-3 and P1-4 named, and it is the file two child tasks are measured against. Also realtime-chain-diagnosis.md, reco-signal-program.md and reco-signals-audit.md."
+  }
 }


### PR DESCRIPTION
Toward #1125.

I have been saying the planning half needs a rule decision, because writing `evidence: not started` nineteen times would turn the gate green and turn the record into noise. That still holds for thirteen of them, which carry nothing but a `prd.md`.

It does not hold for these five. Each produced an artefact worth pointing at, so their record is a fact rather than a placeholder:

| task | artefact |
|---|---|
| `07-28-rust-screenshot-mvp` | `research/pixpin-scrollsnap-feature-audit.md` |
| `07-30-docs-roadmap-consolidation-cleanup` | three inventories — one sweeps 125 markdown files with per-file last-commit dates and states it modified nothing |
| `08-03-app-shell-ai-redesign` | `design.md`, whose values it says are measured from the design boards rather than estimated |
| `08-04-settings-rewrite` | `design.md`, plus a scope reduction dated 2026-08-05 marked user-confirmed |
| `08-05-search-audit-remediation` | four research files; `audit-findings-digest.md` is what two child tasks are measured against |

`docs:verify` 84 → 69. `DOC-TASK-META` 69 → 54.

## The sixth one is deliberately left alone

`07-17-unify-ota-update-flow` has a `design.md` too, and I filled it first. Two reasons I backed it out:

1. It is the single entry in `TASK_RULE_ALLOWLIST`, and `verify-docs.mjs:296-299` requires an allowlist entry to **match a current metadata violation**. Filling the fields removes the violation the entry points at, so the gate then reports `DOC-TASK-ALLOWLIST`. I measured that — 70 findings with the sixth included, 69 without.
2. More to the point, the allowlist rationale says a concurrent owner retains this OTA parent's lifecycle metadata until its child acceptance closes. That is a deferral on record as someone's decision, and filling it would overwrite it.

Refs #1125