### PR TITLE
ci(tuff-native): build and load-verify the audio addon

### DIFF
--- a/.github/workflows/native-protocol.yml
+++ b/.github/workflows/native-protocol.yml
@@ -103,6 +103,20 @@ jobs:
           pnpm -C packages/tuff-native run test:screenshot-protocol &&
           pnpm -C packages/tuff-native run verify:screenshot-production
 
+      # native-audio is already a member of packages/tuff-native/Cargo.toml, so the cargo
+      # fmt/clippy/test/build steps above have always covered the crate on all three runners.
+      # What nothing ran was build:audio -- the step that copies the compiled library to
+      # build/Release/tuff_native_audio.node, which is the artifact audio.js actually opens.
+      # So the crate could compile while the addon the runtime loads was never produced (#322).
+      #
+      # The verifier passes on a runner with no microphone and fails when the module is absent:
+      # it separates reasons the native module produces (no-input-device, input-probe-failed,
+      # platform-not-supported) from reasons the JS wrapper produces when the binding is missing.
+      - name: Build production audio addon and verify it loads
+        run: >-
+          pnpm -C packages/tuff-native run build:audio &&
+          pnpm -C packages/tuff-native run verify:audio-production
+
       - name: Build deterministic screenshot addon
         env:
           TUFF_SCREENSHOT_PROTOCOL_TEST_BACKEND: '1'

--- a/packages/test/src/native/tuff-native-audio.test.ts
+++ b/packages/test/src/native/tuff-native-audio.test.ts
@@ -18,6 +18,38 @@ function withDisabledAudio<T>(run: () => T): T {
   }
 }
 
