### PR TITLE
docs(trellis): the OTA task is waiting on a Mac, not on a signed build

### DIFF
--- a/.trellis/tasks/07-22-ota-one-click-background-update/task.json
+++ b/.trellis/tasks/07-22-ota-one-click-background-update/task.json
@@ -23,8 +23,8 @@
   "relatedFiles": [],
   "notes": "",
   "meta": {
-    "nextAction": "Obtain the remaining official macOS trusted-package silent-update, restart, and health-ack runtime evidence.",
-    "blocker": "The official trusted macOS package acceptance criterion remains unchecked.",
-    "evidence": "prd.md acceptance criteria distinguish completed focused/package checks from the pending official runtime proof."
+    "nextAction": "Run the N to N+1 smoke on a Mac. The artifacts exist: v2.4.14-beta.1 and v2.4.14-beta.2 both ship a signed macOS arm64 .app.zip, and both release jobs report Developer ID signing with \"notarization successful\". What is left is the run and its phase timings, not a build.",
+    "blocker": "A macOS benchmark host. Not, as this said before, the absence of an official trusted package -- that arrived on 2026-08-03.",
+    "evidence": "Nine of the ten prd criteria are checked. The code paths behind them have named tests in update-install-coordinator.test.ts: \"prepares and starts one helper even when BEFORE_APP_QUIT and WILL_QUIT repeat\" covers the single-helper rule, \"keeps a macOS update ready when the current build cannot use silent install\" covers the non-writable case staying ready instead of elevating, \"confirms the target version once, promotes its package, and writes a matching health ack\" and \"refuses to acknowledge health when startup runs a version other than the plan target\" cover the health handshake, and \"marks a previous-version restart as recovered when a matching recovery marker exists\" covers one-shot recovery. The unchecked criterion is the end-to-end timing on real hardware, which no test can stand in for."
   }
 }


### PR DESCRIPTION
Toward #316.

`07-22-ota-one-click-background-update` said its blocker was *"the official trusted macOS package acceptance criterion remains unchecked"*, and its nextAction was to *"obtain the remaining official macOS trusted-package evidence"*. That reads as waiting for an artifact.

**The artifact arrived on 2026-08-03.**

```
v2.4.14-beta.1   macos-latest-beta-tuff-2.4.14-beta.1-arm64.app.zip
v2.4.14-beta.2   macos-latest-beta-tuff-2.4.14-beta.2-arm64.app.zip

both release jobs:  TUFF_MAC_NATIVE_SIGNING_MODE: developer-id
                    • notarization successful
                    "codesign": true,  "notarization": true
```

I checked at the build rather than trusting the `.sig`, which is only electron-updater's own signature. `build-and-release.yml` hard-fails when the signing mode is not `developer-id` or notarization is not via the App Store Connect API key, so the build could not have produced these otherwise.

So the blocker is **a benchmark host**, and the nextAction is **run the smoke and record phase timings**. Those are different asks, and the old wording sends the next person looking for a release that already exists.

## The evidence field now names what the nine checked criteria rest on

From `update-install-coordinator.test.ts`:

```
prepares and starts one helper even when BEFORE_APP_QUIT and WILL_QUIT repeat
  -> the single-helper rule

keeps a macOS update ready when the current build cannot use silent install
  -> the non-writable case staying ready instead of quitting or elevating

confirms the target version once, promotes its package, and writes a matching health ack
refuses to acknowledge health when startup runs a version other than the plan target
  -> the health handshake, both directions

marks a previous-version restart as recovered when a matching recovery marker exists
  -> one-shot recovery
```

## Status stays `in_progress`

The tenth criterion is click-to-new-process within 15 seconds on real hardware. Nothing in the tree stands in for that.

Refs #316