### PR TITLE
fix(tuff-native): publish the audio production verifier

### DIFF
--- a/packages/tuff-native/package.json
+++ b/packages/tuff-native/package.json
@@ -54,6 +54,7 @@
     "binding.gyp",
     "scripts/build-screenshot.js",
     "scripts/verify-screenshot-production.js",
+    "scripts/verify-audio-production.js",
     "scripts/build-audio.js",
     "protocol-contract.js",
     "protocol-contract.d.ts",

--- a/packages/tuff-native/protocol-package.test.js
+++ b/packages/tuff-native/protocol-package.test.js
@@ -34,6 +34,11 @@ test('package files include protocol owners without fixtures or Cargo targets', 
     'screenshot-protocol.js',
     'screenshot-protocol.d.ts',
     'scripts/verify-screenshot-production.js',
+    // The audio pair was added mirroring the screenshot pair and this entry was left out, so the
+    // published tarball shipped build-audio.js and audio.js with no way to verify either.
+    // Criterion 3 of #322 -- "packaged runtime resolves the same module path as audio.js" --
+    // cannot be checked from the package without it.
+    'scripts/verify-audio-production.js',
     'native-core/Cargo.toml',
     'native-core/src',
     'native-napi/Cargo.toml',


### PR DESCRIPTION
Toward #322.

`scripts/verify-audio-production.js` was **not in `files`**, so the published tarball shipped `build-audio.js` and `audio.js` with nothing to verify either. Its screenshot twin has always been packaged, and `protocol-package.test.js` asserted that one and not this one — the audio pair was added mirroring the screenshot pair and this entry was simply left out.

Proven with `npm pack --dry-run`, which is its own positive control:

```
before   70 files   screenshot verifier: true   audio verifier: false
after    71 files   screenshot verifier: true   audio verifier: true
```

The test now requires both, so the pair cannot come apart again. Removing the entry fails with `missing package file entry: scripts/verify-audio-production.js`.

## Why it matters for this issue

Criterion 3 reads *"Packaged runtime resolves the same module path as `audio.js`/`native-loader.js`."* **That was not checkable from the published package at all** — the verifier that answers it was the one file left out of it.

The other three criteria this PR does not touch: `native-protocol.yml` does build the Cargo audio addon on all three runners and does call `verify:audio-production` after `build:audio`, on macOS, Windows and Linux. (I first reported that nothing called these scripts — wrong: I searched for the file name while the workflow calls the npm script name `verify:audio-production`, with a colon. A positive control on `build:audio` is what showed the scan was reading the wrong form.)

Refs #322