### PR TITLE
test(plugins): run the plugin suites that nothing was running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,14 @@ jobs:
       - name: Validate plugin manifests and package policy
         run: pnpm plugins:validate && pnpm plugins:validate:self-test
 
+      # The per-plugin index.test.cjs suites were passing long before anything ran them.
+      # plugins/* is in the pnpm workspace, but most of these directories ship no package.json,
+      # so pnpm -r never reaches them, and the App suites matrix is [core-app, nexus]. Commit
+      # 911fe1c6f cut 2,274 lines from seven plugin suites in packages/test while rewriting the
+      # preludes they covered, which is how that baseline went green (#330).
+      - name: Run plugin suites
+        run: pnpm test:plugins && pnpm test:plugins:self-test
+
       # `pnpm lint` reaches plugins either as workspaces or through a hand-maintained brace
       # list, and touch-dictation was in neither (#562). The list is the kind that drifts
       # silently, so this asserts the two paths between them still cover every directory.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "release:notes:verify": "node scripts/release-notes-gateway.mjs verify",
     "plugins:validate": "tsx scripts/validate-plugin-package-policy.ts && node scripts/validate-plugins.mjs",
     "plugins:validate:self-test": "node scripts/validate-plugins.mjs --self-test",
+    "test:plugins": "node scripts/test-plugins.mjs",
+    "test:plugins:self-test": "node scripts/test-plugins.mjs --self-test",
     "plugins:release:audit": "tsx scripts/plugin-source-package-audit.ts",
     "publish:check": "node scripts/validate-publish-manifests.mjs",
     "publish:check:pack": "node scripts/validate-publish-manifests.mjs --pack",

--- a/scripts/test-plugins.mjs
+++ b/scripts/test-plugins.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
 /**
  * Runs the per-plugin `index.test.cjs` suites.
  *
@@ -17,7 +18,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { spawnSync } from 'node:child_process'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const pluginsDir = path.join(repoRoot, 'plugins')
@@ -56,19 +56,23 @@ export function classifySuiteRun({ status, stdout }) {
   const pass = read('pass')
   const fail = read('fail')
 
-  if (status !== 0) return { ok: false, pass, fail, reason: `exited ${status}` }
-  if (pass === null) return { ok: false, pass, fail, reason: 'exit 0 but no test counts in output' }
-  if (pass === 0) return { ok: false, pass, fail, reason: 'exit 0 but ran no tests' }
+  if (status !== 0)
+    return { ok: false, pass, fail, reason: `exited ${status}` }
+  if (pass === null)
+    return { ok: false, pass, fail, reason: 'exit 0 but no test counts in output' }
+  if (pass === 0)
+    return { ok: false, pass, fail, reason: 'exit 0 but ran no tests' }
   return { ok: true, pass, fail, reason: null }
 }
 
 export function findSuites(root = pluginsDir) {
-  if (!fs.existsSync(root)) return []
+  if (!fs.existsSync(root))
+    return []
   return fs
     .readdirSync(root, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => ({ name: entry.name, file: path.join(root, entry.name, 'index.test.cjs') }))
-    .filter((suite) => fs.existsSync(suite.file))
+    .filter(entry => entry.isDirectory())
+    .map(entry => ({ name: entry.name, file: path.join(root, entry.name, 'index.test.cjs') }))
+    .filter(suite => fs.existsSync(suite.file))
     .sort((a, b) => a.name.localeCompare(b.name))
 }
 
@@ -81,40 +85,41 @@ function selfTest() {
     {
       name: 'a passing suite passes',
       actual: classifySuiteRun({ status: 0, stdout: 'ℹ pass 4\nℹ fail 0\n' }).ok,
-      expected: true
+      expected: true,
     },
     {
       name: 'the TAP reporter shape is read too',
       actual: classifySuiteRun({ status: 0, stdout: '# pass 4\n# fail 0\n' }).ok,
-      expected: true
+      expected: true,
     },
     {
       name: 'a non-zero exit fails even when the counts look clean',
       actual: classifySuiteRun({ status: 1, stdout: 'ℹ pass 4\nℹ fail 0\n' }).ok,
-      expected: false
+      expected: false,
     },
     {
       name: 'exit 0 with unreadable output fails rather than passing blind',
       actual: classifySuiteRun({ status: 0, stdout: 'something else entirely' }).ok,
-      expected: false
+      expected: false,
     },
     {
       name: 'exit 0 having run no tests fails',
       actual: classifySuiteRun({ status: 0, stdout: 'ℹ pass 0\nℹ fail 0\n' }).ok,
-      expected: false
-    }
+      expected: false,
+    },
   ]
 
   let failures = 0
   for (const testCase of cases) {
     const ok = testCase.actual === testCase.expected
-    if (!ok) failures += 1
+    if (!ok)
+      failures += 1
     console.log(`${ok ? '\x1B[32m  ok\x1B[0m' : '\x1B[31mFAIL\x1B[0m'}  ${testCase.name}`)
   }
   console.log(
     failures === 0
       ? `\n\x1B[32mSelf-test passed: ${cases.length} cases.\x1B[0m\n`
-      : `\n\x1B[31mSelf-test failed: ${failures}/${cases.length} cases.\x1B[0m\n`
+      : `\n\x1B[31mSelf-test failed: ${failures}/${cases.length} cases.\x1B[0m\n`,
   )
   return failures
 }
@@ -127,7 +132,7 @@ const suites = findSuites()
 
 if (discoveryFoundNothing(suites)) {
   console.error(
-    '\x1B[31mNo plugins/*/index.test.cjs found — this run would report success without executing a single plugin test.\x1B[0m\n'
+    '\x1B[31mNo plugins/*/index.test.cjs found — this run would report success without executing a single plugin test.\x1B[0m\n',
   )
   process.exit(1)
 }
