### PR TITLE
sec(plugin): take the channel key off the renderer command line

### DIFF
--- a/apps/core-app/src/main/core/channel-core.plugin-view-alias.test.ts
+++ b/apps/core-app/src/main/core/channel-core.plugin-view-alias.test.ts
@@ -1,0 +1,296 @@
+/**
+ * The plugin channel key no longer travels to the plugin view (#697).
+ *
+ * It used to arrive as a renderer command-line argument, where any unprivileged process on the
+ * machine reads it out of the process table. A per-surface alias replaces it on the wire, which
+ * only works if the translation happens at *every* boundary — and a missed one is silent in both
+ * directions. An unmasked outbound message hands the credential straight back to the surface this
+ * change took it away from; an untranslated inbound one leaves the message unattributed, and the
+ * plugin view drops a reply whose key it does not recognise without raising anything.
+ *
+ * So the assertions below are about the wire bytes rather than about the helper functions, which
+ * `plugin-view-registry.test.ts` covers on their own.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+// The import chain reaches talex-mica-electron, @sentry/electron and precore, all of which touch
+// Electron at module scope.
+import '../modules/ai/intelligence-test-harness'
+
+import {
+  registerPluginWebContents,
+  resolvePluginViewNonce,
+  unregisterPluginWebContents
+} from '../modules/plugin/runtime/plugin-view-registry'
+import { genTouchChannel } from './channel-core'
+
+interface ChannelInternals {
+  __handle_main: (event: unknown, arg: unknown) => void
+  regChannel: (type: string, eventName: string, callback: (data: unknown) => unknown) => () => void
+  _sendTo: (
+    win: unknown,
+    type: string,
+    eventName: string,
+    arg: unknown,
+    header?: Record<string, unknown>
+  ) => Promise<unknown>
+  __parse_raw_data: (
+    event: unknown,
+    arg: unknown
+  ) => { header: { uniqueKey?: string; declaredKey?: string }; plugin?: string }
+  resolveIdentity: (key: string) => unknown
+}
+
+const ACTIVATION = {
+  name: 'com.acme.demo',
+  pluginInstanceId: 'instance-1',
+  activationGeneration: 1,
+  key: 'plugin-channel-key'
+}
+
+/**
+ * `_sendTo` returns a promise that settles on the reply, which a fake window never sends. The
+ * send itself happens synchronously inside the executor, so these calls are not awaited.
+ */
+function fakeWindow(webContentsId: number): {
+  win: unknown
+  sent: Array<{ channel: string; payload: unknown }>
+} {
+  const sent: Array<{ channel: string; payload: unknown }> = []
+  return {
+    sent,
+    win: {
+      webContents: {
+        id: webContentsId,
+        isDestroyed: () => false,
+        send: (channel: string, payload: unknown) => sent.push({ channel, payload })
+      }
+    }
+  }
+}
+
+function fakeSender(webContentsId: number): unknown {
+  return { sender: { id: webContentsId, isDestroyed: () => false } }
+}
+
+/** An event whose replies are captured, both the async `sender.send` and the sync `returnValue`. */
+function fakeReplyEvent(webContentsId: number): {
+  event: unknown
+  replies: unknown[]
+  returned: unknown[]
+} {
+  const replies: unknown[] = []
+  const returned: unknown[] = []
+  const event = {
+    sender: {
+      id: webContentsId,
+      isDestroyed: () => false,
+      send: (_channel: string, payload: unknown) => replies.push(payload)
+    },
+    get returnValue(): unknown {
+      return returned.at(-1)
+    },
+    set returnValue(value: unknown) {
+      returned.push(value)
+    }
+  }
+  return { event, replies, returned }
+}
+
+function replyKey(payload: unknown): unknown {
+  return (payload as { header?: { uniqueKey?: unknown } } | undefined)?.header?.uniqueKey
+}
+
+const channel = genTouchChannel({
+  window: { window: {} },
+  app: { on: vi.fn() }
+} as never) as unknown as ChannelInternals
+
+function sentKey(sent: Array<{ channel: string; payload: unknown }>): unknown {
+  return (sent[0]?.payload as { header?: { uniqueKey?: unknown } } | undefined)?.header?.uniqueKey
+}
+
+describe('outbound messages carry the alias, not the key', () => {
+  it('replaces the key when the target is the surface it belongs to', () => {
+    const token = registerPluginWebContents(7301, ACTIVATION)
+    const nonce = resolvePluginViewNonce(7301)
+    const { win, sent } = fakeWindow(7301)
+
+    void channel._sendTo(
+      win,
+      'plugin',
+      'demo:event',
+      { plugin: ACTIVATION.name },
+      {
+        uniqueKey: ACTIVATION.key
+      }
+    )
+
+    expect(sent).toHaveLength(1)
+    expect(sentKey(sent)).toBe(nonce)
+    // The assertion that matters: the credential is not in the payload under any field.
+    expect(JSON.stringify(sent[0]?.payload)).not.toContain(ACTIVATION.key)
+
+    unregisterPluginWebContents(7301, token)
+  })
+
+  /**
+   * The app renderer receives bridged plugin messages and matches on the key itself, as does the
+   * plugin host process. Masking there would make them drop everything with no error raised, so
+   * the pass-through is asserted rather than assumed.
+   */
+  it('leaves the key alone for a target that is not a registered plugin surface', () => {
+    const { win, sent } = fakeWindow(7302)
+
+    void channel._sendTo(
+      win,
+      'plugin',
+      'demo:event',
+      { plugin: ACTIVATION.name },
+      {
+        uniqueKey: ACTIVATION.key
+      }
+    )
+
+    expect(sentKey(sent)).toBe(ACTIVATION.key)
+  })
+
+  it('stops masking once the surface is unregistered', () => {
+    const token = registerPluginWebContents(7303, ACTIVATION)
+    const nonce = resolvePluginViewNonce(7303)
+    const before = fakeWindow(7303)
+
+    void channel._sendTo(
+      before.win,
+      'plugin',
+      'demo:event',
+      { plugin: ACTIVATION.name },
+      {
+        uniqueKey: ACTIVATION.key
+      }
+    )
+    // Positive control: without this the case below passes even if masking never worked.
+    expect(sentKey(before.sent)).toBe(nonce)
+
+    unregisterPluginWebContents(7303, token)
+
+    const after = fakeWindow(7303)
+    void channel._sendTo(
+      after.win,
+      'plugin',
+      'demo:event',
+      { plugin: ACTIVATION.name },
+      {
+        uniqueKey: ACTIVATION.key
+      }
+    )
+
+    expect(sentKey(after.sent)).toBe(ACTIVATION.key)
+  })
+})
+
+describe('inbound messages resolve the alias back to the key', () => {
+  it('hands downstream the real key, so identity checks still compare like for like', () => {
+    const token = registerPluginWebContents(7401, ACTIVATION)
+    const nonce = resolvePluginViewNonce(7401)
+
+    const parsed = channel.__parse_raw_data(fakeSender(7401), {
+      name: 'demo:event',
+      header: { status: 'request', uniqueKey: nonce },
+      code: 0,
+      data: {}
+    })
+
+    expect(parsed.header.uniqueKey).toBe(ACTIVATION.key)
+    expect(parsed.plugin).toBe(ACTIVATION.name)
+
+    unregisterPluginWebContents(7401, token)
+  })
+
+  /**
+   * Replies echo the header back to the sender, and the plugin view filters on the value it sent.
+   * Echoing the resolved key instead would both leak it and make the view drop its own reply.
+   */
+  it('keeps the value the sender put on the wire for the reply to echo', () => {
+    const token = registerPluginWebContents(7402, ACTIVATION)
+    const nonce = resolvePluginViewNonce(7402)
+
+    const parsed = channel.__parse_raw_data(fakeSender(7402), {
+      name: 'demo:event',
+      header: { status: 'request', uniqueKey: nonce },
+      code: 0,
+      data: {}
+    })
+
+    expect(parsed.header.declaredKey).toBe(nonce)
+    expect(parsed.header.declaredKey).not.toBe(ACTIVATION.key)
+
+    unregisterPluginWebContents(7402, token)
+  })
+
+  it('does not resolve an alias whose surface is gone', () => {
+    const token = registerPluginWebContents(7403, ACTIVATION)
+    const nonce = resolvePluginViewNonce(7403)
+
+    const before = channel.__parse_raw_data(fakeSender(7403), {
+      name: 'demo:event',
+      header: { status: 'request', uniqueKey: nonce },
+      code: 0,
+      data: {}
+    })
+    expect(before.header.uniqueKey).toBe(ACTIVATION.key)
+
+    unregisterPluginWebContents(7403, token)
+
+    const after = channel.__parse_raw_data(fakeSender(7403), {
+      name: 'demo:event',
+      header: { status: 'request', uniqueKey: nonce },
+      code: 0,
+      data: {}
+    })
+
+    expect(after.header.uniqueKey).toBe(nonce)
+    expect(after.plugin).toBeUndefined()
+  })
+
+  /**
+   * The reply path is the one that leaks in both directions at once: it echoes the header back to
+   * the sender, so echoing the resolved key would hand the credential to the surface this change
+   * took it away from *and* make the view drop its own reply, since the view filters on the value
+   * it sent. Both of those are silent.
+   *
+   * Driven through the real dispatch rather than asserted on `declaredKey`, because the field
+   * existing proves nothing about which one the reply picks up.
+   */
+  it('echoes the alias back on a reply, not the key', () => {
+    const token = registerPluginWebContents(7405, ACTIVATION)
+    const nonce = resolvePluginViewNonce(7405)
+    const { event, replies, returned } = fakeReplyEvent(7405)
+
+    // No handler is registered for this name, which is the reply path that needs no plugin runtime.
+    channel.__handle_main(event, {
+      name: 'demo:no-such-handler',
+      header: { status: 'request', uniqueKey: nonce },
+      code: 0,
+      data: {}
+    })
+
+    const reply = replies[0] ?? returned[0]
+    expect(reply, 'the dispatch produced no reply to inspect').toBeTruthy()
+    expect(replyKey(reply)).toBe(nonce)
+    expect(JSON.stringify(reply)).not.toContain(ACTIVATION.key)
+
+    unregisterPluginWebContents(7405, token)
+  })
+
+  it('leaves a sender that is not using an alias untouched', () => {
+    const parsed = channel.__parse_raw_data(fakeSender(7404), {
+      name: 'demo:event',
+      header: { status: 'request', uniqueKey: 'some-other-key' },
+      code: 0,
+      data: {}
+    })
+
+    expect(parsed.header.uniqueKey).toBe('some-other-key')
+  })
+})

