### PR TITLE
fix(types): give Object.freeze the type it was throwing away (#548)

### DIFF
--- a/apps/core-app/src/main/modules/privacy/data-owner.ts
+++ b/apps/core-app/src/main/modules/privacy/data-owner.ts
@@ -475,7 +475,10 @@ export function definePrivacyDataOwner(candidate: PrivacyDataOwnerCandidate): Pr
       return result
     }
 
-    return Object.freeze({
+    // Explicit type argument: `Object.freeze<T>(o: T)` infers T from its argument, so the
+    // enclosing function's `: PrivacyDataOwner` return type never reaches the object literal
+    // and every callback parameter below fell back to `any` (#548).
+    return Object.freeze<PrivacyDataOwner>({
       categories,
       inspect: (request, signal) => serialize(() => inspect(request, signal)),
       previewDelete: (request, signal) => serialize(() => previewDelete(request, signal)),

--- a/apps/core-app/src/main/modules/privacy/privacy-secret-service.ts
+++ b/apps/core-app/src/main/modules/privacy/privacy-secret-service.ts
@@ -440,7 +440,10 @@ export function createMainPrivacySecretFileAdapter(
     values.showOpenDialog as MainPrivacySecretFileAdapterOptions['showOpenDialog']
   ).bind(options)
 
-  return Object.freeze({
+  // Same reason as data-owner.ts: Object.freeze infers its type parameter from the argument,
+  // so `: PrivacySecretFileAdapter` on the function above never reaches this literal and every
+  // callback parameter here defaulted to `any` (#548).
+  return Object.freeze<PrivacySecretFileAdapter>({
     writeBackup: async (envelope, signal) => {
       if (
         typeof envelope !== 'string' ||
@@ -835,7 +838,7 @@ export function createPrivacySecretService(
     return Object.freeze(entries)
   }
 
-  return Object.freeze({
+  return Object.freeze<PrivacySecretService>({
     backupPreview: (externalSignal) =>
       serialize(externalSignal, async (signal) => {
         try {

--- a/scripts/check-implicit-any-debt.mjs
+++ b/scripts/check-implicit-any-debt.mjs
@@ -34,7 +34,7 @@ const CORE_APP = path.join(REPO_ROOT, 'apps/core-app')
  * only -- every error the flag produces is in that range, so a rise here is new untyped code and
  * not some unrelated type break.
  */
-export const KNOWN_IMPLICIT_ANY_ERRORS = 227
+export const KNOWN_IMPLICIT_ANY_ERRORS = 201
 
 /** Resolves the workspace's own tsc rather than trusting a .bin shim on PATH. */
 function resolveTsc() {


### PR DESCRIPTION
Toward #548. You chose main process first — and the ratchet's own note says the renderer already turned `noImplicitAny` back on in `tsconfig.web.json`, so **all 227 were main process** regardless.

## One cause, 26 errors

`Object.freeze<T>(o: T): Readonly<T>` infers `T` **from its argument**. A declared return type on the enclosing function therefore never reaches the object literal inside the call, and every callback parameter in that literal falls back to `any`:

```ts
export function definePrivacyDataOwner(candidate): PrivacyDataOwner {
  return Object.freeze({
    inspect: (request, signal) => ...,   // ← both `any`, despite the return type above
```

Naming the type argument restores contextual typing for the whole literal at once:

```ts
return Object.freeze<PrivacyDataOwner>({
```

Three edits, 26 errors, no behaviour change:

| file | before | after |
|---|---|---|
| `privacy/data-owner.ts` | 12 | 0 |
| `privacy/privacy-secret-service.ts` (two sites) | 14 | 0 |
| **total main process** | **227** | **201** |

## Why these files first

Not the largest count — `plugin-module.ts` has 21 — but the untyped parameters here are secret backup envelopes, restore plans, retention policies and deletion requests. Handling those as `any` is worse than handling a plugin manifest field as `any`, and the fix happened to be one line each rather than annotating 26 parameters by hand.

## Verification

- Ratchet lowered to 201 and checked in **both** directions: `200` fails, `202` fails, `201` passes. A ratchet that only fails upward would let the next 26 fixes go unrecorded.
- **No new non-TS7xxx diagnostics.** This is the check that actually matters: contextual typing can surface real mismatches that were invisible while the parameters were `any`, and a fix that trades 26 implicit-anys for 3 genuine type errors is not a fix. Count went 227 → 215 → 211 → 201 with the non-TS7xxx count at 0 throughout.
- Privacy suite: 20 files / 146 tests pass. `scripts` gate: 23 files / 225 tests pass. `typecheck` unchanged at its pre-existing count.

## What is left

201, concentrated in the plugin host:

```
21  plugin/plugin-module.ts
19  plugin/host/plugin-host-child-runtime.ts
17  plugin/host/plugin-business-capabilities.ts
16  plugin/host/plugin-runtime-service.ts
13  plugin/host/plugin-runtime-host.ts
```

Worth checking whether the same `Object.freeze` shape accounts for a chunk of those too before annotating anything by hand.
