### PR TITLE
fix(csp): send report-only violations somewhere they can be read (#689)

### DIFF
--- a/apps/core-app/src/main/channel/common.ts
+++ b/apps/core-app/src/main/channel/common.ts
@@ -1541,6 +1541,27 @@ export class CommonChannelModule extends BaseModule {
           payload && typeof payload === 'object' ? (payload as OpenDevToolsOptions) : undefined
         touchApp.window.openDevTools(options)
       }),
+      transport.on(AppEvents.security.reportCspViolation, (payload, context) => {
+        // Host renderer only: a plugin view reporting its own violations would let it write
+        // arbitrary lines into the host's log under a security-sounding prefix.
+        this.assertHostOnly(context, 'security.reportCspViolation')
+        if (!payload || typeof payload !== 'object') return
+
+        // The enforcing policy blocks nothing the report-only one names, so every line here is
+        // a finding rather than an error: it is what narrowing default-src and connect-src for
+        // real would have refused (#689). Collected in the main log because the renderer logger
+        // only reaches a devtools console nobody has open during real use.
+        log.warn(
+          `[csp-report-only] ${payload.effectiveDirective} would block ${payload.blockedURI || '<inline>'}`,
+          {
+            meta: {
+              documentURI: payload.documentURI,
+              sourceFile: payload.sourceFile,
+              line: payload.lineNumber
+            }
+          }
+        )
+      }),
       transport.on(AppEvents.system.getCwd, (_payload, context) => {
         this.assertHostOnly(context, 'system.getCwd')
         return process.cwd()

--- a/apps/core-app/src/renderer/csp-policy.test.ts
+++ b/apps/core-app/src/renderer/csp-policy.test.ts
@@ -62,3 +62,49 @@ describe('renderer content security policy', () => {
     expect(html).not.toMatch(/\son[a-z]+\s*=\s*["']/i)
   })
 })
+
+describe('report-only CSP violations reach somewhere they can be read (#689)', () => {
+  const entry = readFileSync(fileURLToPath(new URL('./src/main.ts', import.meta.url)), 'utf8')
+  /**
+   * Bounded to the listener itself. The first version of this sliced to end-of-file, so the
+   * `.catch(` assertion below matched unrelated code further down and passed against a
+   * mutation that removed the real one.
+   */
+  const listenerStart = entry.indexOf('securitypolicyviolation')
+  const listenerEnd = entry.indexOf('function registerRouterEvents', listenerStart)
+  const listener = entry.slice(listenerStart, listenerEnd)
+
+  it('is reading the listener and not the whole file', () => {
+    // Without this the two assertions below can pass on text that has nothing to do with the
+    // listener, which is exactly how the first version of this block was wrong.
+    expect(listenerStart).toBeGreaterThan(-1)
+    expect(listenerEnd).toBeGreaterThan(listenerStart)
+    expect(listener.length).toBeLessThan(1500)
+  })
+
+  it('forwards violations to the main process', () => {
+    // The report-only policy exists to produce a runtime inventory of what the renderer
+    // actually reaches, so default-src and connect-src can stop being wildcards. That
+    // inventory was unreachable: createRendererLogger writes to the renderer console and
+    // nowhere else, so the findings only ever existed in a devtools panel nobody has open
+    // during real use. A policy that reports into a void is indistinguishable from no policy.
+    expect(listener).toContain('AppEvents.security.reportCspViolation')
+  })
+
+  it('does not swallow the report when the send fails', () => {
+    // Fire-and-forget, but explicitly: an unhandled rejection here would surface as noise in
+    // the very console this moved the reporting out of.
+    expect(listener).toMatch(/\.catch\(/)
+  })
+
+  it('the renderer logger it replaced really is console-only', () => {
+    // Positive control for the claim above. If this ever starts persisting, the test at the
+    // top of this block is asserting a workaround for a problem that no longer exists.
+    const rendererLog = readFileSync(
+      fileURLToPath(new URL('./src/utils/renderer-log.ts', import.meta.url)),
+      'utf8'
+    )
+    expect(rendererLog).toMatch(/console\.(log|info|warn|error)/)
+    expect(rendererLog).not.toMatch(/transport|ipcRenderer|window\.electron/)
+  })
+})

--- a/apps/core-app/src/renderer/src/main.ts
+++ b/apps/core-app/src/renderer/src/main.ts
@@ -68,14 +68,19 @@ function reportContentSecurityPolicyViolations(): void {
   document.addEventListener('securitypolicyviolation', (event) => {
     // The enforcing policy blocks nothing here, so anything reaching this listener is a request
     // the narrow candidate would have refused — a finding, not an error.
-    mainLog.warn(
-      `[csp-report-only] ${event.effectiveDirective} would block ${event.blockedURI || '<inline>'}`,
-      {
+    // Forwarded to main rather than logged here: createRendererLogger writes to the renderer
+    // console and nowhere else, so the inventory this policy exists to produce only existed in
+    // a devtools panel nobody has open during real use (#689).
+    transport
+      .send(AppEvents.security.reportCspViolation, {
+        effectiveDirective: event.effectiveDirective,
+        blockedURI: event.blockedURI,
         documentURI: event.documentURI,
         sourceFile: event.sourceFile,
-        line: event.lineNumber
-      }
-    )
+        lineNumber: event.lineNumber
+      })
+      // A dropped report must not disturb the page that produced it.
+      .catch(() => {})
   })
 }
 

--- a/packages/utils/transport/events/app.ts
+++ b/packages/utils/transport/events/app.ts
@@ -17,6 +17,7 @@ import type {
   BatteryStatusPayload,
   BuildVerificationStatus,
   CounterPayload,
+  CspViolationReport,
   DevToolsOptions,
   ExecuteCommandRequest,
   ExecuteCommandResponse,
@@ -629,6 +630,20 @@ export const AppEvents = {
       .module("debug")
       .event("open-devtools")
       .define<DevToolsOptions | void, void>(),
+  },
+
+  /**
+   * Security telemetry from the renderer.
+   */
+  security: {
+    /**
+     * Report a violation of the renderer's report-only CSP so it reaches the main process log
+     * (#689). Fire-and-forget: a dropped report must never disturb the page it came from.
+     */
+    reportCspViolation: defineEvent("app")
+      .module("security")
+      .event("report-csp-violation")
+      .define<CspViolationReport, void>(),
   },
 
   /**

--- a/packages/utils/transport/events/types/app.ts
+++ b/packages/utils/transport/events/types/app.ts
@@ -470,3 +470,21 @@ export type {
   TrackDurationPayload,
   TrackEventPayload,
 } from '../../../analytics'
+
+/**
+ * A report-only Content-Security-Policy violation, forwarded from the renderer (#689).
+ *
+ * The report-only policy exists to produce a runtime inventory of what the renderer actually
+ * reaches, so that `default-src` and `connect-src` can stop being wildcards. That inventory was
+ * unreachable: the renderer logger writes to the renderer console and nowhere else, so the
+ * findings only existed in devtools nobody has open during real use.
+ */
+export interface CspViolationReport {
+  /** The directive that would have blocked the request. */
+  effectiveDirective: string;
+  /** The blocked URI, or an empty string for inline sources. */
+  blockedURI: string;
+  documentURI: string;
+  sourceFile?: string;
+  lineNumber?: number;
+}

--- a/scripts/check-drizzle-snapshot-drift.mjs
+++ b/scripts/check-drizzle-snapshot-drift.mjs
@@ -1,74 +1,156 @@
 #!/usr/bin/env node
 /**
- * Stops the drizzle snapshot chain drifting further from the journal (#1303).
+ * Stops the drizzle snapshot baseline from drifting further behind the migrations.
  *
- * `drizzle-kit` diffs against the newest snapshot. The newest here is `0014`, written
- * 2025-12-10, while the journal runs to `0037` — so `db:generate`'s first output re-emits
- * every change from the 23 migrations in between, and cannot be committed.
+ * `drizzle-kit generate` diffs `schema.ts` against the highest `meta/NNNN_snapshot.json`. That
+ * snapshot stopped at 0014 while the journal reached 0037, so the generator's first output
+ * re-proposes every table migrations 0015+ already created -- 45 `CREATE TABLE`, none with
+ * `IF NOT EXISTS`, which would fail on any existing installation. A developer following
+ * CLAUDE.md gets that file with nothing indicating the baseline is stale (#1303).
  *
- * Repairing that is a migration-history decision (rebuild each intermediate state, or flatten
- * to a new baseline) and belongs to the maintainer. What does not need a decision is that the
- * gap should not get *bigger* while it waits: every hand-written migration added today widens
- * it silently, and the only symptom is that the generator stays unusable.
+ * Rebuilding the baseline is a decision between replaying 0015+ and rebaselining at the current
+ * schema, and it changes files that run against users' databases. This check does not make that
+ * decision. It ratchets: the gap recorded below is what exists today, and adding a migration
+ * without a snapshot makes it bigger, which fails.
  *
- * So this pins the known gap and fails when it grows. It is a ratchet, not a fix: the number
- * below is a debt, and lowering it is the repair.
+ * The reverse also fails. If someone rebaselines and the gap shrinks, the recorded number is
+ * wrong and has to be updated -- otherwise it silently becomes a ceiling nobody is measuring
+ * against, which is how a tolerance turns into a permanent exemption.
  */
-import { readdirSync, readFileSync } from 'node:fs'
+import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
-const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
-const META = path.join(REPO_ROOT, 'apps/core-app/resources/db/migrations/meta')
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const metaDir = path.join(repoRoot, 'apps/core-app/resources/db/migrations/meta')
 
 /**
- * Journal indexes with no snapshot, as of 2026-08-11.
+ * The gap on 2026-08-11: journal at 0037, snapshots at 0014.
  *
- * `0011` and `0012` are not a later deletion — `git log --diff-filter=A` finds no commit that
- * ever added them, and `--diff-filter=D` finds no snapshot deletion at all. The chain was
- * never complete, so there is no lost history to recover before deciding what to do.
+ * This is a record of a known defect, not a budget. #1303 owns closing it, and closing it means
+ * this constant goes to 0 and stays there.
  */
-export const KNOWN_MISSING_SNAPSHOTS = 25
+const EXPECTED_GAP = 23
 
-export function snapshotGap(metaDir = META) {
-  const journal = JSON.parse(readFileSync(path.join(metaDir, '_journal.json'), 'utf8'))
-  const snapshots = new Set(
-    readdirSync(metaDir)
-      .filter(name => name.endsWith('_snapshot.json'))
-      .map(name => name.slice(0, 4)),
+export function highestJournalIndex(journal) {
+  const entries = Array.isArray(journal?.entries) ? journal.entries : []
+  if (entries.length === 0)
+    return null
+  return entries.reduce((max, entry) => {
+    const tag = typeof entry?.tag === 'string' ? entry.tag : ''
+    const match = tag.match(/^(\d+)/)
+    return match ? Math.max(max, Number(match[1])) : max
+  }, -1)
+}
+
+export function highestSnapshotIndex(fileNames) {
+  const indexes = (Array.isArray(fileNames) ? fileNames : [])
+    .map(name => name.match(/^(\d+)_snapshot\.json$/))
+    .filter(Boolean)
+    .map(match => Number(match[1]))
+  return indexes.length === 0 ? null : Math.max(...indexes)
+}
+
+/**
+ * A missing journal or an empty snapshot set is a failure, not a clean run.
+ *
+ * Both look identical to "no drift" if they are allowed to return 0, and both happen for real --
+ * a moved directory, a partial checkout, a renamed meta folder. Same rule as validate-plugins.mjs.
+ */
+export function evaluate(journalIndex, snapshotIndex, expectedGap) {
+  if (journalIndex === null)
+    return { ok: false, reason: 'no journal entries found — the check read nothing' }
+  if (snapshotIndex === null)
+    return { ok: false, reason: 'no meta/NNNN_snapshot.json found — the check read nothing' }
+
+  const gap = journalIndex - snapshotIndex
+  if (gap > expectedGap) {
+    return {
+      ok: false,
+      gap,
+      reason: `snapshot baseline fell further behind: journal ${journalIndex}, snapshot ${snapshotIndex}, `
+        + `gap ${gap} > recorded ${expectedGap}. A migration was added without a snapshot; `
+        + `drizzle-kit generate now diffs against an even older picture (#1303)`,
+    }
+  }
+  if (gap < expectedGap) {
+    return {
+      ok: false,
+      gap,
+      reason: `the gap shrank to ${gap} (journal ${journalIndex}, snapshot ${snapshotIndex}). `
+        + `Lower EXPECTED_GAP in this script to ${gap} so it keeps measuring something`,
+    }
+  }
+  return { ok: true, gap }
+}
+
+function selfTest() {
+  const journal = { entries: [{ tag: '0000_a' }, { tag: '0037_z' }, { tag: '0012_m' }] }
+  const cases = [
+    { name: 'highest journal index ignores ordering', actual: highestJournalIndex(journal), expected: 37 },
+    { name: 'an empty journal reads as null, not 0', actual: highestJournalIndex({ entries: [] }), expected: null },
+    { name: 'a missing journal reads as null', actual: highestJournalIndex(undefined), expected: null },
+    {
+      name: 'highest snapshot index ignores non-snapshot files',
+      actual: highestSnapshotIndex(['0014_snapshot.json', '_journal.json', '0002_snapshot.json']),
+      expected: 14,
+    },
+    { name: 'an empty snapshot set reads as null, not 0', actual: highestSnapshotIndex([]), expected: null },
+    { name: 'the recorded gap passes', actual: evaluate(37, 14, 23).ok, expected: true },
+    { name: 'a widened gap fails', actual: evaluate(38, 14, 23).ok, expected: false },
+    { name: 'a narrowed gap fails, so the record cannot go stale', actual: evaluate(37, 15, 23).ok, expected: false },
+    { name: 'no journal fails instead of reporting no drift', actual: evaluate(null, 14, 23).ok, expected: false },
+    { name: 'no snapshots fails instead of reporting no drift', actual: evaluate(37, null, 23).ok, expected: false },
+    { name: 'a closed gap passes only when recorded as closed', actual: evaluate(37, 37, 0).ok, expected: true },
+  ]
+
+  let failures = 0
+  for (const testCase of cases) {
+    const ok = testCase.actual === testCase.expected
+    if (!ok)
+      failures += 1
+    console.log(`${ok ? '\x1B[32m  ok\x1B[0m' : '\x1B[31mFAIL\x1B[0m'}  ${testCase.name}`)
+  }
+  console.log(
+    failures === 0
+      ? `\n\x1B[32mSelf-test passed: ${cases.length} cases.\x1B[0m\n`
+      : `\n\x1B[31mSelf-test failed: ${failures}/${cases.length} cases.\x1B[0m\n`,
   )
-
-  const missing = journal.entries
-    .map(entry => String(entry.idx).padStart(4, '0'))
-    .filter(index => !snapshots.has(index))
-
-  return { journalEntries: journal.entries.length, snapshots: snapshots.size, missing }
+  return failures
 }
 
-function main() {
-  const { journalEntries, snapshots, missing } = snapshotGap()
+if (process.argv.includes('--self-test'))
+  process.exit(selfTest() > 0 ? 1 : 0)
 
-  if (missing.length > KNOWN_MISSING_SNAPSHOTS) {
-    console.error(
-      `[check-drizzle-snapshot-drift] ${missing.length} journal entries have no snapshot, up from ${KNOWN_MISSING_SNAPSHOTS}.\n`
-      + `  journal: ${journalEntries}  snapshots: ${snapshots}\n`
-      + `  newly unbacked: ${missing.slice(KNOWN_MISSING_SNAPSHOTS).join(', ')}\n\n`
-      + 'A migration was added by hand without advancing the snapshot chain, which pushes\n'
-      + 'drizzle-kit\'s diff baseline further from reality (#1303). Either write the snapshot\n'
-      + 'alongside the migration, or raise the pinned number deliberately and say why.',
-    )
-    process.exit(1)
-  }
-
-  if (missing.length < KNOWN_MISSING_SNAPSHOTS) {
-    console.error(
-      `[check-drizzle-snapshot-drift] only ${missing.length} entries lack a snapshot, down from ${KNOWN_MISSING_SNAPSHOTS}.\n`
-      + 'The debt shrank — lower KNOWN_MISSING_SNAPSHOTS so the ratchet holds the new floor.',
-    )
-    process.exit(1)
-  }
+let journal
+try {
+  journal = JSON.parse(fs.readFileSync(path.join(metaDir, '_journal.json'), 'utf8'))
+}
+catch (error) {
+  console.error(`\x1B[31mCould not read the drizzle journal: ${error.message}\x1B[0m\n`)
+  process.exit(1)
 }
 
-if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href)
-  main()
+let fileNames
+try {
+  fileNames = fs.readdirSync(metaDir)
+}
+catch (error) {
+  console.error(`\x1B[31mCould not read ${path.relative(repoRoot, metaDir)}: ${error.message}\x1B[0m\n`)
+  process.exit(1)
+}
+
+const journalIndex = highestJournalIndex(journal)
+const snapshotIndex = highestSnapshotIndex(fileNames)
+const verdict = evaluate(journalIndex, snapshotIndex, EXPECTED_GAP)
+
+if (!verdict.ok) {
+  console.error(`\n\x1B[31m  ✗\x1B[0m ${verdict.reason}\n`)
+  process.exit(1)
+}
+
+console.log(
+  `\ndrizzle snapshot baseline: journal ${journalIndex}, snapshot ${snapshotIndex}, `
+  + `gap ${verdict.gap} (recorded, tracked on #1303).\n`,
+)

--- a/scripts/check-drizzle-snapshot-drift.mjs
+++ b/scripts/check-drizzle-snapshot-drift.mjs
@@ -1,156 +1,74 @@
 #!/usr/bin/env node
 /**
- * Stops the drizzle snapshot baseline from drifting further behind the migrations.
+ * Stops the drizzle snapshot chain drifting further from the journal (#1303).
  *
- * `drizzle-kit generate` diffs `schema.ts` against the highest `meta/NNNN_snapshot.json`. That
- * snapshot stopped at 0014 while the journal reached 0037, so the generator's first output
- * re-proposes every table migrations 0015+ already created -- 45 `CREATE TABLE`, none with
- * `IF NOT EXISTS`, which would fail on any existing installation. A developer following
- * CLAUDE.md gets that file with nothing indicating the baseline is stale (#1303).
+ * `drizzle-kit` diffs against the newest snapshot. The newest here is `0014`, written
+ * 2025-12-10, while the journal runs to `0037` — so `db:generate`'s first output re-emits
+ * every change from the 23 migrations in between, and cannot be committed.
  *
- * Rebuilding the baseline is a decision between replaying 0015+ and rebaselining at the current
- * schema, and it changes files that run against users' databases. This check does not make that
- * decision. It ratchets: the gap recorded below is what exists today, and adding a migration
- * without a snapshot makes it bigger, which fails.
+ * Repairing that is a migration-history decision (rebuild each intermediate state, or flatten
+ * to a new baseline) and belongs to the maintainer. What does not need a decision is that the
+ * gap should not get *bigger* while it waits: every hand-written migration added today widens
+ * it silently, and the only symptom is that the generator stays unusable.
  *
- * The reverse also fails. If someone rebaselines and the gap shrinks, the recorded number is
- * wrong and has to be updated -- otherwise it silently becomes a ceiling nobody is measuring
- * against, which is how a tolerance turns into a permanent exemption.
+ * So this pins the known gap and fails when it grows. It is a ratchet, not a fix: the number
+ * below is a debt, and lowering it is the repair.
  */
-import fs from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
-const metaDir = path.join(repoRoot, 'apps/core-app/resources/db/migrations/meta')
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const META = path.join(REPO_ROOT, 'apps/core-app/resources/db/migrations/meta')
 
 /**
- * The gap on 2026-08-11: journal at 0037, snapshots at 0014.
+ * Journal indexes with no snapshot, as of 2026-08-11.
  *
- * This is a record of a known defect, not a budget. #1303 owns closing it, and closing it means
- * this constant goes to 0 and stays there.
+ * `0011` and `0012` are not a later deletion — `git log --diff-filter=A` finds no commit that
+ * ever added them, and `--diff-filter=D` finds no snapshot deletion at all. The chain was
+ * never complete, so there is no lost history to recover before deciding what to do.
  */
-const EXPECTED_GAP = 23
+export const KNOWN_MISSING_SNAPSHOTS = 25
 
-export function highestJournalIndex(journal) {
-  const entries = Array.isArray(journal?.entries) ? journal.entries : []
-  if (entries.length === 0)
-    return null
-  return entries.reduce((max, entry) => {
-    const tag = typeof entry?.tag === 'string' ? entry.tag : ''
-    const match = tag.match(/^(\d+)/)
-    return match ? Math.max(max, Number(match[1])) : max
-  }, -1)
-}
-
-export function highestSnapshotIndex(fileNames) {
-  const indexes = (Array.isArray(fileNames) ? fileNames : [])
-    .map(name => name.match(/^(\d+)_snapshot\.json$/))
-    .filter(Boolean)
-    .map(match => Number(match[1]))
-  return indexes.length === 0 ? null : Math.max(...indexes)
-}
-
-/**
- * A missing journal or an empty snapshot set is a failure, not a clean run.
- *
- * Both look identical to "no drift" if they are allowed to return 0, and both happen for real --
- * a moved directory, a partial checkout, a renamed meta folder. Same rule as validate-plugins.mjs.
- */
-export function evaluate(journalIndex, snapshotIndex, expectedGap) {
-  if (journalIndex === null)
-    return { ok: false, reason: 'no journal entries found — the check read nothing' }
-  if (snapshotIndex === null)
-    return { ok: false, reason: 'no meta/NNNN_snapshot.json found — the check read nothing' }
-
-  const gap = journalIndex - snapshotIndex
-  if (gap > expectedGap) {
-    return {
-      ok: false,
-      gap,
-      reason: `snapshot baseline fell further behind: journal ${journalIndex}, snapshot ${snapshotIndex}, `
-        + `gap ${gap} > recorded ${expectedGap}. A migration was added without a snapshot; `
-        + `drizzle-kit generate now diffs against an even older picture (#1303)`,
-    }
-  }
-  if (gap < expectedGap) {
-    return {
-      ok: false,
-      gap,
-      reason: `the gap shrank to ${gap} (journal ${journalIndex}, snapshot ${snapshotIndex}). `
-        + `Lower EXPECTED_GAP in this script to ${gap} so it keeps measuring something`,
-    }
-  }
-  return { ok: true, gap }
-}
-
-function selfTest() {
-  const journal = { entries: [{ tag: '0000_a' }, { tag: '0037_z' }, { tag: '0012_m' }] }
-  const cases = [
-    { name: 'highest journal index ignores ordering', actual: highestJournalIndex(journal), expected: 37 },
-    { name: 'an empty journal reads as null, not 0', actual: highestJournalIndex({ entries: [] }), expected: null },
-    { name: 'a missing journal reads as null', actual: highestJournalIndex(undefined), expected: null },
-    {
-      name: 'highest snapshot index ignores non-snapshot files',
-      actual: highestSnapshotIndex(['0014_snapshot.json', '_journal.json', '0002_snapshot.json']),
-      expected: 14,
-    },
-    { name: 'an empty snapshot set reads as null, not 0', actual: highestSnapshotIndex([]), expected: null },
-    { name: 'the recorded gap passes', actual: evaluate(37, 14, 23).ok, expected: true },
-    { name: 'a widened gap fails', actual: evaluate(38, 14, 23).ok, expected: false },
-    { name: 'a narrowed gap fails, so the record cannot go stale', actual: evaluate(37, 15, 23).ok, expected: false },
-    { name: 'no journal fails instead of reporting no drift', actual: evaluate(null, 14, 23).ok, expected: false },
-    { name: 'no snapshots fails instead of reporting no drift', actual: evaluate(37, null, 23).ok, expected: false },
-    { name: 'a closed gap passes only when recorded as closed', actual: evaluate(37, 37, 0).ok, expected: true },
-  ]
-
-  let failures = 0
-  for (const testCase of cases) {
-    const ok = testCase.actual === testCase.expected
-    if (!ok)
-      failures += 1
-    console.log(`${ok ? '\x1B[32m  ok\x1B[0m' : '\x1B[31mFAIL\x1B[0m'}  ${testCase.name}`)
-  }
-  console.log(
-    failures === 0
-      ? `\n\x1B[32mSelf-test passed: ${cases.length} cases.\x1B[0m\n`
-      : `\n\x1B[31mSelf-test failed: ${failures}/${cases.length} cases.\x1B[0m\n`,
+export function snapshotGap(metaDir = META) {
+  const journal = JSON.parse(readFileSync(path.join(metaDir, '_journal.json'), 'utf8'))
+  const snapshots = new Set(
+    readdirSync(metaDir)
+      .filter(name => name.endsWith('_snapshot.json'))
+      .map(name => name.slice(0, 4)),
   )
-  return failures
+
+  const missing = journal.entries
+    .map(entry => String(entry.idx).padStart(4, '0'))
+    .filter(index => !snapshots.has(index))
+
+  return { journalEntries: journal.entries.length, snapshots: snapshots.size, missing }
 }
 
-if (process.argv.includes('--self-test'))
-  process.exit(selfTest() > 0 ? 1 : 0)
+function main() {
+  const { journalEntries, snapshots, missing } = snapshotGap()
 
-let journal
-try {
-  journal = JSON.parse(fs.readFileSync(path.join(metaDir, '_journal.json'), 'utf8'))
-}
-catch (error) {
-  console.error(`\x1B[31mCould not read the drizzle journal: ${error.message}\x1B[0m\n`)
-  process.exit(1)
-}
+  if (missing.length > KNOWN_MISSING_SNAPSHOTS) {
+    console.error(
+      `[check-drizzle-snapshot-drift] ${missing.length} journal entries have no snapshot, up from ${KNOWN_MISSING_SNAPSHOTS}.\n`
+      + `  journal: ${journalEntries}  snapshots: ${snapshots}\n`
+      + `  newly unbacked: ${missing.slice(KNOWN_MISSING_SNAPSHOTS).join(', ')}\n\n`
+      + 'A migration was added by hand without advancing the snapshot chain, which pushes\n'
+      + 'drizzle-kit\'s diff baseline further from reality (#1303). Either write the snapshot\n'
+      + 'alongside the migration, or raise the pinned number deliberately and say why.',
+    )
+    process.exit(1)
+  }
 
-let fileNames
-try {
-  fileNames = fs.readdirSync(metaDir)
-}
-catch (error) {
-  console.error(`\x1B[31mCould not read ${path.relative(repoRoot, metaDir)}: ${error.message}\x1B[0m\n`)
-  process.exit(1)
-}
-
-const journalIndex = highestJournalIndex(journal)
-const snapshotIndex = highestSnapshotIndex(fileNames)
-const verdict = evaluate(journalIndex, snapshotIndex, EXPECTED_GAP)
-
-if (!verdict.ok) {
-  console.error(`\n\x1B[31m  ✗\x1B[0m ${verdict.reason}\n`)
-  process.exit(1)
+  if (missing.length < KNOWN_MISSING_SNAPSHOTS) {
+    console.error(
+      `[check-drizzle-snapshot-drift] only ${missing.length} entries lack a snapshot, down from ${KNOWN_MISSING_SNAPSHOTS}.\n`
+      + 'The debt shrank — lower KNOWN_MISSING_SNAPSHOTS so the ratchet holds the new floor.',
+    )
+    process.exit(1)
+  }
 }
 
-console.log(
-  `\ndrizzle snapshot baseline: journal ${journalIndex}, snapshot ${snapshotIndex}, `
-  + `gap ${verdict.gap} (recorded, tracked on #1303).\n`,
-)
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href)
+  main()


### PR DESCRIPTION
Toward #689. You chose "先上 report-only 量实际违规" — this makes that measurement actually possible.

## What I found instead

The report-only policy is already there, and so is the listener. Both were added under #913/#689 and both look right. What is missing is the last link:

```ts
// renderer/src/utils/renderer-log.ts
function emit(method, scope, args) {
  ...
  console.warn(...payload)   // ← and nowhere else
}
```

`createRendererLogger` writes to the **renderer console only**. It never reaches the main process or a log file. So the inventory the report-only policy exists to produce — the thing narrowing `default-src` and `connect-src` has been waiting on — only ever existed in a devtools panel nobody has open during real use.

A policy that reports into a void is indistinguishable from no policy. The wildcards could have stayed forever with the report-only block looking like progress.

## What this changes

Violations go over the transport to the main process and land in the app log.

- **Host renderer only.** A plugin view reporting its own violations could write arbitrary lines into the host's log behind a `[csp-report-only]` prefix, so the handler asserts host-only like its neighbours.
- **Fire-and-forget, explicitly.** `.catch(() => {})` — an unhandled rejection would surface as noise in the very console this moved the reporting out of.

**The policies themselves are untouched.** The enforcing one still carries the wildcards. They come out when the log stays quiet in real use, which is now something that can be observed rather than assumed.

## One correction to the issue

#689 says the renderer CSP is "effectively disabled (`script-src *` with `unsafe-inline`)". That is no longer true — `script-src` is `'self' 'unsafe-eval' blob: data:`, tightened under #913, with `csp-policy.test.ts` asserting that `'unsafe-inline'` cannot come back as a one-word edit. What remains open is `default-src` and `connect-src`, which is what this unblocks.

## Verification

Mutation-checked, both directions:

| mutation | result |
|---|---|
| listener sends a different event (i.e. back to console-only) | 1 failed |
| `.catch` removed | 1 failed |
| restored | 10 passed |

**The `.catch` case failed to fail at first.** My guard sliced `main.ts` from the listener to end-of-file, so `.catch(` matched unrelated code further down and passed against a mutation that removed the real one. It is now bounded to the listener, with a test asserting the bound is a bound — the class of mistake that makes a guard look green while measuring nothing is the same one this PR is about.

Also included: a positive control that `renderer-log.ts` really is console-only, so if it ever starts persisting, this workaround is visibly asserting a problem that no longer exists.

- 7 test files / 88 tests pass across `csp-policy` and `src/main/channel`.
- eslint clean on all changed files; the new event type-resolves (verified by a deliberate typo producing a type error, since "no new errors" would also be the result of it not resolving at all).
