### PR TITLE
docs(trellis): reconcile the CatalogService task with its implementation

### DIFF
--- a/.trellis/tasks/07-13-catalog-service-mvp/prd.md
+++ b/.trellis/tasks/07-13-catalog-service-mvp/prd.md
@@ -33,7 +33,7 @@ The detailed EARS contract is `.spec-workflow/specs/catalog-service-mvp/requirem
 - [x] Nexus manifest/download requests use NetworkService and content-addressed paths; no update, invalid response, and download failure leave SQLite and active registry unchanged.
 - [x] Plugin SDK official resolve/search/collision checks follow the active registry dynamically while existing plugin overlays remain intact and isolated.
 - [x] Diagnostics report the required low-sensitive state and degraded baseline fallback.
-- [ ] Focused shared contract, SQLite lifecycle, remote flow, plugin integration, lint, and CoreApp node/web typechecks pass.
+- [x] Focused shared contract, SQLite lifecycle, remote flow, plugin integration, lint, and CoreApp node/web typechecks pass.
 - [ ] R8 PRD, execution plan, quality baseline, changelog, task artifacts, and developer documentation state the exact completed/open boundary.
 
 ## Risk / Approval Gate

--- a/.trellis/tasks/07-13-catalog-service-mvp/task.json
+++ b/.trellis/tasks/07-13-catalog-service-mvp/task.json
@@ -3,7 +3,7 @@
   "name": "catalog-service-mvp",
   "title": "Implement CatalogService MVP",
   "description": "Land R8-F signed fail-closed CatalogService for verified pack import, activation, rollback and diagnostics without expanding into R8-G CI gates.",
-  "status": "planning",
+  "status": "in_progress",
   "dev_type": null,
   "scope": null,
   "package": null,
@@ -20,11 +20,17 @@
   "subtasks": [],
   "children": [],
   "parent": null,
-  "relatedFiles": [],
-  "notes": "Planning-only R8-F slice; it does not declare global priority.",
+  "relatedFiles": [
+    "apps/core-app/src/main/modules/catalog/catalog-service.ts",
+    "apps/core-app/src/main/modules/catalog/catalog-verifier.ts",
+    "apps/core-app/src/main/modules/catalog/catalog-repository.ts",
+    "apps/core-app/src/main/modules/catalog/catalog-remote.ts",
+    "apps/core-app/src/main/modules/catalog/catalog-lifecycle.integration.test.ts"
+  ],
+  "notes": "The implementation landed while the R8-F lane was paused, which is why the record and the code disagreed. apps/core-app/src/main/modules/catalog/ holds verifier, repository, service, remote and module, and a focused run is 6 files / 38 tests passing -- the same baseline #305 cites. Seven of the nine prd criteria were already checked.\n\nThe eighth is now checked too, verified rather than assumed: catalog 38/38, plugin-localization-channels 12/12, and CI carries the rest of that criterion -- the full core-app suite at 5846 passed, Typecheck (workspace), and lint through the PR quality gate.\n\nThe ninth is the real residual and it is documentation, not code: the R8 prd, execution plan, quality baseline, changelog and developer docs still have to state the completed/open boundary. Nothing about the service needs reimplementing, which is what #305 exists to prevent.",
   "meta": {
-    "nextAction": "Resume signed pack import, activation, rollback, and diagnostics after TODO.md releases the R8-F pause.",
-    "blocker": "Paused until the P1 stability sequence in docs/plan-prd/TODO.md is complete.",
-    "evidence": "prd.md acceptance checklist and CatalogService signature/import/rollback tests."
+    "nextAction": "Write the completed/open boundary into the R8 prd, execution plan, quality baseline, changelog and developer docs -- the ninth criterion, and the only one still open. No service code needs writing.",
+    "blocker": "None for the remaining scope. docs/plan-prd/TODO.md:37 still lists R8-F as paused, but that pause governs further lane work; it does not describe what already landed, and treating it as a blocker is what let this record drift from the code.",
+    "evidence": "Focused run: 6 files / 38 tests passing across verifier, repository, service, remote, module and lifecycle integration -- the baseline named in #305. plugin-localization-channels 12/12 for the plugin-integration half of criterion 8. CI carries the rest: core-app suite 5846 passed, Typecheck (workspace) green."
   }
 }


### PR DESCRIPTION
Toward #305 — the first two acceptance criteria.

`07-13-catalog-service-mvp` was still `planning`, with a nextAction reading *"Resume signed pack import, activation, rollback, and diagnostics after TODO.md releases the R8-F pause"*. **All of that is implemented.**

`apps/core-app/src/main/modules/catalog/` holds verifier, repository, service, remote and module, and a focused run is **6 files / 38 tests passing** — the exact baseline #305 cites. Seven of the nine prd criteria were already checked.

## Criterion 8, now checked because it was verified

> Focused shared contract, SQLite lifecycle, remote flow, plugin integration, lint, and CoreApp node/web typechecks pass.

```
catalog/                       38 passed (38)   contract, SQLite lifecycle, remote flow
plugin-localization-channels   12 passed (12)   plugin integration
CI core-app suite              5846 passed
CI Typecheck (workspace)       green            node + web
lint                           PR quality gate
```

## Criterion 9 is the residual, and it is documentation

> R8 PRD, execution plan, quality baseline, changelog, task artifacts, and developer documentation state the exact completed/open boundary.

That is now the `nextAction`, and it says plainly that **no service code needs writing** — which is the duplicate implementation #305 exists to prevent.

## On the pause, which I checked rather than dismissed

`docs/plan-prd/TODO.md:37` still lists R8-F as paused, so the old blocker was not fabricated. But the implementation landed *under* that pause while the record kept describing the work as not-yet-started. The pause governs further lane work; it does not describe what already exists, and reading it as a blocker on the whole task is precisely how this record drifted from the code. The blocker now says that.

`planning` → `in_progress`, because `planning` cannot be right for something with a passing implementation — #305's first acceptance criterion.

## Not in this PR

The other three tasks #305 names — `07-09-unify-search-provider-lifecycle` prerequisites, and the two audit parents — are untouched. They need their prds read, and I have written up what I found on the issue.

Refs #305