### PR TITLE
fix(search): discover Linux apps through XDG instead of three fixed paths

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/addon/apps/linux.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/linux.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { resolveApplicationRoots } from './linux'
+
+const HOME = '/home/tester'
+
+describe('linux application roots', () => {
+  it('applies the XDG defaults when the environment says nothing', () => {
+    const roots = resolveApplicationRoots({}, HOME)
+
+    expect(roots).toContain('/usr/share/applications')
+    expect(roots).toContain('/usr/local/share/applications')
+    expect(roots).toContain(`${HOME}/.local/share/applications`)
+  })
+
+  // The regression this function exists for. flatpak exports to its own prefixes and never copies
+  // into /usr/share/applications, so the previous hardcoded list made every flatpak-installed
+  // application invisible to search -- silently, since a missing directory is indistinguishable
+  // from an empty one to findDesktopFiles.
+  it('covers both flatpak export prefixes', () => {
+    const roots = resolveApplicationRoots({}, HOME)
+
+    expect(roots).toContain('/var/lib/flatpak/exports/share/applications')
+    expect(roots).toContain(`${HOME}/.local/share/flatpak/exports/share/applications`)
+  })
+
+  it('keeps the snap prefix, which is outside XDG on most distributions', () => {
+    expect(resolveApplicationRoots({}, HOME)).toContain('/var/lib/snapd/desktop/applications')
+  })
+
+  it('reads XDG_DATA_DIRS instead of assuming the defaults', () => {
+    const roots = resolveApplicationRoots({ XDG_DATA_DIRS: '/opt/nix/share:/srv/apps' }, HOME)
+
+    expect(roots).toContain('/opt/nix/share/applications')
+    expect(roots).toContain('/srv/apps/applications')
+    expect(roots).not.toContain('/usr/local/share/applications')
+  })
+
+  it('reads XDG_DATA_HOME for the per-user prefix, including its flatpak subtree', () => {
+    const roots = resolveApplicationRoots({ XDG_DATA_HOME: '/data/xdg' }, HOME)
+
+    expect(roots).toContain('/data/xdg/applications')
+    expect(roots).toContain('/data/xdg/flatpak/exports/share/applications')
+    expect(roots).not.toContain(`${HOME}/.local/share/applications`)
+  })
+
+  it('ignores blank and whitespace-only entries in XDG_DATA_DIRS', () => {
+    const roots = resolveApplicationRoots({ XDG_DATA_DIRS: '/a::  :/b' }, HOME)
+
+    expect(roots).toContain('/a/applications')
+    expect(roots).toContain('/b/applications')
+    expect(roots.filter((root) => root === 'applications')).toHaveLength(0)
+  })
+
+  // A duplicated root would scan the same directory twice and emit two entries for one app,
+  // because uniqueId is the .desktop path.
+  it('does not repeat a root that appears twice', () => {
+    const roots = resolveApplicationRoots({ XDG_DATA_DIRS: '/usr/share:/usr/share' }, HOME)
+
+    expect(roots.filter((root) => root === '/usr/share/applications')).toHaveLength(1)
+    expect(new Set(roots).size).toBe(roots.length)
+  })
+
+  it('falls back to the defaults when XDG_DATA_DIRS is set but empty', () => {
+    expect(resolveApplicationRoots({ XDG_DATA_DIRS: '   ' }, HOME)).toContain(
+      '/usr/share/applications'
+    )
+  })
+})

--- a/apps/core-app/src/main/modules/box-tool/addon/apps/linux.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/linux.ts
@@ -6,11 +6,43 @@ import type { ScannedAppInfo } from './app-types'
 
 type AppInfo = ScannedAppInfo
 
