### PR TITLE
fix(audit): the nuxt closure comes from @sentry/nuxt, not vue-sonner

### DIFF
--- a/.github/prod-audit-allowlist.json
+++ b/.github/prod-audit-allowlist.json
@@ -4,14 +4,15 @@
     "must appear here or CI fails. Entries expire; an expired entry fails the same gate. An entry whose",
     "advisory no longer appears also fails, so the list cannot only grow and cannot silently pre-approve",
     "a re-introduction. Removing an entry is the fix in that case.",
-    "This list is the state on 2026-08-11, not an endorsement of it. #328 owns clearing it."
+    "This list is the state on 2026-08-11, not an endorsement of it. #328 owns clearing it.",
+    "2026-08-12: the eight nuxt-closure reasons said core-app's vue-sonner optional peer. Measured wrong — moving vue-sonner to devDependencies changed the --prod audit by zero advisories. The real path is apps/nexus's @sentry/nuxt. An exception list is only worth its reasons."
   ],
   "advisories": [
     {
       "id": "GHSA-279x-mwfv-vcqv",
       "module": "@nuxt/devtools",
       "severity": "critical",
-      "reason": "Reaches --prod through core-app's vue-sonner, whose optional nuxt peer pnpm satisfied from nexus. core-app is Electron+Vite and never loads a Nuxt module; nexus keeps nuxt in devDependencies. Severing that edge is #328's open decision.",
+      "reason": "Reaches --prod under the same @sentry/nuxt closure as nuxt: @sentry/nuxt -> nuxt -> @nuxt/devtools@2.7.0. The patched range starts at 3.3.1, which needs @nuxt/kit ^4.5.1, i.e. the Nuxt 4.5 line — blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
     },
@@ -27,7 +28,7 @@
       "id": "GHSA-28wg-ghj8-5hjv",
       "module": "nanoid",
       "severity": "high",
-      "reason": "Transitive under the same nuxt closure as @nuxt/devtools.",
+      "reason": "Transitive under the same @sentry/nuxt -> nuxt closure. Moves when that closure moves.",
       "owner": "#328",
       "expires": "2026-11-09"
     },
@@ -35,7 +36,7 @@
       "id": "GHSA-2v37-7h3g-55p8",
       "module": "nanoid",
       "severity": "high",
-      "reason": "Transitive under the same nuxt closure as @nuxt/devtools.",
+      "reason": "Transitive under the same @sentry/nuxt -> nuxt closure. Moves when that closure moves.",
       "owner": "#328",
       "expires": "2026-11-09"
     },
@@ -43,7 +44,7 @@
       "id": "GHSA-9473-5f9j-94wq",
       "module": "nuxt",
       "severity": "high",
-      "reason": "Same vue-sonner optional-peer edge; not loaded by core-app.",
+      "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction — a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
     },
@@ -51,7 +52,7 @@
       "id": "GHSA-9pgf-384g-p7mv",
       "module": "nuxt",
       "severity": "high",
-      "reason": "Same vue-sonner optional-peer edge; not loaded by core-app.",
+      "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction — a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
     },
@@ -59,7 +60,7 @@
       "id": "GHSA-hxcr-hm88-mpq6",
       "module": "nuxt",
       "severity": "high",
-      "reason": "Same vue-sonner optional-peer edge; not loaded by core-app.",
+      "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction — a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
     },
@@ -67,7 +68,7 @@
       "id": "GHSA-hxvh-4h3w-prp9",
       "module": "nuxt",
       "severity": "high",
-      "reason": "Same vue-sonner optional-peer edge; not loaded by core-app.",
+      "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction — a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
     },
@@ -75,7 +76,7 @@
       "id": "GHSA-wm8w-6qjm-cv43",
       "module": "nuxt",
       "severity": "high",
-      "reason": "Same vue-sonner optional-peer edge; not loaded by core-app.",
+      "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction — a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
     }


### PR DESCRIPTION
Corrects eight reasons in `.github/prod-audit-allowlist.json`. **No advisory ids change and the gate still passes** — only the reasons move, which is the whole value of the file.

## The reasons were wrong, and they were mine

They said the nuxt cluster reaches `--prod` through core-app's production dependency `vue-sonner`, whose optional `nuxt` peer pnpm satisfied from the copy `apps/nexus` has. That was my attribution on #328.

Measured the way #1630 measured `astro` — move the dependency, regenerate the lockfile, re-run the audit:

```
vue-sonner in dependencies      low 2, moderate 8, high 8, critical 1
vue-sonner in devDependencies   low 2, moderate 8, high 8, critical 1
```

**Zero change.** And `--prod` is not broken either: without it the same tree reports `low 3, moderate 12, high 10`.

## The real path

`pnpm -C apps/nexus why nuxt --prod`:

```
@talex-touch/tuff-nexus (dependencies)
  └─ @sentry/nuxt@10.65.0
       └─ nuxt@4.4.8
            └─ @nuxt/devtools@2.7.0 → @nuxt/kit
```

`@sentry/nuxt` is a **runtime** dependency — Sentry reporting is behaviour, not a build input — and a Sentry integration for Nuxt depends on Nuxt by construction. So this closure is **not** reclassifiable the way `astro` (#1630) and `vue-sonner` are. It moves only when #1098's `unhead` 2 → 3 migration lands.

## What went wrong in the original reasoning

The lockfile *does* record core-app resolving the peer-linked variant `vue-sonner@2.0.9(...)(nuxt@4.4.8(...))`. That edge is real.

I read **the existence of an edge as the cause of the closure**, when it was a consequence — pnpm satisfied an optional peer from a copy that was already present for an unrelated reason. Removing the edge leaves the copy exactly where it was.

Refs #328 #1098