### PR TITLE
docs(task): stop the record prescribing a tool this repo does not have (#482)

### DIFF
--- a/.trellis/tasks/07-27-bilingual-whats-changed/implement.md
+++ b/.trellis/tasks/07-27-bilingual-whats-changed/implement.md
@@ -45,7 +45,7 @@ node scripts/check-release-gates.mjs --tag "v<version>" --version "<version>" --
 ```bash
 pnpm exec vitest run scripts/generate-release-notes.test.mjs scripts/check-release-gates.test.mjs scripts/check-release-gates/local-checks.test.mjs
 pnpm quality:pr
-actionlint .github/workflows/build-and-release.yml .github/workflows/ci.yml
+mise run workflows:lint   # actionlint + shellcheck, both pinned in mise.toml (#482 / PR #1628)
 ```
 
 ## 4. RED/GREEN — 生成 CoreApp 内置 catalog
@@ -156,7 +156,19 @@ pnpm -C apps/core-app run build
 git diff --check
 ```
 
-对 UI 还需在桌面与窄窗口做 Playwright/packaged screenshot 验收，检查 modal、主从布局、滚动、文字溢出、focus 与语言切换。发布 workflow 变更必须用 actionlint 和一次不发布真实 release 的 dry-run/fixture 验证。
+对 UI 仍需在桌面与窄窗口做视觉验收，检查 modal、主从布局、滚动、文字溢出、focus 与语言切换。
+
+> **这一条尚未完成，且本仓库没有可用来完成它的工具（#482）。** 原文写的是「Playwright/packaged
+> screenshot」，但 Playwright **不是本仓库任何包的依赖**（三个 package.json 里声明数为 0）。仓库里
+> 仅有的两处 `playwright` 字样都不是它：`packages/tuff-cli` 里是一条**可检测外部工具的目录条目**，
+> `apps/nexus/build/check-runtime-evidence.mjs` 里是一个**历史遗留的目录名** `output/playwright/`，
+> 存放的是带日期的 JSON 运行时证据，不是截图。
+>
+> CoreApp 侧没有任何截图设施：`apps/nexus/scripts/audit-cdp-client.mjs` 那套 headless Chrome 只服务
+> Nexus 这个 Web 应用，接不了 Electron 窗口。
+>
+> 所以这条验收需要**在一台能跑 GUI 的机器上启动应用**手工完成，或先补一套 CoreApp 截图工具。在那之
+> 前，任何静态检查与单元测试都不得记为视觉验收 —— 这正是 #482 立项的原因。发布 workflow 变更必须用 actionlint 和一次不发布真实 release 的 dry-run/fixture 验证。
 
 ## Risk / Rollback Points
 


### PR DESCRIPTION
Toward #482, third acceptance criterion.

## Criterion 1 is met

> - [x] actionlint completes successfully for `build-and-release.yml`.

Wired in #1628 and running on every PR in the `PR Quality` job. Verified from the CI log rather than the checks column: `TUFF_NATIVE_OCR_REQUIRED`-style env visibility showed `actionlint 1.7.12` **and** `shellcheck 0.10.0` both on PATH, executing `actionlint -shellcheck 'shellcheck -S info'`.

The task record's own command was `actionlint <files>`, which is not equivalent: **without shellcheck on PATH, actionlint silently skips all run-block analysis** and reports 0 findings where CI reports 32. The record now names the mise task, which pins both.

## Criterion 2 cannot be met from here, and the record was pointing at a tool that does not exist

The line read:

> 对 UI 还需在桌面与窄窗口做 **Playwright/packaged screenshot** 验收

**Playwright is not a dependency of any package in this repo** — all three `package.json` files declare it zero times, checked with a positive control (`vitest` found in 3 of 3, so the scan works).

The only two `playwright` strings in the tree are neither:

| location | what it actually is |
|---|---|
| `packages/tuff-cli/src/cli/local-capabilities.ts:18` | a catalogue entry for a tool the CLI can *detect*, not one it has |
| `apps/nexus/build/check-runtime-evidence.mjs:8` | a historical directory name, `output/playwright/`, holding **dated JSON** runtime evidence — not images |

And there is no CoreApp screenshot tooling of any kind. `apps/nexus/scripts/audit-cdp-client.mjs` drives headless Chrome against the Nexus **web** app; it cannot attach to an Electron window.

So the record was asking the next person to run something that has never existed here. They would install Playwright, discover nothing uses it, and be no closer.

## What this changes

The line now states plainly that this acceptance needs a machine that can run the GUI — or new CoreApp screenshot tooling — and that until then **no static check or unit test may be recorded as visual acceptance**. That is criterion 3, and it is the thing #482 exists to prevent.

Documentation only; no code, no behaviour.

## What is left on #482

Criterion 2. It needs a GUI run I cannot perform: desktop and narrow-window captures of the release-notes modal and the Update history route. #482 stays open for it.
