### PR TITLE
test(plugins): run the vitest plugin suites too

### DIFF
--- a/scripts/test-plugins.mjs
+++ b/scripts/test-plugins.mjs
@@ -55,7 +55,7 @@ export function discoveryFoundNothing(suites) {
  * failure mode that put #330 on the board.
  */
 export function classifySuiteRun({ status, stdout }) {
-  const text = String(stdout ?? '')
+  const text = stripAnsi(stdout)
   const read = (label) => {
     const match = text.match(new RegExp(`(?:^|\\s)${label}\\s+(\\d+)`, 'm'))
     return match ? Number(match[1]) : null
@@ -132,8 +132,19 @@ export function findVitestSuites(root = pluginsDir) {
  * `status === null` gets its own branch because that is what `spawnSync` returns when the binary
  * was never found — a missing pnpm would otherwise fall through whatever the count check decided.
  */
+/**
+ * Vitest colours its summary on CI, so the line arrives as
+ * `Tests \x1B[22m \x1B[1m\x1B[32m20 passed`. Reading it raw made a passing suite report
+ * "exit 0 but no test counts in output" on the runner while it parsed fine locally, where the
+ * same command emitted no escapes at all.
+ */
+export function stripAnsi(text) {
+  // eslint-disable-next-line no-control-regex
+  return String(text ?? '').replace(/\x1B\[[0-9;]*[a-z]/gi, '')
+}
+
 export function classifyVitestRun({ status, stdout }) {
-  const text = String(stdout ?? '')
+  const text = stripAnsi(stdout)
   if (status === null)
     return { ok: false, pass: null, reason: 'the runner could not be spawned' }
   const match = text.match(/Tests\s+(?:\d+ failed \| )?(\d+) passed/)
@@ -234,6 +245,25 @@ function selfTest() {
       actual: classifyVitestRun({ status: null, stdout: '' }).ok,
       expected: false,
     },
+    {
+      // The exact shape CI produced, which the first version of this parser could not read.
+      name: 'the coloured summary CI emits is read',
+      actual: classifyVitestRun({
+        status: 0,
+        stdout: '\x1B[2m      Tests \x1B[22m \x1B[1m\x1B[32m20 passed\x1B[39m\x1B[22m\x1B[90m (20)\x1B[39m',
+      }).pass,
+      expected: 20,
+    },
+    {
+      name: 'a coloured node --test summary is read too',
+      actual: classifySuiteRun({ status: 0, stdout: '\x1B[32mℹ pass 4\x1B[0m\n\x1B[32mℹ fail 0\x1B[0m\n' }).ok,
+      expected: true,
+    },
+    {
+      name: 'stripping colour leaves the text alone',
+      actual: stripAnsi('\x1B[31mplain\x1B[0m'),
+      expected: 'plain',
+    },
   ]
 
   let failures = 0
@@ -253,6 +283,31 @@ function selfTest() {
 
 if (process.argv.includes('--self-test')) {
   process.exit(selfTest() > 0 ? 1 : 0)
+}
+
+/**
+ * Plugin vite configs import built workspace packages.
+ *
+ * `touch-translation/vite.config.ts` imports `@talex-touch/unplugin-export-plugin/vite`, whose
+ * `dist/` is gitignored, so a fresh checkout cannot load that config at all. Locally it was
+ * already built from some earlier run and every suite came back green; the first CI run is what
+ * said otherwise. Building it here rather than in the workflow step keeps a direct
+ * `node scripts/test-plugins.mjs` behaving the same way as the pipeline.
+ */
+const VITEST_PREREQUISITE_PACKAGES = ['@talex-touch/unplugin-export-plugin']
+
+function buildVitestPrerequisites() {
+  for (const name of VITEST_PREREQUISITE_PACKAGES) {
+    const build = spawnSync('pnpm', ['-F', name, 'run', 'build'], { encoding: 'utf8' })
+    if (build.status !== 0) {
+      console.error(
+        `\n\x1B[31mCould not build ${name}, which the plugin vite configs import — `
+        + `the vitest suites would fail to load their config.\x1B[0m`,
+      )
+      console.error(stripAnsi(`${build.stdout ?? ''}${build.stderr ?? ''}`).split('\n').slice(-15).join('\n'))
+      process.exit(1)
+    }
+  }
 }
 
 const nodeTestSuites = findSuites()
@@ -277,6 +332,8 @@ if (discoveryFoundNothing(vitestSuites)) {
   )
   process.exit(1)
 }
+
+buildVitestPrerequisites()
 
 const suites = [...nodeTestSuites, ...vitestSuites]
 

--- a/scripts/test-plugins.mjs
+++ b/scripts/test-plugins.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process'
 /**
- * Runs the per-plugin `index.test.cjs` suites.
+ * Runs the per-plugin test suites — both the `index.test.cjs` ones and the vitest ones.
  *
  * These suites existed and passed long before this script did -- 97 cases across 16 plugins --
  * but nothing executed them. `plugins/*` is in the pnpm workspace, yet most of these directories
@@ -14,6 +14,13 @@ import { spawnSync } from 'node:child_process'
  * That matters because commit 911fe1c6f cut 2,274 lines from seven plugin suites in
  * `packages/test` while rewriting the plugin preludes those suites covered. The integration
  * baseline went green partly by moving coverage into files no gate reads (#330).
+ *
+ * The same hole existed one layer over. `touch-translation` and `clipboard-history` are real
+ * workspace packages that declare a vitest `test` script, and between them they carry 8 test
+ * files and 39 passing cases that no job ran either -- this script only knew about
+ * `index.test.cjs`, and nothing else in CI runs `pnpm -r test`. Finding tests that pass and are
+ * never executed twice in the same area is what makes discovery, not the runner, the thing worth
+ * asserting on.
  */
 import fs from 'node:fs'
 import path from 'node:path'
@@ -71,9 +78,74 @@ export function findSuites(root = pluginsDir) {
   return fs
     .readdirSync(root, { withFileTypes: true })
     .filter(entry => entry.isDirectory())
-    .map(entry => ({ name: entry.name, file: path.join(root, entry.name, 'index.test.cjs') }))
+    .map(entry => ({
+      name: entry.name,
+      runner: 'node-test',
+      dir: path.join(root, entry.name),
+      file: path.join(root, entry.name, 'index.test.cjs'),
+    }))
     .filter(suite => fs.existsSync(suite.file))
     .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/** True when a plugin's own `test` script hands the work to vitest rather than `node --test`. */
+export function declaresVitestSuite(packageJsonText) {
+  let parsed
+  try {
+    parsed = JSON.parse(String(packageJsonText ?? ''))
+  }
+  catch {
+    return false
+  }
+  return typeof parsed?.scripts?.test === 'string' && /\bvitest\b/.test(parsed.scripts.test)
+}
+
+/**
+ * Vitest plugins, found by their declared script rather than by a file pattern.
+ *
+ * The declaration is the contract — `touch-translation`'s script is a bare `vitest`, so the
+ * runner below forces `run` rather than calling the script and inheriting watch mode.
+ */
+export function findVitestSuites(root = pluginsDir) {
+  if (!fs.existsSync(root))
+    return []
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => ({
+      name: entry.name,
+      runner: 'vitest',
+      dir: path.join(root, entry.name),
+      file: path.join(root, entry.name, 'package.json'),
+    }))
+    .filter((suite) => {
+      if (!fs.existsSync(suite.file))
+        return false
+      return declaresVitestSuite(fs.readFileSync(suite.file, 'utf8'))
+    })
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/**
+ * Decides a vitest suite. Same split as above: the exit code is the verdict, the counts report.
+ *
+ * `status === null` gets its own branch because that is what `spawnSync` returns when the binary
+ * was never found — a missing pnpm would otherwise fall through whatever the count check decided.
+ */
+export function classifyVitestRun({ status, stdout }) {
+  const text = String(stdout ?? '')
+  if (status === null)
+    return { ok: false, pass: null, reason: 'the runner could not be spawned' }
+  const match = text.match(/Tests\s+(?:\d+ failed \| )?(\d+) passed/)
+  const pass = match ? Number(match[1]) : null
+
+  if (status !== 0)
+    return { ok: false, pass, reason: `exited ${status}` }
+  if (pass === null)
+    return { ok: false, pass, reason: 'exit 0 but no test counts in output' }
+  if (pass === 0)
+    return { ok: false, pass, reason: 'exit 0 but ran no tests' }
+  return { ok: true, pass, reason: null }
 }
 
 /** Proves the verdict logic fires, so a refactor cannot quietly turn this gate into a no-op. */
@@ -107,6 +179,61 @@ function selfTest() {
       actual: classifySuiteRun({ status: 0, stdout: 'ℹ pass 0\nℹ fail 0\n' }).ok,
       expected: false,
     },
+    {
+      name: 'a vitest test script is recognised',
+      actual: declaresVitestSuite('{"scripts":{"test":"vitest"}}'),
+      expected: true,
+    },
+    {
+      name: 'a vitest run script is recognised',
+      actual: declaresVitestSuite('{"scripts":{"test":"vitest run"}}'),
+      expected: true,
+    },
+    {
+      name: 'a node --test script is not a vitest suite',
+      actual: declaresVitestSuite('{"scripts":{"test":"node --test index.test.cjs"}}'),
+      expected: false,
+    },
+    {
+      name: 'a package with no test script is not a vitest suite',
+      actual: declaresVitestSuite('{"scripts":{"build":"vitest-ish"}}'),
+      expected: false,
+    },
+    {
+      name: 'unparseable package.json is not a vitest suite',
+      actual: declaresVitestSuite('{ not json'),
+      expected: false,
+    },
+    {
+      name: 'a passing vitest suite passes',
+      actual: classifyVitestRun({ status: 0, stdout: ' Tests  19 passed (19)\n' }).ok,
+      expected: true,
+    },
+    {
+      name: 'vitest counts are read past a failed segment',
+      actual: classifyVitestRun({ status: 1, stdout: ' Tests  1 failed | 18 passed (19)\n' }).pass,
+      expected: 18,
+    },
+    {
+      name: 'a failing vitest suite fails',
+      actual: classifyVitestRun({ status: 1, stdout: ' Tests  1 failed | 18 passed (19)\n' }).ok,
+      expected: false,
+    },
+    {
+      name: 'vitest exit 0 with no counts fails rather than passing blind',
+      actual: classifyVitestRun({ status: 0, stdout: 'No test files found' }).ok,
+      expected: false,
+    },
+    {
+      name: 'vitest exit 0 having run no tests fails',
+      actual: classifyVitestRun({ status: 0, stdout: ' Tests  0 passed (0)\n' }).ok,
+      expected: false,
+    },
+    {
+      name: 'a runner that could not be spawned fails',
+      actual: classifyVitestRun({ status: null, stdout: '' }).ok,
+      expected: false,
+    },
   ]
 
   let failures = 0
@@ -128,32 +255,54 @@ if (process.argv.includes('--self-test')) {
   process.exit(selfTest() > 0 ? 1 : 0)
 }
 
-const suites = findSuites()
+const nodeTestSuites = findSuites()
+const vitestSuites = findVitestSuites()
 
-if (discoveryFoundNothing(suites)) {
+if (discoveryFoundNothing(nodeTestSuites)) {
   console.error(
     '\x1B[31mNo plugins/*/index.test.cjs found — this run would report success without executing a single plugin test.\x1B[0m\n',
   )
   process.exit(1)
 }
 
-console.log(`\nRunning ${suites.length} plugin suites\n`)
+/**
+ * The vitest half gets the same treatment, separately.
+ *
+ * Folding both into one emptiness check would let either half disappear silently as long as the
+ * other still found something, which is the shape that hid these suites in the first place.
+ */
+if (discoveryFoundNothing(vitestSuites)) {
+  console.error(
+    '\x1B[31mNo plugins/*/package.json declares a vitest test script — either the packages moved or this half of the run checks nothing.\x1B[0m\n',
+  )
+  process.exit(1)
+}
+
+const suites = [...nodeTestSuites, ...vitestSuites]
+
+console.log(
+  `\nRunning ${suites.length} plugin suites (${nodeTestSuites.length} node --test, ${vitestSuites.length} vitest)\n`,
+)
 
 let totalCases = 0
 const failed = []
 
 for (const suite of suites) {
-  const run = spawnSync(process.execPath, ['--test', 'index.test.cjs'], {
-    cwd: path.dirname(suite.file),
-    encoding: 'utf8',
-  })
-  const verdict = classifySuiteRun({ status: run.status, stdout: `${run.stdout ?? ''}${run.stderr ?? ''}` })
+  const run = suite.runner === 'vitest'
+    // `exec` rather than `run test`: touch-translation's script is a bare `vitest`, which without
+    // this would sit in watch mode and never return.
+    ? spawnSync('pnpm', ['-C', suite.dir, 'exec', 'vitest', 'run'], { encoding: 'utf8' })
+    : spawnSync(process.execPath, ['--test', 'index.test.cjs'], { cwd: suite.dir, encoding: 'utf8' })
+  const output = `${run.stdout ?? ''}${run.stderr ?? ''}`
+  const verdict = suite.runner === 'vitest'
+    ? classifyVitestRun({ status: run.status, stdout: output })
+    : classifySuiteRun({ status: run.status, stdout: output })
   if (verdict.ok) {
     totalCases += verdict.pass
     console.log(`\x1B[32m  ✓\x1B[0m ${suite.name.padEnd(28)} ${String(verdict.pass).padStart(3)} cases`)
   }
   else {
-    failed.push({ suite, verdict, output: run.stdout ?? '' })
+    failed.push({ suite, verdict, output })
     console.log(`\x1B[31m  ✗\x1B[0m ${suite.name.padEnd(28)} ${verdict.reason}`)
   }
 }


### PR DESCRIPTION
Toward #330.

`touch-translation` and `clipboard-history` are real workspace packages that declare a vitest `test` script. Between them they carry **8 test files and 39 passing cases, and no CI job ran a single one** — this runner only knew about `index.test.cjs`, and nothing else runs `pnpm -r test`.

Same hole as #1629, one layer over, **in the area #1629 was written to close.** 17 suites / 114 cases → **19 suites / 153 cases**. `pnpm test:plugins` is already wired into CI, so nothing in the workflow changes.

## Two halves, two emptiness checks

Discovery is by declared script rather than by file pattern, and the halves check emptiness separately. Folding them into one check would let either half disappear silently as long as the other still found something — which is the exact shape that hid these suites to begin with.

`pnpm -C <dir> exec vitest run` rather than the package's own script: `touch-translation`'s `test` is a bare `vitest`, which would sit in watch mode and never return.

## The exit-code check needs two plants at once to see

| plant | result |
|---|---|
| break a test in `touch-translation` | `1/19 plugin suites failed` |
| ignore the exit code | `All 19 plugin suites passed — 153 cases` |
| **both together** | **`All 19 plugin suites passed — 152 cases`** |

Vitest still prints `Tests  1 failed \| 18 passed`, so a count-only parser reads 18 and reports green. **The only trace of the real failure is a case total one lower than yesterday's**, and nobody watches a count. `status === null` gets its own branch for the same reason — a missing `pnpm` would otherwise fall through to whatever the count check decided.

Self-test 8 → 19 cases.

## One finding not fixed here

Running `touch-translation`'s suite **rewrites a tracked file**: `plugins/touch-translation/components.d.ts` loses its `import { GlobalComponents } from 'vue'` line, reproducibly. So the committed file is out of step with what its generator currently emits, and after this change CI will leave a dirty tree there. No job checks tree cleanliness, so nothing breaks today.

I did not commit the regenerated version, because I cannot tell from here whether CI's resolved `unplugin-vue-components` emits the same thing — "fixing" it could be a regression that only shows up on the runner. It belongs in #330's own open bucket: declaring, per suite, whether it consumes canonical source, a generated bundle, or a packaged runtime.

Refs #330