### PR TITLE
ref(quick-ops): extract the QR PNG encoder and decode-test it

### DIFF
--- a/apps/core-app/src/main/modules/plugin/host/plugin-browser-data-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-browser-data-capabilities.ts
@@ -1418,7 +1418,7 @@ export function createPluginBrowserDataCapabilities(
     }
   }
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'browser-data.scan',
     permission: 'fs.read',
     timeoutMs: PLUGIN_BROWSER_DATA_TIMEOUT_MS,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-browser-open-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-browser-open-capabilities.ts
@@ -978,7 +978,7 @@ export function createPluginBrowserOpenCapabilities(
     return Object.freeze({ target: record.target })
   }
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'system.browser-open',
     permission: 'system.shell',
     timeoutMs: PLUGIN_BROWSER_OPEN_TIMEOUT_MS,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-host-session.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-host-session.ts
@@ -195,7 +195,7 @@ function snapshotOwner(owner: HostMessageOwner): HostMessageOwner {
   ) {
     throw new PluginHostSessionError('PLUGIN_HOST_SESSION_INVALID_OWNER')
   }
-  return Object.freeze({
+  return Object.freeze<HostMessageOwner>({
     protocolVersion: HOST_PROTOCOL_VERSION,
     activationHandle,
     hostGeneration: Number(hostGeneration)

--- a/apps/core-app/src/main/modules/plugin/host/plugin-intelligence-context-stream-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-intelligence-context-stream-capabilities.ts
@@ -508,7 +508,7 @@ export function createPluginIntelligenceContextStreamCapabilities(
     return current
   }
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'intelligence.stream',
     permission: 'intelligence.basic',
     timeoutMs: 30_000,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-process-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-process-capabilities.ts
@@ -707,7 +707,7 @@ export function createPluginSnipasteProcessCapability(
     return record
   }
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'process.spawn',
     permission: 'system.shell',
     timeoutMs: PLUGIN_SNIPASTE_PROCESS_TIMEOUT_MS,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-system-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-system-capabilities.ts
@@ -662,7 +662,7 @@ export function createPluginSystemActionCapabilities(
     return Number(identity.hostGeneration)
   }
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'system.invoke',
     timeoutMs: PLUGIN_SYSTEM_ACTION_TIMEOUT_MS,
     maxConcurrency: 1,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-window-manager-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-window-manager-capabilities.ts
@@ -1385,7 +1385,7 @@ export function createPluginWindowManagerCapabilities(
   const actionsForWindow = (): readonly PluginWindowManagerActionId[] =>
     platform === 'darwin' ? MAC_WINDOW_ACTIONS : WINDOWS_ACTIONS
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'system.window-manager',
     permission: 'system.shell',
     timeoutMs: PLUGIN_WINDOW_MANAGER_TIMEOUT_MS,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-window-preset-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-window-preset-capabilities.ts
@@ -930,7 +930,7 @@ export function createPluginWindowPresetCapabilities(
     return parseWindows(stdout)
   }
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'system.window-presets',
     permission: 'system.shell',
     timeoutMs: PLUGIN_WINDOW_PRESET_TIMEOUT_MS,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-workspace-script-capabilities.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-workspace-script-capabilities.ts
@@ -1295,7 +1295,7 @@ export function createPluginWorkspaceScriptCapabilities(
     return record
   }
 
-  const definition: PluginHostCapabilityDefinition = Object.freeze({
+  const definition: PluginHostCapabilityDefinition = Object.freeze<PluginHostCapabilityDefinition>({
     id: 'process.workspace-scripts',
     permission: 'fs.read',
     timeoutMs: PLUGIN_WORKSPACE_SCRIPT_TIMEOUT_MS,

--- a/apps/core-app/src/main/modules/privacy/owners/clipboard-retention-owner.ts
+++ b/apps/core-app/src/main/modules/privacy/owners/clipboard-retention-owner.ts
@@ -70,7 +70,7 @@ export interface ClipboardImagePersistenceAdapter {
 export function createClipboardImageRetentionAdapter(
   persistence: ClipboardImagePersistenceAdapter
 ): ClipboardImageRetentionOwner {
-  return Object.freeze({
+  return Object.freeze<ClipboardImageRetentionOwner>({
     deleteReferences: (references, signal) =>
       persistence.deleteOwnedImageReferences(references, signal),
     reconcileOrphans: (signal, maxRows) => persistence.cleanupOrphanClipboardImages(signal, maxRows)
@@ -85,14 +85,16 @@ export interface ClipboardRetentionOwnerOptions {
   readonly onDeleted?: (ids: readonly number[]) => void
 }
 
-const missingImageOwner: ClipboardImageRetentionOwner = Object.freeze({
-  async deleteReferences(references) {
-    return { deletedCount: 0, deletedByteCount: 0, failedCount: references.length }
-  },
-  async reconcileOrphans() {
-    return { deletedCount: 0, deletedByteCount: 0, failedCount: 0 }
+const missingImageOwner: ClipboardImageRetentionOwner = Object.freeze<ClipboardImageRetentionOwner>(
+  {
+    async deleteReferences(references) {
+      return { deletedCount: 0, deletedByteCount: 0, failedCount: references.length }
+    },
+    async reconcileOrphans() {
+      return { deletedCount: 0, deletedByteCount: 0, failedCount: 0 }
+    }
   }
-})
+)
 
 function disabledDelete(): PrivacyOwnerDeleteResult {
   return privacyDeleteResult(CATEGORY, 'PRIVACY_OWNER_DISABLED', emptyDeleteProgress(), {

--- a/apps/core-app/src/main/modules/privacy/plugin-ordinary-data-export.ts
+++ b/apps/core-app/src/main/modules/privacy/plugin-ordinary-data-export.ts
@@ -247,7 +247,7 @@ async function exportRoot(
 export function createPluginOrdinaryDataOwner(
   request: PluginOrdinaryDataExportRequest
 ): PrivacyDataOwner {
-  return Object.freeze({
+  return Object.freeze<PrivacyDataOwner>({
     categories: Object.freeze([CATEGORY]),
     inspect: async () => emptyInspection(),
     previewDelete: async () => emptyPreview(),

--- a/apps/core-app/src/main/modules/privacy/privacy-export.ts
+++ b/apps/core-app/src/main/modules/privacy/privacy-export.ts
@@ -487,7 +487,7 @@ function makeWriter(
   category: { records: number; bytes: number },
   categoryName: PrivacyDataCategory
 ): PrivacyOwnerExportWriter {
-  return Object.freeze({
+  return Object.freeze<PrivacyOwnerExportWriter>({
     write: async (record) => {
       const normalized = normalizeOwnerRecord(categoryName, record)
       const measuredBytes = measureJsonBytes(normalized, limits.maxRecordBytes)
@@ -844,7 +844,7 @@ export function createPrivacyCategoryExporter(
       }
   const limits = normalizeLimits(values.limits)
 
-  return Object.freeze({
+  return Object.freeze<PrivacyCategoryExporter>({
     exportCategories: async (rawRequest, providedSignal) => {
       const request = normalizeExportRequest(rawRequest)
       const signal = providedSignal ?? request.signal ?? new AbortController().signal

--- a/apps/core-app/src/main/modules/privacy/privacy-module.ts
+++ b/apps/core-app/src/main/modules/privacy/privacy-module.ts
@@ -216,7 +216,7 @@ async function createProductionService(): Promise<PrivacyLifecycleService> {
 }
 
 function defaultDependencies(): PrivacyLifecycleModuleDependencies {
-  return Object.freeze({
+  return Object.freeze<PrivacyLifecycleModuleDependencies>({
     resolveTransport: (context) =>
       resolveMainRuntime(context, 'PrivacyLifecycleModule.onInit')
         .transport as unknown as PrivacyTransportAdapter,

--- a/apps/core-app/src/main/modules/privacy/privacy-owner-export.test.ts
+++ b/apps/core-app/src/main/modules/privacy/privacy-owner-export.test.ts
@@ -34,7 +34,7 @@ function fakeClient(
 
 function collector() {
   const records: Readonly<Record<string, unknown>>[] = []
-  const writer: PrivacyOwnerExportWriter = Object.freeze({
+  const writer: PrivacyOwnerExportWriter = Object.freeze<PrivacyOwnerExportWriter>({
     write: async (record) => {
       records.push(record)
       return { byteCount: Buffer.byteLength(JSON.stringify(record), 'utf8') }

--- a/apps/core-app/src/main/modules/privacy/retention-coordinator.ts
+++ b/apps/core-app/src/main/modules/privacy/retention-coordinator.ts
@@ -134,7 +134,7 @@ export function createPrivacyRetentionCoordinator(
     await operation
   }
 
-  return Object.freeze({
+  return Object.freeze<PrivacyRetentionCoordinator>({
     initializeAfterStorageReady: async () => {
       if (state !== 'created') throw new Error('PRIVACY_RETENTION_COORDINATOR_ALREADY_INITIALIZED')
       try {

--- a/apps/core-app/src/main/modules/privacy/retention-policy-store.ts
+++ b/apps/core-app/src/main/modules/privacy/retention-policy-store.ts
@@ -27,7 +27,7 @@ export interface PrivacyRetentionPolicyStore {
 export function createPrivacyRetentionPolicyStore(
   adapter: PrivacyRetentionPolicyStorageAdapter
 ): PrivacyRetentionPolicyStore {
-  return Object.freeze({
+  return Object.freeze<PrivacyRetentionPolicyStore>({
     async load() {
       return normalizePrivacyRetentionPolicy(await adapter.read())
     },

--- a/apps/core-app/src/main/modules/quick-ops/index.ts
+++ b/apps/core-app/src/main/modules/quick-ops/index.ts
@@ -44,11 +44,11 @@ import type {
   QuickOpsSystemInfoGetResponse
 } from '@talex-touch/utils/transport/events/types'
 import type { ITuffTransportMain } from '@talex-touch/utils/transport/main'
-import type { PreviewAbilityContext, PreviewCardPayload } from '@talex-touch/utils/core-box/preview'
+import type { PreviewAbilityContext } from '@talex-touch/utils/core-box/preview'
+import { extractQrSvg, isQrSvgPayload, renderQrSvgToPng } from './quick-ops-qr-png'
 import crypto from 'node:crypto'
 import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { deflateSync } from 'node:zlib'
 import { app, clipboard, shell } from 'electron'
 import {
   QuickOpsDeveloperAbility,
@@ -1862,130 +1862,6 @@ function withQuickOpsDeveloperClipboardInput(
       }
     ]
   }
-}
-
-function isQrSvgPayload(payload: PreviewCardPayload): boolean {
-  return payload.meta?.quickOps?.render?.kind === 'qr-code-svg'
-}
-
-function extractQrSvg(payload: PreviewCardPayload): string | null {
-  const render = payload.meta?.quickOps?.render
-  const dataUrl = typeof render?.dataUrl === 'string' ? render.dataUrl : payload.primaryValue
-  const prefix = 'data:image/svg+xml;charset=utf-8,'
-  if (!dataUrl.startsWith(prefix)) return null
-
-  try {
-    const svg = decodeURIComponent(dataUrl.slice(prefix.length))
-    return svg.startsWith('<svg ') ? svg : null
-  } catch {
-    return null
-  }
-}
-
-function renderQrSvgToPng(svg: string, scale = 8): Buffer | null {
-  const size = extractQrSvgSize(svg)
-  if (!size || scale < 1) return null
-
-  const outputSize = size * scale
-  const pixels = Buffer.alloc(outputSize * outputSize, 0xff)
-  for (const module of extractQrSvgDarkModules(svg)) {
-    if (module.x < 0 || module.y < 0 || module.x >= size || module.y >= size) continue
-
-    const startX = module.x * scale
-    const startY = module.y * scale
-    const width = Math.max(1, module.width) * scale
-    const height = Math.max(1, module.height) * scale
-    for (let y = startY; y < Math.min(outputSize, startY + height); y += 1) {
-      for (let x = startX; x < Math.min(outputSize, startX + width); x += 1) {
-        pixels[y * outputSize + x] = 0x00
-      }
-    }
-  }
-
-  return encodeGrayscalePng(outputSize, outputSize, pixels)
-}
-
-function extractQrSvgSize(svg: string): number | null {
-  const match = /\bviewBox="0 0 (?<width>\d+) (?<height>\d+)"/.exec(svg)
-  const width = Number(match?.groups?.width)
-  const height = Number(match?.groups?.height)
-  if (!Number.isInteger(width) || width <= 0 || width !== height || width > 256) return null
-  return width
-}
-
-function extractQrSvgDarkModules(svg: string): Array<{
-  x: number
-  y: number
-  width: number
-  height: number
-}> {
-  const groupMatch = /<g fill="#000">(?<body>.*?)<\/g>/.exec(svg)
-  const body = groupMatch?.groups?.body
-  if (!body) return []
-
-  const rects: Array<{ x: number; y: number; width: number; height: number }> = []
-  const rectPattern =
-    /<rect x="(?<x>\d+)" y="(?<y>\d+)" width="(?<width>\d+)" height="(?<height>\d+)"\/>/g
-  for (const match of body.matchAll(rectPattern)) {
-    const x = Number(match.groups?.x)
-    const y = Number(match.groups?.y)
-    const width = Number(match.groups?.width)
-    const height = Number(match.groups?.height)
-    if (
-      Number.isInteger(x) &&
-      Number.isInteger(y) &&
-      Number.isInteger(width) &&
-      Number.isInteger(height)
-    ) {
-      rects.push({ x, y, width, height })
-    }
-  }
-  return rects
-}
-
-function encodeGrayscalePng(width: number, height: number, pixels: Buffer): Buffer {
-  const scanlines = Buffer.alloc((width + 1) * height)
-  for (let y = 0; y < height; y += 1) {
-    const rowStart = y * (width + 1)
-    scanlines[rowStart] = 0
-    pixels.copy(scanlines, rowStart + 1, y * width, (y + 1) * width)
-  }
-
-  const header = Buffer.alloc(13)
-  header.writeUInt32BE(width, 0)
-  header.writeUInt32BE(height, 4)
-  header[8] = 8
-  header[9] = 0
-  header[10] = 0
-  header[11] = 0
-  header[12] = 0
-
-  return Buffer.concat([
-    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
-    createPngChunk('IHDR', header),
-    createPngChunk('IDAT', deflateSync(scanlines)),
-    createPngChunk('IEND', Buffer.alloc(0))
-  ])
-}
-
-function createPngChunk(type: string, data: Buffer): Buffer {
-  const typeBuffer = Buffer.from(type, 'ascii')
-  const length = Buffer.alloc(4)
-  length.writeUInt32BE(data.length, 0)
-  const crc = Buffer.alloc(4)
-  crc.writeUInt32BE(calculateCrc32(Buffer.concat([typeBuffer, data])), 0)
-  return Buffer.concat([length, typeBuffer, data, crc])
-}
-
-function calculateCrc32(input: Buffer): number {
-  let crc = 0xffffffff
-  for (const byte of input) {
-    crc ^= byte
-    for (let bit = 0; bit < 8; bit += 1) {
-      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0)
-    }
-  }
-  return (crc ^ 0xffffffff) >>> 0
 }
 
 function createQuickOpsSystemInfoResponse(): QuickOpsSystemInfoGetResponse {

--- a/apps/core-app/src/main/modules/quick-ops/quick-ops-qr-png.test.ts
+++ b/apps/core-app/src/main/modules/quick-ops/quick-ops-qr-png.test.ts
@@ -1,0 +1,309 @@
+import { createPreviewSdk, QuickOpsDeveloperAbility } from '@talex-touch/utils/core-box/preview'
+import { inflateSync } from 'node:zlib'
+import { describe, expect, it } from 'vitest'
+import {
+  calculateCrc32,
+  extractQrSvg,
+  extractQrSvgDarkModules,
+  extractQrSvgSize,
+  isQrSvgPayload,
+  renderQrSvgToPng
+} from './quick-ops-qr-png'
+
+/**
+ * The QuickOps QR encoder (#339).
+ *
+ * This is a hand-rolled grayscale PNG writer — CRC-32, chunk framing, IHDR, a zlib scanline
+ * stream — and the only assertion it had was that the output starts with the eight-byte PNG
+ * signature, which this code writes unconditionally before doing any of that work. A wrong CRC,
+ * a truncated IHDR or a mis-framed IDAT all survive that check and produce a file no decoder
+ * opens.
+ *
+ * So the tests below decode rather than inspect: every chunk's length and CRC are recomputed
+ * from the bytes on disk, and the pixels come back through `inflateSync`. `decodePng` shares no
+ * code with the encoder, which is the point — a matching bug in both would otherwise agree.
+ */
+
+interface DecodedPng {
+  width: number
+  height: number
+  bitDepth: number
+  colorType: number
+  /** Row-major, one byte per pixel, filter bytes already stripped. */
+  pixels: Buffer
+  chunkTypes: string[]
+}
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+/**
+ * A minimal PNG reader that refuses anything it cannot verify.
+ *
+ * It re-derives each chunk's CRC with the standard polynomial rather than calling the encoder's
+ * `calculateCrc32`, so the two implementations have to agree independently.
+ */
+function decodePng(buffer: Buffer): DecodedPng {
+  expect(buffer.subarray(0, 8)).toEqual(PNG_SIGNATURE)
+
+  const chunkTypes: string[] = []
+  let header: { width: number; height: number; bitDepth: number; colorType: number } | null = null
+  const idatParts: Buffer[] = []
+  let offset = 8
+
+  while (offset < buffer.length) {
+    const length = buffer.readUInt32BE(offset)
+    const type = buffer.toString('ascii', offset + 4, offset + 8)
+    const data = buffer.subarray(offset + 8, offset + 8 + length)
+    const declaredCrc = buffer.readUInt32BE(offset + 8 + length)
+
+    expect(
+      { type, crc: declaredCrc },
+      `chunk ${type} carries a CRC the bytes do not produce`
+    ).toEqual({ type, crc: referenceCrc32(buffer.subarray(offset + 4, offset + 8 + length)) })
+
+    chunkTypes.push(type)
+    if (type === 'IHDR') {
+      expect(length, 'IHDR must be 13 bytes').toBe(13)
+      header = {
+        width: data.readUInt32BE(0),
+        height: data.readUInt32BE(4),
+        bitDepth: data[8]!,
+        colorType: data[9]!
+      }
+      // Anything other than 0/0/0 here is a stream this decoder — and most others — cannot read.
+      expect(
+        { compression: data[10], filter: data[11], interlace: data[12] },
+        'IHDR compression/filter/interlace must all be 0'
+      ).toEqual({ compression: 0, filter: 0, interlace: 0 })
+    }
+    if (type === 'IDAT') idatParts.push(Buffer.from(data))
+
+    offset += 12 + length
+  }
+
+  expect(offset, 'trailing bytes after the last chunk').toBe(buffer.length)
+  expect(chunkTypes.at(-1), 'the stream must end with IEND').toBe('IEND')
+  expect(header, 'no IHDR chunk').not.toBeNull()
+
+  const { width, height, bitDepth, colorType } = header!
+  const raw = inflateSync(Buffer.concat(idatParts))
+  expect(raw.length, 'inflated size does not match the declared dimensions').toBe(
+    (width + 1) * height
+  )
+
+  const pixels = Buffer.alloc(width * height)
+  for (let y = 0; y < height; y += 1) {
+    const rowStart = y * (width + 1)
+    // Only filter type 0 is emitted; any other value would make the pixel copy below wrong.
+    expect(raw[rowStart], `scanline ${y} uses a filter this encoder does not emit`).toBe(0)
+    raw.copy(pixels, y * width, rowStart + 1, rowStart + 1 + width)
+  }
+
+  return { width, height, bitDepth, colorType, pixels, chunkTypes }
+}
+
+/** The CRC-32 from the PNG specification, written independently of the encoder's copy. */
+function referenceCrc32(input: Buffer): number {
+  const table = Array.from({ length: 256 }, (_, index) => {
+    let value = index
+    for (let bit = 0; bit < 8; bit += 1)
+      value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1
+    return value >>> 0
+  })
+  let crc = 0xffffffff
+  for (const byte of input) crc = table[(crc ^ byte) & 0xff]! ^ (crc >>> 8)
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+function svgWith(viewBox: number, rects: string): string {
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${viewBox} ${viewBox}" ` +
+    `shape-rendering="crispEdges"><rect width="${viewBox}" height="${viewBox}" fill="#fff"/>` +
+    `<g fill="#000">${rects}</g></svg>`
+  )
+}
+
+function module(x: number, y: number): string {
+  return `<rect x="${x}" y="${y}" width="1" height="1"/>`
+}
+
+describe('renderQrSvgToPng', () => {
+  it('produces a stream a decoder can read end to end', () => {
+    const png = renderQrSvgToPng(svgWith(8, module(1, 1) + module(6, 6)), 4)
+
+    expect(png).not.toBeNull()
+    const decoded = decodePng(png!)
+
+    expect(decoded.chunkTypes).toEqual(['IHDR', 'IDAT', 'IEND'])
+    expect({ width: decoded.width, height: decoded.height }).toEqual({ width: 32, height: 32 })
+    // Grayscale, 8 bits per sample — the two IHDR fields the pixel reader above depends on.
+    expect({ bitDepth: decoded.bitDepth, colorType: decoded.colorType }).toEqual({
+      bitDepth: 8,
+      colorType: 0
+    })
+  })
+
+  it('places dark modules where the SVG put them', () => {
+    const scale = 4
+    const png = renderQrSvgToPng(svgWith(8, module(1, 1) + module(6, 6)), scale)
+    const decoded = decodePng(png!)
+    const at = (x: number, y: number): number => decoded.pixels[y * decoded.width + x]!
+
+    // Each 1×1 module becomes a scale×scale block: opposite corners inside, and the pixel just
+    // past each edge still white. An off-by-one in the fill loop moves or smears exactly here.
+    for (const [mx, my] of [
+      [1, 1],
+      [6, 6]
+    ] as const) {
+      expect(at(mx * scale, my * scale)).toBe(0x00)
+      expect(at(mx * scale + scale - 1, my * scale + scale - 1)).toBe(0x00)
+      expect(at(mx * scale - 1, my * scale)).toBe(0xff)
+      expect(at(mx * scale + scale, my * scale)).toBe(0xff)
+    }
+
+    expect(at(0, 0)).toBe(0xff)
+    // Two modules, scale² pixels each — a count, so a fill that ran long shows up as a total.
+    const dark = decoded.pixels.reduce((total, value) => total + (value === 0x00 ? 1 : 0), 0)
+    expect(dark).toBe(2 * scale * scale)
+  })
+
+  /**
+   * The save handler is a transport event, so the payload arrives from a plugin or the renderer
+   * rather than from this repo's generator. An SVG whose rects these regexes cannot read used to
+   * encode to a blank white square and be reported as `state: 'saved'` — a file that opens fine
+   * and scans as nothing.
+   */
+  it('refuses an SVG whose modules it could not read instead of encoding a blank square', () => {
+    const singleQuoted = svgWith(8, `<rect x='1' y='1' width='1' height='1'/>`)
+    expect(extractQrSvgDarkModules(singleQuoted)).toEqual([])
+    expect(renderQrSvgToPng(singleQuoted)).toBeNull()
+
+    expect(renderQrSvgToPng(svgWith(8, ''))).toBeNull()
+    expect(renderQrSvgToPng(svgWith(8, '<rect x="1" y="1" width="1" height="1" />'))).toBeNull()
+  })
+
+  it('refuses sizes and scales it cannot encode', () => {
+    expect(renderQrSvgToPng(svgWith(8, module(1, 1)), 0)).toBeNull()
+    expect(renderQrSvgToPng('<svg viewBox="0 0 8 9"></svg>')).toBeNull()
+    expect(renderQrSvgToPng(svgWith(257, module(1, 1)))).toBeNull()
+    expect(renderQrSvgToPng('not an svg')).toBeNull()
+  })
+
+  it('drops modules outside the viewBox rather than writing past the buffer', () => {
+    const png = renderQrSvgToPng(svgWith(8, module(1, 1) + module(9, 9)), 4)
+    const decoded = decodePng(png!)
+    const dark = decoded.pixels.reduce((total, value) => total + (value === 0x00 ? 1 : 0), 0)
+
+    expect(dark).toBe(16)
+  })
+})
+
+describe('extractQrSvg', () => {
+  it('reads the SVG out of the render metadata', () => {
+    const svg = svgWith(8, module(1, 1))
+    const dataUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+
+    expect(extractQrSvg({ primaryValue: dataUrl } as never)).toBe(svg)
+    expect(
+      extractQrSvg({
+        primaryValue: 'ignored',
+        meta: { quickOps: { render: { kind: 'qr-code-svg', dataUrl } } }
+      } as never)
+    ).toBe(svg)
+  })
+
+  it('refuses payloads that are not an SVG data URL', () => {
+    expect(extractQrSvg({ primaryValue: 'https://example.test' } as never)).toBeNull()
+    expect(
+      extractQrSvg({ primaryValue: 'data:image/svg+xml;charset=utf-8,%3Cscript%3E' } as never)
+    ).toBeNull()
+    expect(
+      extractQrSvg({ primaryValue: 'data:image/svg+xml;charset=utf-8,%E0%A4%A' } as never)
+    ).toBeNull()
+  })
+
+  it('recognises only the QR render kind', () => {
+    expect(
+      isQrSvgPayload({ meta: { quickOps: { render: { kind: 'qr-code-svg' } } } } as never)
+    ).toBe(true)
+    expect(
+      isQrSvgPayload({ meta: { quickOps: { render: { kind: 'color-swatch' } } } } as never)
+    ).toBe(false)
+    expect(isQrSvgPayload({} as never)).toBe(false)
+  })
+})
+
+/**
+ * The regexes in this module parse a string built by `renderQrSvg` in
+ * `packages/utils/core-box/preview/abilities/quickops-developer-ability.ts`. Nothing declares that
+ * contract — no shared constant, no schema — so a whitespace change or an added attribute on the
+ * generator side would leave this side matching nothing.
+ *
+ * With the guard above that is now a refusal rather than a blank PNG, but a refusal is still the
+ * QR feature not working. This drives the real ability so the drift fails here first.
+ */
+describe('the SVG the preview ability actually emits', () => {
+  async function generateQrSvg(text: string): Promise<string> {
+    const sdk = createPreviewSdk({ abilities: [new QuickOpsDeveloperAbility()] })
+    const card = await sdk.resolve({
+      query: { text, inputs: [] },
+      signal: new AbortController().signal
+    } as never)
+
+    expect(card?.payload, `the ability returned no card for "${text}"`).toBeTruthy()
+    const svg = extractQrSvg(card!.payload as never)
+    expect(svg, 'the emitted payload is not an SVG data URL this module can read').not.toBeNull()
+    return svg!
+  }
+
+  it('parses into the module grid the generator drew', async () => {
+    const svg = await generateQrSvg('qr code https://tuff.talex.app')
+
+    // Version 2 at ECC level L is 25 modules; the generator adds a 4-module quiet zone per side.
+    expect(extractQrSvgSize(svg)).toBe(33)
+
+    const modules = extractQrSvgDarkModules(svg)
+    expect(modules.length).toBeGreaterThan(0)
+    expect(modules.length).toBe((svg.match(/<rect x=/g) ?? []).length)
+
+    // The top-left finder pattern sits at the quiet-zone offset in every QR ever drawn, so this
+    // pins the coordinate origin the two sides agree on rather than just "something matched".
+    const dark = new Set(modules.map(({ x, y }) => `${x},${y}`))
+    for (let offset = 0; offset < 7; offset += 1) {
+      expect(dark.has(`${4 + offset},4`), `finder pattern missing at ${4 + offset},4`).toBe(true)
+      expect(dark.has(`4,${4 + offset}`), `finder pattern missing at 4,${4 + offset}`).toBe(true)
+    }
+    expect(dark.has('9,9'), 'the finder pattern interior should be light').toBe(false)
+  })
+
+  it('encodes to a PNG whose dark pixels match its own module count', async () => {
+    const svg = await generateQrSvg('qr code tuff')
+    const scale = 2
+    const decoded = decodePng(renderQrSvgToPng(svg, scale)!)
+    const size = extractQrSvgSize(svg)!
+
+    expect({ width: decoded.width, height: decoded.height }).toEqual({
+      width: size * scale,
+      height: size * scale
+    })
+
+    const dark = decoded.pixels.reduce((total, value) => total + (value === 0x00 ? 1 : 0), 0)
+    expect(dark).toBe(extractQrSvgDarkModules(svg).length * scale * scale)
+  })
+})
+
+describe('calculateCrc32', () => {
+  // Published CRC-32 vectors: a bad table or a missing final inversion fails all three.
+  it('matches the published vectors', () => {
+    expect(calculateCrc32(Buffer.from('', 'ascii'))).toBe(0)
+    expect(calculateCrc32(Buffer.from('123456789', 'ascii'))).toBe(0xcbf43926)
+    expect(calculateCrc32(Buffer.from('IEND', 'ascii'))).toBe(0xae426082)
+  })
+
+  it('agrees with an independent implementation across byte patterns', () => {
+    for (const size of [1, 7, 64, 255, 1024]) {
+      const input = Buffer.from(Array.from({ length: size }, (_, index) => (index * 37) % 256))
+      expect(calculateCrc32(input)).toBe(referenceCrc32(input))
+    }
+  })
+})

--- a/apps/core-app/src/main/modules/quick-ops/quick-ops-qr-png.ts
+++ b/apps/core-app/src/main/modules/quick-ops/quick-ops-qr-png.ts
@@ -1,0 +1,148 @@
+import type { PreviewCardPayload } from '@talex-touch/utils/core-box/preview'
+import { deflateSync } from 'node:zlib'
+
+/**
+ * Turns the QuickOps QR preview payload into a PNG.
+ *
+ * This lived inside `index.ts` next to sixty unrelated response builders, which mattered because
+ * of what it is: a hand-rolled grayscale PNG encoder — CRC-32, chunk framing, IHDR — reached from
+ * a transport handler that any plugin can call with a payload it composed itself. The only test it
+ * had asserted the eight-byte PNG signature, a constant this file writes unconditionally, so a
+ * wrong CRC or a malformed IHDR would have produced a file no decoder accepts and still passed.
+ *
+ * The SVG it parses is produced in a different package — `renderQrSvg` in
+ * `packages/utils/core-box/preview/abilities/quickops-developer-ability.ts` — and the two are
+ * coupled by nothing but the regexes below matching that function's exact output. Extracted for
+ * #339 so both of those can be tested directly.
+ */
+
+export function isQrSvgPayload(payload: PreviewCardPayload): boolean {
+  return payload.meta?.quickOps?.render?.kind === 'qr-code-svg'
+}
+
+export function extractQrSvg(payload: PreviewCardPayload): string | null {
+  const render = payload.meta?.quickOps?.render
+  const dataUrl = typeof render?.dataUrl === 'string' ? render.dataUrl : payload.primaryValue
+  const prefix = 'data:image/svg+xml;charset=utf-8,'
+  if (!dataUrl.startsWith(prefix)) return null
+
+  try {
+    const svg = decodeURIComponent(dataUrl.slice(prefix.length))
+    return svg.startsWith('<svg ') ? svg : null
+  } catch {
+    return null
+  }
+}
+
+export function renderQrSvgToPng(svg: string, scale = 8): Buffer | null {
+  const size = extractQrSvgSize(svg)
+  if (!size || scale < 1) return null
+
+  // No dark modules means the rect pattern below did not match anything the caller sent. A real QR
+  // always has three finder patterns, so the two cases this distinguishes are an SVG written in a
+  // shape these regexes do not read and a deliberately empty one — and both would otherwise encode
+  // to a blank white square that `saveQuickOpsDeveloperPreview` reports as `state: 'saved'`.
+  const darkModules = extractQrSvgDarkModules(svg)
+  if (darkModules.length === 0) return null
+
+  const outputSize = size * scale
+  const pixels = Buffer.alloc(outputSize * outputSize, 0xff)
+  for (const module of darkModules) {
+    if (module.x < 0 || module.y < 0 || module.x >= size || module.y >= size) continue
+
+    const startX = module.x * scale
+    const startY = module.y * scale
+    const width = Math.max(1, module.width) * scale
+    const height = Math.max(1, module.height) * scale
+    for (let y = startY; y < Math.min(outputSize, startY + height); y += 1) {
+      for (let x = startX; x < Math.min(outputSize, startX + width); x += 1) {
+        pixels[y * outputSize + x] = 0x00
+      }
+    }
+  }
+
+  return encodeGrayscalePng(outputSize, outputSize, pixels)
+}
+
+export function extractQrSvgSize(svg: string): number | null {
+  const match = /\bviewBox="0 0 (?<width>\d+) (?<height>\d+)"/.exec(svg)
+  const width = Number(match?.groups?.width)
+  const height = Number(match?.groups?.height)
+  if (!Number.isInteger(width) || width <= 0 || width !== height || width > 256) return null
+  return width
+}
+
+export function extractQrSvgDarkModules(svg: string): Array<{
+  x: number
+  y: number
+  width: number
+  height: number
+}> {
+  const groupMatch = /<g fill="#000">(?<body>.*?)<\/g>/.exec(svg)
+  const body = groupMatch?.groups?.body
+  if (!body) return []
+
+  const rects: Array<{ x: number; y: number; width: number; height: number }> = []
+  const rectPattern =
+    /<rect x="(?<x>\d+)" y="(?<y>\d+)" width="(?<width>\d+)" height="(?<height>\d+)"\/>/g
+  for (const match of body.matchAll(rectPattern)) {
+    const x = Number(match.groups?.x)
+    const y = Number(match.groups?.y)
+    const width = Number(match.groups?.width)
+    const height = Number(match.groups?.height)
+    if (
+      Number.isInteger(x) &&
+      Number.isInteger(y) &&
+      Number.isInteger(width) &&
+      Number.isInteger(height)
+    ) {
+      rects.push({ x, y, width, height })
+    }
+  }
+  return rects
+}
+
+export function encodeGrayscalePng(width: number, height: number, pixels: Buffer): Buffer {
+  const scanlines = Buffer.alloc((width + 1) * height)
+  for (let y = 0; y < height; y += 1) {
+    const rowStart = y * (width + 1)
+    scanlines[rowStart] = 0
+    pixels.copy(scanlines, rowStart + 1, y * width, (y + 1) * width)
+  }
+
+  const header = Buffer.alloc(13)
+  header.writeUInt32BE(width, 0)
+  header.writeUInt32BE(height, 4)
+  header[8] = 8
+  header[9] = 0
+  header[10] = 0
+  header[11] = 0
+  header[12] = 0
+
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    createPngChunk('IHDR', header),
+    createPngChunk('IDAT', deflateSync(scanlines)),
+    createPngChunk('IEND', Buffer.alloc(0))
+  ])
+}
+
+export function createPngChunk(type: string, data: Buffer): Buffer {
+  const typeBuffer = Buffer.from(type, 'ascii')
+  const length = Buffer.alloc(4)
+  length.writeUInt32BE(data.length, 0)
+  const crc = Buffer.alloc(4)
+  crc.writeUInt32BE(calculateCrc32(Buffer.concat([typeBuffer, data])), 0)
+  return Buffer.concat([length, typeBuffer, data, crc])
+}
+
+export function calculateCrc32(input: Buffer): number {
+  let crc = 0xffffffff
+  for (const byte of input) {
+    crc ^= byte
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0)
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}

--- a/scripts/check-implicit-any-debt.mjs
+++ b/scripts/check-implicit-any-debt.mjs
@@ -34,7 +34,7 @@ const CORE_APP = path.join(REPO_ROOT, 'apps/core-app')
  * only -- every error the flag produces is in that range, so a rise here is new untyped code and
  * not some unrelated type break.
  */
-export const KNOWN_IMPLICIT_ANY_ERRORS = 85
+export const KNOWN_IMPLICIT_ANY_ERRORS = 37
 
 /** Resolves the workspace's own tsc rather than trusting a .bin shim on PATH. */
 function resolveTsc() {


### PR DESCRIPTION
Toward #339.

`quick-ops/index.ts` carried a **hand-rolled grayscale PNG writer** — CRC-32, chunk framing, IHDR, a zlib scanline stream — among sixty unrelated response builders. It moves to `quick-ops-qr-png.ts`. Not for the 123 lines: #339 says explicitly that no extraction is justified by a line count, and this one isn't. It's justified by what could not be tested where it sat.

## The only assertion was a constant

```js
expect(png.subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
```

Those eight bytes are written unconditionally, **before** any of the encoding happens. Seven planted defects show what that let through:

| plant | new tests failing |
|---|---|
| CRC polynomial off by one bit | 6 of 12 |
| IHDR height + 1 | 4 of 12 |
| scanline filter byte `0 → 1` | 4 of 12 |
| IHDR colorType grayscale → RGB | 1 of 12 |
| dark pixel `0x00 → 0x01` | 3 of 12 |
| generator emits `height="1" />` | 2 of 12 |
| the blank-QR guard removed | 1 of 12 |

**Every one passed the signature check.** Each was reverted and the suite returned to 12 green.

The new tests **decode rather than inspect**: every chunk's CRC is recomputed from the bytes on disk with an independently written table-driven CRC-32 (the encoder's is loop-driven — a shared bug can't agree with itself), the pixels come back through `inflateSync`, and the dark ones are counted against the module count.

## A contract across two packages with nothing holding it

The SVG these regexes parse is built by `renderQrSvg` in `packages/utils/core-box/preview/abilities/quickops-developer-ability.ts`. The two are coupled by nothing but the regex matching that function's exact output — no shared constant, no schema. **Adding a single space to a `<rect>` in the generator stopped every module from matching**, and the old test never noticed because it used a hand-written SVG literal instead of the generator.

Two tests now drive the real `QuickOpsDeveloperAbility` through this encoder and check the top-left finder pattern lands at the quiet-zone origin, so that drift fails here first.

## A blank QR was a successful save

`developerPreview.save` is a transport event, so the payload comes from a plugin or the renderer, not from this repo's generator. An SVG in a shape these regexes don't read produced **zero dark modules → an all-white PNG → `state: 'saved'`** — a file that opens fine and scans as nothing.

Zero dark modules is now a refusal. A real QR always has three finder patterns, so there is no valid input this rejects. It returns `degraded / qr-png-render-failed`, the path already there for a failed render.

## Verification

quick-ops suite **194 passed (8 files)**, including the existing 116-test `index.test.ts`. `typecheck:node` clean **under the package's own flags** — my first run omitted `--composite false` and reported a phantom `TS6307` in an unrelated sentry file. Positive-controlled both times.

Refs #339