### PR TITLE
fix(window): give Linux transparent windows a way out (#806)

### DIFF
--- a/apps/core-app/src/main/core/touch-window.ts
+++ b/apps/core-app/src/main/core/touch-window.ts
@@ -11,7 +11,11 @@ import { app, BrowserWindow, nativeTheme } from 'electron'
 import { IS_WINDOWS_11, MicaBrowserWindow, useMicaElectron, WIN10 } from 'talex-mica-electron'
 import { createLogger } from '../utils/logger'
 import { operationalErrorService } from '../modules/observability'
-import { shouldApplyMicaFallback } from './window-effects'
+import {
+  OPAQUE_WINDOW_ENV_VAR,
+  shouldApplyMicaFallback,
+  withOpaqueFallback
+} from './window-effects'
 import { OpenExternalUrlEvent, TalexEvents, touchEventBus } from './eventbus/touch-event'
 
 const touchWindowLog = createLogger('TouchWindow')
@@ -35,7 +39,11 @@ export class TouchWindow implements TalexTouch.ITouchWindow {
   window: BrowserWindow
   private isMicaWindow: boolean = false
 
-  constructor(options?: TalexTouch.TouchWindowConstructorOptions) {
+  constructor(rawOptions?: TalexTouch.TouchWindowConstructorOptions) {
+    // Every window in the app is built through here, so this is the one place the escape
+    // hatch has to be applied for it to mean anything (#806).
+    const options = withOpaqueFallback(rawOptions, process.env)
+
     if (isWindows) {
       try {
         // Use MicaBrowserWindow on Windows for better Mica/Acrylic effects
@@ -87,6 +95,15 @@ export class TouchWindow implements TalexTouch.ITouchWindow {
       // Fallback for Windows if MicaBrowserWindow is not used
       this.window.setBackgroundMaterial('mica')
       touchWindowLog.debug('Apply MicaMaterial on window (fallback)')
+    } else if (process.platform === 'linux') {
+      // Linux has no equivalent effect to apply, and Electron exposes nothing to ask whether
+      // this session composites. Named rather than left as a fall-through so the next reader
+      // sees that the gap is known, and so the log says what to do when the window turns out
+      // to be black or invisible — which is not something you can fix from inside a window
+      // you cannot see (#806).
+      touchWindowLog.debug(
+        `No window effect on linux; set ${OPAQUE_WINDOW_ENV_VAR}=1 if transparent windows render black or invisible`
+      )
     }
 
     // Registered against webContents directly, not inside ready-to-show. That event fires only

--- a/apps/core-app/src/main/core/window-effects.test.ts
+++ b/apps/core-app/src/main/core/window-effects.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from 'vitest'
-import { shouldApplyMicaFallback } from './window-effects'
+import {
+  BoxWindowOption,
+  MainWindowOption,
+  ScreenshotEditorWindowOption,
+  ScreenshotOverlayWindowOption
+} from '../config/default'
+import {
+  OPAQUE_WINDOW_BACKGROUND,
+  OPAQUE_WINDOW_ENV_VAR,
+  shouldApplyMicaFallback,
+  shouldForceOpaqueWindow,
+  withOpaqueFallback
+} from './window-effects'
 
 describe('window effects platform guards', () => {
   it('only applies mica fallback on Windows non-mica windows', () => {
@@ -7,5 +19,67 @@ describe('window effects platform guards', () => {
     expect(shouldApplyMicaFallback('win32', true)).toBe(false)
     expect(shouldApplyMicaFallback('linux', false)).toBe(false)
     expect(shouldApplyMicaFallback('darwin', false)).toBe(false)
+  })
+})
+
+describe('opaque window escape hatch', () => {
+  const ON = { [OPAQUE_WINDOW_ENV_VAR]: '1' }
+
+  it('reads only the explicit opt-in values', () => {
+    expect(shouldForceOpaqueWindow({ [OPAQUE_WINDOW_ENV_VAR]: '1' })).toBe(true)
+    expect(shouldForceOpaqueWindow({ [OPAQUE_WINDOW_ENV_VAR]: 'true' })).toBe(true)
+    expect(shouldForceOpaqueWindow({ [OPAQUE_WINDOW_ENV_VAR]: '0' })).toBe(false)
+    expect(shouldForceOpaqueWindow({ [OPAQUE_WINDOW_ENV_VAR]: '' })).toBe(false)
+    expect(shouldForceOpaqueWindow({})).toBe(false)
+  })
+
+  it('changes nothing while the hatch is closed', () => {
+    const options = { transparent: true, frame: false }
+    expect(withOpaqueFallback(options, {})).toBe(options)
+  })
+
+  it('makes a transparent window with no colour of its own opaque', () => {
+    expect(withOpaqueFallback({ transparent: true, frame: false }, ON)).toEqual({
+      transparent: false,
+      frame: false,
+      backgroundColor: OPAQUE_WINDOW_BACKGROUND
+    })
+  })
+
+  it('leaves a window that named its own colour alone', () => {
+    // A capture overlay you cannot see through is a capture overlay you cannot use, so the
+    // deliberate `#00000000` outranks the escape hatch.
+    const overlay = { transparent: true, backgroundColor: '#00000000' }
+    expect(withOpaqueFallback(overlay, ON)).toBe(overlay)
+  })
+
+  it('leaves an already-opaque window alone', () => {
+    const editor = { transparent: false, backgroundColor: '#111315' }
+    expect(withOpaqueFallback(editor, ON)).toBe(editor)
+  })
+
+  it('tolerates being handed nothing', () => {
+    expect(withOpaqueFallback(undefined, ON)).toBeUndefined()
+  })
+
+  // Pins the hatch against the options the app actually ships rather than hand-written
+  // stand-ins, so a window option changing shape cannot leave these tests passing on
+  // examples that no longer resemble it.
+  it('covers the shipped window options it is meant to rescue', () => {
+    for (const shipped of [MainWindowOption, BoxWindowOption]) {
+      expect(shipped.transparent).toBe(true)
+      expect(shipped.backgroundColor).toBeUndefined()
+
+      const rescued = withOpaqueFallback(shipped, ON)
+      expect(rescued?.transparent).toBe(false)
+      expect(rescued?.backgroundColor).toBe(OPAQUE_WINDOW_BACKGROUND)
+    }
+  })
+
+  it('leaves the shipped screenshot windows exactly as they are', () => {
+    expect(withOpaqueFallback(ScreenshotOverlayWindowOption, ON)).toBe(
+      ScreenshotOverlayWindowOption
+    )
+    expect(withOpaqueFallback(ScreenshotEditorWindowOption, ON)).toBe(ScreenshotEditorWindowOption)
   })
 })

--- a/apps/core-app/src/main/core/window-effects.ts
+++ b/apps/core-app/src/main/core/window-effects.ts
@@ -1,3 +1,60 @@
 export function shouldApplyMicaFallback(platform: NodeJS.Platform, isMicaWindow: boolean): boolean {
   return platform === 'win32' && !isMicaWindow
 }
+
+/**
+ * Opaque colour used when transparency is given up. Same value as
+ * ScreenshotEditorWindowOption, which is the one window option that already ships the
+ * `transparent: false` plus explicit `backgroundColor` pair.
+ */
+export const OPAQUE_WINDOW_BACKGROUND = '#111315'
+
+/**
+ * Environment variable that forces every window opaque.
+ *
+ * Electron offers no way to ask a Linux session whether it has a compositor, and the effects
+ * chain has no Linux branch at all: darwin gets vibrancy, win32 gets mica, Linux falls
+ * through. Six of the eight window option sets request `transparent: true` with no
+ * `backgroundColor`, and AppImage and deb are shipped targets — so on a session without ARGB
+ * visuals those windows paint black or invisible (#806).
+ *
+ * The audit suggested making Linux opaque unconditionally. That is deliberately not done
+ * here: most Linux desktops do run a compositor, and a blanket default would flatten the
+ * launcher's translucency for all of them to protect the ones that cannot show it.
+ *
+ * What is actually missing is not a different default — it is a way out. Someone who cannot
+ * see the launcher cannot click a setting to fix it, so the recovery has to be reachable
+ * from outside the UI.
+ */
+export const OPAQUE_WINDOW_ENV_VAR = 'TUFF_OPAQUE_WINDOWS'
+
+export function shouldForceOpaqueWindow(env: NodeJS.ProcessEnv): boolean {
+  const raw = env[OPAQUE_WINDOW_ENV_VAR]
+  return raw === '1' || raw === 'true'
+}
+
+/**
+ * Applies the opaque fallback to a window's construction options.
+ *
+ * Returns the options untouched unless the escape hatch is set, so the default behaviour on
+ * every platform is exactly what it was.
+ *
+ * Only windows that ask for transparency *without* naming a `backgroundColor` are converted —
+ * the same set the transparent-window ratchet counts. A window that names its own colour has
+ * made a decision worth keeping: ScreenshotOverlayWindowOption asks for `#00000000` because a
+ * capture overlay you cannot see through is a capture overlay you cannot use, and forcing it
+ * opaque would trade an invisible launcher for an unusable screenshot tool.
+ */
+export function withOpaqueFallback<T extends { transparent?: boolean; backgroundColor?: string }>(
+  options: T | undefined,
+  env: NodeJS.ProcessEnv
+): T | undefined {
+  if (!options || !shouldForceOpaqueWindow(env)) return options
+  if (options.transparent !== true || options.backgroundColor !== undefined) return options
+
+  return {
+    ...options,
+    transparent: false,
+    backgroundColor: OPAQUE_WINDOW_BACKGROUND
+  }
+}


### PR DESCRIPTION
Closes #806.

## The finding holds; the prescription does not

The audit's location is exact. Confirmed by inventorying every window option set:

| option | transparent | backgroundColor |
|---|---|---|
| MainWindowOption | `true` | — |
| BoxWindowOption | `true` | — |
| DivisionBoxWindowOption | `true` | — |
| AssistantFloatingBallWindowOption | `true` | — |
| AssistantVoicePanelWindowOption | `true` | — |
| OmniPanelWindowOption | `true` | — |
| ScreenshotOverlayWindowOption | `true` | `#00000000` |
| ScreenshotEditorWindowOption | `false` | `#111315` |

Six ask for transparency with no colour to fall back to — exactly the number `check-transparent-window-debt.mjs` pins. AppImage and deb are shipped targets, and there is no Linux branch anywhere: `touch-window.ts` handles darwin and win32 then falls through, and `window-effects.ts` only tests `win32`.

**The suggested fix was not taken.** "Add a Linux branch that sets an opaque backgroundColor" would flatten the launcher's translucency on every Linux desktop that *does* composite — which is most of them — to protect the ones that cannot. That trades a rare failure for a universal regression.

The alternative in the issue, "detect compositor capability at runtime", has no implementation: Electron exposes no API for it, and nothing in the main process currently sets any of the Linux transparency switches (`--enable-transparent-visuals` and friends are absent repo-wide).

## What is actually missing

Not a different default — a way out. The failure is self-sealing: someone whose launcher renders black or invisible cannot click a setting to fix it, because the window holding that setting is the one they cannot see. So the recovery has to be reachable from outside the UI.

`TUFF_OPAQUE_WINDOWS=1` converts transparent windows to an opaque background. Applied at the `TouchWindow` constructor — the single point every window in the app is built through — so it cannot be half-applied.

The Linux branch is now named instead of a fall-through, and its log line states the remedy, which is how someone hitting this finds the variable at all.

## Scoped to the six

Only windows that ask for transparency **without naming a colour** convert. `ScreenshotOverlayWindowOption` asks for `#00000000` on purpose: a capture overlay you cannot see through is a capture overlay you cannot use, and forcing it opaque would trade an invisible launcher for an unusable screenshot tool.

## Verification

- `window-effects.test.ts`: 9 tests, including negative controls pinned against the **shipped** option objects rather than hand-written stand-ins, so a window option changing shape cannot leave the tests passing on examples that no longer resemble it.
- Mutation-checked — each fails 2 tests:

  | mutation | result |
  |---|---|
  | drop the "already names a colour" guard | 2 failed |
  | force the hatch permanently open | 2 failed |
  | set the colour but leave `transparent: true` | 2 failed |
  | restored | 9 passed |

- `check-transparent-window-debt.mjs`: still `holds at 6 of 8` — this changes no defaults.
- `typecheck:node` clean; 31 test files / 259 tests pass across `src/main/core` plus every suite referencing `TouchWindow`.
- eslint under the core-app config: 0 problems.

## Not covered

Whether transparency *works* on a given Linux session is still undetected — this makes the failure recoverable, not impossible. Verifying the rendering itself needs a Linux desktop without a compositor, which no runner in this repo provides.
