### PR TITLE
build(core-app): vue-sonner is a build input, not a shipped dependency

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -143,7 +143,6 @@
     "vue": "catalog:frontend",
     "vue-i18n": "^11.4.0",
     "vue-router": "^4.6.4",
-    "vue-sonner": "^2.0.9",
     "zod": "3.25.76"
   },
   "optionalDependencies": {
@@ -191,6 +190,7 @@
     "vitest": "^3.2.7",
     "vue-draggable-plus": "^0.6.1",
     "vue-eslint-parser": "^10.4.1",
+    "vue-sonner": "^2.0.9",
     "vue-tsc": "^3.3.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,9 +441,6 @@ importers:
       vue-router:
         specifier: ^4.6.4
         version: 4.6.4(vue@3.5.39(typescript@5.9.3))
-      vue-sonner:
-        specifier: ^2.0.9
-        version: 2.0.9(@nuxt/kit@4.4.8(magicast@0.5.3))(@nuxt/schema@4.4.8)(nuxt@4.4.8(bc90f1595c7cc9bc6b08337d210bd65b))
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -559,6 +556,9 @@ importers:
       vue-eslint-parser:
         specifier: ^10.4.1
         version: 10.4.1(eslint@9.39.4(jiti@2.7.0))
+      vue-sonner:
+        specifier: ^2.0.9
+        version: 2.0.9(@nuxt/kit@4.4.8(magicast@0.5.3))(@nuxt/schema@4.4.8)(nuxt@4.4.8(bc90f1595c7cc9bc6b08337d210bd65b))
       vue-tsc:
         specifier: ^3.3.6
         version: 3.3.7(typescript@5.9.3)


### PR DESCRIPTION
Toward #328's packaging half. **This changes no advisory** — I measured that first, and it is why the change is justified on its own terms rather than on the audit's.

## What it fixes

`electron-builder.yml` packs `node_modules/**`, and electron-builder prunes that to production dependencies. So `vue-sonner` ships inside the installer today. **Nothing loads it there:**

```
src/main       0 files import vue-sonner
src/preload    0 files
src/renderer  83 files
```

and `electron.vite.config.ts` applies `externalizeDepsPlugin` only to `main:` and `preload:`. The `renderer:` section externalises `electron`, `fs`, `child_process` and `original-fs` — not npm packages — so `vue-sonner` is compiled **into** the renderer bundle. The copy under `node_modules` is a build input the runtime never opens.

Same shape as `astro` in #1630: a dependency classified by where it is written rather than by when it runs.

## What it does not do, measured rather than assumed

```
vue-sonner in dependencies      low 2, moderate 8, high 8, critical 1
vue-sonner in devDependencies   low 2, moderate 8, high 8, critical 1
```

The nuxt closure it appeared to carry comes from `apps/nexus`'s own production dependency `@sentry/nuxt` — corrected on #328, and in the allowlist reasons by #1650.

## Verification

```
renderer suite   145 files / 838 tests passed
typecheck        no new errors
```

Refs #328