--- a/apps/core-app/src/main/core/channel-core.ts
+++ b/apps/core-app/src/main/core/channel-core.ts
@@ -13,13 +13,35 @@ import { perfMonitor, registerPerfReportListener } from '../utils/perf-monitor'
 import { enterPerfContext } from '../utils/perf-context'
 import { appendWorkflowDebugLog } from '../utils/workflow-debug'
 import { resolveMissingHandlerPolicy } from './channel-missing-handler-policy'
-import { resolvePluginRegistrationByWebContents } from '../modules/plugin/runtime/plugin-view-registry'
+import {
+  maskPluginViewChannelKey,
+  resolvePluginKeyByViewNonce,
+  resolvePluginRegistrationByWebContents,
+  resolvePluginViewNonce
+} from '../modules/plugin/runtime/plugin-view-registry'
 import { resolveChannelCallerIdentity } from './channel-caller-identity'
 import {
+  PLUGIN_VIEW_NONCE_CHANNEL,
   RAW_MAIN_PROCESS_CHANNEL,
   RAW_PLUGIN_PROCESS_CHANNEL,
   resolveRawProcessChannel
 } from '../../shared/ipc/raw-channel'
+
+/**
+ * Rewrites the outbound channel key to the target surface's alias, in place (#697).
+ *
+ * Applied at every `webContents.send`, because a missed one is silent in both directions: the
+ * plugin view drops a message whose key it does not recognise, and a message that keeps the key
+ * hands the credential back to the surface this change took it away from.
+ */
+function maskOutboundChannelKey(webContents: Electron.WebContents, data: unknown): void {
+  if (!data || typeof data !== 'object') return
+  const header = (data as { header?: unknown }).header
+  if (!header || typeof header !== 'object') return
+  const current = (header as Record<string, unknown>).uniqueKey
+  if (typeof current !== 'string' || !current) return
+  ;(header as Record<string, unknown>).uniqueKey = maskPluginViewChannelKey(webContents.id, current)
+}
 
 const CHANNEL_DEFAULT_TIMEOUT = 60_000
 const CHANNEL_PAYLOAD_WARN_BYTES = 256 * 1024
