### PR TITLE
ci(482): wire actionlint into PR Quality

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -172,19 +172,19 @@ jobs:
             # 标签触发：从标签提取版本信息
             REF_NAME_LOWER=$(echo "$REF_NAME" | tr '[:upper:]' '[:lower:]')
             if [[ "$REF_NAME_LOWER" == *"beta"* ]]; then
-              echo "type=beta" >> $GITHUB_OUTPUT
+              echo "type=beta" >> "$GITHUB_OUTPUT"
             elif [[ "$REF_NAME_LOWER" == *"snapshot"* ]]; then
-              echo "type=snapshot" >> $GITHUB_OUTPUT
+              echo "type=snapshot" >> "$GITHUB_OUTPUT"
             else
-              echo "type=release" >> $GITHUB_OUTPUT
+              echo "type=release" >> "$GITHUB_OUTPUT"
             fi
-            echo "tag=$REF_NAME" >> $GITHUB_OUTPUT
-            echo "version=${REF_NAME#v}" >> $GITHUB_OUTPUT
+            echo "tag=$REF_NAME" >> "$GITHUB_OUTPUT"
+            echo "version=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
           else
             # 手动触发：只设置构建类型，不处理版本和标签
-            echo "type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
-            echo "tag=" >> $GITHUB_OUTPUT
-            echo "version=" >> $GITHUB_OUTPUT
+            echo "type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
           fi
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -1016,31 +1016,31 @@ jobs:
           if [ -n "$RECOVER_RUN_ID" ]; then
             REF_NAME_LOWER=$(echo "$SYNC_TAG" | tr '[:upper:]' '[:lower:]')
             if [[ "$REF_NAME_LOWER" == *"beta"* ]]; then
-              echo "type=beta" >> $GITHUB_OUTPUT
+              echo "type=beta" >> "$GITHUB_OUTPUT"
             elif [[ "$REF_NAME_LOWER" == *"snapshot"* ]]; then
-              echo "type=snapshot" >> $GITHUB_OUTPUT
+              echo "type=snapshot" >> "$GITHUB_OUTPUT"
             else
-              echo "type=release" >> $GITHUB_OUTPUT
+              echo "type=release" >> "$GITHUB_OUTPUT"
             fi
-            echo "tag=$SYNC_TAG" >> $GITHUB_OUTPUT
-            echo "name=Release $SYNC_TAG" >> $GITHUB_OUTPUT
-            echo "target_ref=$SYNC_TAG" >> $GITHUB_OUTPUT
+            echo "tag=$SYNC_TAG" >> "$GITHUB_OUTPUT"
+            echo "name=Release $SYNC_TAG" >> "$GITHUB_OUTPUT"
+            echo "target_ref=$SYNC_TAG" >> "$GITHUB_OUTPUT"
             if [[ "$REF_NAME_LOWER" == *"beta"* || "$REF_NAME_LOWER" == *"snapshot"* ]]; then
-              echo "prerelease=true" >> $GITHUB_OUTPUT
+              echo "prerelease=true" >> "$GITHUB_OUTPUT"
             else
-              echo "prerelease=false" >> $GITHUB_OUTPUT
+              echo "prerelease=false" >> "$GITHUB_OUTPUT"
             fi
           elif [ "$EVENT_NAME" = "push" ]; then
             # 标签触发：使用标签信息创建 release
             REF_NAME_LOWER=$(echo "$REF_NAME" | tr '[:upper:]' '[:lower:]')
-            echo "type=release" >> $GITHUB_OUTPUT
-            echo "tag=$REF_NAME" >> $GITHUB_OUTPUT
-            echo "name=Release $REF_NAME" >> $GITHUB_OUTPUT
-            echo "target_ref=$TARGET_SHA" >> $GITHUB_OUTPUT
+            echo "type=release" >> "$GITHUB_OUTPUT"
+            echo "tag=$REF_NAME" >> "$GITHUB_OUTPUT"
+            echo "name=Release $REF_NAME" >> "$GITHUB_OUTPUT"
+            echo "target_ref=$TARGET_SHA" >> "$GITHUB_OUTPUT"
             if [[ "$REF_NAME_LOWER" == *"beta"* || "$REF_NAME_LOWER" == *"snapshot"* ]]; then
-              echo "prerelease=true" >> $GITHUB_OUTPUT
+              echo "prerelease=true" >> "$GITHUB_OUTPUT"
             else
-              echo "prerelease=false" >> $GITHUB_OUTPUT
+              echo "prerelease=false" >> "$GITHUB_OUTPUT"
             fi
           else
             # 手动触发：创建 draft release，使用时间戳作为临时标签
@@ -1063,14 +1063,14 @@ jobs:
               beta) CHANNEL_LABEL=beta ;;
               *) CHANNEL_LABEL=master ;;
             esac
-            echo "type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
-            echo "tag=v${BASE_VERSION}-${CHANNEL_LABEL}.${TIMESTAMP}" >> $GITHUB_OUTPUT
-            echo "name=Manual Build ($RELEASE_TYPE) - $TIMESTAMP" >> $GITHUB_OUTPUT
-            echo "target_ref=$TARGET_SHA" >> $GITHUB_OUTPUT
+            echo "type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
+            echo "tag=v${BASE_VERSION}-${CHANNEL_LABEL}.${TIMESTAMP}" >> "$GITHUB_OUTPUT"
+            echo "name=Manual Build ($RELEASE_TYPE) - $TIMESTAMP" >> "$GITHUB_OUTPUT"
+            echo "target_ref=$TARGET_SHA" >> "$GITHUB_OUTPUT"
             if [ "$RELEASE_TYPE" = "snapshot" ] || [ "$RELEASE_TYPE" = "beta" ]; then
