### PR TITLE
fix(nexus): record scene asset ownership on S3 and OSS too (#1644)

### DIFF
--- a/apps/nexus/server/utils/storageObjectStore.test.ts
+++ b/apps/nexus/server/utils/storageObjectStore.test.ts
@@ -95,7 +95,9 @@ function createExternalStorage(channel: 's3' | 'oss', fetchImpl: typeof fetch): 
 }
 
 function createMockExternalFetch() {
-  const objects = new Map<string, { data: Buffer, contentType: string }>()
+  // ownerId is modelled because that is where ownership lives on S3/OSS (#1644). A mock that
+  // dropped it would let the round-trip tests pass while the real backend carried nothing.
+  const objects = new Map<string, { data: Buffer, contentType: string, ownerId?: string }>()
   const requests: Array<{ method: string, url: string, authorization: string | null }> = []
   const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input)
@@ -114,6 +116,8 @@ function createMockExternalFetch() {
       objects.set(url, {
         data: body,
         contentType: headers.get('content-type') || 'application/octet-stream',
+        ownerId:
+          headers.get('x-amz-meta-ownerid') ?? headers.get('x-oss-meta-ownerid') ?? undefined,
       })
       return new Response(null, { status: 200 })
     }
@@ -132,7 +136,10 @@ function createMockExternalFetch() {
         return new Response(null, { status: 404 })
       return new Response(object.data, {
         status: 200,
-        headers: { 'content-type': object.contentType },
+        headers: {
+          'content-type': object.contentType,
+          ...(object.ownerId ? { 'x-amz-meta-ownerid': object.ownerId } : {}),
+        },
       })
     }
 
@@ -733,5 +740,67 @@ describe('storage object ownership (#898)', () => {
 
     expect(read?.ownerId).toBeUndefined()
     expect(read?.storesOwnership).toBe(true)
+  })
+})
+
+describe('external storage ownership (#1644)', () => {
+  for (const channel of ['s3', 'oss'] as const) {
+    it(`signs the ownership header and reads it back over ${channel}`, async () => {
+      const marker = `own-${channel}`
+      const h3Event = event(marker)
+      const memoryStorage = createMemory()
+      const mock = createMockExternalFetch()
+      const external = createExternalStorage(channel, mock.fetchImpl)
+      const shared = {
+        event: h3Event,
+        bucket: null,
+        memoryStorage,
+        externalStorage: external,
+        key: `${marker}.bin`,
+        resourceType: `scene-asset-${marker}`,
+      }
+
+      const stored = await putStorageObject({
+        ...shared,
+        data: Buffer.from('body'),
+        contentType: 'application/octet-stream',
+        ownerId: 'user-external',
+      })
+      const loaded = await getStorageObject(shared)
+
+      expect(stored.storesOwnership).toBe(true)
+      expect(loaded?.ownerId).toBe('user-external')
+      expect(loaded?.storesOwnership).toBe(true)
+
+      // The decisive assertion. The header arriving proves only that it was sent; S3 and OSS both
+      // reject an x-amz-*/x-oss-* header that is not covered by the signature, so what has to be
+      // true is that it appears in SignedHeaders. That is the whole reason it is added to the
+      // record before canonicalizeHeaders rather than merged in afterwards.
+      const put = mock.requests.find((request) => request.method === 'PUT')
+      expect(put?.authorization).toContain(`x-${channel === 'oss' ? 'oss' : 'amz'}-meta-ownerid`)
+    })
+  }
+
+  it('reports an external object written before ownership as unowned, not unrecordable', async () => {
+    const marker = 'own-external-legacy'
+    const h3Event = event(marker)
+    const memoryStorage = createMemory()
+    const external = createExternalStorage('s3', createMockExternalFetch().fetchImpl)
+    const shared = {
+      event: h3Event,
+      bucket: null,
+      memoryStorage,
+      externalStorage: external,
+      key: `${marker}.bin`,
+      resourceType: `scene-asset-${marker}`,
+    }
+
+    await putStorageObject({ ...shared, data: Buffer.from('body') })
+    const loaded = await getStorageObject(shared)
+
+    // Same distinction the download check turns on: this backend can record ownership, so an
+    // object without one is refused rather than waved through.
+    expect(loaded?.ownerId).toBeUndefined()
+    expect(loaded?.storesOwnership).toBe(true)
   })
 })

