### PR TITLE
fix(types): name Object.freeze's type where the variable already declares it (#548)

### DIFF
--- a/apps/core-app/src/main/modules/plugin/host/plugin-filesystem-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-filesystem-capabilities.ts
@@ -79,13 +79,14 @@ const WINDOWS_INVALID_TARGET_NAME = /[<>:"|?*]/
 const ALLOWED_REQUEST_KEYS = ['operation', 'entries'] as const
 const ALLOWED_ENTRY_KEYS = ['source', 'targetName'] as const
 
-const defaultFilesystem: PluginBatchRenameFilesystemAdapter = Object.freeze({
-  lstat: async (filePath) => await fsp.lstat(filePath),
-  realpath: async (filePath) => await fsp.realpath(filePath),
-  open: async (filePath, flags) => await fsp.open(filePath, flags),
-  link: async (existingPath, newPath) => await fsp.link(existingPath, newPath),
-  unlink: async (filePath) => await fsp.unlink(filePath)
-})
+const defaultFilesystem: PluginBatchRenameFilesystemAdapter =
+  Object.freeze<PluginBatchRenameFilesystemAdapter>({
+    lstat: async (filePath) => await fsp.lstat(filePath),
+    realpath: async (filePath) => await fsp.realpath(filePath),
+    open: async (filePath, flags) => await fsp.open(filePath, flags),
+    link: async (existingPath, newPath) => await fsp.link(existingPath, newPath),
+    unlink: async (filePath) => await fsp.unlink(filePath)
+  })
 
 function invalidRequest(): never {
   throw new TypeError('PLUGIN_FILESYSTEM_REQUEST_INVALID')
@@ -794,7 +795,7 @@ export function createPluginBatchRenameFilesystemCapability(
     }
   }
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'filesystem.write',
     permission: 'fs.write',
     timeoutMs: 30_000,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-host-resources.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-host-resources.ts
@@ -362,14 +362,15 @@ export class PluginHostResourceRegistry
       await Promise.all([...pending].map((record) => this.dropRecord(record)))
       pending.clear()
     }
-    const resources: PluginHostCapabilityResourceContext = Object.freeze({
-      register: (kind, dispose) => {
-        if (!active) throw new PluginHostResourceError('PLUGIN_HOST_RESOURCE_CLOSED')
-        const record = this.createRecord(invocationOptions, kind, dispose)
-        pending.add(record)
-        return record.handle
-      }
-    })
+    const resources: PluginHostCapabilityResourceContext =
+      Object.freeze<PluginHostCapabilityResourceContext>({
+        register: (kind, dispose) => {
+          if (!active) throw new PluginHostResourceError('PLUGIN_HOST_RESOURCE_CLOSED')
+          const record = this.createRecord(invocationOptions, kind, dispose)
+          pending.add(record)
+          return record.handle
+        }
+      })
     return Object.freeze({
       resources,
       owns: (value: unknown) =>

--- a/apps/core-app/src/main/modules/plugin/host/plugin-system-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-system-capabilities.ts
@@ -618,16 +618,21 @@ export function createPluginSystemActionCapabilities(
     options.window,
     'showMainWindow'
   )
-  const executor: PluginSystemActionExecutor = Object.freeze({
+  // The type argument is named even though the variable is annotated: Object.freeze<T> infers T
+  // from its argument, so the annotation on the left never reaches the literal and every callback
+  // inside it takes its parameters as `any` (#548).
+  const executor: PluginSystemActionExecutor = Object.freeze<PluginSystemActionExecutor>({
     start: (actionId) => start.call(options.executor, actionId)
   })
-  const confirmation: PluginSystemActionConfirmationService = Object.freeze({
-    confirm: (actionId, signal) => confirm.call(options.confirmation, actionId, signal)
-  })
-  const windowService: PluginSystemActionWindowService = Object.freeze({
-    showMainWindow: (activation, hostGeneration, signal) =>
-      Promise.resolve(showMainWindow.call(options.window, activation, hostGeneration, signal))
-  })
+  const confirmation: PluginSystemActionConfirmationService =
+    Object.freeze<PluginSystemActionConfirmationService>({
+      confirm: (actionId, signal) => confirm.call(options.confirmation, actionId, signal)
+    })
+  const windowService: PluginSystemActionWindowService =
+    Object.freeze<PluginSystemActionWindowService>({
+      showMainWindow: (activation, hostGeneration, signal) =>
+        Promise.resolve(showMainWindow.call(options.window, activation, hostGeneration, signal))
+    })
   const platform = options.platform as NodeJS.Platform
   const expectedActivation = snapshotActivation(options.activation)
   if (!SYSTEM_ACTION_PLUGIN_NAME_SET.has(expectedActivation.name)) invalid()

--- a/scripts/check-implicit-any-debt.mjs
+++ b/scripts/check-implicit-any-debt.mjs
@@ -34,7 +34,7 @@ const CORE_APP = path.join(REPO_ROOT, 'apps/core-app')
  * only -- every error the flag produces is in that range, so a rise here is new untyped code and
  * not some unrelated type break.
  */
-export const KNOWN_IMPLICIT_ANY_ERRORS = 180
+export const KNOWN_IMPLICIT_ANY_ERRORS = 161
 
 /** Resolves the workspace's own tsc rather than trusting a .bin shim on PATH. */
 function resolveTsc() {


### PR DESCRIPTION
Toward #548. Third batch: **180 → 161**.

## The shape that reads as typed and is not

```ts
const executor: PluginSystemActionExecutor = Object.freeze({
  start: (actionId) => ...,   // ← `any`
})
```

The annotation is right there on the left. It still does not reach the literal, because `Object.freeze<T>(o: T): Readonly<T>` infers `T` from its **argument** — the contextual type from the variable never gets a chance.

This is the most misleading variant of the pattern so far: the privacy and `plugin-module` cases at least *looked* untyped. These look finished. That is why one of them carries a comment.

Six sites, 19 errors:

| file | sites | what was untyped |
|---|---|---|
| `plugin-system-capabilities.ts` | 3 | system action execution, its confirmation prompts, the window service behind them |
| `plugin-filesystem-capabilities.ts` | 2 | the batch-rename filesystem adapter — `lstat`, `realpath`, `rename` — and a capability definition |
| `plugin-host-resources.ts` | 1 | a host capability resource context |

## Verification

- Ratchet 180 → 161, **both** directions: `160` fails, `162` fails, `161` passes.
- Non-TS7xxx diagnostics stayed at **0**, as in the two batches before.
- Plugin host suite: 46 files / 759 tests pass.

## Running total

227 → 201 → 180 → 161. Sixty-six errors removed by naming a type argument, no behaviour changed anywhere.

## What is left, and why it is not the same job

161. The remaining clusters split into two kinds:

- **Return-position freezes** (`plugin-host-child-runtime.ts:2900`, `plugin-runtime-service.ts:204/1008`, `plugin-runtime-host.ts:320/366/419`, `plugin-business-capabilities.ts:896/912`, `plugin-intelligence-host-service.ts:543`) — same fix, but the target type has to be read off each enclosing function rather than the line itself.
- **`callbackFields: Object.freeze([])`** in nine files, 3 errors each — an array freeze, not an object one. The errors near it are a different cause and need looking at rather than pattern-matching.
