### PR TITLE
fix(docs): exempt planning tasks from the meta fields they cannot have

### DIFF
--- a/scripts/docs/verify-docs.mjs
+++ b/scripts/docs/verify-docs.mjs
@@ -269,9 +269,21 @@ export function checkTasks(repoRoot, scope) {
     else if (!taskRuleAllowed(file, 'DOC-TASK-META')) {
       if (!nonEmptyString(task.assignee))
         diagnostics.push(diagnostic('DOC-TASK-META', file, null, 'assignee must be a non-empty string'))
-      for (const key of ['nextAction', 'blocker', 'evidence']) {
-        if (!nonEmptyString(task.meta[key]))
-          diagnostics.push(diagnostic('DOC-TASK-META', file, null, `meta.${key} must be a non-empty string`))
+      // `evidence` is empty for a planning task by definition -- it has not started. Demanding it
+      // anyway produced 39 findings across 28 planning tasks and exactly 0 across the 25
+      // in_progress ones, so the rule was already satisfied everywhere it described real work.
+      // Filling the rest would have meant writing "not started" 28 times: the gate goes green and
+      // the record stops saying anything, which is the opposite of what a gate is for (#1254).
+      //
+      // `assignee` above stays required at every status -- it is knowable when the task is created.
+      //
+      // This also stops the count regenerating: task_store.py:291 seeds every new task with
+      // `meta: {}`, so each `task.py create` was adding three findings before any work began.
+      if (task.status !== 'planning') {
+        for (const key of ['nextAction', 'blocker', 'evidence']) {
+          if (!nonEmptyString(task.meta[key]))
+            diagnostics.push(diagnostic('DOC-TASK-META', file, null, `meta.${key} must be a non-empty string`))
+        }
       }
     }
   }


### PR DESCRIPTION
Toward #1254 — removes its dominant cause. **Does not turn the gate green on its own**; see the bottom.

## The issue guessed the cause and the guess was right

`task_store.py:291` seeds every new task with `"meta": {}` while the verifier demanded three non-empty fields. So **each `task.py create` added three findings before any work began** — which is why the count kept regenerating no matter how many files were filled by hand.

## Broken down by status, the split is clean

```
in_progress    25 tasks     0 missing fields
planning       28 tasks    42 missing fields
```

**Every `in_progress` task is already complete.** The rule works everywhere it describes real work, and every remaining finding is a task that has not started — where `evidence` is empty by definition.

The alternative was writing "not started" 28 times. That turns the gate green and stops the record saying anything, which is the opposite of what a gate is for — and it is why I declined to fill those files by hand on #1125.

```
docs:verify   54 findings  ->  15
DOC-TASK-META         39   ->   0
```

`assignee` stays required at every status: it is knowable when the task is created, so an empty one is neglect rather than a fact about the work.

## Negative-controlled

```
clear an in_progress task's meta   ->  DOC-TASK-META=3
restore it                         ->  DOC-TASK-META=0
```

Suite: **21 passed**. Lint clean.

## Why `TASK_RULE_ALLOWLIST` is left alone

Its single entry covers a `planning` task, so this exemption makes it redundant — but **emptying the array fails four fixture tests** in `scripts/docs.test.mjs` that expect exit 0. I bisected it: the allowlist edit alone reproduces the failures, the status check alone does not.

Removing a now-moot entry is not worth breaking the fixtures that guard the rest of this verifier. `DOC-TASK-ALLOWLIST` does not fire on it either, because that check computes `hasMissingMeta` from the task directly rather than from whether a diagnostic was emitted.

## What is left, measured on this PR's own CI run

```
docs:verify failed: shown 15/15; totals DOC-PRD-EMPTY-SECTION=5, DOC-PRD-PLACEHOLDER=10
```

The gate fails on any finding, so it stays red until those 15 are dealt with. They are PRD **content** — empty sections and placeholder text in task prds — not a rule/generator mismatch, so they need reading rather than a rule change. #1254 should stay open for them.

Refs #1254