### PR TITLE
fix(types): finish plugin-module's Object.freeze typing (#548)

### DIFF
--- a/apps/core-app/src/main/modules/plugin/plugin-module.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-module.ts
@@ -92,7 +92,11 @@ import {
   createPluginBusinessCapabilities,
   pluginBusinessSecretPrefix
 } from './host/plugin-business-capabilities'
-import type { PluginBusinessCapabilities } from './host/plugin-business-capabilities'
+import type {
+  PluginBusinessCapabilities,
+  PluginBusinessClipboardHostService,
+  PluginBusinessNetworkService
+} from './host/plugin-business-capabilities'
 import {
   createFixedPluginBrowserDataService,
   createPluginBrowserDataCapabilities,
@@ -110,6 +114,7 @@ import {
   type PluginQuickOpsOperationId
 } from './host/plugin-host-request-reply'
 import { createPluginVoiceCapabilities } from './host/plugin-voice-capabilities'
+import type { PluginVoiceHostService } from './host/plugin-voice-capabilities'
 import { createPluginIntelligenceCapabilities } from './host/plugin-intelligence-capabilities'
 import { createPluginIntelligenceHostService } from './host/plugin-intelligence-host-service'
 import { createPluginIntelligenceContextCapabilities } from './host/plugin-intelligence-context-capabilities'
@@ -1939,7 +1944,7 @@ export class PluginModule extends BaseModule {
             pluginLog.warn(message, { error: 'PLUGIN_SECRET_UNAVAILABLE' })
           )
       }),
-      clipboard: Object.freeze({
+      clipboard: Object.freeze<PluginBusinessClipboardHostService>({
         read: async (request, context, signal) => {
           const service = getClipboardHostService()
           if (!service) throw new Error('PLUGIN_BUSINESS_CLIPBOARD_UNAVAILABLE')
@@ -1960,7 +1965,7 @@ export class PluginModule extends BaseModule {
         await openValidatedExternalUrl(url, {
           opener: async (target) => await shell.openExternal(target)
         }),
-      network: Object.freeze({
+      network: Object.freeze<PluginBusinessNetworkService>({
         requestPinned: async (options, policy) =>
           await getNetworkService().requestPinnedNoRedirect(options, policy),
         resolveAddresses: async (hostname) =>
@@ -2017,7 +2022,7 @@ export class PluginModule extends BaseModule {
         ioRuntime.transport.keyManager?.resolveCurrentIdentity?.(pluginName),
       resolveHostGeneration: (activation) =>
         this.runtimeService?.resolve(activation)?.owner.hostGeneration,
-      service: Object.freeze({
+      service: Object.freeze<PluginVoiceHostService>({
         dictate: async (payload, signal, caller) => {
           if (signal.aborted) throw new Error('PLUGIN_VOICE_CANCELLED')
           const result = await voiceService.dictate(payload, undefined, signal, caller)

--- a/scripts/check-implicit-any-debt.mjs
+++ b/scripts/check-implicit-any-debt.mjs
@@ -34,7 +34,7 @@ const CORE_APP = path.join(REPO_ROOT, 'apps/core-app')
  * only -- every error the flag produces is in that range, so a rise here is new untyped code and
  * not some unrelated type break.
  */
-export const KNOWN_IMPLICIT_ANY_ERRORS = 201
+export const KNOWN_IMPLICIT_ANY_ERRORS = 180
 
 /** Resolves the workspace's own tsc rather than trusting a .bin shim on PATH. */
 function resolveTsc() {


### PR DESCRIPTION
Toward #548. Second batch: **201 → 180**, `plugin-module.ts` now clean.

## Same cause, one level deeper

The privacy batch was `Object.freeze` swallowing a function's declared return type. These are the same call, filling **fields of a factory's options object**:

```ts
createPluginBusinessCapabilities({
  clipboard: Object.freeze({
    read: async (request, context, signal) => ...,   // ← all `any`
```

`PluginBusinessCapabilitiesOptions.clipboard` is typed `PluginBusinessClipboardHostService`, and that type would have reached the literal — except `Object.freeze<T>(o: T)` infers `T` from the argument, so the contextual type never arrives.

| field | type | errors |
|---|---|---|
| `clipboard` | `PluginBusinessClipboardHostService` | 12 |
| `network` | `PluginBusinessNetworkService` | 3 |
| voice `service` | `PluginVoiceHostService` | 6 |
| **total** | | **21** |

Three type arguments and three imports. No behaviour change.

## What was untyped

Worth naming, because "implicit any" reads as cosmetic: clipboard reads, **pinned network requests along with the TLS policy that pins them**, DNS resolution results, and dictation payloads. All crossing the plugin boundary.

## Verification

- Ratchet 201 → 180, checked **both** directions: `179` fails, `181` fails, `180` passes.
- **Non-TS7xxx diagnostics stayed at 0** through every step (201 → 183 → 180). This is the check that matters: restoring contextual typing can surface genuine mismatches that `any` was hiding, and trading implicit-anys for real type errors is not progress.
- Plugin suite: **88 of 89 files pass**. The one failure is `plugin-sqlite-worker.integration.test.ts` reporting `Missing .../out/main/plugin-sqlite-worker.js` — a build artefact this checkout does not have and CI builds in the step added by #1610. Not related to this change.

## Remaining 180

```
19  plugin/host/plugin-host-child-runtime.ts
17  plugin/host/plugin-business-capabilities.ts
16  plugin/host/plugin-runtime-service.ts
13  plugin/host/plugin-runtime-host.ts
11  plugin/host/plugin-system-capabilities.ts
11  plugin/host/plugin-filesystem-capabilities.ts
```

`plugin-host-child-runtime.ts:2901` is a different shape — `(callback, delay)` looks like a timer facade rather than a frozen capability record, so the next batch will not be pure pattern-matching.
