### PR TITLE
fix(deps): astro is a build tool, not a production dependency

### DIFF
--- a/apps/reverse-proxy-design/package.json
+++ b/apps/reverse-proxy-design/package.json
@@ -10,11 +10,9 @@
     "preview": "astro preview --host 127.0.0.1 --port 4321",
     "deploy": "pnpm run build && wrangler deploy"
   },
-  "dependencies": {
-    "astro": "^6.3.1"
-  },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
+    "astro": "^6.3.1",
     "typescript": "catalog:dev",
     "wrangler": "catalog:dev"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -782,14 +782,13 @@ importers:
         version: 4.107.1(@cloudflare/workers-types@4.20260702.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   apps/reverse-proxy-design:
-    dependencies:
-      astro:
-        specifier: ^6.3.1
-        version: 6.4.8(@types/node@24.13.2)(db0@0.3.4(@libsql/client@0.17.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@libsql/client@0.17.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)))(ioredis@5.11.1)(jiti@2.7.0)(rollup@2.80.0)(sass@1.101.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.9
         version: 0.9.9(prettier@3.8.3)(typescript@5.9.3)
+      astro:
+        specifier: ^6.3.1
+        version: 6.4.8(@types/node@24.13.2)(db0@0.3.4(@libsql/client@0.17.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@libsql/client@0.17.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)))(ioredis@5.11.1)(jiti@2.7.0)(rollup@2.80.0)(sass@1.101.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
       typescript:
         specifier: catalog:dev
         version: 5.9.3


### PR DESCRIPTION
Toward #328 — removes the `sharp` High from the production audit.

## Why `sharp` survived the obvious fix

Because the obvious fix was already applied. `apps/core-app` declares `sharp ^0.35.3` and resolves **0.35.3**, above the `>=0.35.0` patch line. The advisory was never about that copy.

`sharp@0.34.5` has exactly two dependents in the lockfile:

| dependent | declared as | in `--prod`? |
|---|---|---|
| `astro` (via `apps/reverse-proxy-design`) | **`dependencies`** | yes |
| `miniflare` (via `wrangler`) | `devDependencies` everywhere | no |

So one production edge was keeping it there.

## Why moving it is safe rather than a reclassification argument

`apps/reverse-proxy-design` is `private: true`, `astro` was its **only** production dependency, and every script is build-time — `dev` / `build` / `preview` / `deploy`, where `deploy` is `pnpm run build && wrangler deploy` against the built static output. `@astrojs/check`, `typescript` and `wrangler` are already devDependencies.

Checked before changing anything: nothing runs `install --prod` anywhere in the repo, no workflow builds this app, and `electron-builder.yml` does not reference it.

## Measured, not deduced

```
before   low 3, moderate 10, high 9, critical 1     sharp listed HIGH
after    low 2, moderate  8, high 8, critical 1     sharp absent
```

Total 23 → 19. The lockfile change is the importer entry moving between two blocks at the same resolved version, and `astro` still resolves — `v6.4.8`.

## Scope

This is one advisory. The remaining Critical/High set is `@nuxt/devtools`, `electron`, `nanoid`, `nuxt` — none of which this touches, and the `nuxt` cluster has a separate root cause I have written up on the issue.

Refs #328