### PR TITLE
build(tuff-intelligence): stop shipping a dist nothing resolves

### DIFF
--- a/packages/tuff-intelligence/package.json
+++ b/packages/tuff-intelligence/package.json
@@ -38,7 +38,6 @@
   "module": "src/index.ts",
   "types": "src/index.ts",
   "files": [
-    "dist",
     "src"
   ],
   "engines": {


### PR DESCRIPTION
Closes the third tail of #970.

## The manifest already answers the question

That item asks whether to rebuild `dist` and sync it with the next utils release, or to mark `dist` as a non-consumption surface. **Everything resolves `src`:**

```
main / module / types    src/index.ts
exports "."              ./src/index.ts
exports "./client"       ./src/client.ts
```

`dist/` is also gitignored — 0 tracked files — so there is no committed copy that could be stale. The "stopped at 7-29" observation was a local build artifact on whoever looked, not a repository state. (Mine reads today's date, for the same reason.)

## What contradicted that

```json
"files": ["dist", "src"]
```

Whatever stale `dist` happened to sit on the publisher's disk got packed into the tarball — **296 KiB of 531, 56% of the package** — with no entry point resolving it and no `prepublishOnly` to rebuild it. So the package shipped a copy of itself that was guaranteed to drift and guaranteed not to be used, which is exactly the confusion this issue is about.

Also worth noting for the issue's plan: `utils:publish` only publishes `@talex-touch/utils`, so "sync it with the next utils release" had no vehicle either.

## Measured

```
tarball    64 files / 531 KiB   ->   61 files / 234 KiB
dist entries                    ->   0
```

Nothing deep-imports it. The only two hits for `tuff-intelligence/dist` anywhere in the repo are July 2026 optimization reports that already classified it as build output rather than a source defect; 120 files reference the package itself.

Both validators agree, including the packing one that actually builds the tarball and checks every entry point resolves inside it:

```
publish:check        passed (source)
publish:check:pack   passed (source+pack)
```

Dropping `"dist"` makes the manifest self-consistent — the package ships what it resolves — which retires the staleness question rather than answering it once.

Refs #970