### PR TITLE
fix(types): name the return type on the plugin host's frozen records (#548)

### DIFF
--- a/apps/core-app/src/main/modules/plugin/host/plugin-business-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-business-capabilities.ts
@@ -893,7 +893,7 @@ function snapshotFeatureHost(input: unknown): PluginBusinessFeatureHost {
   const removeItem = readMethod(input, 'removeItem')
   const clearItems = readMethod(input, 'clearItems')
   const listItems = readMethod(input, 'listItems')
-  return Object.freeze({
+  return Object.freeze<PluginBusinessFeatureHost>({
     pushItems: (scope, items, signal, replacements) =>
       pushItems.call(input, scope, items, signal, replacements) as never,
     updateItem: (scope, id, patch, signal) =>
@@ -909,7 +909,7 @@ function snapshotSqliteClient(input: unknown): PluginSqliteResourceClient {
   const query = readMethod(input, 'query')
   const transaction = readMethod(input, 'transaction')
   const close = readMethod(input, 'close')
-  return Object.freeze({
+  return Object.freeze<PluginSqliteResourceClient>({
     execute: (sql, params) =>
       execute.call(input, sql, params) as ReturnType<PluginSqliteResourceClient['execute']>,
     query: (sql, params) =>

--- a/apps/core-app/src/main/modules/plugin/host/plugin-host-child-runtime.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-host-child-runtime.ts
@@ -2897,7 +2897,7 @@ function createContextBridge(
       : 'PLUGIN_HOST_CAPABILITY_HANDLER_FAILED'
   }
 
-  return Object.freeze({
+  return Object.freeze<ContextBridge>({
     setTimeout: (callback, delay) => timers.setTimeout(callback, delay),
     setInterval: (callback, delay) => timers.setInterval(callback, delay),
     setImmediate: (callback) => timers.setImmediate(callback),

--- a/apps/core-app/src/main/modules/plugin/host/plugin-intelligence-context-host-service.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-intelligence-context-host-service.ts
@@ -744,7 +744,7 @@ export function createPluginIntelligenceContextHostService(
   const invoke = dependencies.invoke
   if (!isDirectFunction(invoke)) fail(code)
 
-  return Object.freeze({
+  return Object.freeze<PluginIntelligenceContextHostService>({
     contextInvoke: async (request, signal, caller) => {
       assertCallBoundary(signal, caller)
       if (signal.aborted) cancelled()

--- a/apps/core-app/src/main/modules/plugin/host/plugin-intelligence-host-service.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-intelligence-host-service.ts
@@ -540,7 +540,7 @@ export function createPluginIntelligenceHostService(
     fail(code)
   }
 
-  return Object.freeze({
+  return Object.freeze<PluginIntelligenceHostService>({
     invoke: async (capabilityId, payload, options, signal, caller) => {
       assertCallBoundary(capabilityId, signal, caller)
       const projectedPayload =

--- a/apps/core-app/src/main/modules/plugin/host/plugin-runtime-host.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-runtime-host.ts
@@ -317,7 +317,7 @@ function snapshotProcessFactory(value: unknown): PluginRuntimeProcessFactory {
     if (typeof artifactExists !== 'function' || typeof spawn !== 'function') {
       throw new PluginRuntimeHostError('PLUGIN_RUNTIME_HOST_INVALID_OPTIONS')
     }
-    return Object.freeze({
+    return Object.freeze<PluginRuntimeProcessFactory>({
       artifactExists: (artifactPath) => artifactExists.call(factory, artifactPath),
       spawn: (options) => spawn.call(factory, options)
     })
@@ -363,7 +363,7 @@ function snapshotCapabilityDispatcher(
     ) {
       throw new PluginRuntimeHostError('PLUGIN_RUNTIME_HOST_INVALID_OPTIONS')
     }
-    return Object.freeze({
+    return Object.freeze<PluginRuntimeCapabilityDispatcher>({
       owner: expectedOwner,
       activation: expectedActivation,
       dispatch: (capability, payload, signal) =>
@@ -416,7 +416,7 @@ function snapshotResourceDispatcher(
     ) {
       throw new PluginRuntimeHostError('PLUGIN_RUNTIME_HOST_INVALID_OPTIONS')
     }
-    return Object.freeze({
+    return Object.freeze<PluginHostResourceDispatcher>({
       owner: expectedOwner,
       activation: expectedActivation,
       beginInvocation: (options) => beginInvocation.call(dispatcher, options),

--- a/apps/core-app/src/main/modules/plugin/host/plugin-runtime-service.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-runtime-service.ts
@@ -201,7 +201,7 @@ function snapshotKeyManager(input: unknown): RuntimeKeyManager {
 function snapshotProcessFactory(input: unknown): PluginRuntimeProcessFactory {
   const artifactExists = readMethod(input, 'artifactExists')
   const spawn = readMethod(input, 'spawn')
-  return Object.freeze({
+  return Object.freeze<PluginRuntimeProcessFactory>({
     artifactExists: (artifactPath: string) =>
       artifactExists.call(input, artifactPath) as boolean | Promise<boolean>,
     spawn: (options) =>
@@ -1005,7 +1005,7 @@ export class PluginRuntimeService {
       await call(method, payload, signal)
     }
 
-    return Object.freeze({
+    return Object.freeze<PluginRuntimeLifecycleProxy>({
       onMessage: (key, info) => callVoid('onMessage', [key, info]),
       onLaunch: (feature) => callVoid('onLaunch', [feature]),
       onFeatureTriggered: async (id, data, feature, signal) =>

--- a/scripts/check-implicit-any-debt.mjs
+++ b/scripts/check-implicit-any-debt.mjs
@@ -34,7 +34,7 @@ const CORE_APP = path.join(REPO_ROOT, 'apps/core-app')
  * only -- every error the flag produces is in that range, so a rise here is new untyped code and
  * not some unrelated type break.
  */
-export const KNOWN_IMPLICIT_ANY_ERRORS = 161
+export const KNOWN_IMPLICIT_ANY_ERRORS = 85
 
 /** Resolves the workspace's own tsc rather than trusting a .bin shim on PATH. */
 function resolveTsc() {


### PR DESCRIPTION
Toward #548. Fourth batch and the largest: **161 → 85**.

## Return position, same cause

```ts
export function createPluginRuntimeProcessFactory(...): PluginRuntimeProcessFactory {
  ...
  return Object.freeze({
    spawn: (options) => ...,   // ← `any`
```

The return type is declared on the signature and still does not reach the literal, because `Object.freeze<T>(o: T)` infers `T` from its argument.

Ten sites, 76 errors:

| file | sites | type |
|---|---|---|
| `plugin-host-child-runtime.ts` | 1 | `ContextBridge` |
| `plugin-runtime-service.ts` | 2 | `PluginRuntimeProcessFactory`, `PluginRuntimeLifecycleProxy` |
| `plugin-runtime-host.ts` | 3 | `PluginRuntimeProcessFactory`, `PluginRuntimeCapabilityDispatcher`, `PluginHostResourceDispatcher` |
| `plugin-business-capabilities.ts` | 2 | `PluginBusinessFeatureHost`, `PluginSqliteResourceClient` |
| `plugin-intelligence-host-service.ts` | 1 | `PluginIntelligenceHostService` |
| `plugin-intelligence-context-host-service.ts` | 1 | `PluginIntelligenceContextHostService` |

**Not mechanical**, unlike batch 3: the target type had to be read off each enclosing function rather than the same line, and two of them return `T | null`, so the type argument is the non-null half. Substituting the declared union verbatim would have been wrong.

## What was untyped

The plugin **child runtime's entire context bridge** — every call crossing into the child process — plus the runtime process factory on both implementations, the lifecycle proxy, the capability and host-resource dispatchers, the business feature host, the SQLite resource client, and both intelligence host services.

## Verification

- Ratchet 161 → 85, **both** directions: `84` fails, `86` fails, `85` passes.
- Non-TS7xxx diagnostics stayed at **0**. With 76 errors resolved at once this is the assertion carrying the most weight: contextual typing arriving in ten previously-untyped records could easily have surfaced a real mismatch, and none appeared.
- Plugin suite: 88 of 89 files pass. The exception is `plugin-sqlite-worker.integration.test.ts` reporting a missing `out/main/plugin-sqlite-worker.js` — a build artefact this checkout does not have and CI builds.

## Running total

**227 → 201 → 180 → 161 → 85.** 142 errors removed across four PRs, entirely by naming a type argument. No behaviour changed.

## What is left

85, and the easy shape is exhausted. The bulk is `callbackFields: Object.freeze([])` in nine files at 3 errors each — an **array** freeze, where the nearby errors have a different cause and need reading rather than pattern-matching.
