### PR TITLE
docs(trellis): fill the five R3 signal PRDs so docs:verify goes green

### DIFF
--- a/.trellis/tasks/08-05-reco-behavior-learning/prd.md
+++ b/.trellis/tasks/08-05-reco-behavior-learning/prd.md
@@ -6,11 +6,32 @@ R3e: prev_app co-occurrence table (schema context format already reserved), expo
 
 ## Requirements
 
-- TBD
+- R1: `prev_app` co-occurrence table. `usage_logs.context` already reserves the
+  prev_app format (`schema.ts:209`), but `recordExecute` writes only `{scoring}`.
+- R2: Exposure-CTR negative feedback — decay for items shown and not clicked. The
+  `cancelCount` skeleton exists; exposure recording is what is missing. Consumes the
+  metric data R2 produces.
+- R3: Session rhythm. Consecutive queries in the same category temporarily raise that
+  category's weight for the rest of the session.
+- R4: Window title, hashed or whitelisted, **default off**. The schema already
+  reserves prev_app and window_title; this is the highest-privacy-cost item in the
+  batch, which is why it ships disabled.
+- R5: Wi-Fi place buckets (SSID / gateway MAC) as the compromise for location. Real
+  geolocation stays parked — it is the only candidate signal that would leave the
+  on-device rule, and needs its own task if it is ever revived.
+- R6: Depends on R1's sourceId identity fix and on R2's exposure metrics; neither
+  substitute is acceptable, because without them the learned weights train on the
+  broken identity.
 
 ## Acceptance Criteria
 
-- [ ] TBD
+- [ ] Every signal in this pack has a settings toggle and enters the
+      `unavailableSignals` system; window title is off by default.
+- [ ] Unit tests cover three states per signal: available, unavailable, toggle off.
+- [ ] hit-rate@k (the R2 metric) shows no significant regression, and the exposure
+      side of that metric is populated rather than assumed.
+- [ ] No raw window title or SSID is persisted — only hashes or bucket ids.
+- [ ] `research/reco-signals-audit.md` and the digest are updated.
 
 ## Notes
 

--- a/.trellis/tasks/08-05-reco-calendar-signal/prd.md
+++ b/.trellis/tasks/08-05-reco-calendar-signal/prd.md
@@ -6,11 +6,27 @@ R3d: EventKit native binding (tuff-native) + calendar permission registry id + i
 
 ## Requirements
 
-- TBD
+- R1: EventKit binding in `tuff-native` for calendar access.
+- R2: A calendar permission id in the permission registry. The registry carries 27
+  ids today and none of them covers calendar.
+- R3: Imminent event -> a "join meeting" candidate N minutes before it starts,
+  parsing Zoom / Google Meet / Tencent Meeting links out of the event itself.
+- R4: Post-meeting -> notes and minutes tools.
+- R5: Chinese holiday and make-up-workday calendar corrects `isWorkingHours`. The
+  make-up workday schedule needs built-in data; it cannot be derived from the date.
+- R6: Registers through the R3a substrate with its own settings toggle. Event content
+  is handled on-device and stored as hash or category, never raw event text.
 
 ## Acceptance Criteria
 
-- [ ] TBD
+- [ ] The calendar signal has a settings toggle and enters the `unavailableSignals`
+      system, including the case where calendar permission is denied.
+- [ ] Unit tests cover three states: available, unavailable (permission denied or no
+      EventKit), toggle off.
+- [ ] hit-rate@k (the R2 metric) shows no significant regression.
+- [ ] The new permission id appears in the permission registry, and denying it leaves
+      the rest of the recommendation path working.
+- [ ] `research/reco-signals-audit.md` and the digest are updated.
 
 ## Notes
 

--- a/.trellis/tasks/08-05-reco-file-activity-signals/prd.md
+++ b/.trellis/tasks/08-05-reco-file-activity-signals/prd.md
@@ -6,11 +6,26 @@ R3c: recent downloads/new screenshots (reuse file watcher event stream), active 
 
 ## Requirements
 
-- TBD
+- R1: Recent downloads and new screenshots. A new file in Downloads points at open /
+  move / share; a screenshot on the Desktop points at annotation.
+- R2: Active project directories, clustered by mtime, point at the matching IDE or
+  terminal.
+- R3: Clipboard pattern detection. Consecutive copies of the same type point at batch
+  tools and at pinning clipboard history.
+- R4: All three reuse the existing file-index watcher event stream rather than adding
+  a second watcher.
+- R5: Each registers through the R3a substrate with its own settings toggle. Content
+  is stored as hash or category only, never raw, per the privacy tiering precondition.
 
 ## Acceptance Criteria
 
-- [ ] TBD
+- [ ] Every signal in this pack has a settings toggle and enters the
+      `unavailableSignals` system.
+- [ ] Unit tests cover three states per signal: available, unavailable, toggle off.
+- [ ] hit-rate@k (the R2 metric) shows no significant regression.
+- [ ] No second filesystem watcher is introduced; the existing event stream is the
+      only source.
+- [ ] `research/reco-signals-audit.md` and the digest are updated.
 
 ## Notes
 

