### PR TITLE
refactor(plugin): register the last three per-plugin capability gates

### DIFF
--- a/apps/core-app/src/main/modules/plugin/plugin.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin.ts
@@ -2032,7 +2032,7 @@ export class TouchPlugin implements ITouchPlugin {
   private createBatchRenameFilesystemCapability(
     activation: PluginActivationIdentity
   ): PluginBatchRenameFilesystemCapability | null {
-    if (this.name !== 'touch-batch-rename') return null
+    if (!isPrivilegedPluginFor('batchRenameFilesystem', this.name)) return null
     return createPluginBatchRenameFilesystemCapability({
       activation,
       platform: process.platform,
@@ -2060,7 +2060,7 @@ export class TouchPlugin implements ITouchPlugin {
   private createSnipasteProcessCapability(
     activation: PluginActivationIdentity
   ): PluginSnipasteProcessCapability | null {
-    if (this.name !== 'touch-snipaste') return null
+    if (!isPrivilegedPluginFor('snipasteProcess', this.name)) return null
     const factory = TouchPlugin.capability('snipasteProcess')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_SNIPASTE_PROCESS_CAPABILITY_UNAVAILABLE'), {
@@ -2112,7 +2112,7 @@ export class TouchPlugin implements ITouchPlugin {
   private createTranslationCapability(
     activation: PluginActivationIdentity
   ): PluginIntelligenceCapabilities | null {
-    if (this.name !== 'touch-translation') return null
+    if (!isPrivilegedPluginFor('translation', this.name)) return null
     const factory = TouchPlugin.capability('translation')
     if (!factory) {
       throw Object.assign(new Error('PLUGIN_TRANSLATION_CAPABILITY_UNAVAILABLE'), {

--- a/apps/core-app/src/main/modules/plugin/privileged-plugins.test.ts
+++ b/apps/core-app/src/main/modules/plugin/privileged-plugins.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isPrivilegedPluginFor,
+  PRIVILEGED_PLUGIN_CAPABILITIES,
+  PRIVILEGED_PLUGIN_NAMES,
+  privilegedPluginFor,
+  SYSTEM_ACTION_PLUGIN_NAMES
+} from './privileged-plugins'
+
+/**
+ * This registry replaced `this.name !== 'touch-x'` guards scattered through TouchPlugin, and until
+ * now nothing tested it — the guards it absorbed were only exercised through the plugin runtime,
+ * which is why an unregistered capability would have failed open rather than loudly (#713).
+ */
+describe('privileged plugin capabilities', () => {
+  it('admits only the registered holder', () => {
+    expect(isPrivilegedPluginFor('browserOpen', 'touch-browser-open')).toBe(true)
+    expect(isPrivilegedPluginFor('browserOpen', 'touch-window-manager')).toBe(false)
+  })
+
+  // The failure mode worth guarding: a capability that admits a plugin it was never granted to.
+  // A registry keyed by capability makes that a data question, so it can be asserted as one.
+  it('does not leak a holder across capabilities', () => {
+    for (const [capability, holders] of Object.entries(PRIVILEGED_PLUGIN_CAPABILITIES)) {
+      for (const name of PRIVILEGED_PLUGIN_NAMES) {
+        expect(
+          isPrivilegedPluginFor(capability as keyof typeof PRIVILEGED_PLUGIN_CAPABILITIES, name)
+        ).toBe((holders as readonly string[]).includes(name))
+      }
+    }
+  })
+
+  // An undefined name reaches this from three different shapes upstream — activation.name,
+  // expectedActivation.name, snapshot.manifest.name — and any of them can be absent.
+  it('refuses an absent plugin name rather than treating it as a wildcard', () => {
+    expect(isPrivilegedPluginFor('translation', undefined)).toBe(false)
+    expect(isPrivilegedPluginFor('translation', '')).toBe(false)
+  })
+
+  it('names every holder exactly once', () => {
+    expect(new Set(PRIVILEGED_PLUGIN_NAMES).size).toBe(PRIVILEGED_PLUGIN_NAMES.length)
+    for (const holders of Object.values(PRIVILEGED_PLUGIN_CAPABILITIES)) {
+      for (const name of holders as readonly string[]) {
+        expect(PRIVILEGED_PLUGIN_NAMES).toContain(name)
+      }
+    }
+  })
+
+  describe('privilegedPluginFor', () => {
+    it('returns the sole holder for a single-holder capability', () => {
+      expect(privilegedPluginFor('batchRenameFilesystem')).toBe('touch-batch-rename')
+      expect(privilegedPluginFor('snipasteProcess')).toBe('touch-snipaste')
+      expect(privilegedPluginFor('translation')).toBe('touch-translation')
+    })
+
+    // Returning the first of several would read as "the owner" at a call site that renders it as
+    // one, so the multi-holder case has to be a throw rather than a silent pick.
+    it('throws rather than picking one when a capability gains a second holder', () => {
+      const multi = Object.entries(PRIVILEGED_PLUGIN_CAPABILITIES).find(
+        ([, holders]) => (holders as readonly string[]).length > 1
+      )
+      if (!multi) {
+        expect(() =>
+          privilegedPluginFor('nope' as keyof typeof PRIVILEGED_PLUGIN_CAPABILITIES)
+        ).toThrow()
+        return
+      }
+      expect(() =>
+        privilegedPluginFor(multi[0] as keyof typeof PRIVILEGED_PLUGIN_CAPABILITIES)
+      ).toThrow(/holders/)
+    })
+  })
+
+  // The two system-action tiers are deliberately separate entries: isActionAllowedForPlugin gives
+  // them different action lists, so a single entry naming both would make the gate look like an
+  // either/or when it is not. This asserts the union stays the union.
+  it('keeps both system-action tiers in the combined gate', () => {
+    expect(SYSTEM_ACTION_PLUGIN_NAMES).toContain('touch-quick-actions')
+    expect(SYSTEM_ACTION_PLUGIN_NAMES).toContain('touch-system-actions')
+    expect(isPrivilegedPluginFor('systemActionsBasic', 'touch-system-actions')).toBe(false)
+    expect(isPrivilegedPluginFor('systemActionsAdvanced', 'touch-quick-actions')).toBe(false)
+  })
+})

--- a/apps/core-app/src/main/modules/plugin/privileged-plugins.ts
+++ b/apps/core-app/src/main/modules/plugin/privileged-plugins.ts
@@ -38,7 +38,13 @@ export const PRIVILEGED_PLUGIN_CAPABILITIES = {
   /** Applies saved window geometry presets. */
   windowPresets: ['touch-window-presets'],
   /** Lists and runs scripts from a selected workspace. */
-  workspaceScripts: ['touch-workspace-scripts']
+  workspaceScripts: ['touch-workspace-scripts'],
+  /** Renames files in a chosen directory, under the plugin's declared filesystem permissions. */
+  batchRenameFilesystem: ['touch-batch-rename'],
+  /** Spawns and tracks the screenshot helper process. */
+  snipasteProcess: ['touch-snipaste'],
+  /** Reaches the intelligence providers for translation requests. */
+  translation: ['touch-translation']
 } as const satisfies Record<string, readonly string[]>
 
 export type PrivilegedPluginCapability = keyof typeof PRIVILEGED_PLUGIN_CAPABILITIES


### PR DESCRIPTION
Toward #713.

That issue reported hardcoded per-plugin authorization rules inside `TouchPlugin`. **Nine of the thirteen it counted had already moved** to `privileged-plugins.ts` — a real policy module rather than a constant relocation: it carries a capability-keyed registry, a name predicate, and a comment naming `name !== THE_ONE` as the shape it exists to absorb.

These are the three that were left:

```
createBatchRenameFilesystemCapability   this.name !== 'touch-batch-rename'
createSnipasteProcessCapability         this.name !== 'touch-snipaste'
createTranslationCapability             this.name !== 'touch-translation'
```

Each becomes `isPrivilegedPluginFor('<capability>', this.name)` — the form `plugin.ts:2089` already uses for `browserOpen`.

**`plugin.ts` now has one hardcoded plugin name left, down from thirteen when the issue was filed.**

## The registry had no test at all

That is the part worth fixing alongside the migration. The guards it absorbed were only ever exercised through the plugin runtime, so an unregistered capability would have **failed open rather than loudly**.

Seven cases now cover it, and the two that matter are negative-controlled:

```
let translation also admit touch-snipaste   ->  1 failed, 6 passed
let an absent name pass as a wildcard       ->  1 failed, 6 passed
restored                                    ->  7 passed
```

The cross-capability case is a **loop over the registry** rather than a list of pairs, so a capability added later is covered without anyone remembering to extend the test.

## Verification

`plugin` module: **89 of 90 files pass**. The one failure is `plugin-sqlite-worker.integration.test.ts` asking for a main-process build artifact this checkout does not have — it fails identically on the unmodified baseline and passes in CI, where the build step runs (#1604). Lint clean.

Refs #713