@@ -140,13 +145,14 @@ const failed = []
 for (const suite of suites) {
   const run = spawnSync(process.execPath, ['--test', 'index.test.cjs'], {
     cwd: path.dirname(suite.file),
-    encoding: 'utf8'
+    encoding: 'utf8',
   })
   const verdict = classifySuiteRun({ status: run.status, stdout: `${run.stdout ?? ''}${run.stderr ?? ''}` })
   if (verdict.ok) {
     totalCases += verdict.pass
     console.log(`\x1B[32m  ✓\x1B[0m ${suite.name.padEnd(28)} ${String(verdict.pass).padStart(3)} cases`)
-  } else {
+  }
+  else {
     failed.push({ suite, verdict, output: run.stdout ?? '' })
     console.log(`\x1B[31m  ✗\x1B[0m ${suite.name.padEnd(28)} ${verdict.reason}`)
   }

--- a/scripts/test-plugins.mjs
+++ b/scripts/test-plugins.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * Runs the per-plugin `index.test.cjs` suites.
+ *
+ * These suites existed and passed long before this script did -- 97 cases across 16 plugins --
+ * but nothing executed them. `plugins/*` is in the pnpm workspace, yet most of these directories
+ * ship no `package.json`, so they are not workspace packages and `pnpm -r test` never reaches
+ * them; the ones that do declare `test: node --test index.test.cjs` are not covered by any CI job
+ * either, because the App suites matrix is `[core-app, nexus]` and the only plugin step in CI is
+ * `pnpm plugins:validate`, which reads manifests. The archived record for task 297 shows the way
+ * they were actually run: `node --test plugins/touch-window-manager/index.test.cjs`, by hand, once.
+ *
+ * That matters because commit 911fe1c6f cut 2,274 lines from seven plugin suites in
+ * `packages/test` while rewriting the plugin preludes those suites covered. The integration
+ * baseline went green partly by moving coverage into files no gate reads (#330).
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const pluginsDir = path.join(repoRoot, 'plugins')
+
+/**
+ * Discovery returning nothing is not a pass.
+ *
+ * Every assertion this script makes is per suite, so an empty list makes the run check nothing
+ * while printing success and exiting 0 -- a renamed directory or a partial checkout is
+ * indistinguishable from a clean sweep. Same rule, same reason, as validate-plugins.mjs (#1586).
+ */
+export function discoveryFoundNothing(suites) {
+  return !Array.isArray(suites) || suites.length === 0
+}
+
+/**
+ * Decides a single suite from what `node --test` actually returned.
+ *
+ * The exit code is the verdict; the counts are for the report. That split is deliberate. I first
+ * wrote the aggregation the other way round, matching `# pass` from the TAP reporter when the
+ * default reporter emits `ℹ pass`, and every one of the sixteen green suites was reported as
+ * failing with no output to show for it. A parser that cannot read the output must not be the
+ * thing that decides the verdict.
+ *
+ * A zero-test run is still a failure, and that is the case worth having. `node --test` exits 0
+ * on a file whose tests have all been deleted or renamed out of collection, so exit-code-alone
+ * would hand a green tick to a suite that stopped asserting anything -- which is the exact
+ * failure mode that put #330 on the board.
+ */
+export function classifySuiteRun({ status, stdout }) {
+  const text = String(stdout ?? '')
+  const read = (label) => {
+    const match = text.match(new RegExp(`(?:^|\\s)${label}\\s+(\\d+)`, 'm'))
+    return match ? Number(match[1]) : null
+  }
+  const pass = read('pass')
+  const fail = read('fail')
+
+  if (status !== 0) return { ok: false, pass, fail, reason: `exited ${status}` }
+  if (pass === null) return { ok: false, pass, fail, reason: 'exit 0 but no test counts in output' }
+  if (pass === 0) return { ok: false, pass, fail, reason: 'exit 0 but ran no tests' }
+  return { ok: true, pass, fail, reason: null }
+}
+
+export function findSuites(root = pluginsDir) {
+  if (!fs.existsSync(root)) return []
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({ name: entry.name, file: path.join(root, entry.name, 'index.test.cjs') }))
+    .filter((suite) => fs.existsSync(suite.file))
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/** Proves the verdict logic fires, so a refactor cannot quietly turn this gate into a no-op. */
+function selfTest() {
+  const cases = [
+    { name: 'empty discovery is a failure', actual: discoveryFoundNothing([]), expected: true },
+    { name: 'non-array discovery is a failure', actual: discoveryFoundNothing(null), expected: true },
+    { name: 'a found suite is not empty discovery', actual: discoveryFoundNothing([{ name: 'x' }]), expected: false },
+    {
+      name: 'a passing suite passes',
+      actual: classifySuiteRun({ status: 0, stdout: 'ℹ pass 4\nℹ fail 0\n' }).ok,
+      expected: true
+    },
+    {
+      name: 'the TAP reporter shape is read too',
+      actual: classifySuiteRun({ status: 0, stdout: '# pass 4\n# fail 0\n' }).ok,
+      expected: true
+    },
+    {
+      name: 'a non-zero exit fails even when the counts look clean',
+      actual: classifySuiteRun({ status: 1, stdout: 'ℹ pass 4\nℹ fail 0\n' }).ok,
+      expected: false
+    },
+    {
+      name: 'exit 0 with unreadable output fails rather than passing blind',
+      actual: classifySuiteRun({ status: 0, stdout: 'something else entirely' }).ok,
+      expected: false
+    },
+    {
+      name: 'exit 0 having run no tests fails',
+      actual: classifySuiteRun({ status: 0, stdout: 'ℹ pass 0\nℹ fail 0\n' }).ok,
+      expected: false
+    }
+  ]
+
+  let failures = 0
+  for (const testCase of cases) {
+    const ok = testCase.actual === testCase.expected
+    if (!ok) failures += 1
+    console.log(`${ok ? '\x1B[32m  ok\x1B[0m' : '\x1B[31mFAIL\x1B[0m'}  ${testCase.name}`)
+  }
+  console.log(
+    failures === 0
+      ? `\n\x1B[32mSelf-test passed: ${cases.length} cases.\x1B[0m\n`
+      : `\n\x1B[31mSelf-test failed: ${failures}/${cases.length} cases.\x1B[0m\n`
+  )
+  return failures
+}
+
+if (process.argv.includes('--self-test')) {
+  process.exit(selfTest() > 0 ? 1 : 0)
+}
+
+const suites = findSuites()
+
+if (discoveryFoundNothing(suites)) {
+  console.error(
+    '\x1B[31mNo plugins/*/index.test.cjs found — this run would report success without executing a single plugin test.\x1B[0m\n'
+  )
+  process.exit(1)
+}
+
+console.log(`\nRunning ${suites.length} plugin suites\n`)
+
+let totalCases = 0
+const failed = []
+
+for (const suite of suites) {
+  const run = spawnSync(process.execPath, ['--test', 'index.test.cjs'], {
+    cwd: path.dirname(suite.file),
+    encoding: 'utf8'
+  })
+  const verdict = classifySuiteRun({ status: run.status, stdout: `${run.stdout ?? ''}${run.stderr ?? ''}` })
+  if (verdict.ok) {
+    totalCases += verdict.pass
+    console.log(`\x1B[32m  ✓\x1B[0m ${suite.name.padEnd(28)} ${String(verdict.pass).padStart(3)} cases`)
+  } else {
+    failed.push({ suite, verdict, output: run.stdout ?? '' })
+    console.log(`\x1B[31m  ✗\x1B[0m ${suite.name.padEnd(28)} ${verdict.reason}`)
+  }
+}
+
+if (failed.length > 0) {
+  for (const entry of failed) {
+    console.error(`\n\x1B[31m--- ${entry.suite.name}: ${entry.verdict.reason} ---\x1B[0m`)
+    console.error(entry.output.split('\n').slice(-25).join('\n'))
+  }
+  console.error(`\n\x1B[31m${failed.length}/${suites.length} plugin suites failed.\x1B[0m\n`)
+  process.exit(1)
+}
+
+console.log(`\n\x1B[32mAll ${suites.length} plugin suites passed — ${totalCases} cases.\x1B[0m\n`)


### PR DESCRIPTION
Fixes part of #330.

## What I found

The integration baseline is green today — 28 files, `240 passed | 4 todo`. It was 301 passing / 26 failing when the issue was filed. But it also **lost 90 cases** getting there, 334 → 244, concentrated in exactly the plugin files the issue names as failing:

```
browser-open      31 -> 4     translation      22 -> 7
system-actions    17 -> 7     browser-bookmarks 16 -> 8
quick-actions     16 -> 5     window-manager   14 -> 3
workspace-scripts 11 -> 5     window-presets   10 -> 3
```

`911fe1c6f` (*feat(plugin): isolate fixed-action official preludes [task 297]*, committed the same day this issue was filed) cut 2,274 lines from seven of those files while rewriting the preludes they covered. **Cutting them was reasonable in kind** — the implementations changed shape, and the same commit added per-plugin `index.test.cjs` files.

What is not reasonable is that nothing runs those files:

- `plugins/*` is in the pnpm workspace, but `touch-browser-open`, `touch-quick-actions`, `touch-window-presets` and `touch-window-manager` ship **no `package.json` at all**, so they are not workspace packages and `pnpm -r` never reaches them.
- The ones that *do* declare `test: node --test index.test.cjs` are not covered by any job either. The App suites matrix is `[core-app, nexus]`, and the only plugin step in CI is `pnpm plugins:validate`, which reads manifests.
- The archived record for task 297 shows how they were actually run: `node --test plugins/touch-window-manager/index.test.cjs` — by hand, once.

## What this does

I ran all sixteen. **They pass, 97 cases, no repair needed.** This wires them in so they stay that way.

```
pnpm test:plugins            16 suites, 97 cases
pnpm test:plugins:self-test  8 cases
```

## Two design notes worth the review time

**The exit code is the verdict; the counts are only for the report.** I wrote it the other way round first, matching `# pass` from the TAP reporter when the default reporter emits `ℹ pass` — and it reported all sixteen green suites as failing, with no output to show for it. A parser that cannot read the output must not be the thing that decides the verdict.

**A zero-test run still fails.** `node --test` exits 0 on a file whose tests have all been deleted or renamed out of collection, so exit-code-alone would hand a green tick to a suite that stopped asserting anything — the exact failure mode that put this issue on the board. The self-test covers both reporter shapes, non-zero exit, unreadable output, and exit-0-having-run-nothing.

## What this does not do

It does not restore the 90 cases, and it does not close the issue. `touch-system-actions` went 17 → 7 in `packages/test` and has **no package-local test file at all**, so that coverage is currently nowhere. The remaining fixture questions in the issue body — declaring whether each test consumes canonical source, generated bundle, or packaged runtime — are untouched.

Refs #330