+/**
+ * Whether the `.node` binding actually loaded, which is not the same question as
+ * `support.supported`.
+ *
+ * `getNativeAudioSupport` returns `supported: false` for two unrelated situations, and the test
+ * below only holds for one of them:
+ *
+ *   - the binding is absent, so the wrapper answers with `native-module-not-loaded`, an
+ *     export-mismatch message, or `disabled-by-env`. Its strict methods then throw
+ *     ERR_NATIVE_AUDIO_UNAVAILABLE, which is the fallback contract being asserted.
+ *   - the binding loaded and the *native* module reported there is no usable input device --
+ *     `no-input-device`, `input-probe-failed: …`, `platform-not-supported`
+ *     (native-audio/src/lib.rs, build_native_audio_support). Strict methods then reach Rust and
+ *     do not throw that code at all.
+ *
+ * Guarding on `support.supported` conflated the two. It happened to pass only while nothing in
+ * CI ever built the addon; once native-protocol.yml started running `build:audio`, a headless
+ * Linux runner hit the second case and this test asserted a throw that could not occur (#322).
+ */
+function nativeBindingLoaded(support: nativeAudio.NativeAudioSupport): boolean {
+  if (support.supported)
+    return true
+  const reason = support.reason
+  if (typeof reason !== 'string')
+    return false
+  return (
+    reason === 'no-input-device'
+    || reason === 'platform-not-supported'
+    || reason.startsWith('input-probe-failed: ')
+  )
+}
+
 describe('tuff-native audio contract', () => {
   it('exports the complete audio facade', () => {
     expect(typeof nativeAudio.getNativeAudioSupport).toBe('function')
@@ -45,7 +77,7 @@ describe('tuff-native audio contract', () => {
 
   it('uses strict capture errors and best-effort utility fallbacks when unavailable', () => {
     const support = nativeAudio.getNativeAudioSupport()
-    if (support.supported)
+    if (nativeBindingLoaded(support))
       return
 
     expect(() => nativeAudio.startCapture()).toThrow(

--- a/packages/tuff-native/package.json
+++ b/packages/tuff-native/package.json
@@ -110,6 +110,7 @@
     "build:protocol-fixture": "node scripts/build-protocol-fixture.js",
     "test:protocol": "node --test protocol-contract.test.js protocol-napi.test.js protocol-carrier.test.js protocol-package.test.js protocol-error-cause.test.js protocol-error-envelope.test.js",
     "test:screenshot-protocol": "node --test screenshot-addon-contract.test.js screenshot-protocol.test.js",
+    "verify:audio-production": "node scripts/verify-audio-production.js",
     "verify:screenshot-production": "node scripts/verify-screenshot-production.js",
     "rebuild": "node-gyp rebuild",
     "check:everything": "node scripts/everything-selfcheck.js"

--- a/packages/tuff-native/scripts/verify-audio-production.js
+++ b/packages/tuff-native/scripts/verify-audio-production.js
@@ -1,0 +1,71 @@
+'use strict'
+
+/**
+ * Proves `tuff_native_audio.node` was built and loads, without requiring a microphone.
+ *
+ * The audio crate is already a member of `packages/tuff-native/Cargo.toml`, so
+ * `cargo build --workspace --release` in native-protocol.yml compiles it on all three runners.
+ * What nothing did was run `build:audio` — the step that copies the compiled library to
+ * `build/Release/tuff_native_audio.node` — or load the result. So the crate could compile
+ * while the artifact the runtime actually opens was never produced (#322).
+ *
+ * The check has to work on a headless runner with no audio device, and the useful distinction
+ * is *who* produced the unsupported reason:
+ *
+ *   - the native module itself reports `no-input-device`, `input-probe-failed: …` or
+ *     `platform-not-supported` (native-audio/src/lib.rs `build_native_audio_support`). Reaching
+ *     any of those means the addon loaded, which is the thing being verified.
+ *   - the JS wrapper reports `native-module-not-loaded`, an `ERR_NATIVE_EXPORT_MISMATCH`
+ *     message, or a loader error string when the `.node` is absent or incomplete. That is the
+ *     packaging bug.
+ *
+ * So an absent microphone passes and an absent module fails, which is the same shape as
+ * verify-screenshot-production.js accepting `display-server-unavailable` on Linux.
+ */
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const process = require('node:process')
+const { getNativeAudioSupport } = require('../audio')
+
+const modulePath = path.join(__dirname, '..', 'build', 'Release', 'tuff_native_audio.node')
+
+assert.ok(
+  fs.existsSync(modulePath),
+  `tuff_native_audio.node missing at ${modulePath} — run \`pnpm -C packages/tuff-native build:audio\``,
+)
+
+const support = getNativeAudioSupport()
+
+// The native module reports Rust's `std::env::consts::OS`; the JS wrapper, when the binding is
+// absent, reports `process.platform`. Those names differ on macOS and Windows, so this assertion
+// is itself proof of which side answered — a wrapper fallback would say `darwin`, not `macos`.
+// They coincide on Linux, which is why the reason check below still has to carry that platform.
+const RUST_OS_NAME = { darwin: 'macos', win32: 'windows', linux: 'linux' }
+const expectedOs = RUST_OS_NAME[process.platform] ?? process.platform
+assert.equal(
+  support.platform,
+  expectedOs,
+  `expected the native module's OS name (${expectedOs}); got ${support.platform}`,
+)
+
+// Reasons the native module can produce. Anything outside this set — including `undefined`
+// alongside `supported: false` — came from the wrapper, which means the binding never loaded.
+const NATIVE_REASONS = new Set(['no-input-device', 'platform-not-supported'])
+function isNativeReason(reason) {
+  return typeof reason === 'string'
+    && (NATIVE_REASONS.has(reason) || reason.startsWith('input-probe-failed: '))
+}
+
+if (!support.supported) {
+  assert.ok(
+    isNativeReason(support.reason),
+    `native audio addon did not load: ${support.reason ?? 'no reason reported'}`,
+  )
+  console.log(`[verify-audio-production] addon loaded; no device on this host (${support.reason})`)
+}
+else {
+  assert.equal(support.reason, undefined)
+  console.log('[verify-audio-production] addon loaded and an input device is available')
+}


### PR DESCRIPTION
Fixes part of #322.

## The recorded finding was half right, and the half that was wrong matters

The audit note says no workflow builds or loads the audio addon, on the grounds that `native-protocol.yml` never mentions "audio". **The string is absent; the coverage is not.**

`native-audio` is a member of `packages/tuff-native/Cargo.toml`, so these existing steps have always compiled, linted and tested the crate on `macos-latest`, `windows-2022` **and** `ubuntu-latest`:

```
cargo fmt   --workspace --check
cargo clippy --workspace --all-targets -D warnings
cargo test  --workspace
cargo build --workspace --release
```

A keyword scan concluded otherwise because `--workspace` does not name its members. Worth recording, because it is the same shape as the bug being fixed: something that looks absent because of how it was looked for.

## What genuinely never ran

`build:audio` — the step that copies the compiled library to `build/Release/tuff_native_audio.node` and re-signs it on macOS. **That file is what `audio.js` opens.** So the crate could compile green while the artifact the runtime loads was never produced, which is the packaging gap this issue is about.

## The verifier works without a microphone

The useful distinction is which side produced the unsupported reason:

| source | reasons |
|---|---|
| **native module** (`build_native_audio_support`) | `no-input-device`, `input-probe-failed: …`, `platform-not-supported` — reaching any of these proves it loaded |
| **JS wrapper**, binding absent or refused | `native-module-not-loaded`, an export-mismatch message, `disabled-by-env` |

It also asserts the platform string is Rust's `std::env::consts::OS` name rather than Node's. Not cosmetic: the wrapper's fallback fills in `process.platform`, so `macos` vs `darwin` is itself proof of which side answered. They coincide on Linux, which is why the reason set still has to carry that platform.

## Verified all three paths locally, after building the addon on macOS

```
addon present, input device   ->  exit 0
addon removed                ->  exit 1, names the build command
wrapper-produced reason      ->  exit 1, "expected the native module's OS name (macos); got darwin"
```

`native-protocol.yml` triggers on `packages/tuff-native/**` and on its own path, so this PR exercises the new step on all three runners.

## Scope

This does not close #322. Release packaging, `afterPack` verification and the preflight requirement are untouched — `apps/core-app/scripts/build-target.js` requires only `tuff_native_ocr.node` plus `tuff_native_everything.node` on Windows, and carries a comment at line 156 saying the screenshot addon is not covered either.

Refs #322