### PR TITLE
fix(nexus): authorize scene asset downloads against a recorded owner (#898)

### DIFF
--- a/apps/nexus/server/api/dashboard/provider-registry/scenes/[id]/run.post.ts
+++ b/apps/nexus/server/api/dashboard/provider-registry/scenes/[id]/run.post.ts
@@ -3,7 +3,7 @@ import { requireAdmin } from '../../../../../utils/auth'
 import { runSceneOrchestrator } from '../../../../../utils/sceneOrchestrator'
 
 export default defineEventHandler(async (event) => {
-  await requireAdmin(event)
+  const { userId } = await requireAdmin(event)
   const id = String(getRouterParam(event, 'id') || '').trim()
 
   if (!id) {
@@ -16,6 +16,7 @@ export default defineEventHandler(async (event) => {
     capability: body?.capability,
     providerId: body?.providerId,
     dryRun: body?.dryRun,
+    ownerId: userId,
   })
 
   return { run }

--- a/apps/nexus/server/api/v1/scenes/[id]/run.post.ts
+++ b/apps/nexus/server/api/v1/scenes/[id]/run.post.ts
@@ -3,7 +3,7 @@ import { requireAuth } from '../../../../utils/auth'
 import { runSceneOrchestrator } from '../../../../utils/sceneOrchestrator'
 
 export default defineEventHandler(async (event) => {
-  await requireAuth(event)
+  const { userId } = await requireAuth(event)
   const id = String(getRouterParam(event, 'id') || '').trim()
 
   if (!id) {
@@ -16,6 +16,7 @@ export default defineEventHandler(async (event) => {
     capability: body?.capability,
     providerId: body?.providerId,
     dryRun: body?.dryRun,
+    ownerId: userId,
   })
 
   return { run }

--- a/apps/nexus/server/api/v1/scenes/assets/[key].get.ts
+++ b/apps/nexus/server/api/v1/scenes/assets/[key].get.ts
@@ -15,10 +15,24 @@ function readSceneAssetKey(event: Parameters<typeof getRouterParam>[0]): string 
 }
 
 export default defineEventHandler(async (event) => {
-  await requireAuthOrApiKey(event)
+  const { userId } = await requireAuthOrApiKey(event)
   const key = readSceneAssetKey(event)
 
   const asset = await requireSceneAsset(event, key)
+
+  // Until now the only barrier was knowing the key, and a key travels: referrers, shared links,
+  // proxy and CDN logs. requireAuthOrApiKey with no scopes established that *someone* was
+  // authenticated, never that it was this asset's owner (#898).
+  //
+  // 404 rather than 403 so a wrong answer does not confirm the key exists.
+  //
+  // An object with no recorded owner on a backend that records them predates this check, and is
+  // refused for the same reason a mismatch is: there is nothing here that says the caller may
+  // read it. Scene assets are run outputs rather than durable user data, so the cost of that is
+  // a re-run.
+  if (asset.storesOwnership && asset.ownerId !== userId) {
+    throw createError({ statusCode: 404, statusMessage: 'Scene asset not found.' })
+  }
   const buffer = Buffer.isBuffer(asset.data)
     ? asset.data
     : Buffer.from(asset.data)

--- a/apps/nexus/server/utils/sceneAssetStorage.ts
+++ b/apps/nexus/server/utils/sceneAssetStorage.ts
@@ -39,7 +39,7 @@ export async function uploadSceneAsset(
   key: string,
   data: Buffer,
   contentType?: string | null,
-  options: SceneAssetStorageOptions = {},
+  options: SceneAssetStorageOptions & { ownerId?: string | null } = {},
 ): Promise<SceneAssetUploadResult> {
   const bucket = getSceneAssetBucket(event)
   const governanceResourceId = options.governanceResourceId ?? buildSceneAssetGovernanceResourceId(key)
@@ -54,6 +54,7 @@ export async function uploadSceneAsset(
     governanceResourceId,
     resourceType: options.resourceType ?? 'scene-asset',
     defaultContentType: DEFAULT_CONTENT_TYPE,
+    ownerId: options.ownerId,
   })
 }
 
@@ -61,7 +62,7 @@ export async function getSceneAsset(
   event: H3Event,
   key: string,
   options: Pick<SceneAssetStorageOptions, 'governanceResourceId' | 'resourceType'> = {},
-): Promise<{ data: Buffer, contentType: string, sha256: string } | null> {
+): Promise<{ data: Buffer, contentType: string, sha256: string, ownerId?: string, storesOwnership: boolean } | null> {
   const bucket = getSceneAssetBucket(event)
   const governanceResourceId = options.governanceResourceId ?? buildSceneAssetGovernanceResourceId(key)
   const object = await getStorageObject({
@@ -74,7 +75,13 @@ export async function getSceneAsset(
     defaultContentType: DEFAULT_CONTENT_TYPE,
   })
   return object
-    ? { data: object.data, contentType: object.contentType, sha256: object.sha256 }
+    ? {
+        data: object.data,
+        contentType: object.contentType,
+        sha256: object.sha256,
+        ownerId: object.ownerId,
+        storesOwnership: object.storesOwnership,
+      }
     : null
 }
 
@@ -82,7 +89,7 @@ export async function requireSceneAsset(
   event: H3Event,
   key: string,
   options: Pick<SceneAssetStorageOptions, 'governanceResourceId' | 'resourceType'> = {},
-): Promise<{ data: Buffer, contentType: string, sha256: string }> {
+): Promise<{ data: Buffer, contentType: string, sha256: string, ownerId?: string, storesOwnership: boolean }> {
   const result = await getSceneAsset(event, key, options)
   if (!result)
     throw createError({ statusCode: 404, statusMessage: 'Scene asset not found.' })

--- a/apps/nexus/server/utils/sceneOrchestrator.ts
+++ b/apps/nexus/server/utils/sceneOrchestrator.ts
@@ -114,6 +114,13 @@ export interface SceneRunInput {
   capability?: unknown
   providerId?: unknown
   dryRun?: unknown
+  /**
+   * Who the run belongs to, recorded with every asset it uploads so the download endpoint has
+   * something to authorize against. Both callers authenticate; neither used to keep the result,
+   * so a run had no owner and the assets it produced were readable by any authenticated
+   * caller who had the key (#898).
+   */
+  ownerId?: string
 }
 
 export interface SceneAdapterContext {
@@ -1356,6 +1363,7 @@ function replaceSceneAssetOutput(
 async function uploadSceneAdapterAssets(input: {
   event: H3Event
   runId: string
+  ownerId?: string
   sceneId: string
   providerId: string
   capability: string
@@ -1410,6 +1418,7 @@ async function uploadSceneAdapterAssets(input: {
       const stored = await uploadSceneAsset(input.event, assetContext.key, data, contentType, {
         governanceResourceId: assetContext.governanceResourceId,
         resourceType: assetContext.resourceType,
+        ownerId: input.ownerId,
       })
       await completeUploadGovernance(input.event, uploadAttempt, {
         resourceId: assetContext.governanceResourceId,
@@ -1931,6 +1940,7 @@ export async function runSceneOrchestrator(
         const assetResult = await uploadSceneAdapterAssets({
           event,
           runId,
+          ownerId: request.ownerId,
           sceneId: scene.id,
           providerId: provider.id,
           capability: plan.capability,

--- a/apps/nexus/server/utils/storageObjectStore.test.ts
+++ b/apps/nexus/server/utils/storageObjectStore.test.ts
@@ -37,16 +37,19 @@ function createMemory() {
 }
 
 function createMockBucket() {
-  const objects = new Map<string, { data: Buffer, contentType: string }>()
+  const objects = new Map<string, { data: Buffer, contentType: string, customMetadata?: Record<string, string> }>()
 
   return {
-    put: async (key: string, data: ArrayBuffer | Uint8Array, options?: { httpMetadata?: { contentType?: string } }) => {
+    // customMetadata is modelled because that is where ownership lives on R2 (#898). A mock that
+    // dropped it would let the round-trip test pass without the real backend ever carrying one.
+    put: async (key: string, data: ArrayBuffer | Uint8Array, options?: { httpMetadata?: { contentType?: string }, customMetadata?: Record<string, string> }) => {
       const buffer = data instanceof ArrayBuffer
         ? Buffer.from(data)
         : Buffer.from(data.buffer, data.byteOffset, data.byteLength)
       objects.set(key, {
         data: buffer,
         contentType: options?.httpMetadata?.contentType || 'application/octet-stream',
+        customMetadata: options?.customMetadata,
       })
     },
     get: async (key: string) => {
@@ -58,6 +61,7 @@ function createMockBucket() {
         httpMetadata: {
           contentType: object.contentType,
         },
+        customMetadata: object.customMetadata,
         arrayBuffer: async () => object.data.buffer.slice(
           object.data.byteOffset,
           object.data.byteOffset + object.data.byteLength,
@@ -649,5 +653,85 @@ describe('storageObjectStore', () => {
       limit: 10,
     })
     expect(rows.filter(row => row.action === 'storage.write')).toHaveLength(0)
+  })
+})
+
+describe('storage object ownership (#898)', () => {
+  const base = { resourceType: 'scene-asset', externalStorage: null as any }
+
+  it('round-trips the owner through memory storage', async () => {
+    const memoryStorage = createMemory()
+    await putStorageObject({
+      ...base,
+      event: event('own-memory'),
+      bucket: null,
+      memoryStorage,
+      key: 'scene_run_a-cap-1-b.png',
+      data: Buffer.from('body'),
+      ownerId: 'user-1',
+    })
+
+    const read = await getStorageObject({
+      ...base,
+      event: event('own-memory'),
+      bucket: null,
+      memoryStorage,
+      key: 'scene_run_a-cap-1-b.png',
+    })
+
+    expect(read?.ownerId).toBe('user-1')
+    expect(read?.storesOwnership).toBe(true)
+  })
+
+  it('round-trips the owner through the bucket', async () => {
+    const memoryStorage = createMemory()
+    const bucket = createMockBucket() as any
+    await putStorageObject({
+      ...base,
+      event: event('own-bucket'),
+      bucket,
+      memoryStorage,
+      key: 'scene_run_c-cap-1-d.png',
+      data: Buffer.from('body'),
+      ownerId: 'user-2',
+    })
+
+    const read = await getStorageObject({
+      ...base,
+      event: event('own-bucket'),
+      bucket,
+      memoryStorage,
+      key: 'scene_run_c-cap-1-d.png',
+    })
+
+    expect(read?.ownerId).toBe('user-2')
+    expect(read?.storesOwnership).toBe(true)
+  })
+
+  it('reports an object written before ownership tracking as unowned, not unrecordable', async () => {
+    // The distinction the download check turns on: a backend that records ownership and has
+    // none for this object is a refusal, whereas a backend that cannot record it at all is a
+    // different question entirely. Collapsing the two either locks people out or waves
+    // everything through.
+    const memoryStorage = createMemory()
+    await putStorageObject({
+      ...base,
+      event: event('own-legacy'),
+      bucket: null,
+      memoryStorage,
+      key: 'scene_run_e-cap-1-f.png',
+      data: Buffer.from('body'),
+    })
+
+    const read = await getStorageObject({
+      ...base,
+      event: event('own-legacy'),
+      bucket: null,
+      memoryStorage,
+      key: 'scene_run_e-cap-1-f.png',
+    })
+
+    expect(read?.ownerId).toBeUndefined()
+    expect(read?.storesOwnership).toBe(true)
   })
 })

--- a/apps/nexus/server/utils/storageObjectStore.ts
+++ b/apps/nexus/server/utils/storageObjectStore.ts
@@ -13,6 +13,7 @@ export const STORAGE_OBJECT_WRITE_RETRY_DELAYS_MS = [250, 1000] as const
 export interface StorageObjectRecord {
   data: Buffer
   contentType: string
+  ownerId?: string
 }
 
 export type StorageObjectMemory = Map<string, StorageObjectRecord>
@@ -26,6 +27,18 @@ export interface StorageObjectResult {
   storageChannel: string
   storageProvider: string
   uploadRetry?: StorageUploadRetryMetadata
+  /**
+   * Who wrote the object, when the backend kept that alongside it.
+   *
+   * Read together with `storesOwnership`, never on its own: absent-and-recordable means the
+   * object predates ownership tracking, absent-and-not-recordable means this backend never
+   * had anywhere to put it. A caller that cannot tell those apart will either lock people out
+   * of their own data or let an authorization check pass on a backend that never answered it
+   * (#898).
+   */
+  ownerId?: string
+  /** Whether this backend stores ownership at all. */
+  storesOwnership: boolean
 }
 
 export interface StorageObjectExternalConfig {
@@ -55,6 +68,8 @@ interface PutStorageObjectInput extends StorageObjectContext {
   data: Buffer | ArrayBuffer | Uint8Array
   contentType?: string | null
   actorId?: unknown
+  /** Recorded with the object so a later read can authorize against it. */
+  ownerId?: string | null
   retryPolicy?: Partial<StorageObjectWriteRetryPolicy>
 }
 
@@ -712,6 +727,9 @@ export async function putStorageObject(input: PutStorageObjectInput): Promise<Om
         httpMetadata: {
           contentType,
         },
+        // R2 hands customMetadata back on get(), so this is the whole of the ownership
+        // record -- no second object and no side table to keep in step with the first.
+        ...(input.ownerId ? { customMetadata: { ownerId: input.ownerId } } : {}),
       })
     })
     : undefined
@@ -720,6 +738,7 @@ export async function putStorageObject(input: PutStorageObjectInput): Promise<Om
     input.memoryStorage.set(input.key, {
       data: data.buffer,
       contentType,
+      ...(input.ownerId ? { ownerId: input.ownerId } : {}),
     })
   }
 
@@ -744,6 +763,8 @@ export async function putStorageObject(input: PutStorageObjectInput): Promise<Om
     storageChannel: backend.channel,
     storageProvider: backend.provider,
     uploadRetry,
+    ownerId: input.ownerId ?? undefined,
+    storesOwnership: !backend.externalStorage,
   }
 }
 
@@ -784,6 +805,10 @@ export async function getStorageObject(input: StorageObjectContext): Promise<Sto
       contentType: object.contentType,
       storageChannel: backend.channel,
       storageProvider: backend.provider,
+      // S3/OSS reads go through a signed request whose headers are part of the signature, so
+      // carrying x-amz-meta-* here means changing what gets signed. Left alone rather than
+      // changed blind against a backend no test in this repo exercises -- tracked as #1644.
+      storesOwnership: false,
     }
   }
 
@@ -824,6 +849,8 @@ export async function getStorageObject(input: StorageObjectContext): Promise<Sto
       contentType,
       storageChannel: backend.channel,
       storageProvider: backend.provider,
+      ownerId: object.customMetadata?.ownerId || undefined,
+      storesOwnership: true,
     }
   }
 
@@ -860,6 +887,8 @@ export async function getStorageObject(input: StorageObjectContext): Promise<Sto
     contentType,
     storageChannel: backend.channel,
     storageProvider: backend.provider,
+    ownerId: object.ownerId,
+    storesOwnership: true,
   }
 }
 

--- a/apps/nexus/test/api/dashboard/provider-registry/scene-run.api.test.ts
+++ b/apps/nexus/test/api/dashboard/provider-registry/scene-run.api.test.ts
@@ -78,6 +78,9 @@ describe('/api/dashboard/provider-registry/scenes/:id/run', () => {
         capability: 'text.translate',
         providerId: 'prv_tencent_cloud_mt',
         dryRun: true,
+        // Admin runs are owned by the admin, so no bypass is needed on the download
+        // path -- the owner check answers for them like anyone else (#898).
+        ownerId: 'admin_1',
       },
     )
     expect(result).toEqual({

--- a/apps/nexus/test/api/v1/scenes/assets.get.test.ts
+++ b/apps/nexus/test/api/v1/scenes/assets.get.test.ts
@@ -66,7 +66,9 @@ describe('/api/v1/scenes/assets/:key', () => {
     const governanceResourceId = buildSceneAssetGovernanceResourceId(key)
     h3Mocks.getRouterParam.mockReturnValue(key)
 
-    await uploadSceneAsset(event, key, Buffer.from('scene-asset-bytes'), 'image/png')
+    await uploadSceneAsset(event, key, Buffer.from('scene-asset-bytes'), 'image/png', {
+      ownerId: 'scene-asset-reader@example.com',
+    })
 
     const result = await assetHandler(event)
     const rows = await listPlatformGovernanceEvents(event, {
@@ -102,6 +104,39 @@ describe('/api/v1/scenes/assets/:key', () => {
     ]))
     expect(JSON.stringify(rows)).not.toContain(key)
     expect(JSON.stringify(rows)).not.toContain('scene-asset-reader@example.com')
+  })
+
+  it('refuses an asset belonging to someone else', async () => {
+    // The test above is named for downloading a *private* asset but only ever proved that an
+    // authenticated caller gets bytes back. That passed just as well when the endpoint served
+    // any key to anyone (#898), so the name was doing work the assertions were not.
+    const key = `scene_run_${crypto.randomUUID()}-text.translate-other-${crypto.randomUUID()}.png`
+    const event = makeEvent(key)
+    h3Mocks.getRouterParam.mockReturnValue(key)
+
+    await uploadSceneAsset(event, key, Buffer.from('someone-elses-bytes'), 'image/png', {
+      ownerId: 'scene-asset-owner@example.com',
+    })
+
+    // 404, not 403 -- a distinguishable answer would confirm the key exists.
+    await expect(assetHandler(event)).rejects.toMatchObject({
+      statusCode: 404,
+      statusMessage: 'Scene asset not found.',
+    })
+    expect(h3Mocks.send).not.toHaveBeenCalled()
+  })
+
+  it('refuses an asset stored before ownership was recorded', async () => {
+    const key = `scene_run_${crypto.randomUUID()}-text.translate-legacy-${crypto.randomUUID()}.png`
+    const event = makeEvent(key)
+    h3Mocks.getRouterParam.mockReturnValue(key)
+
+    await uploadSceneAsset(event, key, Buffer.from('legacy-bytes'), 'image/png')
+
+    await expect(assetHandler(event)).rejects.toMatchObject({
+      statusCode: 404,
+      statusMessage: 'Scene asset not found.',
+    })
   })
 
   it('rejects missing and path-like scene asset keys before storage reads', async () => {

--- a/apps/nexus/test/api/v1/scenes/scene-runtime.api.test.ts
+++ b/apps/nexus/test/api/v1/scenes/scene-runtime.api.test.ts
@@ -78,6 +78,10 @@ describe('/api/v1/scenes/:id/run', () => {
         capability: 'text.translate',
         providerId: 'prv_tencent_cloud_mt',
         dryRun: false,
+        // The endpoint authenticated and threw the result away, so every asset the run
+        // produced was stored with no owner and readable by anyone holding the key (#898).
+        // Pinned here because it is this hand-off, not the storage layer, that was missing.
+        ownerId: 'user_1',
       },
     )
     expect(result).toEqual({


### PR DESCRIPTION
Closes #898. Opens #1644 for the one backend this does not cover.

## The finding is real; the fix in the issue could not be applied

Confirmed by reading the whole chain rather than the handler alone — `requireSceneAsset` → `getSceneAsset` → `getStorageObject`. The only policy on the read path is `assertObjectStoragePolicy({ action: 'storage.read' })`, which is quota, not authorization. So "any well-formed key is served" holds.

But the suggested direction —

> Look up the scene run that owns the key and reject when its owner id does not match

— has nothing to look up. **No run ever recorded an owner.** Both entrypoints authenticate and throw the result away:

```ts
await requireAuth(event)      // v1/scenes/[id]/run.post.ts — returns AuthContext, discarded
await requireAdmin(event)     // dashboard/.../run.post.ts  — same
```

`runSceneOrchestrator` never received a user id, so the gap was one layer deeper than reported: not a missing check on the download path, but ownership never being recorded at all.

## What this does

Records it, then checks it.

- `userId` flows from both entrypoints → `runSceneOrchestrator` → `uploadSceneAdapterAssets` → `uploadSceneAsset` → `putStorageObject`.
- Stored **with the object**: `customMetadata.ownerId` on R2, a record field in memory. No side table to drift out of step with the objects it describes.
- The handler refuses a mismatch with **404, not 403**, so a wrong answer does not confirm the key exists.

### `storesOwnership` is not decoration

`getStorageObject` returns it next to `ownerId` because two different situations both produce "no owner", and collapsing them breaks in opposite directions:

| state | meaning | handling |
|---|---|---|
| absent, `storesOwnership: true` | written before this change | **refused** — nothing says the caller may read it |
| absent, `storesOwnership: false` | S3/OSS, which cannot carry it | served; the gap is named, not hidden |

Treating the first as "allow" makes the fix decorative. Treating the second as "deny" breaks a backend I cannot test.

The S3/OSS path signs its headers, so adding `x-amz-meta-*` changes what the signature covers — I did not change that blind against a backend no test in this repo exercises. It is **#1644**, with the specific trap written down: `resolveObjectStorageBackend` falls through to bucket/memory when external storage is unconfigured, so a test that forgets to configure it passes for the wrong reason.

## A correction to the report

The stated attack does not work:

> can GET `/api/v1/scenes/assets/scene_run_<uuid>.<ext>` for another user's run

The real key is built at `sceneOrchestrator.ts:1286`:

```js
const key = `${input.runId}-${capabilityToken}-${assetId}-${randomUUID()}.${extension}`
```

with `runId = scene_run_${randomUUID()}` — so `scene_run_<uuid>-<token>-<assetId>-<uuid>.<ext>`, **two independent random UUIDs**. Knowing a run id does not let you construct an asset key, and enumeration is impractical.

The real exposure is that a leaked key had no second barrier — referrers, shared links, proxy and CDN logs. Still a genuine authorization hole, but lower severity than "any user can read any run".

## Verification

Mutation-checked, one per storage path — each fails exactly the round-trip test for that path and nothing else:

| mutation | result |
|---|---|
| R2 `put` drops `customMetadata` | 1 failed (bucket round-trip) |
| memory `put` drops `ownerId` | 1 failed (memory round-trip) |
| R2 `get` stops reading `customMetadata` | 1 failed (bucket round-trip) |
| restored | 12 passed |

The mock bucket had to be taught `customMetadata` first — without that the R2 test would have passed while the real backend carried nothing.

- 86 test files / 547 tests pass across `nexus/server`.
- eslint under the nexus config: 0 problems on all seven changed files.

## No admin bypass

The issue suggested "allowing admins explicitly". Not added: the dashboard entrypoint runs under `requireAdmin`, so an admin's own runs are already owned by them and readable. An extra role check would be a second way into other people's data with no caller that needs it.
