### PR TITLE
ci: stop the drizzle snapshot baseline drifting further

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,15 @@ jobs:
       - name: macOS file-icon guard
         run: pnpm check:file-icon-guard && pnpm check:file-icon-guard:self-test
 
+      # drizzle-kit generate diffs schema.ts against the highest meta/NNNN_snapshot.json. That
+      # stopped at 0014 while the journal reached 0037, so its first output re-proposes every
+      # table 0015+ already created -- 45 CREATE TABLE, none with IF NOT EXISTS, which fails on
+      # any existing install. Rebuilding the baseline is #1303's decision and touches files that
+      # run against users' databases; this only stops the gap growing, and fails in both
+      # directions so the recorded number cannot quietly become a ceiling nobody measures.
+      - name: drizzle snapshot drift
+        run: pnpm check:drizzle-snapshot-drift && pnpm check:drizzle-snapshot-drift:self-test
+
       # `pnpm lint` reaches plugins either as workspaces or through a hand-maintained brace
       # list, and touch-dictation was in neither (#562). The list is the kind that drifts
       # silently, so this asserts the two paths between them still cover every directory.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "check:prod-audit:self-test": "node scripts/check-prod-audit.mjs --self-test",
     "check:file-icon-guard": "node scripts/check-file-icon-guard.mjs",
     "check:file-icon-guard:self-test": "node scripts/check-file-icon-guard.mjs --self-test",
+    "check:drizzle-snapshot-drift": "node scripts/check-drizzle-snapshot-drift.mjs",
+    "check:drizzle-snapshot-drift:self-test": "node scripts/check-drizzle-snapshot-drift.mjs --self-test",
     "plugins:release:audit": "tsx scripts/plugin-source-package-audit.ts",
     "publish:check": "node scripts/validate-publish-manifests.mjs",
     "publish:check:pack": "node scripts/validate-publish-manifests.mjs --pack",

--- a/scripts/check-drizzle-snapshot-drift.mjs
+++ b/scripts/check-drizzle-snapshot-drift.mjs
@@ -1,74 +1,156 @@
 #!/usr/bin/env node
 /**
- * Stops the drizzle snapshot chain drifting further from the journal (#1303).
+ * Stops the drizzle snapshot baseline from drifting further behind the migrations.
  *
- * `drizzle-kit` diffs against the newest snapshot. The newest here is `0014`, written
- * 2025-12-10, while the journal runs to `0037` — so `db:generate`'s first output re-emits
- * every change from the 23 migrations in between, and cannot be committed.
+ * `drizzle-kit generate` diffs `schema.ts` against the highest `meta/NNNN_snapshot.json`. That
+ * snapshot stopped at 0014 while the journal reached 0037, so the generator's first output
+ * re-proposes every table migrations 0015+ already created -- 45 `CREATE TABLE`, none with
+ * `IF NOT EXISTS`, which would fail on any existing installation. A developer following
+ * CLAUDE.md gets that file with nothing indicating the baseline is stale (#1303).
  *
- * Repairing that is a migration-history decision (rebuild each intermediate state, or flatten
- * to a new baseline) and belongs to the maintainer. What does not need a decision is that the
- * gap should not get *bigger* while it waits: every hand-written migration added today widens
- * it silently, and the only symptom is that the generator stays unusable.
+ * Rebuilding the baseline is a decision between replaying 0015+ and rebaselining at the current
+ * schema, and it changes files that run against users' databases. This check does not make that
+ * decision. It ratchets: the gap recorded below is what exists today, and adding a migration
+ * without a snapshot makes it bigger, which fails.
  *
- * So this pins the known gap and fails when it grows. It is a ratchet, not a fix: the number
- * below is a debt, and lowering it is the repair.
+ * The reverse also fails. If someone rebaselines and the gap shrinks, the recorded number is
+ * wrong and has to be updated -- otherwise it silently becomes a ceiling nobody is measuring
+ * against, which is how a tolerance turns into a permanent exemption.
  */
-import { readdirSync, readFileSync } from 'node:fs'
+import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
-const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
-const META = path.join(REPO_ROOT, 'apps/core-app/resources/db/migrations/meta')
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const metaDir = path.join(repoRoot, 'apps/core-app/resources/db/migrations/meta')
 
 /**
- * Journal indexes with no snapshot, as of 2026-08-11.
+ * The gap on 2026-08-11: journal at 0037, snapshots at 0014.
  *
- * `0011` and `0012` are not a later deletion — `git log --diff-filter=A` finds no commit that
- * ever added them, and `--diff-filter=D` finds no snapshot deletion at all. The chain was
- * never complete, so there is no lost history to recover before deciding what to do.
+ * This is a record of a known defect, not a budget. #1303 owns closing it, and closing it means
+ * this constant goes to 0 and stays there.
  */