@@ -49,6 +71,14 @@ interface RawChannelHeaderData {
   type: ChannelType
   _originData?: unknown
   uniqueKey?: string
+  /**
+   * Exactly what the sender put on the wire, before the plugin-view alias was resolved (#697).
+   *
+   * `uniqueKey` above is the real channel key, because every downstream identity check compares
+   * against it. Replies have to echo this instead: the plugin view filters on the value it sent,
+   * and it never learns the key.
+   */
+  declaredKey?: string
   event?: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent
   plugin?: string
 }
@@ -151,6 +181,12 @@ class TouchChannel {
 
     ipcMain.on(RAW_MAIN_PROCESS_CHANNEL, this.__handle_main.bind(this))
     ipcMain.on(RAW_PLUGIN_PROCESS_CHANNEL, this.__handle_main.bind(this))
+    ipcMain.on(PLUGIN_VIEW_NONCE_CHANNEL, (event) => {
+      // The alias belongs to the asking surface and nothing else, so it is looked up by sender id
+      // rather than accepted from the payload. An unregistered sender gets null, which the plugin
+      // view preload treats as fatal (#697).
+      event.returnValue = resolvePluginViewNonce(event.sender?.id) ?? null
+    })
 
     perfMonitor.start()
     if (!perfReportListenerRegistered) {
@@ -205,7 +241,10 @@ class TouchChannel {
 
       if (header && typeof header === 'object' && header !== null) {
         const rawUniqueKey = (header as Record<string, unknown>).uniqueKey
-        const uniqueKey = typeof rawUniqueKey === 'string' ? rawUniqueKey : undefined
+        const declaredKey = typeof rawUniqueKey === 'string' ? rawUniqueKey : undefined
+        // A plugin view sends its per-surface alias; everything else — the app renderer, the
+        // plugin host process — still sends the key itself, and passes through untouched (#697).
+        const uniqueKey = resolvePluginKeyByViewNonce(declaredKey) ?? declaredKey
         let senderDestroyed = true
         try {
           senderDestroyed = e.sender.isDestroyed()
@@ -227,7 +266,8 @@ class TouchChannel {
             type: caller.pluginName ? ChannelType.PLUGIN : ChannelType.MAIN,
             _originData: arg,
             event: e,
-            uniqueKey
+            uniqueKey,
+            declaredKey
           },
           sync: sync as RawChannelSyncData | undefined,
           code: code as DataCode,
@@ -312,7 +352,7 @@ class TouchChannel {
       )
       delete rData.header.event
       if (rawData.header.uniqueKey) {
-        rData.header.uniqueKey = rawData.header.uniqueKey
+        rData.header.uniqueKey = rawData.header.declaredKey ?? rawData.header.uniqueKey
       }
 
       let finalData: RawStandardChannelData
@@ -388,7 +428,7 @@ class TouchChannel {
           delete rData.header.event
 
           if (rawData.header.uniqueKey) {
-            rData.header.uniqueKey = rawData.header.uniqueKey
+            rData.header.uniqueKey = rawData.header.declaredKey ?? rawData.header.uniqueKey
           }
 
           let finalData: unknown
@@ -713,6 +753,7 @@ class TouchChannel {
           return
         }
 
+        maskOutboundChannelKey(webContents, finalData)
         webContents.send(_channelCategory, finalData)
 
         const timeoutMs = finalData.sync?.timeout ?? CHANNEL_DEFAULT_TIMEOUT
@@ -864,6 +905,7 @@ class TouchChannel {
     const channel = resolveRawProcessChannel(type)
 
     try {
+      maskOutboundChannelKey(webContents, finalData)
       webContents.send(channel, finalData)
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error)
@@ -921,6 +963,7 @@ class TouchChannel {
     }
 
     try {
+      maskOutboundChannelKey(webContents, finalData)
       webContents.send(RAW_PLUGIN_PROCESS_CHANNEL, finalData)
     } catch {
       // Ignore send errors for broadcasts

--- a/apps/core-app/src/main/modules/clipboard.ts
+++ b/apps/core-app/src/main/modules/clipboard.ts
@@ -78,6 +78,7 @@ import {
   type ClipboardPollingSettings
 } from './clipboard/clipboard-polling-policy'
 import { registerClipboardHostService } from './clipboard/clipboard-host-service'
+import type { ClipboardHostService } from './clipboard/clipboard-host-service'
 import {
   ClipboardStageBEnrichment,
   type ClipboardStageBJob
@@ -1209,7 +1210,9 @@ export class ClipboardModule extends BaseModule {
   private installClipboardHostService(): void {
     this.clipboardHostServiceDisposer?.()
     this.clipboardHostServiceDisposer = registerClipboardHostService(
-      Object.freeze({
+      // Object.freeze<T> infers T from its argument, so registerClipboardHostService's own
+      // parameter type never reaches this literal and every handler took `any` (#548).
+      Object.freeze<ClipboardHostService>({
         read: async (request, _context, signal) => {
           if (signal.aborted) throw new Error('PLUGIN_HOST_CAPABILITY_CANCELLED')
           if (request.op === 'text') {
@@ -1221,19 +1224,25 @@ export class ClipboardModule extends BaseModule {
           if (signal.aborted) throw new Error('PLUGIN_HOST_CAPABILITY_CANCELLED')
           if (request.op === 'clear') clipboard.clear()
           else {
+            // `files` is destructured out rather than spread-then-overridden: a conditional
+            // spread does not narrow what the first spread already contributed, so the result
+            // kept `readonly string[]` and never matched ClipboardWriteRequest. Invisible while
+            // the parameter was `any` (#548).
+            const { files, ...content } = request.content
             await this.write({
-              ...request.content,
-              ...(request.content.files ? { files: [...request.content.files] } : {})
+              ...content,
+              ...(files ? { files: [...files] } : {})
             })
           }
           if (signal.aborted) throw new Error('PLUGIN_HOST_CAPABILITY_CANCELLED')
         },
         copyAndPaste: async (request, context, signal) => {
           if (signal.aborted) throw new Error('PLUGIN_HOST_CAPABILITY_CANCELLED')
+          const { files, ...rest } = request
           const result = await this.handleCopyAndPasteRequest(
             {
-              ...request,
-              ...(request.files ? { files: [...request.files] } : {})
+              ...rest,
+              ...(files ? { files: [...files] } : {})
             },
             { plugin: context } as HandlerContext
           )

--- a/apps/core-app/src/main/modules/plugin/runtime/plugin-view-host.test.ts
+++ b/apps/core-app/src/main/modules/plugin/runtime/plugin-view-host.test.ts
@@ -37,10 +37,32 @@ describe('plugin view host', () => {
     const bootstrap = parsePluginViewBootstrapArgument(preferences.additionalArguments ?? [])
     expect(bootstrap).toEqual({
       bridgeVersion: PLUGIN_VIEW_BRIDGE_VERSION,
-      channelKey: 'owner-key',
       plugin: { name: 'touch-test', version: '1.2.3', sdkapi: 260615 },
       config: { themeStyle: { dark: true } }
     })
+  })
+
+  /**
+   * `additionalArguments` become real command-line arguments of the renderer process, which any
+   * unprivileged process on the machine reads out of the process table — `ps -ww` on macOS and
+   * Linux, WMI on Windows. The plugin's channel key travelled there until #697.
+   *
+   * This asserts on the raw arguments rather than the parsed bootstrap: dropping the field from
+   * the interface would satisfy a parsed-shape check while the value still sat in the string.
+   */
+  it('puts no channel key in the renderer command line', () => {
+    const preferences = buildPluginViewWebPreferences('trusted-plugin-view', {
+      plugin,
+      themeStyle: { dark: true },
+      source: 'core-box'
+    })
+
+    const commandLine = (preferences.additionalArguments ?? []).join(' ')
+
+    expect(commandLine).toContain('touch-test')
+    expect(commandLine).not.toContain('owner-key')
+    expect(commandLine).not.toContain(encodeURIComponent('owner-key'))
+    expect(commandLine).not.toContain('channelKey')
   })
 
   it('cannot select a legacy preload through an obsolete profile value', () => {

--- a/apps/core-app/src/main/modules/plugin/runtime/plugin-view-host.ts
+++ b/apps/core-app/src/main/modules/plugin/runtime/plugin-view-host.ts
@@ -53,7 +53,6 @@ export function buildPluginViewWebPreferences(
   const partition = buildPluginViewPartition(options.plugin.name, options.source)
   const bootstrapArgument = buildPluginViewBootstrapArgument({
     bridgeVersion: PLUGIN_VIEW_BRIDGE_VERSION,
-    channelKey: options.plugin._uniqueChannelKey,
     plugin: {
       name: options.plugin.name,
       version: options.plugin.version,

--- a/apps/core-app/src/main/modules/plugin/runtime/plugin-view-registry.test.ts
+++ b/apps/core-app/src/main/modules/plugin/runtime/plugin-view-registry.test.ts
@@ -1,9 +1,12 @@
 import type { PluginActivationIdentity } from '@talex-touch/utils/transport/main'
 import { describe, expect, it } from 'vitest'
 import {
+  maskPluginViewChannelKey,
   registerPluginWebContents,
+  resolvePluginKeyByViewNonce,
   resolvePluginNameByWebContents,
   resolvePluginRegistrationByWebContents,
+  resolvePluginViewNonce,
   unregisterPluginWebContents
 } from './plugin-view-registry'
 
@@ -46,5 +49,128 @@ describe('plugin view registry', () => {
   it('returns no registration for invalid sender ids', () => {
     expect(resolvePluginRegistrationByWebContents(undefined)).toBeUndefined()
     expect(resolvePluginRegistrationByWebContents(Number.NaN)).toBeUndefined()
+  })
+})
+
+/**
+ * The per-surface alias that replaced the channel key on the wire (#697).
+ *
+ * The key used to reach the plugin view as a renderer command-line argument, readable from the
+ * process table by any unprivileged process. What matters here is not that an alias exists but
+ * that it stops working the moment its surface does — an alias outliving its registration would
+ * be the same long-lived bearer credential under a different name.
+ */
+describe('plugin view channel alias', () => {
+  it('mints a distinct alias per surface and resolves each back to its own key', () => {
+    const tokenA = registerPluginWebContents(9201, activation(1))
+    const tokenB = registerPluginWebContents(9202, activation(2, { key: 'key-other' }))
+
+    const nonceA = resolvePluginViewNonce(9201)
+    const nonceB = resolvePluginViewNonce(9202)
+
+    expect(nonceA).toBeTruthy()
+    expect(nonceB).toBeTruthy()
+    expect(nonceA).not.toBe(nonceB)
+    expect(resolvePluginKeyByViewNonce(nonceA)).toBe('key-1')
+    expect(resolvePluginKeyByViewNonce(nonceB)).toBe('key-other')
+
+    unregisterPluginWebContents(9201, tokenA)
+    unregisterPluginWebContents(9202, tokenB)
+  })
+
+  it('never hands out the key itself as an alias', () => {
+    const token = registerPluginWebContents(9203, activation(3))
+
+    expect(resolvePluginViewNonce(9203)).not.toBe('key-3')
+    // The key is what the alias exists to keep off the wire, so it must not resolve as one either.
+    expect(resolvePluginKeyByViewNonce('key-3')).toBeUndefined()
+
+    unregisterPluginWebContents(9203, token)
+  })
+
+  /**
+   * The case that is easy to write so it always passes: assert the revoked alias fails *and* that
+   * the very same call succeeded a moment earlier, so a lookup that is broken outright cannot be
+   * mistaken for revocation working.
+   */
+  it('stops resolving an alias once its surface is unregistered', () => {
+    const token = registerPluginWebContents(9204, activation(4))
+    const nonce = resolvePluginViewNonce(9204)
+
+    expect(resolvePluginKeyByViewNonce(nonce)).toBe('key-4')
+
+    expect(unregisterPluginWebContents(9204, token)).toBe(true)
+
+    expect(resolvePluginKeyByViewNonce(nonce)).toBeUndefined()
+    expect(resolvePluginViewNonce(9204)).toBeUndefined()
+  })
+
+  it('drops the previous alias when a surface is re-registered', () => {
+    registerPluginWebContents(9205, activation(5))
+    const first = resolvePluginViewNonce(9205)
+    const token = registerPluginWebContents(9205, activation(6))
+    const second = resolvePluginViewNonce(9205)
+
+    expect(second).not.toBe(first)
+    expect(resolvePluginKeyByViewNonce(first)).toBeUndefined()
+    expect(resolvePluginKeyByViewNonce(second)).toBe('key-6')
+
+    unregisterPluginWebContents(9205, token)
+  })
+
+  it('refuses empty and unknown aliases rather than resolving something', () => {
+    expect(resolvePluginKeyByViewNonce(undefined)).toBeUndefined()
+    expect(resolvePluginKeyByViewNonce('')).toBeUndefined()
+    expect(resolvePluginKeyByViewNonce('not-a-nonce')).toBeUndefined()
+  })
+
+  describe('outbound masking', () => {
+    it('swaps the key for the alias of the surface it belongs to', () => {
+      const token = registerPluginWebContents(9206, activation(7))
+      const nonce = resolvePluginViewNonce(9206)
+
+      expect(maskPluginViewChannelKey(9206, 'key-7')).toBe(nonce)
+
+      unregisterPluginWebContents(9206, token)
+    })
+
+    /**
+     * Everything that is not a registered plugin view still matches on the key itself — the app
+     * renderer receiving a bridged plugin message, the plugin host process. Masking there would
+     * make them drop every message with no error raised anywhere, so the pass-through cases are
+     * asserted as explicitly as the masked one.
+     */
+    it('leaves messages to every other receiver untouched', () => {
+      const token = registerPluginWebContents(9207, activation(8))
+
+      expect(maskPluginViewChannelKey(9208, 'key-8')).toBe('key-8')
+      expect(maskPluginViewChannelKey(undefined, 'key-8')).toBe('key-8')
+      // A registered surface, but a key that is not its own: another plugin's message routed to
+      // the wrong view is a bug worth leaving visible rather than aliasing into looking correct.
+      expect(maskPluginViewChannelKey(9207, 'key-of-another-plugin')).toBe('key-of-another-plugin')
+
+      unregisterPluginWebContents(9207, token)
+    })
+
+    it('passes through absent and non-string keys', () => {
+      const token = registerPluginWebContents(9209, activation(9))
+
+      expect(maskPluginViewChannelKey(9209, undefined)).toBeUndefined()
+      expect(maskPluginViewChannelKey(9209, '')).toBe('')
+      expect(maskPluginViewChannelKey(9209, 42)).toBe(42)
+
+      unregisterPluginWebContents(9209, token)
+    })
+
+    it('stops masking once the surface is gone', () => {
+      const token = registerPluginWebContents(9210, activation(10))
+      const nonce = resolvePluginViewNonce(9210)
+
+      expect(maskPluginViewChannelKey(9210, 'key-10')).toBe(nonce)
+
+      unregisterPluginWebContents(9210, token)
+
+      expect(maskPluginViewChannelKey(9210, 'key-10')).toBe('key-10')
+    })
   })
 })

--- a/apps/core-app/src/main/modules/plugin/runtime/plugin-view-registry.ts
+++ b/apps/core-app/src/main/modules/plugin/runtime/plugin-view-registry.ts
@@ -10,15 +10,37 @@ export interface PluginWebContentsRegistration extends PluginActivationIdentity 
  */
 const pluginWebContentsRegistrations = new Map<number, PluginWebContentsRegistration>()
 
+/**
+ * Per-surface aliases for the plugin channel key (#697).
+ *
+ * The key used to travel to the plugin view as a renderer command-line argument, where any
+ * unprivileged process on the machine reads it out of the process table. It is a long-lived
+ * credential — one value for the whole activation, shared by every window that plugin opens —
+ * so the exposure lasted as long as the plugin did.
+ *
+ * A nonce replaces it on the wire. It is minted here, alongside the registration, because that
+ * is the one place where a surface's lifetime is already known: minting and revocation cannot
+ * drift apart if neither has its own call site. Revocation is what makes the alias worth having,
+ * so it is not left to a caller to remember.
+ */
+const nonceByWebContents = new Map<number, string>()
+const webContentsByNonce = new Map<string, number>()
+
 export function registerPluginWebContents(
   webContentsId: number,
   activation: PluginActivationIdentity
 ): string {
   const registrationToken = randomUUID()
+  // A surface can be re-registered without being destroyed, and the stale alias would otherwise
+  // keep resolving to a registration it no longer belongs to.
+  revokePluginViewNonce(webContentsId)
   pluginWebContentsRegistrations.set(webContentsId, {
     registrationToken,
     ...activation
   })
+  const nonce = randomUUID()
+  nonceByWebContents.set(webContentsId, nonce)
+  webContentsByNonce.set(nonce, webContentsId)
   return registrationToken
 }
 
@@ -33,7 +55,47 @@ export function unregisterPluginWebContents(
   if (registrationToken && current.registrationToken !== registrationToken) {
     return false
   }
+  revokePluginViewNonce(webContentsId)
   return pluginWebContentsRegistrations.delete(webContentsId)
+}
+
+function revokePluginViewNonce(webContentsId: number): void {
+  const previous = nonceByWebContents.get(webContentsId)
+  if (previous === undefined) {
+    return
+  }
+  nonceByWebContents.delete(webContentsId)
+  webContentsByNonce.delete(previous)
+}
+
+/**
+ * The alias this surface presents on the channel. Minted at registration, so it is already
+ * there when the preload asks — every registration site creates the webContents and registers it
+ * before loading any content.
+ */
+export function resolvePluginViewNonce(webContentsId: number | undefined): string | undefined {
+  if (typeof webContentsId !== 'number' || !Number.isFinite(webContentsId)) {
+    return undefined
+  }
+  return nonceByWebContents.get(webContentsId)
+}
+
+/**
+ * Resolves an inbound alias back to the real channel key.
+ *
+ * Returns nothing once the surface is gone. A nonce outliving its registration would be exactly
+ * the bearer credential this replaced, so the lookup goes through the live registration rather
+ * than caching the key beside the nonce.
+ */
+export function resolvePluginKeyByViewNonce(nonce: string | undefined): string | undefined {
+  if (typeof nonce !== 'string' || !nonce) {
+    return undefined
+  }
+  const webContentsId = webContentsByNonce.get(nonce)
+  if (webContentsId === undefined) {
+    return undefined
+  }
+  return pluginWebContentsRegistrations.get(webContentsId)?.key
 }
 
 export function resolvePluginRegistrationByWebContents(
@@ -49,4 +111,26 @@ export function resolvePluginNameByWebContents(
   webContentsId: number | undefined
 ): string | undefined {
   return resolvePluginRegistrationByWebContents(webContentsId)?.name
+}
+
+/**
+ * Replaces the channel key with this surface's alias on the way out (#697).
+ *
+ * Only the surface the key belongs to gets an alias. Anything else — the app renderer receiving a
+ * bridged plugin message, the plugin host process, a window that was never registered — is
+ * returned unchanged, because those receivers match on the key itself and swapping it would make
+ * them drop every message without an error anywhere.
+ */
+export function maskPluginViewChannelKey(
+  webContentsId: number | undefined,
+  uniqueKey: unknown
+): unknown {
+  if (typeof uniqueKey !== 'string' || !uniqueKey) {
+    return uniqueKey
+  }
+  const registration = resolvePluginRegistrationByWebContents(webContentsId)
+  if (!registration || registration.key !== uniqueKey) {
+    return uniqueKey
+  }
+  return resolvePluginViewNonce(webContentsId) ?? uniqueKey
 }

--- a/apps/core-app/src/preload/plugin-view.ts
+++ b/apps/core-app/src/preload/plugin-view.ts
@@ -2,6 +2,7 @@
 // rather than through a global import.
 import { installTransportPortHandoff } from '@talex-touch/utils/transport'
 import { contextBridge } from 'electron'
+import { PLUGIN_VIEW_NONCE_CHANNEL } from '../shared/ipc/raw-channel'
 import { pluginViewRendererIpcAdapter } from '../shared/ipc/plugin-view-renderer-adapter'
 import { parsePluginViewBootstrapArgument } from '../shared/plugin-view-bridge'
 import { createPluginViewChannel } from './plugin-view-channel'
@@ -50,8 +51,24 @@ const disposeTransportPortHandoff = installTransportPortHandoff(
   window
 )
 const bootstrap = parsePluginViewBootstrapArgument(process.argv)
+
+/**
+ * The channel alias for this surface (#697).
+ *
+ * It is fetched rather than read out of `process.argv` because command-line arguments of a
+ * renderer are readable by any unprivileged process on the machine, and this used to be the
+ * plugin's real long-lived channel key. The main process mints a per-surface nonce when it
+ * registers the webContents — before any content loads — so the answer is always ready here.
+ */
+const channelAlias = pluginViewRendererIpcAdapter.sendSync(PLUGIN_VIEW_NONCE_CHANNEL)
+if (typeof channelAlias !== 'string' || !channelAlias) {
+  // Not recoverable: without an alias every message this surface sends is unattributable, and
+  // continuing would leave a plugin page that silently receives nothing.
+  throw new Error('Trusted plugin views require a channel alias from the host.')
+}
+
 const channel = createPluginViewChannel(pluginViewRendererIpcAdapter, {
-  uniqueKey: bootstrap.channelKey
+  uniqueKey: channelAlias
 })
 
 const publicChannel = Object.freeze({

--- a/apps/core-app/src/shared/ipc/plugin-view-renderer-adapter.ts
+++ b/apps/core-app/src/shared/ipc/plugin-view-renderer-adapter.ts
@@ -5,5 +5,7 @@ export const pluginViewRendererIpcAdapter = Object.freeze({
     ipcRenderer.on(channelName, listener),
   removeListener: (channelName: string, listener: (event: unknown, payload: unknown) => void) =>
     ipcRenderer.removeListener(channelName, listener),
-  send: (channelName: string, payload: unknown) => ipcRenderer.send(channelName, payload)
+  send: (channelName: string, payload: unknown) => ipcRenderer.send(channelName, payload),
+  sendSync: (channelName: string, payload?: unknown) =>
+    ipcRenderer.sendSync(channelName, payload) as unknown
 })

--- a/apps/core-app/src/shared/ipc/raw-channel.ts
+++ b/apps/core-app/src/shared/ipc/raw-channel.ts
@@ -1,6 +1,14 @@
 export const RAW_MAIN_PROCESS_CHANNEL = '@main-process-message'
 export const RAW_PLUGIN_PROCESS_CHANNEL = '@plugin-process-message'
 
+/**
+ * Where a plugin view asks for the alias it presents on the plugin channel (#697).
+ *
+ * Synchronous because the preload has to hold the value before the page can send
+ * anything, and the answer comes from a map the main process already has.
+ */
+export const PLUGIN_VIEW_NONCE_CHANNEL = '@plugin-view-nonce'
+
 export function resolveRawProcessChannel(type: 'main' | 'plugin'): string {
   return type === 'plugin' ? RAW_PLUGIN_PROCESS_CHANNEL : RAW_MAIN_PROCESS_CHANNEL
 }

--- a/apps/core-app/src/shared/plugin-view-bridge.test.ts
+++ b/apps/core-app/src/shared/plugin-view-bridge.test.ts
@@ -9,14 +9,12 @@ describe('plugin view bootstrap', () => {
   it('round-trips sanitized metadata without executable source or filesystem paths', () => {
     const argument = buildPluginViewBootstrapArgument({
       bridgeVersion: PLUGIN_VIEW_BRIDGE_VERSION,
-      channelKey: 'secret-key',
       plugin: { name: 'touch-test', version: '1.2.3', sdkapi: 260615 },
       config: { themeStyle: { dark: true } }
     })
 
     expect(parsePluginViewBootstrapArgument([argument])).toEqual({
       bridgeVersion: PLUGIN_VIEW_BRIDGE_VERSION,
-      channelKey: 'secret-key',
       plugin: { name: 'touch-test', version: '1.2.3', sdkapi: 260615 },
       config: { themeStyle: { dark: true } }
     })
@@ -24,9 +22,24 @@ describe('plugin view bootstrap', () => {
     expect(argument).not.toContain('require(')
   })
 
+  // This argument becomes a real command-line argument of the renderer, readable from the process
+  // table by any unprivileged process on the machine. The plugin's channel key used to be in it
+  // (#697); a caller that puts one back should fail here rather than in a `ps` listing.
+  it('carries no channel key even when the caller supplies one', () => {
+    const argument = buildPluginViewBootstrapArgument({
+      bridgeVersion: PLUGIN_VIEW_BRIDGE_VERSION,
+      channelKey: 'plugin-channel-key',
+      plugin: { name: 'touch-test', sdkapi: 260615 },
+      config: { themeStyle: {} }
+    } as never)
+
+    expect(argument).not.toContain('plugin-channel-key')
+    expect(argument).not.toContain('channelKey')
+    expect(parsePluginViewBootstrapArgument([argument])).not.toHaveProperty('channelKey')
+  })
+
   it('rejects missing or unsupported bridge versions', () => {
     const base = {
-      channelKey: 'secret-key',
       plugin: { name: 'touch-test', sdkapi: 260615 },
       config: { themeStyle: {} }
     }

--- a/apps/core-app/src/shared/plugin-view-bridge.ts
+++ b/apps/core-app/src/shared/plugin-view-bridge.ts
@@ -14,7 +14,6 @@ export interface PluginViewConfigSnapshot {
 
 export interface PluginViewBootstrap {
   bridgeVersion: typeof PLUGIN_VIEW_BRIDGE_VERSION
-  channelKey: string
   plugin: PluginViewMetadata
   config: PluginViewConfigSnapshot
 }
@@ -36,13 +35,12 @@ function normalizeBootstrap(value: unknown): PluginViewBootstrap {
     throw new Error('Plugin view bootstrap is invalid.')
   }
 
-  const channelKey = typeof value.channelKey === 'string' ? value.channelKey.trim() : ''
   const bridgeVersion = value.bridgeVersion
   const name = typeof value.plugin.name === 'string' ? value.plugin.name.trim() : ''
   if (bridgeVersion !== PLUGIN_VIEW_BRIDGE_VERSION) {
     throw new Error('Plugin view bridge version is unsupported.')
   }
-  if (!channelKey || channelKey.length > 256 || !name || name.length > 128) {
+  if (!name || name.length > 128) {
     throw new Error('Plugin view bootstrap identity is invalid.')
   }
 
@@ -58,7 +56,6 @@ function normalizeBootstrap(value: unknown): PluginViewBootstrap {
 
   return cloneSerializable({
     bridgeVersion: PLUGIN_VIEW_BRIDGE_VERSION,
-    channelKey,
     plugin: {
       name,
       ...(typeof version === 'string' ? { version } : {}),

--- a/scripts/check-implicit-any-debt.mjs
+++ b/scripts/check-implicit-any-debt.mjs
@@ -34,7 +34,7 @@ const CORE_APP = path.join(REPO_ROOT, 'apps/core-app')
  * only -- every error the flag produces is in that range, so a rise here is new untyped code and
  * not some unrelated type break.
  */
-export const KNOWN_IMPLICIT_ANY_ERRORS = 37
+export const KNOWN_IMPLICIT_ANY_ERRORS = 28
 
 /** Resolves the workspace's own tsc rather than trusting a .bin shim on PATH. */
 function resolveTsc() {


### PR DESCRIPTION
Closes #697.

The plugin's channel key was packed into the plugin view's bootstrap argument, which becomes a **real command-line argument of the renderer process** — readable from the process table by any unprivileged process on the machine (`ps -ww` on macOS/Linux, WMI on Windows). It is one value for the whole activation, shared by every window the plugin opens, so the exposure lasted as long as the plugin did.

**Nothing goes in its place.** The command line now carries only the bridge version, the plugin name and the theme snapshot. The preload asks the host for a per-surface alias instead, over a synchronous IPC the host answers from `event.sender.id` — never from the payload, so a caller cannot ask for someone else's.

## Where the alias lives

Minted inside `registerPluginWebContents`, dropped inside its unregister. That is the one place a surface's lifetime is already known, and **minting and revocation cannot drift apart if neither has its own call site**. An alias that outlived its registration would be the same long-lived bearer credential under a different name — which is the whole reason the key was worth removing.

## Translation at both boundaries

**Inbound**, the alias resolves back to the key before anything downstream sees it, so the six capability modules comparing `context.uniqueKey` against the activation key are untouched — no compatibility shim, no second identity source.

**Outbound**, the key becomes the alias — *only for the surface it belongs to*. Everything else still matches on the key itself: the app renderer receiving a bridged plugin message, and the plugin host process running the Prelude in a `utilityProcess` (verified: zero `webContents` references there, so `webContents.send` never reaches it). Masking those would make them drop every message with no error raised anywhere.

**Replies echo what arrived**, not what was resolved. The plugin view filters on the value it sent, so echoing the key would both hand it back and make the view discard its own reply.

## Two of the guards were not load-bearing when first written

| plant | tests failing |
|---|---|
| drop the `_sendTo` outbound mask | 2 of 29 |
| drop the inbound translation | 2 of 29 |
| echo the resolved key on replies | 1 of 29 — **28/28 before the reply test existed** |
| skip revocation on unregister | 1 of 29 |
| use the key itself as the alias | 3 of 29 |
| mask without checking key ownership | 1 of 29 |
| let the bootstrap whitelist pass it | 1 of 29 — **28/28 when planted at the call site** |

The reply case asserted only a parsed field, which proves nothing about which value the reply picks up; it now drives the real dispatch and reads the emitted payload. The command-line case was the opposite lesson: putting the key back at the call site is *not* a plant, because the bootstrap builder whitelists its output — so the effective plant is in the builder, and that is where it fails.

## What this does not claim

The issue calls the key a bearer credential because `resolveChannelCallerIdentity` once accepted a self-declared key as an identity source. **#698 already removed that** — identity comes from the webContents registration, and `channel-caller-identity.ts` says so in as many words. Leaking the key could not let an attacker impersonate a plugin even before this change. What it could do is sit in `ps` output for the life of the plugin and act as the header filter for all of its messages. That is what this removes.

## Verification

`plugin` / `division-box` / `core-box`: **105 of 106 files pass, 1320 tests**. The one failure is `plugin-sqlite-worker.integration.test.ts` asking for a build artifact this checkout lacks — identical on the baseline, green in CI (#1604). `preload` / `shared` / `core`: 37 files, 207 passed. `typecheck:node` clean under the package's own flags.

Closes #697