### PR TITLE
ci(tests): fail when a test file no job executes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,14 @@ jobs:
       # so pnpm -r never reaches them, and the App suites matrix is [core-app, nexus]. Commit
       # 911fe1c6f cut 2,274 lines from seven plugin suites in packages/test while rewriting the
       # preludes they covered, which is how that baseline went green (#330).
+      # Three times in a month someone found test files that no job executed -- 623 core-app and
+      # 180 nexus (#924), 16 plugin suites (#1629), 8 vitest files in two plugin packages (#1670).
+      # All of them had been passing throughout, which is why nothing complained: a test that never
+      # runs looks exactly like a test that always passes. This is a directory walk and a set
+      # difference, so it does not need to wait for the next person who thinks to count (#330).
+      - name: Check for orphan test files
+        run: pnpm check:orphan-tests && pnpm check:orphan-tests:self-test
+
       - name: Run plugin suites
         run: pnpm test:plugins && pnpm test:plugins:self-test
 

--- a/.github/workflows/package-intelligence-uikit-ci.yml
+++ b/.github/workflows/package-intelligence-uikit-ci.yml
@@ -27,7 +27,11 @@ jobs:
       package-name: intelligence-uikit
       package-path: packages/intelligence-uikit
       run-typecheck: true
-      typecheck-command: pnpm typecheck
+      # tuffex's exports map resolves only into dist/, so without a build every
+      # `@talex-touch/tuffex/*` import is TS2307 -- the same reason ci.yml builds tuffex before the
+      # nexus suite. package-ci.yml runs typecheck first and has no pre-step hook, so the build
+      # goes in the command.
+      typecheck-command: pnpm -F @talex-touch/tuffex build && pnpm typecheck
       run-lint: true
       lint-command: pnpm lint
       run-test: true

--- a/.github/workflows/package-intelligence-uikit-ci.yml
+++ b/.github/workflows/package-intelligence-uikit-ci.yml
@@ -1,0 +1,35 @@
+# Its 2 test files and 6 cases ran in no workflow at all. Every other package under `packages/`
+# that has tests has one of these; this one was simply never written, and the suite passed the
+# whole time, which is why nothing said so (#330).
+name: Intelligence UIKit CI
+
+on:
+  pull_request:
+    paths:
+      - "packages/intelligence-uikit/**"
+      - "packages/utils/**"
+      - ".github/workflows/package-intelligence-uikit-ci.yml"
+      - ".github/workflows/package-ci.yml"
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - "packages/intelligence-uikit/**"
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: ./.github/workflows/package-ci.yml
+    with:
+      package-name: intelligence-uikit
+      package-path: packages/intelligence-uikit
+      run-typecheck: true
+      typecheck-command: pnpm typecheck
+      run-lint: true
+      lint-command: pnpm lint
+      run-test: true
+      test-command: pnpm test
+      run-build: false

--- a/.github/workflows/package-pi-extension-ci.yml
+++ b/.github/workflows/package-pi-extension-ci.yml
@@ -1,0 +1,31 @@
+# Its single test file and 9 cases ran in no workflow at all (#330). The package declares no
+# lint, typecheck or build script, so this runs the one thing it does declare.
+name: Pi Extension Tuff CI
+
+on:
+  pull_request:
+    paths:
+      - "packages/pi-extension-tuff/**"
+      - ".github/workflows/package-pi-extension-ci.yml"
+      - ".github/workflows/package-ci.yml"
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - "packages/pi-extension-tuff/**"
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: ./.github/workflows/package-ci.yml
+    with:
+      package-name: pi-extension-tuff
+      package-path: packages/pi-extension-tuff
+      run-typecheck: false
+      run-lint: false
+      run-test: true
+      test-command: pnpm test
+      run-build: false

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "plugins:validate": "tsx scripts/validate-plugin-package-policy.ts && node scripts/validate-plugins.mjs",
     "plugins:validate:self-test": "node scripts/validate-plugins.mjs --self-test",
     "test:plugins": "node scripts/test-plugins.mjs",
