### PR TITLE
fix(search): find Linux app icons outside /usr/share/icons

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/addon/apps/linux.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/linux.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveApplicationRoots } from './linux'
+import { resolveApplicationRoots, resolveIconRoots } from './linux'
 
 const HOME = '/home/tester'
 
@@ -64,5 +64,54 @@ describe('linux application roots', () => {
     expect(resolveApplicationRoots({ XDG_DATA_DIRS: '   ' }, HOME)).toContain(
       '/usr/share/applications'
     )
+  })
+})
+
+describe('linux icon theme roots', () => {
+  // The gap #1640 left behind: resolveApplicationRoots made flatpak apps discoverable while the
+  // icon lookup still hardcoded /usr/share/icons, so those apps rendered with no icon.
+  it('covers both flatpak icon prefixes', () => {
+    const roots = resolveIconRoots({}, HOME)
+
+    expect(roots).toContain('/var/lib/flatpak/exports/share/icons')
+    expect(roots).toContain(`${HOME}/.local/share/flatpak/exports/share/icons`)
+  })
+
+  it('applies the XDG defaults when the environment says nothing', () => {
+    const roots = resolveIconRoots({}, HOME)
+
+    expect(roots).toContain('/usr/share/icons')
+    expect(roots).toContain('/usr/local/share/icons')
+    expect(roots).toContain(`${HOME}/.local/share/icons`)
+  })
+
+  // A user-installed theme has to win over the system copy of the same name, so the per-user root
+  // cannot sit behind the system ones -- the search returns the first hit.
+  it('puts the per-user root ahead of the system ones', () => {
+    const roots = resolveIconRoots({}, HOME)
+
+    expect(roots.indexOf(`${HOME}/.local/share/icons`)).toBeLessThan(
+      roots.indexOf('/usr/share/icons')
+    )
+  })
+
+  it('reads XDG_DATA_DIRS instead of assuming the defaults', () => {
+    const roots = resolveIconRoots({ XDG_DATA_DIRS: '/opt/nix/share' }, HOME)
+
+    expect(roots).toContain('/opt/nix/share/icons')
+    expect(roots).not.toContain('/usr/share/icons')
+  })
+
+  it('reads XDG_DATA_HOME for the per-user prefix, including its flatpak subtree', () => {
+    const roots = resolveIconRoots({ XDG_DATA_HOME: '/data/xdg' }, HOME)
+
+    expect(roots).toContain('/data/xdg/icons')
+    expect(roots).toContain('/data/xdg/flatpak/exports/share/icons')
+  })
+
+  it('does not repeat a root that appears twice', () => {
+    const roots = resolveIconRoots({ XDG_DATA_DIRS: '/usr/share:/usr/share' }, HOME)
+
+    expect(new Set(roots).size).toBe(roots.length)
   })
 })

--- a/apps/core-app/src/main/modules/box-tool/addon/apps/linux.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/apps/linux.ts
@@ -44,6 +44,34 @@ export function resolveApplicationRoots(
   return [...new Set(roots)]
 }
 
+/**
+ * Icon theme roots, in the order a desktop would consult them.
+ *
+ * The lookup below used to hardcode `/usr/share/icons`, so a flatpak or user-installed app could
+ * be found by resolveApplicationRoots and then render with no icon -- its theme lives under its
+ * own prefix. Per-user roots come first because a user-installed theme should win over the system
+ * copy of the same name.
+ */
+export function resolveIconRoots(
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = os.homedir()
+): string[] {
+  const dataHome = env.XDG_DATA_HOME?.trim() || path.join(home, '.local', 'share')
+  const dataDirs = (env.XDG_DATA_DIRS?.trim() || '/usr/local/share:/usr/share')
+    .split(':')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+
+  const roots = [
+    path.join(dataHome, 'icons'),
+    path.join(dataHome, 'flatpak', 'exports', 'share', 'icons'),
+    '/var/lib/flatpak/exports/share/icons',
+    ...dataDirs.map((dir) => path.join(dir, 'icons'))
+  ]
+
+  return [...new Set(roots)]
+}
+
 async function findIconPath(iconName: string): Promise<string> {
   if (path.isAbsolute(iconName) && (await fs.stat(iconName).catch(() => null))) {
     return iconName
@@ -56,22 +84,38 @@ async function findIconPath(iconName: string): Promise<string> {
   const types = ['apps', 'categories', 'devices', 'mimetypes', 'places', 'status']
   const exts = ['.png', '.svg']
 
+  // Roots are filtered to the ones that exist before the search, not inside it. The theme x size
+  // x type x extension sweep is 432 probes per application in the worst case, and multiplying
+  // that by every candidate root -- most of which are absent on any given machine -- is what
+  // would have made adding flatpak support expensive. Four stats up front bound it instead.
+  const roots: string[] = []
+  for (const root of resolveIconRoots()) {
+    if (await fs.stat(root).catch(() => null)) roots.push(root)
+  }
+
   for (const theme of themes) {
     for (const size of sizes) {
       for (const type of types) {
         for (const ext of exts) {
-          const iconPath = path.join('/usr/share/icons', theme, size, type, `${iconName}${ext}`)
-          if (await fs.stat(iconPath).catch(() => null)) {
-            return iconPath
+          // Roots innermost: a system app still resolves at the first theme that carries it, and a
+          // flatpak app resolves at the same point under its own prefix, rather than after the
+          // whole system sweep has missed.
+          for (const root of roots) {
+            const iconPath = path.join(root, theme, size, type, `${iconName}${ext}`)
+            if (await fs.stat(iconPath).catch(() => null)) {
+              return iconPath
+            }
           }
         }
       }
     }
   }
 
-  const pixmapPath = path.join('/usr/share/pixmaps', `${iconName}.png`)
-  if (await fs.stat(pixmapPath).catch(() => null)) {
-    return pixmapPath
+  for (const root of roots) {
+    const pixmapPath = path.join(path.dirname(root), 'pixmaps', `${iconName}.png`)
+    if (await fs.stat(pixmapPath).catch(() => null)) {
+      return pixmapPath
+    }
   }
 
   return ''


### PR DESCRIPTION
Toward #341 — and the gap #1640 left behind.

#1640 made flatpak and XDG-prefixed applications **discoverable**. Their icons were not: `findIconPath` hardcoded `/usr/share/icons`, and a flatpak app's theme lives under its own export prefix. So that change made more applications appear in search **with no icon**.

Icon roots now come from `XDG_DATA_HOME` / `XDG_DATA_DIRS` plus both flatpak export prefixes, with the per-user root **first** — a user-installed theme has to win over the system copy of the same name, and the search returns its first hit.

## The cost had to be handled, not ignored

The theme × size × type × extension sweep is **432 probes per application** in the worst case. Multiplying that by every candidate root would have been the wrong trade for icons nobody sees.

- Roots are filtered to the ones that **exist** before the sweep starts — four stats up front.
- The root loop sits **innermost**, so a system app still resolves at the first theme carrying it, rather than after a full miss on the user prefix.

The `/usr/share/pixmaps` fallback follows the same roots now, so a flatpak app shipping a pixmap instead of a theme icon is reachable too.

## Negative-controlled

`resolveIconRoots` takes `env` and `home` as parameters, so this is testable without touching `process.env`.

```
drop the two flatpak icon roots     ->  2 failed, 12 passed
put the user root after the system  ->  1 failed, 13 passed
restored                            ->  14 passed
```

`addon/apps` suite: **19 files / 202 passed**. Lint clean.

Refs #341