--- a/.trellis/tasks/08-05-reco-signal-substrate/prd.md
+++ b/.trellis/tasks/08-05-reco-signal-substrate/prd.md
@@ -6,11 +6,31 @@ R3a: unified signal collector registry (descriptor: id/settingKey/ttl/collect, e
 
 ## Requirements
 
-- TBD
+- R1: A collector registry with one descriptor per signal — `id`, `settingKey`,
+  `ttl`, `collect` — supporting both event-driven and snapshot collection, so that
+  20+ signals stay maintainable.
+- R2: Availability tracking is part of the descriptor: every signal reports into the
+  existing `unavailableSignals` set rather than silently returning nothing.
+- R3: The 8 existing signals migrate onto the registry.
+  `ContextProvider.getCurrentContext` (`context-provider.ts:54`) becomes a consumer
+  of the registry instead of the place collection is written.
+- R4: An audio-route signal (headphones/AirPods connected -> music / podcast /
+  meeting apps) replaces the dead bluetooth signal, which is removed together with
+  its settings toggle.
+- R5: Each signal carries its own settings toggle, per the first of the three
+  preconditions in `reco-signals-audit.md` (privacy tiering: on-device only, content
+  stored as hash or category).
 
 ## Acceptance Criteria
 
-- [ ] TBD
+- [ ] Every signal reached through the substrate has a settings toggle and reports
+      into `unavailableSignals`.
+- [ ] Unit tests cover three states per signal: available, unavailable, toggle off.
+- [ ] hit-rate@k (the R2 metric) shows no significant regression after the 8 signals
+      are migrated.
+- [ ] The bluetooth signal and its settings toggle are both gone — no dead toggle is
+      left in the settings UI.
+- [ ] `research/reco-signals-audit.md` and the digest are updated.
 
 ## Notes
 

--- a/.trellis/tasks/08-05-reco-system-state-signals/prd.md
+++ b/.trellis/tasks/08-05-reco-system-state-signals/prd.md
@@ -6,11 +6,33 @@ R3b: display/dock state, wake/boot/idle-return, charging transitions, external v
 
 ## Requirements
 
-- TBD
+- R1: External display / dock state. Connected reads as desk mode (weight IDE and
+  design apps); disconnected reads as mobile mode.
+- R2: Wake, boot, and return-from-long-idle. Distinguishes a morning routine from a
+  late-night session.
+- R3: Charging transition edge. Battery level is already collected; the missing part
+  is the transition itself — just-plugged-in together with an external display reads
+  as sitting down to work.
+- R4: External volume mount. A USB drive appearing points at file management and
+  backup actions, plus recent files on that volume.
+- R5: IME / input-source switch. A Chinese IME in the foreground slightly favours
+  Chinese-content applications.
+- R6 (stretch): Microphone or camera in use — in a meeting, so do-not-disturb actions
+  and screen-recording tools. The API boundary is explored before this is committed
+  to, per the audit's note.
+- R7: All of the above come from Electron `powerMonitor` / `screen` plus light native
+  commands, register through the R3a substrate, are individually settings-gated, and
+  compute on-device only.
 
 ## Acceptance Criteria
 
-- [ ] TBD
+- [ ] Every signal in this pack has a settings toggle and enters the
+      `unavailableSignals` system.
+- [ ] Unit tests cover three states per signal: available, unavailable, toggle off.
+- [ ] hit-rate@k (the R2 metric) shows no significant regression.
+- [ ] No signal here requires a permission the permission registry does not already
+      carry; anything that would is deferred rather than added quietly.
+- [ ] `research/reco-signals-audit.md` and the digest are updated.
 
 ## Notes
 


### PR DESCRIPTION
Closes #1254.

`Documentation Quality` has been red on **every** app-shell-v2 PR, including PRs touching no documentation at all. The count went `142 → 54 → 15` as the rule-level causes were fixed (#1585, #1651). The last 15 were content rather than rules, and all of them sat in five files:

| code | n | what |
|---|---|---|
| `DOC-PRD-EMPTY-SECTION` | 5 | `## Acceptance Criteria` holding only `- [ ] TBD` |
| `DOC-PRD-PLACEHOLDER` | 10 | that TBD, and the one under `## Requirements` |

**`docs:verify` now passes.**

## The relaxation that looked right and wasn't

The obvious move was the one that worked for `DOC-TASK-META` in #1651: exempt `planning` tasks, on the argument that a task still being planned has not written its requirements yet.

The numbers say otherwise. **28 of the 53 tasks are `planning`, and 23 of those 28 already satisfy this rule.** These five are outliers, not a category — and exempting planning would have dropped the rule's coverage from 53 files to 25 in order to accommodate five. Same shape as #1651, opposite answer, and the data is what separates them.

## Nothing here is invented

Every requirement traces to material the owner already wrote, in `research/reco-signal-program.md` (headed *"2026-08-06 用户批准「都做，本地数据处理」"*) and `research/reco-signals-audit.md`, both under the parent task `08-05-search-audit-remediation`:

- **Requirements** — the signal→task mapping table, plus each task's own Goal paragraph, which already enumerated the work in prose. The five Goals were substantive; only the sections below them were stubs.
- **Acceptance Criteria** — the `验收基线` block, which states four conditions every R3x task must meet: a settings toggle plus entry into `unavailableSignals`; unit tests across available / unavailable / toggle-off; no significant hit-rate@k regression; research docs updated.

Per-task criteria beyond those four come from the same sources — the calendar permission id from the audit's note that the registry's 27 ids include none for calendar; the "no second watcher" line from R3c reusing the existing file-index event stream; window title shipping off by default from the privacy-tiering precondition.

If any line misreads the intent, it is a transcription error worth correcting in place rather than a decision I made.

## Positive-controlled, not just observed to pass

A gate that has just gone green is exactly when it is worth checking it can still go red:

```
put one TBD back               shown 1/1; DOC-PRD-PLACEHOLDER=1
empty an Acceptance Criteria   shown 1/1; DOC-PRD-EMPTY-SECTION=1
restored                       docs:verify passed
```

Run with **CI's own command**, `mise run docs:verify`, not an equivalent. `scripts/docs.test.mjs` 21 passed.

Closes #1254