### PR TITLE
fix(types): clear the implicit-any tail down to four blockers (#548)

### DIFF
--- a/apps/core-app/generator-information.ts
+++ b/apps/core-app/generator-information.ts
@@ -100,7 +100,7 @@ export default function generatorInformation(): Plugin {
   const virtualModuleId = 'talex-touch:information'
   const resolvedVirtualModuleId = `\0${virtualModuleId}`
 
-  let config
+  let config: { command: string } | undefined
 
   return {
     enforce: 'pre',
@@ -130,7 +130,7 @@ export default function generatorInformation(): Plugin {
     load(id) {
       if (id !== resolvedVirtualModuleId) return
 
-      const devMode = config.command === 'serve'
+      const devMode = config?.command === 'serve'
 
       // 开发模式：实时生成构建信息
       if (devMode) {

--- a/apps/core-app/src/main/channel/common.test.ts
+++ b/apps/core-app/src/main/channel/common.test.ts
@@ -126,7 +126,9 @@ vi.mock('node:fs', () => ({
 }))
 
 vi.mock('node:child_process', () => {
-  execFileMock[Symbol.for('nodejs.util.promisify.custom')] = (command: string, args: string[]) =>
+  ;(execFileMock as unknown as Record<symbol, unknown>)[
+    Symbol.for('nodejs.util.promisify.custom')
+  ] = (command: string, args: string[]) =>
     new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
       execFileMock(command, args, {}, (error: Error | null, stdout = '', stderr = '') => {
         if (error) {

--- a/apps/core-app/src/main/modules/ai/intelligence-sdk.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-sdk.test.ts
@@ -2298,7 +2298,9 @@ describe('tuffIntelligenceSDK invoke', () => {
     ])
     expect(chat).toHaveBeenCalledOnce()
     const [chatPayload] = chat.mock.calls[0] ?? []
-    const prompt = chatPayload.messages.map(({ content }) => content).join('\n')
+    const prompt = chatPayload.messages
+      .map(({ content }: { content: string }) => content)
+      .join('\n')
     expect(prompt).toContain('Compatibility windows reject remote URLs.')
     expect(prompt).not.toContain('The indexing runtime owns durable search mutations.')
     expect(result.result.answer).toBe('Compatibility windows reject remote URLs.')

--- a/apps/core-app/src/main/modules/box-tool/addon/files/services/file-provider-full-scan-insert-service.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/services/file-provider-full-scan-insert-service.test.ts
@@ -28,7 +28,7 @@ describe('file-provider-full-scan-insert-service', () => {
       }
     ]
     const inserted = records.map((record, index) => ({ ...record, id: index + 1 }))
-    const upsertFiles = vi.fn(async (chunk) =>
+    const upsertFiles = vi.fn(async (chunk: Array<{ path: string }>) =>
       inserted.filter((record) => chunk.some((item) => item.path === record.path))
     )
     const emitRecordBatch = vi.fn(async () => {})

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.trace.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.trace.test.ts
@@ -640,7 +640,9 @@ describe('search-core search-trace', () => {
     const diagnostics = await handler()
 
     expect(diagnostics.summary.total).toBe(5)
-    expect(diagnostics.sources.map((source) => source.descriptor.id)).toEqual([
+    expect(
+      diagnostics.sources.map((source: { descriptor: { id: string } }) => source.descriptor.id)
+    ).toEqual([
       'app-provider',
       'file-provider',
       'everything-provider',

--- a/apps/core-app/src/main/modules/native-capabilities/native-screenshot-macos.integration.test.ts
+++ b/apps/core-app/src/main/modules/native-capabilities/native-screenshot-macos.integration.test.ts
@@ -245,10 +245,17 @@ describe('nativeTransport real macOS screenshot integration', () => {
         expect(first.done).toBe(false)
         expect(first.value.value.pixelFormat).toBe('bgra8-premultiplied')
         expect(first.value.value.stride).toBe(first.value.value.width * 4)
-        expect(first.value.attachments.reduce((total, part) => total + part.length, 0)).toBe(
-          first.value.value.stride * first.value.value.height
-        )
-        expect(first.value.attachments.every((part) => part.length <= 32 * 1024 * 1024)).toBe(true)
+        expect(
+          first.value.attachments.reduce(
+            (total: number, part: { length: number }) => total + part.length,
+            0
+          )
+        ).toBe(first.value.value.stride * first.value.value.height)
+        expect(
+          first.value.attachments.every(
+            (part: { length: number }) => part.length <= 32 * 1024 * 1024
+          )
+        ).toBe(true)
         await iterator.return?.()
         expect((await frames.closed).kind).toBe('cancelled')
 

--- a/apps/core-app/src/main/modules/plugin/host/official-plugin-prelude-simple.test.ts
+++ b/apps/core-app/src/main/modules/plugin/host/official-plugin-prelude-simple.test.ts
@@ -996,7 +996,9 @@ describe('official simple Prelude isolation regression', () => {
     ).resolves.toBe(true)
     expect(first.state.windowPresetStatusCalls).toBe(1)
     const devPreset = first.state.items.find(
-      (item) => item.actions?.[0]?.payload?.actionId === 'preset-dev-split'
+      (item) =>
+        (item.actions as Array<{ payload?: { actionId?: string } }> | undefined)?.[0]?.payload
+          ?.actionId === 'preset-dev-split'
     )
     expect(devPreset).toBeDefined()
 
@@ -1020,7 +1022,9 @@ describe('official simple Prelude isolation regression', () => {
       { id: 'window-presets' }
     ]).promise
     const clearPreset = second.state.items.find(
-      (item) => item.actions?.[0]?.payload?.actionId === 'preset-clear-topmost'
+      (item) =>
+        (item.actions as Array<{ payload?: { actionId?: string } }> | undefined)?.[0]?.payload
+          ?.actionId === 'preset-clear-topmost'
     )
     await expect(
       second.runtime.callLifecycle('onItemAction', [clearPreset, { actionId: 'run-action' }])

--- a/apps/core-app/src/main/modules/plugin/host/plugin-host-resources.test.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-host-resources.test.ts
@@ -496,7 +496,7 @@ describe('PluginHostChildResourceClient', () => {
       owner,
       session,
       allocateRequestId: () => ++requestId,
-      postMessage: (message) => sent.push(message),
+      postMessage: (message: HostWireMessage) => sent.push(message),
       onFatalViolation: vi.fn(),
       onDisposed: disposed,
       maxResources: 64,

--- a/apps/core-app/src/main/modules/plugin/host/plugin-host-session.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-host-session.ts
@@ -376,7 +376,11 @@ export class PluginHostSession {
   ): HostWireMessage {
     const key = 'payload' in message ? 'payload' : 'result' in message ? 'result' : undefined
     if (!key) return message
-    const value = message[key]
+    // Read through the same `in` narrowing that produced `key`, rather than indexing by it.
+    // HostWireMessage is a union without an index signature, so `message[key]` was an implicit
+    // any even though `key` is already narrowed to 'payload' | 'result' (#548).
+    const value =
+      'payload' in message ? message.payload : 'result' in message ? message.result : undefined
     const context: PluginHostWireValueContext = Object.freeze({
       direction,
       messageType: message.type,

--- a/apps/core-app/src/main/modules/system/active-app.test.ts
+++ b/apps/core-app/src/main/modules/system/active-app.test.ts
@@ -30,7 +30,8 @@ const {
 
 vi.mock('node:child_process', () => {
   const execFile = vi.fn()
-  execFile[Symbol.for('nodejs.util.promisify.custom')] = execFilePromiseMock
+  ;(execFile as unknown as Record<symbol, unknown>)[Symbol.for('nodejs.util.promisify.custom')] =
+    execFilePromiseMock
   return { execFile }
 })
 

--- a/scripts/check-implicit-any-debt.mjs
+++ b/scripts/check-implicit-any-debt.mjs
@@ -34,7 +34,7 @@ const CORE_APP = path.join(REPO_ROOT, 'apps/core-app')
  * only -- every error the flag produces is in that range, so a rise here is new untyped code and
  * not some unrelated type break.
  */
-export const KNOWN_IMPLICIT_ANY_ERRORS = 19
+export const KNOWN_IMPLICIT_ANY_ERRORS = 5
 
 /** Resolves the workspace's own tsc rather than trusting a .bin shim on PATH. */
 function resolveTsc() {


### PR DESCRIPTION
Toward #548. Eighth batch: **19 → 5**, and every remaining one is explained.

## The experiment the previous seven batches never ran

I criticised my own approach on the issue: seven PRs spent lowering a hand-maintained counter, while nobody checked whether the switch that counter exists to measure could simply be turned on. So I checked. Adding `"noImplicitAny": true` to `tsconfig.node.json` and running `tsc` **without** the command-line flag reports:

```
错误总数:      19
其中 TS7xxx:   19
非 TS7xxx:      0
```

Identical to what the ratchet measures via the flag. **The `@electron-toolkit` inheritance chain drags in no other strict option** — the fear that flipping it would explode into hundreds is unfounded. So the switch can be flipped as soon as the count hits zero, and the ratchet retired with it. The experiment cost five minutes.

## Fixed here

Symbol-keyed assignment onto two `vi.fn()` mocks; a `HostWireMessage` read that indexed by an already-narrowed key instead of reading through the same `in` checks that produced it; `let config` in the information plugin, inferred from a later assignment and read before it; and six test callbacks whose arrays lost their element type upstream.

## The five that remain

**`plugin.ts:3017` (3)** casts a transport send with `as ITuffTransport['send']`. Declaring the arrow with that type instead fails `TS2322` because the signature is generic — a plain arrow cannot satisfy it. The cast is deliberate and stays.

**`file-provider-opener-service.ts` (1)** needs `@types/plist`. `plist ^3.1.0` is a declared dependency; its types are not. `pnpm -C apps/core-app add` is blocked by that package's own `.npmrc` setting `shamefully-hoist=true`, which conflicts with the root install, and two attempts at a root install hung resolving the package while a concurrent session held this worktree. This one needs a quiet moment, not a code change.

**`ai-orchestrator-store.test.ts` (1)** is a self-referential object literal (`TS7022`) that needs restructuring rather than an annotation.

## A correction to my own earlier reporting

The per-file breakdowns I posted in previous batches matched paths on `^src/`, so `generator-information.ts` never appeared in them. It was always counted in the totals — **those numbers were right** — but the file lists under-reported by two.

## Verification

Ratchet 19 → 5, both directions: `4` fails, `6` fails, `5` passes. Non-TS7xxx stayed at 0 throughout. 59 test files / 921 tests pass across every suite touched.

Running total: **227 → 5**, 222 errors across eight PRs.