-const APP_PATHS = [
-  '/usr/share/applications',
-  '/var/lib/snapd/desktop/applications',
-  `${os.homedir()}/.local/share/applications`
-]
+/**
+ * Resolves the directories that hold `.desktop` entries on this machine.
+ *
+ * The list used to be three hardcoded paths, which missed flatpak entirely -- flatpak exports to
+ * its own prefixes and does not copy into `/usr/share/applications`, so on a Silverblue box, or
+ * for the growing share of Ubuntu/Mint users who install that way, those applications were
+ * invisible to search with nothing to indicate they had been skipped.
+ *
+ * `XDG_DATA_DIRS` and `XDG_DATA_HOME` are the mechanism the desktop already uses to answer this
+ * question, and reading them covers flatpak, nix and custom prefixes without enumerating any of
+ * them. The spec defaults are applied when unset, which is what produced the old `/usr/share`
+ * entry anyway.
+ *
+ * Snap and flatpak roots are then added explicitly rather than relied on through XDG. Both are
+ * normally injected into `XDG_DATA_DIRS` by a profile script, and a profile script only runs for
+ * login shells -- an Electron app launched from a `.desktop` entry or a session manager can
+ * legitimately see a minimal environment. Adding them costs nothing: findDesktopFiles swallows
+ * errors for directories that do not exist.
+ */
+export function resolveApplicationRoots(
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = os.homedir()
+): string[] {
+  const dataHome = env.XDG_DATA_HOME?.trim() || path.join(home, '.local', 'share')
+  const dataDirs = (env.XDG_DATA_DIRS?.trim() || '/usr/local/share:/usr/share')
+    .split(':')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+
+  const roots = [dataHome, ...dataDirs].map((dir) => path.join(dir, 'applications'))
+
+  roots.push('/var/lib/snapd/desktop/applications')
+  roots.push('/var/lib/flatpak/exports/share/applications')
+  roots.push(path.join(dataHome, 'flatpak', 'exports', 'share', 'applications'))
+
+  return [...new Set(roots)]
+}
 
 async function findIconPath(iconName: string): Promise<string> {
   if (path.isAbsolute(iconName) && (await fs.stat(iconName).catch(() => null))) {
@@ -121,7 +153,7 @@ async function findDesktopFiles(dir: string): Promise<string[]> {
 }
 
 export async function getApps(): Promise<AppInfo[]> {
-  const allDesktopFilesPromises = APP_PATHS.map((p) => findDesktopFiles(p))
+  const allDesktopFilesPromises = resolveApplicationRoots().map((p) => findDesktopFiles(p))
   const nestedDesktopFiles = await Promise.all(allDesktopFilesPromises)
   const allDesktopFiles = nestedDesktopFiles.flat()
 


### PR DESCRIPTION
Toward #341, item 2 (application scan parity).

## flatpak applications were invisible, and nothing said so

Linux application discovery used a hardcoded list:

```js
'/usr/share/applications'
'/var/lib/snapd/desktop/applications'
`${os.homedir()}/.local/share/applications`
```

Snap and user installs were covered. **flatpak was not, and could not be** — flatpak exports to its own prefixes and never copies into `/usr/share/applications`. So on a Silverblue box, or for the growing share of Ubuntu/Mint users who install that way, flatpak applications simply did not appear in search.

Silently: `findDesktopFiles` swallows directory errors, so a missing root is indistinguishable from an empty one.

## Reading XDG is the fix, not a longer list

`XDG_DATA_DIRS` and `XDG_DATA_HOME` are the mechanism the desktop already uses to answer this exact question. There were **zero** references to either anywhere in `apps/core-app/src` — checked against a positive control (110 of 1,723 files contain `process.platform`, so the scan reached them).

Reading them covers flatpak, nix and custom prefixes without enumerating any of them, and the spec defaults (`/usr/local/share:/usr/share`) reproduce the old `/usr/share` entry.

Snap and flatpak roots are still added **explicitly** rather than trusted to XDG. Both are normally injected into `XDG_DATA_DIRS` by a profile script, and a profile script only runs for login shells — an Electron app launched from a `.desktop` entry or a session manager can legitimately see a minimal environment. The extra roots cost nothing, since nonexistent directories are already ignored.

Roots are deduplicated: scanning one twice would emit two entries for the same application, because `uniqueId` is the `.desktop` path.

## Negative-controlled

`resolveApplicationRoots` takes `env` and `home` as parameters, so this is testable without touching `process.env`.

```
revert to the three hardcoded paths  ->  5 failed, 3 passed
drop the two flatpak roots           ->  2 failed, 6 passed
drop the dedupe                      ->  1 failed, 7 passed
restored                             ->  8 passed
```

`addon/apps` suite: 19 files / 196 passed. Lint clean under the core-app config.

## Scope

This does not close #341. The OCR stub, the icon lookup in the same file — 6 themes × 6 sizes × 6 types × 2 extensions, up to **432 sequential `fs.stat` per application**, all under `/usr/share/icons` only — and the acceptance matrix are untouched. Measurements for each are on the issue.

Refs #341