+    "check:orphan-tests": "node scripts/check-orphan-tests.mjs",
+    "check:orphan-tests:self-test": "node scripts/check-orphan-tests.mjs --self-test",
     "test:plugins:self-test": "node scripts/test-plugins.mjs --self-test",
     "check:prod-audit": "node scripts/check-prod-audit.mjs",
     "check:prod-audit:self-test": "node scripts/check-prod-audit.mjs --self-test",

--- a/scripts/check-orphan-tests.mjs
+++ b/scripts/check-orphan-tests.mjs
@@ -1,0 +1,379 @@
+#!/usr/bin/env node
+/**
+ * Fails when a test file exists that no CI job executes.
+ *
+ * This is the third time the same defect has been found by hand in a month, each time by someone
+ * happening to count: #924 (623 core-app and 180 nexus files in no workflow), #1629 (16 plugin
+ * suites, 97 cases), #1670 (8 vitest files in two plugin packages, 39 cases). Every one of them
+ * had been passing the whole time, which is why nothing complained — a test that never runs looks
+ * exactly like a test that always passes.
+ *
+ * Finding them takes a directory walk and a set difference. Leaving that to whoever next thinks
+ * to look is the actual problem, so this asserts it on every PR.
+ *
+ * The map below is the whole design. Coverage is declared per directory, and each entry names the
+ * workflow and the command that runs it. The script checks the claim rather than trusting it: a
+ * declared runner whose workflow no longer contains that command fails, and so does a declared
+ * root with no test files under it. A map that can only be edited to add exemptions is a map that
+ * stops meaning anything within a month.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { findSuites, findVitestSuites } from './test-plugins.mjs'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+const SKIP_DIRECTORIES = new Set([
+  '.git',
+  '.nuxt',
+  '.output',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+])
+
+const TEST_FILE = /\.(?:test|spec)\.[cm]?[jt]sx?$/
+
+/**
+ * Directory -> the workflow command that runs its tests.
+ *
+ * `root` is matched as a path prefix, longest first, so a narrower entry can carve an exception
+ * out of a wider one. `workflow` and `command` are verified against the file on disk.
+ */
+export const COVERAGE = [
+  // `${{ matrix.app }}` is GitHub Actions syntax being matched literally, not a JS template.
+  /* eslint-disable no-template-curly-in-string */
+  {
+    root: 'apps/core-app',
+    workflow: '.github/workflows/ci.yml',
+    command: 'pnpm -C "apps/${{ matrix.app }}" exec vitest run',
+  },
+  {
+    root: 'apps/nexus',
+    workflow: '.github/workflows/ci.yml',
+    command: 'pnpm -C "apps/${{ matrix.app }}" exec vitest run',
+  },
+  /* eslint-enable no-template-curly-in-string */
+  {
+    root: 'packages/test',
+    workflow: '.github/workflows/ci.yml',
+    command: 'pnpm -C "packages/test" exec vitest run',
+  },
+  { root: 'packages/utils', workflow: '.github/workflows/package-utils-ci.yml', command: 'test-command: pnpm test' },
+  { root: 'packages/tuffex', workflow: '.github/workflows/package-tuffex-ci.yml', command: 'package-name: tuffex' },
+  { root: 'packages/tuff-cli', workflow: '.github/workflows/package-tuff-cli-ci.yml', command: 'test-command: pnpm test' },
+  { root: 'packages/tuff-cli-core', workflow: '.github/workflows/package-tuff-cli-ci.yml', command: 'test-command: pnpm test' },
+  {
+    root: 'packages/tuff-intelligence',
+    workflow: '.github/workflows/package-tuff-intelligence-ci.yml',
+    command: 'package-name: tuff-intelligence',
+  },
+  {
+    root: 'packages/unplugin-export-plugin',
+    workflow: '.github/workflows/package-unplugin-ci.yml',
+    command: 'test-command: pnpm test',
+  },
+  // Two Windows-only files under a package otherwise covered by the protocol runs below.
+  {
+    root: 'packages/tuff-native/everything-resources.test.js',
+    workflow: '.github/workflows/windows-everything-production.yml',
+    command: 'node --test scripts/everything-selfcheck.test.js everything-resources.test.js',
+  },
+  {
+    root: 'packages/tuff-native/scripts/everything-selfcheck.test.js',
+    workflow: '.github/workflows/windows-everything-production.yml',
+    command: 'node --test scripts/everything-selfcheck.test.js everything-resources.test.js',
+  },
+  {
+    root: 'packages/tuff-native',
+    workflow: '.github/workflows/native-protocol.yml',
+    command: 'pnpm -C packages/tuff-native run test:protocol',
+  },
+  {
+    root: 'packages/intelligence-uikit',
+    workflow: '.github/workflows/package-intelligence-uikit-ci.yml',
+    command: 'test-command: pnpm test',
+  },
+  {
+    root: 'packages/pi-extension-tuff',
+    workflow: '.github/workflows/package-pi-extension-ci.yml',
+    command: 'test-command: pnpm test',
+  },
+  { root: 'scripts', workflow: '.github/workflows/ci.yml', command: 'pnpm test:scripts' },
+  // Fixtures consumed by scripts/docs.test.mjs, not suites of their own.
+  { root: '.trellis/tasks', workflow: '.github/workflows/ci.yml', command: 'mise run docs:verify' },
+]
+
+/**
+ * Orphans that are known and not fixed here, each with the reason.
+ *
+ * This list ratchets in both directions. An entry naming a file that is no longer an orphan
+ * fails, so it cannot outlive the problem it describes -- an exemption list that can only be
+ * appended to is how a gate becomes decoration.
+ */
+export const KNOWN_ORPHANS = [
+  {
+    file: 'plugins/touch-music/src/components/music/word-lyric/WordLyricScroller.test.ts',
+    reason:
+      'The plugin declares no test script and the file cannot run: `Failed to resolve import '
+      + '"@vue/test-utils"`, which is not among its two devDependencies. Wiring it in means adding '
+      + 'a dependency and a script, which is a lockfile change and not this check\'s business. '
+      + 'Untouched since c6de5d63d (2026-07-12).',
+    issue: 330,
+  },
+]
+
+export function partitionKnown(orphans, known = KNOWN_ORPHANS) {
+  const knownFiles = new Set(known.map(entry => entry.file))
+  return {
+    unexpected: orphans.filter(file => !knownFiles.has(file)),
+    staleEntries: known.filter(entry => !orphans.includes(entry.file)).map(entry => entry.file),
+  }
+}
+
+/**
+ * Plugin coverage is asked of the runner, not declared.
+ *
+ * `pnpm test:plugins` reaches a plugin only if it ships `index.test.cjs` or declares a vitest
+ * `test` script. A blanket `plugins` entry in COVERAGE would call every plugin covered and hide
+ * exactly the case this check is for -- `plugins/touch-music` has one test file, no test script
+ * and no `index.test.cjs`, so nothing runs it, and a coarse entry said it was fine.
+ */
+export function pluginCoverage(root = repoRoot, discover = { findSuites, findVitestSuites }) {
+  const pluginsDir = path.join(root, 'plugins')
+  const covered = [...discover.findSuites(pluginsDir), ...discover.findVitestSuites(pluginsDir)]
+  return covered.map(suite => ({
+    root: `plugins/${suite.name}`,
+    workflow: '.github/workflows/ci.yml',
+    command: 'pnpm test:plugins',
+  }))
+}
+
+export function findTestFiles(root, skip = SKIP_DIRECTORIES) {
+  const found = []
+  const walk = (dir) => {
+    let entries
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    }
+    catch {
+      return
+    }
+    for (const entry of entries) {
+      if (skip.has(entry.name))
+        continue
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory())
+        walk(full)
+      else if (TEST_FILE.test(entry.name))
+        found.push(path.relative(root, full))
+    }
+  }
+  walk(root)
+  return found.sort()
+}
+
+/** Longest prefix wins, so a single-file entry can override the package it sits in. */
+export function coverageFor(file, coverage = COVERAGE) {
+  return [...coverage]
+    .sort((a, b) => b.root.length - a.root.length)
+    .find(entry => file === entry.root || file.startsWith(`${entry.root}/`))
+}
+
+export function findOrphans(files, coverage = COVERAGE) {
+  return files.filter(file => !coverageFor(file, coverage))
+}
+
+/**
+ * A declared runner that no longer exists is the failure this map is most likely to develop.
+ *
+ * Renaming a workflow step would otherwise leave every file under that root marked covered by a
+ * command nobody runs — the same silence the whole check exists to break, relocated into the
+ * check itself.
+ */
+export function findBrokenClaims(coverage = COVERAGE, readFile = readWorkflow) {
+  const broken = []
+  for (const entry of coverage) {
+    const text = readFile(entry.workflow)
+    if (text === null) {
+      broken.push({ ...entry, reason: 'the workflow file does not exist' })
+      continue
+    }
+    if (!text.includes(entry.command))
+      broken.push({ ...entry, reason: `the workflow no longer contains \`${entry.command}\`` })
+  }
+  return broken
+}
+
+/** A root that matches nothing means the directory moved and the entry is now decorative. */
+export function findEmptyRoots(files, coverage = COVERAGE) {
+  return coverage
+    .filter(entry => !files.some(file => file === entry.root || file.startsWith(`${entry.root}/`)))
+    .map(entry => entry.root)
+}
+
+function readWorkflow(relative) {
+  try {
+    return fs.readFileSync(path.join(repoRoot, relative), 'utf8')
+  }
+  catch {
+    return null
+  }
+}
+
+function selfTest() {
+  const coverage = [
+    { root: 'apps/a', workflow: 'w.yml', command: 'run a' },
+    { root: 'apps/a/special.test.ts', workflow: 'other.yml', command: 'run special' },
+  ]
+  const workflows = { 'w.yml': 'steps:\n  run a\n', 'other.yml': 'steps:\n  run special\n' }
+  const read = name => workflows[name] ?? null
+
+  const cases = [
+    {
+      name: 'a file under a covered root is not an orphan',
+      actual: findOrphans(['apps/a/one.test.ts'], coverage).length,
+      expected: 0,
+    },
+    {
+      name: 'a file outside every root is an orphan',
+      actual: findOrphans(['packages/b/one.test.ts'], coverage)[0],
+      expected: 'packages/b/one.test.ts',
+    },
+    {
+      name: 'a root prefix does not match a sibling directory with the same start',
+      actual: findOrphans(['apps/another/one.test.ts'], coverage)[0],
+      expected: 'apps/another/one.test.ts',
+    },
+    {
+      name: 'the longest matching root wins',
+      actual: coverageFor('apps/a/special.test.ts', coverage).command,
+      expected: 'run special',
+    },
+    { name: 'an intact claim is not broken', actual: findBrokenClaims(coverage, read).length, expected: 0 },
+    {
+      name: 'a claim whose workflow is gone fails',
+      actual: findBrokenClaims([{ root: 'x', workflow: 'missing.yml', command: 'c' }], read)[0]?.reason,
+      expected: 'the workflow file does not exist',
+    },
+    {
+      name: 'a claim whose command is gone fails',
+      actual: findBrokenClaims([{ root: 'x', workflow: 'w.yml', command: 'run renamed' }], read).length,
+      expected: 1,
+    },
+    {
+      name: 'a root matching no test file fails',
+      actual: findEmptyRoots(['apps/a/one.test.ts'], coverage)[0],
+      expected: 'apps/a/special.test.ts',
+    },
+    {
+      name: 'a root that does match is not reported empty',
+      actual: findEmptyRoots(['apps/a/special.test.ts'], coverage).includes('apps/a'),
+      expected: false,
+    },
+    {
+      name: 'a recorded orphan is not reported as unexpected',
+      actual: partitionKnown(['a.test.ts'], [{ file: 'a.test.ts', reason: 'r', issue: 1 }]).unexpected.length,
+      expected: 0,
+    },
+    {
+      name: 'an unrecorded orphan is reported',
+      actual: partitionKnown(['b.test.ts'], [{ file: 'a.test.ts', reason: 'r', issue: 1 }]).unexpected,
+      expected: ['b.test.ts'],
+    },
+    {
+      name: 'a record whose file stopped being an orphan fails, so the list cannot only grow',
+      actual: partitionKnown([], [{ file: 'a.test.ts', reason: 'r', issue: 1 }]).staleEntries,
+      expected: ['a.test.ts'],
+    },
+    {
+      name: 'every recorded orphan carries a reason',
+      actual: KNOWN_ORPHANS.every(entry => typeof entry.reason === 'string' && entry.reason.length > 40),
+      expected: true,
+    },
+    {
+      name: 'discovery finds the .cjs and .mjs shapes, not just .ts',
+      actual: ['a.test.cjs', 'b.test.mjs', 'c.spec.tsx', 'd.ts'].filter(name => TEST_FILE.test(name)).length,
+      expected: 3,
+    },
+  ]
+
+  let failures = 0
+  for (const testCase of cases) {
+    const ok = JSON.stringify(testCase.actual) === JSON.stringify(testCase.expected)
+    if (!ok) {
+      failures += 1
+      console.log(`\x1B[31mFAIL\x1B[0m  ${testCase.name} — got ${JSON.stringify(testCase.actual)}`)
+    }
+    else {
+      console.log(`\x1B[32m  ok\x1B[0m  ${testCase.name}`)
+    }
+  }
+  console.log(
+    failures === 0
+      ? `\n\x1B[32mSelf-test passed: ${cases.length} cases.\x1B[0m\n`
+      : `\n\x1B[31mSelf-test failed: ${failures}/${cases.length} cases.\x1B[0m\n`,
+  )
+  return failures
+}
+
+if (process.argv.includes('--self-test'))
+  process.exit(selfTest() > 0 ? 1 : 0)
+
+const files = findTestFiles(repoRoot)
+
+// Finding nothing is not a pass. A moved repo root or a broken walk would otherwise report a
+// clean sweep, which is precisely the failure shape this script exists to detect.
+if (files.length === 0) {
+  console.error('\n\x1B[31mNo test files found at all — this check read nothing.\x1B[0m\n')
+  process.exit(1)
+}
+
+const coverage = [...COVERAGE, ...pluginCoverage()]
+const orphans = findOrphans(files, coverage)
+const { unexpected, staleEntries } = partitionKnown(orphans)
+const broken = findBrokenClaims(coverage)
+const empty = findEmptyRoots(files, coverage)
+
+if (unexpected.length > 0) {
+  console.error(`\n\x1B[31m${unexpected.length} test file(s) no CI job runs:\x1B[0m`)
+  for (const file of unexpected)
+    console.error(`  ${file}`)
+  console.error(
+    '\nEither wire them into a workflow and add the root to COVERAGE in this script, or delete them.\n',
+  )
+}
+
+if (staleEntries.length > 0) {
+  console.error('\n\x1B[31mKNOWN_ORPHANS names files that are no longer orphans — remove them:\x1B[0m')
+  for (const file of staleEntries)
+    console.error(`  ${file}`)
+  console.error('')
+}
+
+if (broken.length > 0) {
+  console.error('\n\x1B[31mCOVERAGE claims a runner that is not there:\x1B[0m')
+  for (const entry of broken)
+    console.error(`  ${entry.root} — ${entry.reason} (${entry.workflow})`)
+  console.error('')
+}
+
+if (empty.length > 0) {
+  console.error('\n\x1B[31mCOVERAGE roots matching no test file — the directory moved:\x1B[0m')
+  for (const root of empty)
+    console.error(`  ${root}`)
+  console.error('')
+}
+
+if (unexpected.length > 0 || staleEntries.length > 0 || broken.length > 0 || empty.length > 0)
+  process.exit(1)
+
+console.log(
+  `\n\x1B[32m${files.length} test files, every one reachable by a CI job `
+  + `(${COVERAGE.length} declared roots, ${coverage.length - COVERAGE.length} plugin suites, `
+  + `${KNOWN_ORPHANS.length} recorded orphan).\x1B[0m\n`,
+)

