### PR TITLE
fix(types): type the clipboard host service, and fix what that revealed (#548)

### DIFF
--- a/apps/core-app/src/main/modules/clipboard.ts
+++ b/apps/core-app/src/main/modules/clipboard.ts
@@ -78,6 +78,7 @@ import {
   type ClipboardPollingSettings
 } from './clipboard/clipboard-polling-policy'
 import { registerClipboardHostService } from './clipboard/clipboard-host-service'
+import type { ClipboardHostService } from './clipboard/clipboard-host-service'
 import {
   ClipboardStageBEnrichment,
   type ClipboardStageBJob
@@ -1209,7 +1210,9 @@ export class ClipboardModule extends BaseModule {
   private installClipboardHostService(): void {
     this.clipboardHostServiceDisposer?.()
     this.clipboardHostServiceDisposer = registerClipboardHostService(
-      Object.freeze({
+      // Object.freeze<T> infers T from its argument, so registerClipboardHostService's own
+      // parameter type never reaches this literal and every handler took `any` (#548).
+      Object.freeze<ClipboardHostService>({
         read: async (request, _context, signal) => {
           if (signal.aborted) throw new Error('PLUGIN_HOST_CAPABILITY_CANCELLED')
           if (request.op === 'text') {
@@ -1221,19 +1224,25 @@ export class ClipboardModule extends BaseModule {
           if (signal.aborted) throw new Error('PLUGIN_HOST_CAPABILITY_CANCELLED')
           if (request.op === 'clear') clipboard.clear()
           else {
+            // `files` is destructured out rather than spread-then-overridden: a conditional
+            // spread does not narrow what the first spread already contributed, so the result
+            // kept `readonly string[]` and never matched ClipboardWriteRequest. Invisible while
+            // the parameter was `any` (#548).
+            const { files, ...content } = request.content
             await this.write({
-              ...request.content,
-              ...(request.content.files ? { files: [...request.content.files] } : {})
+              ...content,
+              ...(files ? { files: [...files] } : {})
             })
           }
           if (signal.aborted) throw new Error('PLUGIN_HOST_CAPABILITY_CANCELLED')
         },
         copyAndPaste: async (request, context, signal) => {
           if (signal.aborted) throw new Error('PLUGIN_HOST_CAPABILITY_CANCELLED')
+          const { files, ...rest } = request
           const result = await this.handleCopyAndPasteRequest(
             {
-              ...request,
-              ...(request.files ? { files: [...request.files] } : {})
+              ...rest,
+              ...(files ? { files: [...files] } : {})
             },
             { plugin: context } as HandlerContext
           )

--- a/scripts/check-implicit-any-debt.mjs
+++ b/scripts/check-implicit-any-debt.mjs
@@ -34,7 +34,7 @@ const CORE_APP = path.join(REPO_ROOT, 'apps/core-app')
  * only -- every error the flag produces is in that range, so a rise here is new untyped code and
  * not some unrelated type break.
  */
-export const KNOWN_IMPLICIT_ANY_ERRORS = 37
+export const KNOWN_IMPLICIT_ANY_ERRORS = 28
 
 /** Resolves the workspace's own tsc rather than trusting a .bin shim on PATH. */
 function resolveTsc() {


### PR DESCRIPTION
Toward #548. Sixth batch: **37 → 28**. One type argument, and a real defect it uncovered.

## The check that had been quiet for 190 errors finally fired

`registerClipboardHostService(service: ClipboardHostService)` declares its parameter. `Object.freeze<T>` infers `T` from its argument, so the literal was untyped and all nine handler parameters were `any`.

Naming the type surfaced **two TS2345s that had been there the whole time**:

```ts
{ ...request.content, ...(request.content.files ? { files: [...request.content.files] } : {}) }
```

The intent is to turn the incoming `readonly string[]` into a mutable array. It does not work at the type level: **a conditional spread does not narrow what the first spread already contributed**, so the result keeps `readonly string[]` and never matched `ClipboardWriteRequest` or `ClipboardCopyAndPasteRequest`. Destructuring `files` out before spreading fixes both sites.

Every previous batch in this series reported "non-TS7xxx diagnostics stayed at 0". That line was not decoration — it is the only thing standing between "restored the types" and "traded implicit-anys for real type errors". It held for 190 errors and caught this one.

## Verification

- Ratchet 37 → 28, **both** directions: `27` fails, `29` fails, `28` passes.
- Clipboard suite: 18 files / 95 tests pass.

### Concurrent work, again

Two diagnostics remain in the tree from **another session implementing #697** — `channelKey` being removed from `PluginViewBootstrap`, mid-refactor across six files. Verified those files contribute **no** TS7xxx errors, so 28 is the real count, and none of them are in this commit.

That session also switched this shared worktree's branch under a previous batch, so this PR is pushed from its commit SHA to its own ref rather than by branch name.

## Running total

**227 → 201 → 180 → 161 → 85 → 37 → 28.** 199 errors, six PRs, one real defect found along the way.

## What is left

28, spread thin — 3 each in `plugin.ts`, two intelligence capability files and a macOS screenshot integration test, then a long tail of 1s and 2s. No single shape left to sweep.