--- a/apps/nexus/server/utils/storageObjectStore.ts
+++ b/apps/nexus/server/utils/storageObjectStore.ts
@@ -255,6 +255,7 @@ function signS3Request(input: {
   url: URL
   body: Buffer | null
   contentType?: string | null
+  ownerId?: string | null
   storage: StorageObjectExternalConfig
   now?: Date
 }): Record<string, string> {
@@ -264,6 +265,9 @@ function signS3Request(input: {
     host: input.url.host,
     'x-amz-content-sha256': payloadHash,
     'x-amz-date': longDate,
+    // Included in `headers` before canonicalizeHeaders runs, so it is covered by the signature
+    // rather than sent alongside it -- an unsigned x-amz-* header is rejected outright (#1644).
+    ...(input.ownerId ? { 'x-amz-meta-ownerid': input.ownerId } : {}),
   }
   if (input.contentType)
     headers['content-type'] = input.contentType
@@ -303,6 +307,7 @@ function signOssRequest(input: {
   url: URL
   body: Buffer | null
   contentType?: string | null
+  ownerId?: string | null
   storage: StorageObjectExternalConfig
   now?: Date
 }): Record<string, string> {
@@ -311,6 +316,7 @@ function signOssRequest(input: {
     host: input.url.host,
     'x-oss-content-sha256': 'UNSIGNED-PAYLOAD',
     'x-oss-date': longDate,
+    ...(input.ownerId ? { 'x-oss-meta-ownerid': input.ownerId } : {}),
   }
   if (input.contentType)
     headers['content-type'] = input.contentType
@@ -350,6 +356,7 @@ function buildExternalHeaders(input: {
   url: URL
   body: Buffer | null
   contentType?: string | null
+  ownerId?: string | null
   storage: StorageObjectExternalConfig
 }) {
   return input.storage.channel === 'oss'
@@ -425,13 +432,14 @@ async function resolveObjectStorageBackend(input: StorageObjectContext): Promise
   }
 }
 
-async function putExternalObject(storage: StorageObjectExternalConfig, key: string, data: Buffer, contentType: string): Promise<void> {
+async function putExternalObject(storage: StorageObjectExternalConfig, key: string, data: Buffer, contentType: string, ownerId?: string | null): Promise<void> {
   const url = buildExternalObjectUrl(storage, key)
   const headers = buildExternalHeaders({
     method: 'PUT',
     url,
     body: data,
     contentType,
+    ownerId,
     storage,
   })
   const response = await (storage.fetch ?? fetch)(url, {
@@ -454,7 +462,7 @@ async function getExternalObject(
   storage: StorageObjectExternalConfig,
   key: string,
   fallbackContentType: string,
-): Promise<{ data: Buffer, contentType: string } | null> {
+): Promise<{ data: Buffer, contentType: string, ownerId?: string } | null> {
   const url = buildExternalObjectUrl(storage, key)
   const headers = buildExternalHeaders({
     method: 'GET',
@@ -476,7 +484,13 @@ async function getExternalObject(
   }
   const data = Buffer.from(await response.arrayBuffer())
   const contentType = normalizeContentType(response.headers.get('content-type'), fallbackContentType)
-  return { data, contentType }
+  // Both dialects are read because a single deployment is one or the other and the response is
+  // the only place that says which -- resolveObjectStorageBackend has already picked by then.
+  const ownerId
+    = response.headers.get('x-amz-meta-ownerid')
+      ?? response.headers.get('x-oss-meta-ownerid')
+      ?? undefined
+  return { data, contentType, ownerId: ownerId || undefined }
 }
 
 async function deleteExternalObject(storage: StorageObjectExternalConfig, key: string): Promise<void> {
@@ -719,7 +733,13 @@ export async function putStorageObject(input: PutStorageObjectInput): Promise<Om
   const uploadRetry = backend.externalStorage || backend.bucket
     ? await runStorageWriteWithRetry(backend, input.retryPolicy, async () => {
       if (backend.externalStorage) {
-        await putExternalObject(backend.externalStorage, input.key, data.buffer, contentType)
+        await putExternalObject(
+          backend.externalStorage,
+          input.key,
+          data.buffer,
+          contentType,
+          input.ownerId
+        )
         return
       }
 
@@ -764,7 +784,7 @@ export async function putStorageObject(input: PutStorageObjectInput): Promise<Om
     storageProvider: backend.provider,
     uploadRetry,
     ownerId: input.ownerId ?? undefined,
-    storesOwnership: !backend.externalStorage,
+    storesOwnership: true,
   }
 }
 
@@ -805,10 +825,11 @@ export async function getStorageObject(input: StorageObjectContext): Promise<Sto
       contentType: object.contentType,
       storageChannel: backend.channel,
       storageProvider: backend.provider,
-      // S3/OSS reads go through a signed request whose headers are part of the signature, so
-      // carrying x-amz-meta-* here means changing what gets signed. Left alone rather than
-      // changed blind against a backend no test in this repo exercises -- tracked as #1644.
-      storesOwnership: false,
+      // The metadata header is added to the record *before* canonicalizeHeaders runs, so it is
+      // covered by the signature rather than sent beside it, which S3 and OSS both reject
+      // (#1644). Same mechanism for either dialect, so both are supported.
+      ownerId: object.ownerId,
+      storesOwnership: true,
     }
   }
 


### PR DESCRIPTION
Closes #1644, the half #898 could not reach.

## It was the same shape after all

I filed this expecting the signed-header path to be the obstacle. It is the opposite: both `signS3Request` and `signOssRequest` build a plain `headers` record and hand it to `canonicalizeHeaders`, which derives **both** the canonical and the signed header lists from whatever that record contains. Adding `x-amz-meta-ownerid` (or `x-oss-meta-ownerid`) to the record therefore puts it *inside* the signature.

A metadata header sent *beside* the signature is precisely what S3 and OSS reject. So the ordering — add before canonicalizing, not merge after — is the entire fix, and it works identically for both dialects.

`getExternalObject` reads either dialect back, since a deployment is one or the other and by that point the response is the only thing that says which. `storesOwnership` is now `true` on every backend, so the ownership check in `scenes/assets/[key].get.ts` applies everywhere instead of skipping this one.

## The assertion that carries the weight

```ts
expect(put?.authorization).toContain('x-amz-meta-ownerid')
```

Not `expect(headers.get(...))`. The header **arriving** proves only that it was sent, which is the exact case both providers refuse — a test that checked arrival would pass against a broken implementation. What has to be true is that it appears in the Authorization header's `SignedHeaders` list.

The mock fetch had to learn metadata before any of this could be tested; without that, the round trip would have passed while the real backend carried nothing. Same trap as the R2 mock in #1645.

## Verification

Mutation-checked: dropping the signed header fails 1 test, dropping the read fails 2, restored is 15 passed. Nexus suite 200 files / 1116 tests pass. eslint clean.

The `resolveObjectStorageBackend` trap named in the issue — falling through to bucket/memory when external storage is unconfigured, so a forgetful test passes for the wrong reason — is avoided by passing `externalStorage` explicitly, following the existing external tests in that file.
