### PR TITLE
feat(intelligence): notice when pi's stream protocol moves

### DIFF
--- a/apps/core-app/src/main/modules/ai/providers/pi-cli-provider.ts
+++ b/apps/core-app/src/main/modules/ai/providers/pi-cli-provider.ts
@@ -13,6 +13,7 @@ import { spawn } from 'node:child_process'
 import { delimiter, dirname } from 'node:path'
 import { createInterface } from 'node:readline'
 import { IntelligenceProviderType } from '@talex-touch/tuff-intelligence'
+import { createLogger } from '../../../utils/logger'
 import { IntelligenceProvider } from '../runtime/base-provider'
 import { collectMessageAttachments, spillAttachments } from './attachment-spill'
 import {
@@ -20,8 +21,12 @@ import {
   buildPiPrompt,
   parsePiCliLine,
   PI_CLI_NOT_FOUND,
+  PI_SESSION_PROTOCOL_VERSION,
+  readPiSessionProtocolVersion,
   resolvePiExecutable
 } from './pi-cli-runtime'
+
+const piCliLog = createLogger('Intelligence').child('PiCli')
 
 /** Enough stderr to identify a failure without letting a chatty run grow unbounded in memory. */
 const STDERR_TAIL_LIMIT = 4_000
@@ -142,7 +147,32 @@ export class PiCliProvider extends IntelligenceProvider {
     try {
       const lines = createInterface({ input: child.stdout, crlfDelay: Infinity })
 
+      let protocolChecked = false
+
       for await (const line of lines) {
+        // `pi` is an external CLI with no version constraint in this repo, so an upgrade can change
+        // the stream contract with nothing to announce it. Its first line carries the protocol
+        // version; a mismatch means the shapes this provider parses were read off a different
+        // protocol than the one now running (#970).
+        //
+        // Warn rather than fail: the parser degrades to skipping lines it does not recognise, and
+        // refusing to answer because a number moved would be worse than a partial reply. Once per
+        // run -- this is a diagnostic, not a stream annotation.
+        if (!protocolChecked) {
+          const protocolVersion = readPiSessionProtocolVersion(line)
+          if (protocolVersion !== null) {
+            protocolChecked = true
+            if (protocolVersion !== PI_SESSION_PROTOCOL_VERSION) {
+              piCliLog.warn(
+                'pi session protocol version differs from the one this parser was written against',
+                {
+                  meta: { observed: protocolVersion, expected: PI_SESSION_PROTOCOL_VERSION }
+                }
+              )
+            }
+          }
+        }
+
         const event = parsePiCliLine(line)
         if (!event) continue
 

--- a/apps/core-app/src/main/modules/ai/providers/pi-cli-runtime.test.ts
+++ b/apps/core-app/src/main/modules/ai/providers/pi-cli-runtime.test.ts
@@ -3,7 +3,9 @@ import {
   buildPiArgs,
   buildPiPrompt,
   parsePiCliLine,
-  PI_CLI_DEFAULT_SYSTEM_PROMPT
+  PI_CLI_DEFAULT_SYSTEM_PROMPT,
+  PI_SESSION_PROTOCOL_VERSION,
+  readPiSessionProtocolVersion
 } from './pi-cli-runtime'
 
 /**
@@ -160,6 +162,48 @@ describe('buildPiArgs', () => {
   it('leaves the argument shape untouched when the turn carried no attachment', () => {
     expect(buildPiArgs(prompt, undefined, undefined, [])).toEqual(buildPiArgs(prompt))
     expect(buildPiArgs(prompt).some((arg) => arg.startsWith('@'))).toBe(false)
+  })
+})
+
+describe('pi session protocol version', () => {
+  it('reads the version off a session line', () => {
+    expect(readPiSessionProtocolVersion('{"type":"session","version":3,"id":"x"}')).toBe(3)
+  })
+
+  // The detector exists because `pi` has no version constraint anywhere in this repo, so an
+  // upgrade can move the contract silently. A pin that cannot notice a change is decoration.
+  it('reports a moved version rather than normalising it', () => {
+    expect(readPiSessionProtocolVersion('{"type":"session","version":4,"id":"x"}')).toBe(4)
+    expect(readPiSessionProtocolVersion('{"type":"session","version":4}')).not.toBe(
+      PI_SESSION_PROTOCOL_VERSION
+    )
+  })
+
+  // The `version` here is the point: without the type check this reads it and reports a drift
+  // that never happened. Asserting only on lines that carry no version at all would pass against
+  // a function that ignored the type entirely.
+  it('ignores a version on any event that is not the session line', () => {
+    expect(readPiSessionProtocolVersion('{"type":"turn_start","version":9}')).toBeNull()
+    expect(readPiSessionProtocolVersion('{"type":"message_end","version":9}')).toBeNull()
+    expect(readPiSessionProtocolVersion('{"type":"turn_start"}')).toBeNull()
+    expect(readPiSessionProtocolVersion('{"type":"agent_settled"}')).toBeNull()
+  })
+
+  it('survives the noise a CLI puts on stdout', () => {
+    expect(readPiSessionProtocolVersion('not json at all')).toBeNull()
+    expect(readPiSessionProtocolVersion('')).toBeNull()
+    expect(readPiSessionProtocolVersion('   ')).toBeNull()
+  })
+
+  it('rejects a non-numeric version instead of coercing it', () => {
+    expect(readPiSessionProtocolVersion('{"type":"session","version":"3"}')).toBeNull()
+    expect(readPiSessionProtocolVersion('{"type":"session"}')).toBeNull()
+  })
+
+  // parsePiCliLine's contract is "null for events the chat surface has no use for", and a session
+  // line is still one of those. Drift detection must not change what the mapper returns.
+  it('leaves parsePiCliLine returning null for the same line', () => {
+    expect(parsePiCliLine('{"type":"session","version":3,"id":"x"}')).toBeNull()
   })
 })
 

--- a/apps/core-app/src/main/modules/ai/providers/pi-cli-runtime.ts
+++ b/apps/core-app/src/main/modules/ai/providers/pi-cli-runtime.ts
@@ -340,6 +340,42 @@ function parseUsage(value: unknown): IntelligenceUsageInfo | undefined {
 }
 
 /**
+ * The `session` protocol version this parser was written against.
+ *
+ * `pi` is not a declared dependency -- it is an external CLI with no version constraint anywhere
+ * in the repo -- and the shapes below were read off a live 0.83.0 run. So nothing tells us when
+ * an upgrade changes the contract: the fixtures keep passing against a stream that no longer
+ * matches production, and the first symptom is a user-visible parsing failure (#970).
+ *
+ * The release version would be the wrong thing to pin: it moves on every upgrade, most of which
+ * change nothing here. `pi` already emits `{"type":"session","version":N,…}` as its first line,
+ * and that number moves when the protocol does -- which is the question actually being asked.
+ */
+export const PI_SESSION_PROTOCOL_VERSION = 3
+
+/**
+ * The protocol version from a `session` line, or null for every other line.
+ *
+ * Deliberately separate from `parsePiCliLine` rather than folded into it: that function's contract
+ * is "null for events the chat surface has no use for", and a `session` line is still one of
+ * those. Drift detection is the caller's business, not the mapper's.
+ */
+export function readPiSessionProtocolVersion(line: string): number | null {
+  const trimmed = line.trim()
+  if (!trimmed) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    return null
+  }
+  const record = asRecord(parsed)
+  if (!record || readString(record.type) !== 'session') return null
+  const version = record.version
+  return typeof version === 'number' && Number.isFinite(version) ? version : null
+}
+
+/**
  * Maps one NDJSON line onto the fields this provider forwards. Returns `null` for the many event
  * types the chat surface has no use for (`session`, `turn_start`, tool traffic, …) so the caller can
  * skip them without knowing the full `pi` event vocabulary.


### PR DESCRIPTION
Toward #970's second tail — *"pi 升级契约复核"*.

## The problem is that nothing triggers the re-verification

`pi` is an external CLI with **no version constraint anywhere in the repo**, and the shapes this provider parses were read off a live `0.83.0` run and frozen into fixtures. An upgrade can change json-mode dumping, text-mode semantics or exit codes while the fixtures keep passing against a stream that no longer matches production.

## Pinning the release version would be wrong

It moves on every upgrade, most of which change nothing here. `pi` already emits `{"type":"session","version":N,…}` as its first line, and **that** number moves when the protocol does — which is the question actually being asked.

It costs nothing: the line is already in the stream and already parsed to `null`.

## Why the reader is separate from `parsePiCliLine`

That function's contract is *"null for events the chat surface has no use for"*, and a `session` line is still one of those. Drift detection is the caller's business, not the mapper's. A test pins that `parsePiCliLine` still returns `null` for the same line.

The provider **warns once per run rather than failing**. The parser degrades to skipping lines it does not recognise, and refusing to answer because a number moved would be worse than a partial reply.

## Negative-controlled — and the first pass was not good enough

```
accept a non-numeric version    ->  1 failed, 35 passed
stop checking the event type    ->  36 passed   ← the test was too weak
```

The second control exposed that *"ignores every other event type"* only held because those fixtures carried **no `version` field at all**. A type-blind reader would pass it while reporting drift on any event that happened to carry a version.

Strengthened to assert on `{"type":"turn_start","version":9}`. It now fails that control.

`providers` suite: **8 files / 93 passed**. Lint clean.

Refs #970