-              echo "prerelease=true" >> $GITHUB_OUTPUT
+              echo "prerelease=true" >> "$GITHUB_OUTPUT"
             else
-              echo "prerelease=false" >> $GITHUB_OUTPUT
+              echo "prerelease=false" >> "$GITHUB_OUTPUT"
             fi
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      # actionlint comes from mise's [tools], the same way docs:verify's toolchain does. It runs
+      # here rather than in the Documentation Quality job because that one is red on every PR
+      # (#1254) -- a new check added there would report into a job nobody can read a signal from.
+      - name: Setup mise
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          cache: true
+          install: true
+
       - name: Setup PNPM
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
@@ -164,6 +173,19 @@ jobs:
       # benign lines and get switched off.
       - name: Verify no workflow script injection
         run: pnpm check:workflow-injection && pnpm check:workflow-injection:self-test
+
+      # actionlint was named an "external acceptance gap" in #482 on the grounds that it was
+      # unavailable locally. It was not unavailable -- it was never wired: zero references outside
+      # .trellis task records, none in any workflow, script, or mise.toml.
+      #
+      # This starts green, but not on the first measurement: without shellcheck installed the run
+      # reported 0 findings, and with it (as on every GitHub runner) the same command reported 32,
+      # all in build-and-release.yml. 28 were unquoted `>> $GITHUB_OUTPUT`, fixed in this change;
+      # the other 4 are shellcheck's style tier, which -S info excludes. Both layers are
+      # mutation-checked -- an injected `${{ github.event.* }}` in a run block and an unquoted
+      # variable inside one each turn this step red.
+      - name: Lint workflows
+        run: mise run workflows:lint
 
       # 17 test files under scripts/ — the release machinery — that no workflow ran (#1135).
       # Three are excluded, each with its reason named in the config: one needs a prior build, and

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,10 @@
 [tools]
+actionlint = "1.7.12"
 node = "24.18.0"
 pnpm = "10.34.4"
+# Pinned because actionlint silently skips all run-block analysis when shellcheck is absent:
+# without it the same command reports 0 findings locally and 32 on a GitHub runner.
+shellcheck = "0.10.0"
 
 [tasks."ai-docs:dev"]
 description = "Fast AI docs validation"
@@ -10,6 +14,12 @@ run = "node scripts/ai-docs/verify-ai-docs.mjs"
 description = "Release AI docs validation"
 depends = ["ai-docs:dev"]
 run = "git diff --check -- mise.toml scripts/ai-docs docs/plan-prd/04-implementation docs/plan-prd/03-features docs/plan-prd/TODO.md docs/INDEX.md"
+
+[tasks."workflows:lint"]
+description = "Static analysis of GitHub Actions workflows (actionlint + shellcheck on run blocks)"
+# -S info gates on error/warning/info and drops shellcheck's pure-style tier, which only ever
+# flagged "combine consecutive >> redirects" in this repo.
+run = "actionlint -shellcheck 'shellcheck -S info'"
 
 [tasks."docs:verify"]
 description = "Deterministic read-only documentation verification"


### PR DESCRIPTION
Closes part of #482.

## What #482 got wrong

The issue lists actionlint as an unmet external acceptance gate, explained by the tool being *"unavailable in the local environment"*. Both halves are wrong:

- **It is available locally** — `~/.local/share/mise/installs/actionlint/1.7.12/actionlint`, installed via mise.
- **It had never run because nothing called it** — zero references in any workflow, script, or `mise.toml`; the only three mentions in the repo are `.trellis` task records describing it as unavailable. Verified with a positive control (`check:workflow-injection`, which the same search resolves to both `package.json` and `ci.yml`).

So the required work is *introduce* actionlint, not *run* it.

## The measurement that mattered

My first run reported **0 findings** and I nearly shipped on it. That number was an artefact: **actionlint silently skips all `run:`-block analysis when shellcheck is not on PATH.** GitHub runners ship shellcheck; my machine does not. The same command:

| | findings |
|---|---|
| without shellcheck (my first read) | 0 |
| with shellcheck (what CI would see) | **32** |

All 32 were in `build-and-release.yml`, none above `info`:

- **28 × SC2086** — unquoted `>> $GITHUB_OUTPUT`. Fixed here by quoting. `$GITHUB_OUTPUT` is a runner-provided temp path so these were not live bugs, but the fix is mechanical and removes the need to suppress a whole severity tier.
- **4 × SC2129** — "combine consecutive `>>` redirects", shellcheck's pure-style tier. Excluded via `-S info`.

`shellcheck` is now pinned in `mise.toml` alongside actionlint, so a local run and a CI run measure the same thing rather than differing by an invisible tool-presence check.

## Placement

The step goes in **PR Quality**, not Documentation Quality — which already has mise set up but is red on every PR (#1254). A new check added there reports into a job no one can read a signal from. PR Quality is green and already hosts the workflow-level checks (`Verify action pins`, `Verify no workflow script injection`), so actionlint sits with its peers.

## Mutation-checked, both layers

A gate proves nothing until it can fail. Verified independently for each analysis layer:

| mutation | result |
|---|---|
| clean tree | RC=0 |
| `run: echo "${{ github.event.head_commit.message }}"` | RC=1, `[expression]` |
| `if [ $UNQUOTED == "x" ]` inside a `run:` block | RC=1, `SC2086` |
| mutation removed | RC=0 |

The second case is the one that matters: it proves the shellcheck integration is actually live, rather than silently skipped the way it was during my first measurement.

## Not covered

#482's other half — packaged visual acceptance — is untouched here and stays open.
