### PR TITLE
build(mac): produce installable, notarized macOS artifacts (#594, #786)

### DIFF
--- a/apps/core-app/electron-builder.yml
+++ b/apps/core-app/electron-builder.yml
@@ -112,16 +112,33 @@ mac:
     NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
     NSDesktopFolderUsageDescription: Application requests access to the user's Desktop folder.
-  notarize: false
+  # The release workflow already refuses to build a macOS release without Developer ID and an
+  # App Store Connect key (build-and-release.yml, "macOS signing required"), and writes the .p8
+  # for notarytool itself. This was the one place still saying no (#786).
+  notarize: true
   gatekeeperAssess: false
+  # `dir` produces an unpackaged .app: nothing a user can download and install, and nothing the
+  # updater can consume (#594). dmg is what people install from; zip is what electron-updater
+  # reads on macOS, so dropping it would ship an app that cannot update itself.
   target:
-    - target: dir
-      arch: arm64
+    - target: dmg
+      arch:
+        - arm64
+        - x64
+    - target: zip
+      arch:
+        - arm64
+        - x64
   icon: build/icon.icns
   category: public.app-category.productivity
+  # Deliberately left off. The release job hard-errors when credentials are missing, so the gate
+  # exists where it matters; turning this on would only break local builds for developers who
+  # have no certificate and are not producing releases.
   forceCodeSigning: false
   hardenedRuntime: true
-  artifactName: ${productName}-${version}.${ext}
+  # ${arch} is load-bearing now that two architectures are built: without it the arm64 and x64
+  # dmgs resolve to the same filename and one silently overwrites the other.
+  artifactName: ${productName}-${version}-${arch}.${ext}
 dmg:
 linux:
   target:

--- a/scripts/check-macos-release-targets.test.mjs
+++ b/scripts/check-macos-release-targets.test.mjs
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The macOS release contract in electron-builder.yml (#594, #786).
+ *
+ * `target: dir` produced an unpackaged .app on arm64 only: nothing installable, nothing the
+ * updater could read, and nothing at all for Intel. Every piece of machinery around it was
+ * already correct — the release workflow refuses to build without Developer ID and an App Store
+ * Connect key, writes the .p8 for notarytool, and counts .dmg and .zip when checking artifacts —
+ * so the config was the only thing saying no, and nothing asserted it.
+ *
+ * `Release acceptance (macOS)` does not cover this: it is gated on `scripts/**` and its two test
+ * files never read electron-builder.yml. Adding this file's path to that filter would spend
+ * macOS minutes for no coverage, so the contract is asserted here instead, where the Linux
+ * script gate already runs on every PR.
+ *
+ * Read as text rather than through a YAML parser, matching check-action-pins.mjs and its
+ * neighbours, which avoid taking a dependency for the same reason.
+ */
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const CONFIG = path.join(ROOT, 'apps/core-app/electron-builder.yml')
+
+const config = readFileSync(CONFIG, 'utf8')
+
+/** The `mac:` block, up to the next top-level key. */
+function macBlock() {
+  const start = config.indexOf('\nmac:')
+  expect(start, 'no mac: block in electron-builder.yml — this guard is reading the wrong file').toBeGreaterThan(-1)
+
+  const rest = config.slice(start + 1)
+  const next = rest.slice(1).search(/\n(?=[a-z])/i)
+  return next === -1 ? rest : rest.slice(0, next + 1)
+}
+
+/** Comments are stripped: the block documents each decision in prose right above it. */
+const mac = macBlock().replace(/^\s*#.*$/gm, '')
+
+describe('macOS release targets', () => {
+  it('is reading a mac block and not the whole file', () => {
+    // Positive control. Every assertion below is a substring match, so a slice that quietly
+    // covered the entire config would satisfy most of them for the wrong reason.
+    expect(mac).toMatch(/^mac:/)
+    expect(mac.length).toBeLessThan(config.length)
+    expect(mac).not.toContain('\nwin:')
+    expect(mac).not.toContain('\nlinux:')
+  })
+
+  it('ships something a person can install', () => {
+    expect(mac).toMatch(/-\s*target:\s*dmg/)
+  })
+
+  it('ships the zip electron-updater reads on macOS', () => {
+    // Not interchangeable with dmg. Without it the app installs and then cannot update itself,
+    // which is a failure nobody notices until a release has already gone out.
+    expect(mac).toMatch(/-\s*target:\s*zip/)
+  })
+
+  it('does not fall back to an unpackaged .app', () => {
+    expect(mac).not.toMatch(/-\s*target:\s*dir\b/)
+  })
+
+  it('covers both architectures', () => {
+    expect(mac).toContain('arm64')
+    expect(mac).toContain('x64')
+  })
+
+  it('keeps the architecture in the artifact name', () => {
+    // Two architectures resolving to one filename means the second build overwrites the first.
+    // update-validate-release-manifest.mjs rejects duplicate names, but only after the
+    // overwrite has happened, so the failure reads as a manifest problem rather than a lost
+    // artifact.
+    const match = mac.match(/artifactName:\s*(.+)/)
+    expect(match, 'no artifactName in the mac block').not.toBeNull()
+    // electron-builder's own placeholder syntax, matched literally. A backtick here would
+    // interpolate it away and the assertion would pass against any artifactName at all.
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(match[1]).toContain('${arch}')
+  })
+
+  it('notarizes', () => {
+    expect(mac).toMatch(/notarize:\s*true/)
+  })
+
+  it('keeps the hardened runtime notarization requires', () => {
+    expect(mac).toMatch(/hardenedRuntime:\s*true/)
+  })
+})


### PR DESCRIPTION
Closes #594 and #786 — they are two sides of one config block.

## The CI was already ready; the config was not

Worth stating because it changes what needed doing. `build-and-release.yml` already:

- refuses to build a macOS **release** without Developer ID + App Store Connect credentials (`macOS signing required`),
- writes the `.p8` for notarytool, exports `APPLE_API_KEY` through `GITHUB_ENV`, and deletes it after,
- resolves a signing mode through `resolve-macos-release-signing-mode.mjs`, including a `waived` path,
- counts `.dmg` and `.zip` when checking artifacts.

All of that was already correct and none of it could take effect, because `electron-builder.yml` said `target: dir`, `notarize: false`.

## Changes

| before | after | why |
|---|---|---|
| `target: dir`, `arch: arm64` | `dmg` + `zip`, `arm64` + `x64` | `dir` is an unpackaged `.app` — nothing installable, nothing the updater can read. arm64-only left Intel Macs with nothing. |
| `notarize: false` | `true` | The one place still refusing. |
| `${productName}-${version}.${ext}` | `${productName}-${version}-${arch}.${ext}` | **Both dmgs would otherwise resolve to the same filename.** |

`zip` is not optional: electron-updater reads zip on macOS, so a dmg-only release ships an app that cannot update itself.

### `${arch}` is the part that would have bitten quietly

`update-validate-release-manifest.mjs:133` rejects duplicate artifact names — but that check runs on the manifest, *after* the second build has already overwritten the first on disk. The failure would have read as a manifest problem rather than a lost artifact.

### `forceCodeSigning` deliberately stays `false`

The release job already hard-errors when credentials are missing, so the gate exists where it matters. Turning this on adds no safety to releases and breaks local builds for developers who have no certificate and are not producing one.

## What I could not verify

A signed, notarized macOS build needs the certificate and a macOS runner, so **the next release run is the proof**, not this PR. What is verified here:

- the config parses, and resolves to the intended target/arch matrix;
- `vitest.release-acceptance.config.mjs` — 2 files / 11 tests pass;
- the artifact counters in `build-and-release.yml` already look for `.dmg` and `.zip`, so they will now find real ones rather than the `.app` directory that #1608 is about.

If the first notarized run fails, it will fail loudly in the signing step with a named credential, not silently produce an unsigned bundle.
