### PR TITLE
fix(types): type the capability definitions and privacy factories (#548)

### DIFF
--- a/apps/core-app/src/main/modules/plugin/host/plugin-browser-data-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-browser-data-capabilities.ts
@@ -1418,7 +1418,7 @@ export function createPluginBrowserDataCapabilities(
     }
   }
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'browser-data.scan',
     permission: 'fs.read',
     timeoutMs: PLUGIN_BROWSER_DATA_TIMEOUT_MS,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-browser-open-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-browser-open-capabilities.ts
@@ -978,7 +978,7 @@ export function createPluginBrowserOpenCapabilities(
     return Object.freeze({ target: record.target })
   }
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'system.browser-open',
     permission: 'system.shell',
     timeoutMs: PLUGIN_BROWSER_OPEN_TIMEOUT_MS,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-host-session.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-host-session.ts
@@ -195,7 +195,7 @@ function snapshotOwner(owner: HostMessageOwner): HostMessageOwner {
   ) {
     throw new PluginHostSessionError('PLUGIN_HOST_SESSION_INVALID_OWNER')
   }
-  return Object.freeze({
+  return Object.freeze<HostMessageOwner>({
     protocolVersion: HOST_PROTOCOL_VERSION,
     activationHandle,
     hostGeneration: Number(hostGeneration)

--- a/apps/core-app/src/main/modules/plugin/host/plugin-intelligence-context-stream-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-intelligence-context-stream-capabilities.ts
@@ -508,7 +508,7 @@ export function createPluginIntelligenceContextStreamCapabilities(
     return current
   }
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'intelligence.stream',
     permission: 'intelligence.basic',
     timeoutMs: 30_000,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-process-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-process-capabilities.ts
@@ -707,7 +707,7 @@ export function createPluginSnipasteProcessCapability(
     return record
   }
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'process.spawn',
     permission: 'system.shell',
     timeoutMs: PLUGIN_SNIPASTE_PROCESS_TIMEOUT_MS,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-system-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-system-capabilities.ts
@@ -662,7 +662,7 @@ export function createPluginSystemActionCapabilities(
     return Number(identity.hostGeneration)
   }
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'system.invoke',
     timeoutMs: PLUGIN_SYSTEM_ACTION_TIMEOUT_MS,
     maxConcurrency: 1,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-window-manager-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-window-manager-capabilities.ts
@@ -1385,7 +1385,7 @@ export function createPluginWindowManagerCapabilities(
   const actionsForWindow = (): readonly PluginWindowManagerActionId[] =>
     platform === 'darwin' ? MAC_WINDOW_ACTIONS : WINDOWS_ACTIONS
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'system.window-manager',
     permission: 'system.shell',
     timeoutMs: PLUGIN_WINDOW_MANAGER_TIMEOUT_MS,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-window-preset-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-window-preset-capabilities.ts
@@ -930,7 +930,7 @@ export function createPluginWindowPresetCapabilities(
     return parseWindows(stdout)
   }
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'system.window-presets',
     permission: 'system.shell',
     timeoutMs: PLUGIN_WINDOW_PRESET_TIMEOUT_MS,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-workspace-script-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-workspace-script-capabilities.ts
@@ -1295,7 +1295,7 @@ export function createPluginWorkspaceScriptCapabilities(
     return record
   }
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'process.workspace-scripts',
     permission: 'fs.read',
     timeoutMs: PLUGIN_WORKSPACE_SCRIPT_TIMEOUT_MS,

--- a/apps/core-app/src/main/modules/privacy/owners/clipboard-retention-owner.ts
+++ b/apps/core-app/src/main/modules/privacy/owners/clipboard-retention-owner.ts
@@ -70,7 +70,7 @@ export interface ClipboardImagePersistenceAdapter {
 export function createClipboardImageRetentionAdapter(
   persistence: ClipboardImagePersistenceAdapter
 ): ClipboardImageRetentionOwner {
-  return Object.freeze({
+  return Object.freeze<ClipboardImageRetentionOwner>({
     deleteReferences: (references, signal) =>
       persistence.deleteOwnedImageReferences(references, signal),
     reconcileOrphans: (signal, maxRows) => persistence.cleanupOrphanClipboardImages(signal, maxRows)
@@ -85,14 +85,16 @@ export interface ClipboardRetentionOwnerOptions {
   readonly onDeleted?: (ids: readonly number[]) => void
 }
 
-const missingImageOwner: ClipboardImageRetentionOwner = Object.freeze({
-  async deleteReferences(references) {
-    return { deletedCount: 0, deletedByteCount: 0, failedCount: references.length }
-  },
-  async reconcileOrphans() {
-    return { deletedCount: 0, deletedByteCount: 0, failedCount: 0 }
+const missingImageOwner: ClipboardImageRetentionOwner = Object.freeze<ClipboardImageRetentionOwner>(
+  {
+    async deleteReferences(references) {
+      return { deletedCount: 0, deletedByteCount: 0, failedCount: references.length }
+    },
+    async reconcileOrphans() {
+      return { deletedCount: 0, deletedByteCount: 0, failedCount: 0 }
+    }
   }
-})
+)
 
 function disabledDelete(): PrivacyOwnerDeleteResult {
   return privacyDeleteResult(CATEGORY, 'PRIVACY_OWNER_DISABLED', emptyDeleteProgress(), {

--- a/apps/core-app/src/main/modules/privacy/plugin-ordinary-data-export.ts
+++ b/apps/core-app/src/main/modules/privacy/plugin-ordinary-data-export.ts
@@ -247,7 +247,7 @@ async function exportRoot(
 export function createPluginOrdinaryDataOwner(
   request: PluginOrdinaryDataExportRequest
 ): PrivacyDataOwner {
-  return Object.freeze({
+  return Object.freeze<PrivacyDataOwner>({
     categories: Object.freeze([CATEGORY]),
     inspect: async () => emptyInspection(),
     previewDelete: async () => emptyPreview(),

--- a/apps/core-app/src/main/modules/privacy/privacy-export.ts
+++ b/apps/core-app/src/main/modules/privacy/privacy-export.ts
@@ -487,7 +487,7 @@ function makeWriter(
   category: { records: number; bytes: number },
   categoryName: PrivacyDataCategory
 ): PrivacyOwnerExportWriter {
-  return Object.freeze({
+  return Object.freeze<PrivacyOwnerExportWriter>({
     write: async (record) => {
       const normalized = normalizeOwnerRecord(categoryName, record)
       const measuredBytes = measureJsonBytes(normalized, limits.maxRecordBytes)
@@ -844,7 +844,7 @@ export function createPrivacyCategoryExporter(
       }
   const limits = normalizeLimits(values.limits)
 
-  return Object.freeze({
+  return Object.freeze<PrivacyCategoryExporter>({
     exportCategories: async (rawRequest, providedSignal) => {
       const request = normalizeExportRequest(rawRequest)
       const signal = providedSignal ?? request.signal ?? new AbortController().signal

--- a/apps/core-app/src/main/modules/privacy/privacy-module.ts
+++ b/apps/core-app/src/main/modules/privacy/privacy-module.ts
@@ -216,7 +216,7 @@ async function createProductionService(): Promise<PrivacyLifecycleService> {
 }
 
 function defaultDependencies(): PrivacyLifecycleModuleDependencies {
-  return Object.freeze({
+  return Object.freeze<PrivacyLifecycleModuleDependencies>({
     resolveTransport: (context) =>
       resolveMainRuntime(context, 'PrivacyLifecycleModule.onInit')
         .transport as unknown as PrivacyTransportAdapter,

--- a/apps/core-app/src/main/modules/privacy/privacy-owner-export.test.ts
+++ b/apps/core-app/src/main/modules/privacy/privacy-owner-export.test.ts
@@ -34,7 +34,7 @@ function fakeClient(
 
 function collector() {
   const records: Readonly<Record<string, unknown>>[] = []
-  const writer: PrivacyOwnerExportWriter = Object.freeze({
+  const writer: PrivacyOwnerExportWriter = Object.freeze<PrivacyOwnerExportWriter>({
     write: async (record) => {
       records.push(record)
       return { byteCount: Buffer.byteLength(JSON.stringify(record), 'utf8') }

--- a/apps/core-app/src/main/modules/privacy/retention-coordinator.ts
+++ b/apps/core-app/src/main/modules/privacy/retention-coordinator.ts
@@ -134,7 +134,7 @@ export function createPrivacyRetentionCoordinator(
     await operation
   }
 
-  return Object.freeze({
+  return Object.freeze<PrivacyRetentionCoordinator>({
     initializeAfterStorageReady: async () => {
       if (state !== 'created') throw new Error('PRIVACY_RETENTION_COORDINATOR_ALREADY_INITIALIZED')
       try {

--- a/apps/core-app/src/main/modules/privacy/retention-policy-store.ts
+++ b/apps/core-app/src/main/modules/privacy/retention-policy-store.ts
@@ -27,7 +27,7 @@ export interface PrivacyRetentionPolicyStore {
 export function createPrivacyRetentionPolicyStore(
   adapter: PrivacyRetentionPolicyStorageAdapter
 ): PrivacyRetentionPolicyStore {
-  return Object.freeze({
+  return Object.freeze<PrivacyRetentionPolicyStore>({
     async load() {
       return normalizePrivacyRetentionPolicy(await adapter.read())
     },

--- a/scripts/check-implicit-any-debt.mjs
+++ b/scripts/check-implicit-any-debt.mjs
@@ -34,7 +34,7 @@ const CORE_APP = path.join(REPO_ROOT, 'apps/core-app')
  * only -- every error the flag produces is in that range, so a rise here is new untyped code and
  * not some unrelated type break.
  */
-export const KNOWN_IMPLICIT_ANY_ERRORS = 85
+export const KNOWN_IMPLICIT_ANY_ERRORS = 37
 
 /** Resolves the workspace's own tsc rather than trusting a .bin shim on PATH. */
 function resolveTsc() {


### PR DESCRIPTION
Toward #548. Fifth batch: **85 → 37**.

## A correction to #1660

That PR said the remaining `callbackFields: Object.freeze([])` cluster had *"a different cause"* and needed reading rather than pattern-matching. **That was wrong.** The errors sit inside this:

```ts
const definition: PluginHostCapabilityDefinition = Object.freeze({   // ← line 710, the real enclosure
  ...
  callbackFields: Object.freeze([]),                                  // ← line 716, an array freeze
  async invoke(context, request, signal) {                            // ← line 718, the errors
```

My grouping heuristic walked upward for the nearest `Object.freeze(` and stopped at the array one, three lines closer than the object one that actually encloses the handler. Same cause as every batch before it, same one-line fix, across nine files. Reading the code rather than the tool's grouping would have caught it before it went into a merged PR body.

## This batch

| shape | sites | errors |
|---|---|---|
| type on the variable — 8 × `PluginHostCapabilityDefinition`, plus `ClipboardImageRetentionOwner`, `PrivacyOwnerExportWriter` | 10 | 30 |
| type on the enclosing function's return | 8 | 18 |

What was untyped: **every plugin host capability definition's `invoke` handler** — process spawn, browser data and open, window manager and presets, workspace scripts, system actions, intelligence context streaming — plus the privacy export writer, category exporter, retention coordinator and policy store.

## Verification

- Ratchet 85 → 37, **both** directions: `36` fails, `38` fails, `37` passes.
- Non-TS7xxx diagnostics from these files stayed at **0**.
- Privacy and plugin host suites: 66 files / 905 tests pass.

### Two things caught by process rather than luck

**A `TS6196` appeared mid-batch** in `quick-ops/index.ts`, a file this PR does not touch. It is another session's in-flight refactor extracting `quick-ops-qr-png.ts`, surfaced because "non-TS7xxx must stay 0" is re-checked at every step. Verified it contributes no TS7xxx errors, so 37 is unaffected, and its files are excluded here.

**The branch moved under me.** That same session switched this shared worktree's checked-out branch between my `checkout -B` and my `commit`, so the commit landed on *their* branch. Rather than move their branch pointer back, this PR is pushed from the commit SHA directly to its own ref, leaving their working state untouched. Verified the commit contains exactly the 17 intended files and nothing from `quick-ops`.

## Running total

**227 → 201 → 180 → 161 → 85 → 37.** 190 errors removed across five PRs, all by naming a type argument, no behaviour changed.

## What is left

37, and the shape has genuinely changed this time — verified by reading, not grouping:

```
9  modules/clipboard.ts
3  plugin/plugin.ts
3  plugin/host/plugin-intelligence-context-capabilities.ts
3  plugin/host/plugin-intelligence-capabilities.ts
3  native-capabilities/native-screenshot-macos.integration.test.ts
```