-export const KNOWN_MISSING_SNAPSHOTS = 25
+const EXPECTED_GAP = 23
 
-export function snapshotGap(metaDir = META) {
-  const journal = JSON.parse(readFileSync(path.join(metaDir, '_journal.json'), 'utf8'))
-  const snapshots = new Set(
-    readdirSync(metaDir)
-      .filter(name => name.endsWith('_snapshot.json'))
-      .map(name => name.slice(0, 4)),
+export function highestJournalIndex(journal) {
+  const entries = Array.isArray(journal?.entries) ? journal.entries : []
+  if (entries.length === 0)
+    return null
+  return entries.reduce((max, entry) => {
+    const tag = typeof entry?.tag === 'string' ? entry.tag : ''
+    const match = tag.match(/^(\d+)/)
+    return match ? Math.max(max, Number(match[1])) : max
+  }, -1)
+}
+
+export function highestSnapshotIndex(fileNames) {
+  const indexes = (Array.isArray(fileNames) ? fileNames : [])
+    .map(name => name.match(/^(\d+)_snapshot\.json$/))
+    .filter(Boolean)
+    .map(match => Number(match[1]))
+  return indexes.length === 0 ? null : Math.max(...indexes)
+}
+
+/**
+ * A missing journal or an empty snapshot set is a failure, not a clean run.
+ *
+ * Both look identical to "no drift" if they are allowed to return 0, and both happen for real --
+ * a moved directory, a partial checkout, a renamed meta folder. Same rule as validate-plugins.mjs.
+ */
+export function evaluate(journalIndex, snapshotIndex, expectedGap) {
+  if (journalIndex === null)
+    return { ok: false, reason: 'no journal entries found — the check read nothing' }
+  if (snapshotIndex === null)
+    return { ok: false, reason: 'no meta/NNNN_snapshot.json found — the check read nothing' }
+
+  const gap = journalIndex - snapshotIndex
+  if (gap > expectedGap) {
+    return {
+      ok: false,
+      gap,
+      reason: `snapshot baseline fell further behind: journal ${journalIndex}, snapshot ${snapshotIndex}, `
+        + `gap ${gap} > recorded ${expectedGap}. A migration was added without a snapshot; `
+        + `drizzle-kit generate now diffs against an even older picture (#1303)`,
+    }
+  }
+  if (gap < expectedGap) {
+    return {
+      ok: false,
+      gap,
+      reason: `the gap shrank to ${gap} (journal ${journalIndex}, snapshot ${snapshotIndex}). `
+        + `Lower EXPECTED_GAP in this script to ${gap} so it keeps measuring something`,
+    }
+  }
+  return { ok: true, gap }
+}
+
+function selfTest() {
+  const journal = { entries: [{ tag: '0000_a' }, { tag: '0037_z' }, { tag: '0012_m' }] }
+  const cases = [
+    { name: 'highest journal index ignores ordering', actual: highestJournalIndex(journal), expected: 37 },
+    { name: 'an empty journal reads as null, not 0', actual: highestJournalIndex({ entries: [] }), expected: null },
+    { name: 'a missing journal reads as null', actual: highestJournalIndex(undefined), expected: null },
+    {
+      name: 'highest snapshot index ignores non-snapshot files',
+      actual: highestSnapshotIndex(['0014_snapshot.json', '_journal.json', '0002_snapshot.json']),
+      expected: 14,
+    },
+    { name: 'an empty snapshot set reads as null, not 0', actual: highestSnapshotIndex([]), expected: null },
+    { name: 'the recorded gap passes', actual: evaluate(37, 14, 23).ok, expected: true },
+    { name: 'a widened gap fails', actual: evaluate(38, 14, 23).ok, expected: false },
+    { name: 'a narrowed gap fails, so the record cannot go stale', actual: evaluate(37, 15, 23).ok, expected: false },
+    { name: 'no journal fails instead of reporting no drift', actual: evaluate(null, 14, 23).ok, expected: false },
+    { name: 'no snapshots fails instead of reporting no drift', actual: evaluate(37, null, 23).ok, expected: false },
+    { name: 'a closed gap passes only when recorded as closed', actual: evaluate(37, 37, 0).ok, expected: true },
+  ]
+
+  let failures = 0
+  for (const testCase of cases) {
+    const ok = testCase.actual === testCase.expected
+    if (!ok)
+      failures += 1
+    console.log(`${ok ? '\x1B[32m  ok\x1B[0m' : '\x1B[31mFAIL\x1B[0m'}  ${testCase.name}`)
+  }
+  console.log(
+    failures === 0
+      ? `\n\x1B[32mSelf-test passed: ${cases.length} cases.\x1B[0m\n`
+      : `\n\x1B[31mSelf-test failed: ${failures}/${cases.length} cases.\x1B[0m\n`,
   )
-
-  const missing = journal.entries
-    .map(entry => String(entry.idx).padStart(4, '0'))
-    .filter(index => !snapshots.has(index))
-
-  return { journalEntries: journal.entries.length, snapshots: snapshots.size, missing }
+  return failures
 }
 
-function main() {
-  const { journalEntries, snapshots, missing } = snapshotGap()
+if (process.argv.includes('--self-test'))
+  process.exit(selfTest() > 0 ? 1 : 0)
 
-  if (missing.length > KNOWN_MISSING_SNAPSHOTS) {
-    console.error(
-      `[check-drizzle-snapshot-drift] ${missing.length} journal entries have no snapshot, up from ${KNOWN_MISSING_SNAPSHOTS}.\n`
-      + `  journal: ${journalEntries}  snapshots: ${snapshots}\n`
-      + `  newly unbacked: ${missing.slice(KNOWN_MISSING_SNAPSHOTS).join(', ')}\n\n`
-      + 'A migration was added by hand without advancing the snapshot chain, which pushes\n'
-      + 'drizzle-kit\'s diff baseline further from reality (#1303). Either write the snapshot\n'
-      + 'alongside the migration, or raise the pinned number deliberately and say why.',
-    )
-    process.exit(1)
-  }
-
-  if (missing.length < KNOWN_MISSING_SNAPSHOTS) {
-    console.error(
-      `[check-drizzle-snapshot-drift] only ${missing.length} entries lack a snapshot, down from ${KNOWN_MISSING_SNAPSHOTS}.\n`
-      + 'The debt shrank — lower KNOWN_MISSING_SNAPSHOTS so the ratchet holds the new floor.',
-    )
-    process.exit(1)
-  }
+let journal
+try {
+  journal = JSON.parse(fs.readFileSync(path.join(metaDir, '_journal.json'), 'utf8'))
+}
+catch (error) {
+  console.error(`\x1B[31mCould not read the drizzle journal: ${error.message}\x1B[0m\n`)
+  process.exit(1)
 }
 
-if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href)
-  main()
+let fileNames
+try {
+  fileNames = fs.readdirSync(metaDir)
+}
+catch (error) {
+  console.error(`\x1B[31mCould not read ${path.relative(repoRoot, metaDir)}: ${error.message}\x1B[0m\n`)
+  process.exit(1)
+}
+
+const journalIndex = highestJournalIndex(journal)
+const snapshotIndex = highestSnapshotIndex(fileNames)
+const verdict = evaluate(journalIndex, snapshotIndex, EXPECTED_GAP)
+
+if (!verdict.ok) {
+  console.error(`\n\x1B[31m  ✗\x1B[0m ${verdict.reason}\n`)
+  process.exit(1)
+}
+
+console.log(
+  `\ndrizzle snapshot baseline: journal ${journalIndex}, snapshot ${snapshotIndex}, `
+  + `gap ${verdict.gap} (recorded, tracked on #1303).\n`,
+)


### PR DESCRIPTION
Adds the guard #1303 asks for.

> Whichever is chosen, a guard is worth adding: a check that the highest `meta/NNNN_snapshot.json` matches the highest migration number, so the two cannot silently drift apart again.

This is it, with one change: **it ratchets rather than demanding equality.** Equality fails on arrival, and a gate that is red the day it lands gets a tolerance bolted on within a week — which is the failure mode this repo has spent the day removing.

## The gap has already widened since the issue was written

```
issue recorded    snapshot 0014   journal 0036
today             snapshot 0014   journal 0037
```

Nothing noticed. That is the point.

## What the gap costs

From the issue, re-verified: `drizzle-kit generate` diffs `schema.ts` against the highest snapshot, so its first output re-proposes every table migrations 0015+ already created — **45 `CREATE TABLE`, none carrying `IF NOT EXISTS`**, which would fail on any existing installation. A developer following CLAUDE.md gets that file with nothing indicating the baseline is stale.

## What this does not do

Rebuilding the baseline is #1303's decision — replay 0015+, or rebaseline at the current schema — and it touches files that run against users' databases. This makes neither choice. It only stops the gap growing while the decision is pending.

## It fails in both directions

| | |
|---|---|
| gap **widens** | a migration landed without a snapshot; the generator now diffs against an even older picture |
| gap **narrows** | someone rebaselined and `EXPECTED_GAP` is stale. Left alone it becomes a ceiling nobody measures against — how a recorded tolerance turns into a permanent exemption |

Negative-controlled live, both directions:

```
add a journal entry, no snapshot  ->  gap 24 > recorded 23,                    exit 1
add a snapshot                    ->  "the gap shrank to 22 … lower EXPECTED_GAP", exit 1
both reverted                     ->  exit 0
```

`--self-test` covers 11 cases, including the two that matter most: an empty journal and an empty snapshot set read as `null` rather than `0`, so a moved directory or a partial checkout **fails** instead of reporting no drift.

Refs #1303