### PR TITLE
fix(search): release the Everything provider's transport listeners

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/addon/files/everything-provider.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/everything-provider.test.ts
@@ -235,6 +235,8 @@ interface MutableEverythingProvider {
   }>
   refreshBackendState: (reason: 'startup' | 'manual-check' | 'toggle-enable') => Promise<boolean>
   registerChannels: (context: { touchApp: { channel: unknown } }) => void
+  onDestroy: () => void
+  channelDisposers: Array<() => void>
   onLoad: (context: { touchApp: { channel: unknown } }) => Promise<void>
   startupRefreshPromise: Promise<void> | null
 }
@@ -353,6 +355,55 @@ afterEach(() => {
 })
 
 describe('everything-provider fallback chain', () => {
+  // transportOn is a bare vi.fn() elsewhere, so it returns undefined and the provider collects
+  // nothing — which is why the pre-existing 51 cases pass either way. These two hand it a real
+  // disposer, which is the only shape in which the leak is observable.
+  it('releases every transport listener it registered when the provider is destroyed', async () => {
+    await withPlatform('win32', async () => {
+      const provider = everythingProvider as unknown as MutableEverythingProvider
+      vi.spyOn(provider, 'refreshBackendState').mockResolvedValue(false)
+      appTaskWaitForIdle.mockImplementation(() => new Promise(() => {}))
+      const disposers: Array<() => void> = []
+      transportOn.mockImplementation(() => {
+        const dispose = vi.fn()
+        disposers.push(dispose)
+        return dispose
+      })
+
+      await provider.onLoad({ touchApp: { channel: {} } })
+      expect(disposers).toHaveLength(6)
+      expect(provider.channelDisposers).toHaveLength(6)
+
+      provider.onDestroy()
+
+      for (const dispose of disposers) expect(dispose).toHaveBeenCalledTimes(1)
+      expect(provider.channelDisposers).toHaveLength(0)
+    })
+  })
+
+  // registerChannels runs from onLoad, and onLoad can run again on a provider reload. Without the
+  // release at the top of registerChannels the second pass would stack a second set of six on the
+  // same events, and the first set would be unreachable — a leak that only shows up after a reload.
+  it('does not stack listeners when channels are registered twice', async () => {
+    await withPlatform('win32', async () => {
+      const provider = everythingProvider as unknown as MutableEverythingProvider
+      const disposers: Array<() => void> = []
+      transportOn.mockImplementation(() => {
+        const dispose = vi.fn()
+        disposers.push(dispose)
+        return dispose
+      })
+
+      provider.registerChannels({ touchApp: { channel: {} } })
+      provider.registerChannels({ touchApp: { channel: {} } })
+
+      expect(disposers).toHaveLength(12)
+      expect(provider.channelDisposers).toHaveLength(6)
+      for (const dispose of disposers.slice(0, 6)) expect(dispose).toHaveBeenCalledTimes(1)
+      for (const dispose of disposers.slice(6)) expect(dispose).not.toHaveBeenCalled()
+    })
+  })
+
   it('loads settings and channels without blocking on startup backend detection', async () => {
     await withPlatform('win32', async () => {
       const provider = everythingProvider as unknown as MutableEverythingProvider

--- a/apps/core-app/src/main/modules/box-tool/addon/files/everything-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/everything-provider.ts
@@ -165,6 +165,7 @@ class EverythingProvider implements ISearchProvider<ProviderContext> {
   readonly supportedInputTypes = [TuffInputType.Text, TuffInputType.Files]
   readonly priority = 'fast' as const
 
+  private channelDisposers: Array<() => void> = []
   private esPath: string | null = null
   private configuredCliPath: string | null = null
   private isAvailable = false
@@ -1144,11 +1145,48 @@ class EverythingProvider implements ISearchProvider<ProviderContext> {
       .build()
   }
 
+  private disposeChannels(): void {
+    for (const dispose of this.channelDisposers.splice(0)) {
+      try {
+        dispose()
+      } catch (error) {
+        this.logWarn('Failed to dispose Everything transport listener', error)
+      }
+    }
+  }
+
+  /**
+   * Called by SearchProviderRegistry.destroy() (search-provider-registry.ts:411), which wraps it
+   * per provider in try/catch. Synchronous because that hook is — releasing listeners needs no
+   * await, but a provider that had async teardown could not express it here.
+   */
+  onDestroy(): void {
+    this.disposeChannels()
+  }
+
   private registerChannels(context: ProviderContext): void {
     const channel = context.touchApp.channel
     const keyManager =
       (channel as { keyManager?: unknown } | null | undefined)?.keyManager ?? channel
-    const transport = getTuffTransportMain(channel, keyManager)
+    const rawTransport = getTuffTransportMain(channel, keyManager)
+
+    // Every `transport.on` below returns a disposer, and all six were being dropped: the file had
+    // no disposer array, no unregister, and no `off(` — so the listeners could not be released even
+    // deliberately. Nothing collected them from outside either: this provider is absent from
+    // SearchCore.destroy(), it has no `onDeactivate` for the registry's fallback to call, and
+    // `onDestroy` did not exist. Three teardown paths, all no-ops (#334).
+    //
+    // Wrapping `on` rather than editing the six call sites keeps the handlers untouched, so this
+    // cannot change which events are registered — only whether they can be let go of.
+    this.disposeChannels()
+    const transport = {
+      ...rawTransport,
+      on: ((...args: Parameters<typeof rawTransport.on>) => {
+        const dispose = rawTransport.on(...args)
+        if (typeof dispose === 'function') this.channelDisposers.push(dispose)
+        return dispose
+      }) as typeof rawTransport.on
+    }
 
     transport.on(everythingStatusEvent, async (payload) => {
       if (payload?.refresh && process.platform === 'win32') {


### PR DESCRIPTION
Toward #334 — the one item in that issue that is a live defect rather than an architectural cost.

## Three teardown paths, all no-ops

`everything-provider` registers **six** transport listeners and dropped every disposer. The file had no disposer array, no unregister, and no `off(` — so they could not be released even deliberately. Nothing released them from outside either:

| path | state |
|---|---|
| `SearchCore.destroy()` | 88 lines (`search-core.ts:2111-2199`), mentions `everything` **zero** times |
| `onDestroy` | did not exist |
| `onDeactivate` | does not exist either, so the registry's fallback at `search-provider-registry.ts:412` is also a no-op |

The provider is registered only under `process.platform === 'win32'` (`search-core.ts:322-324`), which is presumably how this survived: the release acceptance host is a Mac, where `onLoad` never runs.

## What the change does

Wraps `transport.on` rather than editing the six call sites, so the handlers are untouched and this **cannot** change which events get registered — only whether they can be let go of.

`registerChannels` also releases before registering. It runs from `onLoad`, and `onLoad` can run again on a provider reload; without that, a second pass stacks a second set of six on the same events and orphans the first.

## Negative-controlled

```
onDestroy no longer disposing       ->  1 failed, 52 passed
no release before re-registering    ->  1 failed, 52 passed
disposers not collected             ->  2 failed, 51 passed
restored                            ->  53 passed
```

Both new cases hand `transportOn` a **real disposer**. It is a bare `vi.fn()` everywhere else and returns `undefined`, which is exactly why the existing 51 cases pass with or without any of this — the leak is only observable once there is something to drop. That is worth knowing about this file generally.

`search-core.contracts` + `search-provider-registry`: 28 passed. Lint clean under the core-app config.

## One thing I did not work around

`onDestroy` is synchronous, because the hook is. `ISearchProvider` declares **no disposal member at all** — `onDestroy` exists only on a local interface at `search-provider-registry.ts:58` — so a provider needing async teardown cannot express it, and a provider author reading the SDK interface has no way to know the hook exists.

That contract gap is #334's to fix. This change lives inside it rather than pre-empting it.

Refs #334