### PR TITLE
fix(types): down to one, and it is not a code problem (#548)

### DIFF
--- a/apps/core-app/src/main/modules/ai/ai-orchestrator-store.test.ts
+++ b/apps/core-app/src/main/modules/ai/ai-orchestrator-store.test.ts
@@ -79,7 +79,10 @@ const storeMocks = vi.hoisted(() => {
         imports.splice(0, imports.length, ...survivors)
       }
     }),
-    transaction: async (operation: (tx: typeof db) => Promise<void>) => await operation(db)
+    // `typeof db` inside db's own initializer is a circular reference, which is what made the
+    // whole object implicitly any (#548). The callback receives db itself either way, so the
+    // parameter is typed by what callers actually do with it rather than by db's own shape.
+    transaction: async (operation: (tx: unknown) => Promise<void>) => await operation(db)
   }
 
   return {

--- a/apps/core-app/src/main/modules/plugin/plugin.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin.ts
@@ -25,7 +25,7 @@ import type {
   PluginStandardChannelData
 } from '@talex-touch/utils/plugin/sdk/channel-client'
 import type { IndexedSourceDescriptor, SearchProviderDescriptor } from '@talex-touch/utils/search'
-import type { ITuffTransport } from '@talex-touch/utils/transport'
+import type { ITuffTransport, SendOptions, TuffEvent } from '@talex-touch/utils/transport'
 import type {
   ClipboardActionResult,
   ClipboardCopyAndPasteRequest,
@@ -3014,9 +3014,13 @@ export class TouchPlugin implements ITouchPlugin {
     }
     const pluginIntelligenceTransport: ITuffTransport = {
       ...pluginSdkTransport,
-      send: ((event, payload, options) =>
+      // The cast stays: ITuffTransport['send'] is an intersection of two generic signatures and
+      // no plain arrow satisfies it. But `as` applies to the finished function, so it never typed
+      // the parameters on the way in -- annotating them explicitly is what removes the implicit
+      // any without pretending the overload can be implemented directly (#548).
+      send: ((event: TuffEvent<unknown, unknown>, payload: unknown, options?: SendOptions) =>
         pluginSdkTransport.send(
-          event,
+          event as never,
           withPluginSdkapiPayload(payload, this.sdkapi) as never,
           options
         )) as ITuffTransport['send'],

--- a/scripts/check-implicit-any-debt.mjs
+++ b/scripts/check-implicit-any-debt.mjs
@@ -34,7 +34,7 @@ const CORE_APP = path.join(REPO_ROOT, 'apps/core-app')
  * only -- every error the flag produces is in that range, so a rise here is new untyped code and
  * not some unrelated type break.
  */
-export const KNOWN_IMPLICIT_ANY_ERRORS = 5
+export const KNOWN_IMPLICIT_ANY_ERRORS = 1
 
 /** Resolves the workspace's own tsc rather than trusting a .bin shim on PATH. */
 function resolveTsc() {


### PR DESCRIPTION
Toward #548. Ninth batch: **5 → 1**. The only implicit any left in the main process is a missing type package.

## A correction to #1671

That PR said `plugin.ts:3017`'s three errors stay because the cast is deliberate. **The cast is deliberate** — `ITuffTransport['send']` is an intersection of two generic signatures and no plain arrow implements it, which I verified by trying and getting `TS2322`.

But that answered only half the question. `as` applies to the **finished** function, so it never types the parameters on the way in — and those can be annotated independently of whether the overload is implementable. Three errors gone, cast intact:

```ts
send: ((
  event: TuffEvent<unknown, unknown>,
  payload: unknown,
  options?: SendOptions
) => pluginSdkTransport.send(event as never, ...)) as ITuffTransport['send'],
```

I stopped at "the cast is necessary" and treated that as the end of the enquiry. It wasn't.

## The other one

`ai-orchestrator-store.test.ts`'s mock `db` was implicitly any because its own initializer referenced `typeof db` — in the type of the transaction callback's parameter. The callback receives `db` either way, so the parameter is now typed by what callers do with it rather than by `db`'s own shape, and the circularity goes.

## What remains, and why it is not code

`file-provider-opener-service.ts` imports `plist`. `plist ^3.1.0` is a declared dependency; `@types/plist` is not.

- `pnpm -C apps/core-app add -D @types/plist` → `ERR_PNPM_PUBLIC_HOIST_PATTERN_DIFF`, because `apps/core-app/.npmrc` sets `shamefully-hoist=true` and the root install did not.
- Three root installs have now hung at `resolved 201, reused 201, downloaded 0` on that package specifically, while unrelated installs in the same worktree finish in 13–45 seconds. That is registry reachability for this one package, not contention.

Each attempt reverted `package.json` cleanly; no half-updated lockfile was left behind.

## The end state this sets up

Ratchet 5 → 1, both directions: `0` fails, `2` fails, `1` passes.

Once `@types/plist` installs, the count reaches **zero** and `tsconfig.node.json` can take `"noImplicitAny": true` — already measured in #1671 as producing no diagnostics beyond the ones being counted. At that point **the ratchet script and its test should be deleted, not maintained at zero.** A ratchet is for debt that will never reach zero; this one has.

Running total: **227 → 1**, 226 errors across nine PRs.
