### PR TITLE
test(widget): assert unregister releases policy state and keeps guarding

### DIFF
--- a/apps/core-app/src/renderer/src/modules/plugin/widget-registry.test.ts
+++ b/apps/core-app/src/renderer/src/modules/plugin/widget-registry.test.ts
@@ -2,7 +2,7 @@
 import type { Component } from 'vue'
 import { createApp, h, nextTick, ref } from 'vue'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import { getWidgetSandboxAuditLog } from './widget-sandbox-policy'
+import { getWidgetSandboxAuditLog, guardWidgetDomNavigation } from './widget-sandbox-policy'
 
 const transportState = vi.hoisted(() => ({
   handlers: new Map<string, Function>(),
@@ -11,6 +11,7 @@ const transportState = vi.hoisted(() => ({
 }))
 let handleWidgetRegister: typeof import('./widget-registry').handleWidgetRegister
 let handleWidgetFailed: typeof import('./widget-registry').handleWidgetFailed
+let handleWidgetUnregister: typeof import('./widget-registry').handleWidgetUnregister
 let buildWidgetSandboxEvidence: typeof import('./widget-registry').buildWidgetSandboxEvidence
 let getWidgetFailure: typeof import('./widget-registry').getWidgetFailure
 let getWidgetSandboxEvidence: typeof import('./widget-registry').getWidgetSandboxEvidence
@@ -101,7 +102,8 @@ describe('widget-registry runtime hosts', () => {
       getWidgetFailure,
       getWidgetSandboxEvidence,
       handleWidgetFailed,
-      handleWidgetRegister
+      handleWidgetRegister,
+      handleWidgetUnregister
     } = await import('./widget-registry'))
     // 30s, not 10s. This import pulls a large graph and takes ~4.5s on its own, but the
     // hook runs while the rest of the 636-file suite is being transformed concurrently,
@@ -203,6 +205,67 @@ describe('widget-registry runtime hosts', () => {
       code: 'WIDGET_COMPILE_FAILED',
       hash: 'new-hash'
     })
+  })
+
+  it('unregistering a widget releases its renderer, styles, evidence and policy state', async () => {
+    const payload = {
+      ...makePayload(
+        'vue',
+        [
+          'const { h } = require("vue")',
+          'module.exports = {',
+          '  name: "DisposableWidget",',
+          '  setup() {',
+          '    return () => h("strong", "disposable")',
+          '  }',
+          '}'
+        ].join('\n')
+      ),
+      styles: '.disposable-widget { color: blue; }'
+    }
+
+    await handleWidgetRegister(payload)
+    expect(await getRenderer(payload.widgetId)).toBeDefined()
+    expect(document.head.querySelector(`style[data-widget-id="${payload.widgetId}"]`)).toBeTruthy()
+    expect(getWidgetSandboxEvidence(payload.widgetId)).toBeDefined()
+
+    handleWidgetUnregister({ widgetId: payload.widgetId })
+
+    expect(transportState.renderers.has(payload.widgetId)).toBe(false)
+    expect(document.head.querySelector(`style[data-widget-id="${payload.widgetId}"]`)).toBeNull()
+    expect(getWidgetSandboxEvidence(payload.widgetId)).toBeNull()
+  })
+
+  // Disposal releases the policy but deliberately keeps the id in `disposedWidgetIds`, so
+  // `guardWidgetDomNavigation` still returns true for a widget that no longer has one. Without
+  // that, a torn-down widget's in-flight click would find no policy, fall straight through the
+  // `!policy && !disposedWidgetIds.has(id)` guard, and navigate the host -- teardown would open
+  // the exact hole the sandbox exists to close. This assertion is what stops a future
+  // "clean up everything on unregister" change from looking correct.
+  it('keeps guarding DOM navigation for a widget after its policy is disposed', async () => {
+    const payload = await register(
+      'vue',
+      [
+        'const { h } = require("vue")',
+        'module.exports = { name: "NavWidget", setup() { return () => h("div", "nav") } }'
+      ].join('\n')
+    )
+
+    handleWidgetUnregister({ widgetId: payload.widgetId })
+
+    const link = document.createElement('a')
+    link.href = 'https://outside.invalid/'
+    document.body.appendChild(link)
+
+    let guarded: boolean | null = null
+    const listener = (event: Event): void => {
+      guarded = guardWidgetDomNavigation(payload.widgetId, event)
+    }
+    document.addEventListener('click', listener, true)
+    link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    document.removeEventListener('click', listener, true)
+
+    expect(guarded).toBe(true)
   })
 
   it('builds widget sandbox evidence for the runtime boundary', () => {


### PR DESCRIPTION
Closes the last open criterion on #317.

## The gap

> Unregister/unmount removes policy state, listeners, and audit ownership.

The behaviour is implemented. `handleWidgetUnregister` clears the runtime source, the failure record and the sandbox evidence, then `clearRegisteredWidgetRuntime` drops the hash, unregisters the renderer, removes injected styles, and calls `disposeWidgetSandboxPolicy`.

Nothing asserted any of it. Before this PR, `unregister` appeared **exactly once** across both widget test files — as a mock helper at `widget-registry.test.ts:41`.

## Two tests, because teardown pulls in two directions

**1. Unregister releases the renderer, the injected `<style>` element, and the sandbox evidence.**

**2. Navigation is still guarded *after* disposal.** `disposeWidgetSandboxPolicy` deletes the policy but deliberately adds the id to `disposedWidgetIds`, and `guardWidgetDomNavigation` reads `!policy && !disposedWidgetIds.has(id)`. Drop that line and a torn-down widget's in-flight click finds no policy, falls straight through the guard, and navigates the host — teardown would open the exact hole the sandbox exists to close.

The second one is the reason this is two tests and not one. A future "clean up everything on unregister" change would look obviously correct and would break it.

## Negative-controlled, not just observed green

```
remove clearWidgetSandboxEvidence  ->  test 1 fails, 21 pass
remove disposedWidgetIds.add       ->  test 2 fails, 21 pass
restored                           ->  22 pass
```

Each fails for the behaviour it names, and neither is load-bearing on the other.

## Two things my first draft got wrong

Both mine, not the implementation's: `getWidgetSandboxEvidence` returns `null` after clearing, not `undefined`; and `composedPath()` is empty once dispatch has finished, so the guard has to be asked from a live capture listener — which is also how the host calls it.

## On verification

Local `vue-tsc` could not be run here — mise's `command_not_found_handler` intercepts it under `apps/core-app` and returns without checking anything. I caught that with a deliberately planted type error, which produced **zero** diagnostics. The workspace typecheck job is the check for this.

Refs #317