--- a/scripts/test-plugins.mjs
+++ b/scripts/test-plugins.mjs
@@ -281,96 +281,111 @@ function selfTest() {
   return failures
 }
 
+/**
+ * Everything after this point runs the suites, so it must not fire on import.
+ *
+ * check-orphan-tests.mjs asks this module which plugins it would run rather than restating the
+ * rule. Restating it would let the two drift in the dangerous direction — a runner that narrowed
+ * its discovery while the guard still called those plugins covered.
+ */
+const invokedDirectly
+  = process.argv[1] !== undefined && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+
 if (process.argv.includes('--self-test')) {
   process.exit(selfTest() > 0 ? 1 : 0)
 }
 
-/**
- * Plugin vite configs import built workspace packages.
- *
- * `touch-translation/vite.config.ts` imports `@talex-touch/unplugin-export-plugin/vite`, whose
- * `dist/` is gitignored, so a fresh checkout cannot load that config at all. Locally it was
- * already built from some earlier run and every suite came back green; the first CI run is what
- * said otherwise. Building it here rather than in the workflow step keeps a direct
- * `node scripts/test-plugins.mjs` behaving the same way as the pipeline.
- */
-const VITEST_PREREQUISITE_PACKAGES = ['@talex-touch/unplugin-export-plugin']
+function main() {
+  /**
+   * Plugin vite configs import built workspace packages.
+   *
+   * `touch-translation/vite.config.ts` imports `@talex-touch/unplugin-export-plugin/vite`, whose
+   * `dist/` is gitignored, so a fresh checkout cannot load that config at all. Locally it was
+   * already built from some earlier run and every suite came back green; the first CI run is what
+   * said otherwise. Building it here rather than in the workflow step keeps a direct
+   * `node scripts/test-plugins.mjs` behaving the same way as the pipeline.
+   */
+  const VITEST_PREREQUISITE_PACKAGES = ['@talex-touch/unplugin-export-plugin']
 
-function buildVitestPrerequisites() {
-  for (const name of VITEST_PREREQUISITE_PACKAGES) {
-    const build = spawnSync('pnpm', ['-F', name, 'run', 'build'], { encoding: 'utf8' })
-    if (build.status !== 0) {
-      console.error(
-        `\n\x1B[31mCould not build ${name}, which the plugin vite configs import — `
-        + `the vitest suites would fail to load their config.\x1B[0m`,
-      )
-      console.error(stripAnsi(`${build.stdout ?? ''}${build.stderr ?? ''}`).split('\n').slice(-15).join('\n'))
-      process.exit(1)
+  function buildVitestPrerequisites() {
+    for (const name of VITEST_PREREQUISITE_PACKAGES) {
+      const build = spawnSync('pnpm', ['-F', name, 'run', 'build'], { encoding: 'utf8' })
+      if (build.status !== 0) {
+        console.error(
+          `\n\x1B[31mCould not build ${name}, which the plugin vite configs import — `
+          + `the vitest suites would fail to load their config.\x1B[0m`,
+        )
+        console.error(stripAnsi(`${build.stdout ?? ''}${build.stderr ?? ''}`).split('\n').slice(-15).join('\n'))
+        process.exit(1)
+      }
     }
   }
-}
 
-const nodeTestSuites = findSuites()
-const vitestSuites = findVitestSuites()
+  const nodeTestSuites = findSuites()
+  const vitestSuites = findVitestSuites()
 
-if (discoveryFoundNothing(nodeTestSuites)) {
-  console.error(
-    '\x1B[31mNo plugins/*/index.test.cjs found — this run would report success without executing a single plugin test.\x1B[0m\n',
+  if (discoveryFoundNothing(nodeTestSuites)) {
+    console.error(
+      '\x1B[31mNo plugins/*/index.test.cjs found — this run would report success without executing a single plugin test.\x1B[0m\n',
+    )
+    process.exit(1)
+  }
+
+  /**
+   * The vitest half gets the same treatment, separately.
+   *
+   * Folding both into one emptiness check would let either half disappear silently as long as the
+   * other still found something, which is the shape that hid these suites in the first place.
+   */
+  if (discoveryFoundNothing(vitestSuites)) {
+    console.error(
+      '\x1B[31mNo plugins/*/package.json declares a vitest test script — either the packages moved or this half of the run checks nothing.\x1B[0m\n',
+    )
+    process.exit(1)
+  }
+
+  buildVitestPrerequisites()
+
+  const suites = [...nodeTestSuites, ...vitestSuites]
+
+  console.log(
+    `\nRunning ${suites.length} plugin suites (${nodeTestSuites.length} node --test, ${vitestSuites.length} vitest)\n`,
   )
-  process.exit(1)
-}
 
-/**
- * The vitest half gets the same treatment, separately.
- *
- * Folding both into one emptiness check would let either half disappear silently as long as the
- * other still found something, which is the shape that hid these suites in the first place.
- */
-if (discoveryFoundNothing(vitestSuites)) {
-  console.error(
-    '\x1B[31mNo plugins/*/package.json declares a vitest test script — either the packages moved or this half of the run checks nothing.\x1B[0m\n',
-  )
-  process.exit(1)
-}
+  let totalCases = 0
+  const failed = []
 
-buildVitestPrerequisites()
-
-const suites = [...nodeTestSuites, ...vitestSuites]
-
-console.log(
-  `\nRunning ${suites.length} plugin suites (${nodeTestSuites.length} node --test, ${vitestSuites.length} vitest)\n`,
-)
-
-let totalCases = 0
-const failed = []
-
-for (const suite of suites) {
-  const run = suite.runner === 'vitest'
-    // `exec` rather than `run test`: touch-translation's script is a bare `vitest`, which without
-    // this would sit in watch mode and never return.
-    ? spawnSync('pnpm', ['-C', suite.dir, 'exec', 'vitest', 'run'], { encoding: 'utf8' })
-    : spawnSync(process.execPath, ['--test', 'index.test.cjs'], { cwd: suite.dir, encoding: 'utf8' })
-  const output = `${run.stdout ?? ''}${run.stderr ?? ''}`
-  const verdict = suite.runner === 'vitest'
-    ? classifyVitestRun({ status: run.status, stdout: output })
-    : classifySuiteRun({ status: run.status, stdout: output })
-  if (verdict.ok) {
-    totalCases += verdict.pass
-    console.log(`\x1B[32m  ✓\x1B[0m ${suite.name.padEnd(28)} ${String(verdict.pass).padStart(3)} cases`)
+  for (const suite of suites) {
+    const run = suite.runner === 'vitest'
+      // `exec` rather than `run test`: touch-translation's script is a bare `vitest`, which without
+      // this would sit in watch mode and never return.
+      ? spawnSync('pnpm', ['-C', suite.dir, 'exec', 'vitest', 'run'], { encoding: 'utf8' })
+      : spawnSync(process.execPath, ['--test', 'index.test.cjs'], { cwd: suite.dir, encoding: 'utf8' })
+    const output = `${run.stdout ?? ''}${run.stderr ?? ''}`
+    const verdict = suite.runner === 'vitest'
+      ? classifyVitestRun({ status: run.status, stdout: output })
+      : classifySuiteRun({ status: run.status, stdout: output })
+    if (verdict.ok) {
+      totalCases += verdict.pass
+      console.log(`\x1B[32m  ✓\x1B[0m ${suite.name.padEnd(28)} ${String(verdict.pass).padStart(3)} cases`)
+    }
+    else {
+      failed.push({ suite, verdict, output })
+      console.log(`\x1B[31m  ✗\x1B[0m ${suite.name.padEnd(28)} ${verdict.reason}`)
+    }
   }
-  else {
-    failed.push({ suite, verdict, output })
-    console.log(`\x1B[31m  ✗\x1B[0m ${suite.name.padEnd(28)} ${verdict.reason}`)
+
+  if (failed.length > 0) {
+    for (const entry of failed) {
+      console.error(`\n\x1B[31m--- ${entry.suite.name}: ${entry.verdict.reason} ---\x1B[0m`)
+      console.error(entry.output.split('\n').slice(-25).join('\n'))
+    }
+    console.error(`\n\x1B[31m${failed.length}/${suites.length} plugin suites failed.\x1B[0m\n`)
+    process.exit(1)
   }
+
+  console.log(`\n\x1B[32mAll ${suites.length} plugin suites passed — ${totalCases} cases.\x1B[0m\n`)
 }
 
-if (failed.length > 0) {
-  for (const entry of failed) {
-    console.error(`\n\x1B[31m--- ${entry.suite.name}: ${entry.verdict.reason} ---\x1B[0m`)
-    console.error(entry.output.split('\n').slice(-25).join('\n'))
-  }
-  console.error(`\n\x1B[31m${failed.length}/${suites.length} plugin suites failed.\x1B[0m\n`)
-  process.exit(1)
-}
-
-console.log(`\n\x1B[32mAll ${suites.length} plugin suites passed — ${totalCases} cases.\x1B[0m\n`)
+if (invokedDirectly)
+  main()


### PR DESCRIPTION
Toward #330.

**Three times in a month someone found test files nothing ran**, each time by happening to count: 623 core-app and 180 nexus files in no workflow (#924), 16 plugin suites / 97 cases (#1629), 8 vitest files / 39 cases in two plugin packages (#1670). All of them passed throughout, which is why nothing complained — **a test that never runs looks exactly like a test that always passes.**

Finding them is a directory walk and a set difference. Leaving that to whoever next thinks to look is the actual defect. It now runs on every PR: **1350 test files, every one reachable by a CI job.**

## Counting first turned up three more

| | | |
|---|---|---|
| `packages/intelligence-uikit` | 2 files, 6 cases, no workflow | passes |
| `packages/pi-extension-tuff` | 1 file, 9 cases, no workflow | passes |
| `plugins/touch-music` | 1 file, no runner | **does not even load** |

Every other package under `packages/` with tests has a `package-*-ci.yml`. Those two were simply never written, and both suites are green — this PR adds their workflows.

`touch-music` is different: it declares no test script, and the file fails on `Failed to resolve import "@vue/test-utils"`, which is not among its two devDependencies. Untouched since `c6de5d63d` (2026-07-12). Fixing it means adding a dependency and a script — a lockfile change, not this check's business — so it is **recorded with that reason** rather than quietly excluded.

## The map verifies its own claims

An exemption list that can only be appended to is how a gate becomes decoration, so every direction fails:

| | |
|---|---|
| a workflow that no longer contains the declared command | fails |
| a declared root with no test files under it | fails |
| a recorded orphan that stopped being one | fails |
| discovery returning nothing | fails |

**Plugin coverage is asked of `test-plugins.mjs` rather than declared**, because `pnpm test:plugins` reaches a plugin only if it ships `index.test.cjs` or declares a vitest script. My first version had a blanket `plugins` entry — and it called `touch-music` covered. Restating the rule would have let the two drift in the dangerous direction. `test-plugins.mjs`'s main body now runs only when invoked directly, so importing it does not run 19 suites.

## Five plants, each caught

```
rename a workflow's test command     COVERAGE claims a runner that is not there
drop the scripts coverage entry      27 test file(s) no CI job runs
leave a fixed orphan in the record   fails
break discovery entirely             No test files found at all
point a root at a moved directory    186 test file(s) no CI job runs
```

Self-test 22 cases. `actionlint` clean on both new workflows and on `ci.yml`.

Refs #330