### PR TITLE
feat(search): count what the query cache actually does

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-cache-telemetry.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-cache-telemetry.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest'
+import { classifySearchCacheLookup, SearchCacheTelemetry } from './search-cache-telemetry'
+
+/**
+ * #346 asks whether the query cache earns its complexity and says to remove it if not. The
+ * counters here are what that decision will be made from, so the shape they report has to be
+ * right before anyone reads a number off it.
+ *
+ * The case that matters most is the reason breakdown. A hit rate near zero reads as "nobody
+ * repeats queries" unless the misses are separated by cause — and this cache is cleared by any
+ * index commit, including from providers a query never reached.
+ */
+/**
+ * The lookup classification, which decides which miss column a run lands in.
+ *
+ * It used to sit inline in `SearchCore.executeSearch` where nothing could assert it: a plant that
+ * reported every revision mismatch as `expired` passed the whole search-engine suite.
+ */
+describe('classifySearchCacheLookup', () => {
+  const base = { currentRevision: 7, now: 1_000, ttlMs: 5_000 }
+
+  it('serves a fresh entry at the current revision', () => {
+    expect(classifySearchCacheLookup({ ...base, entry: { revision: 7, timestamp: 900 } })).toBe(
+      'hit'
+    )
+  })
+
+  it('reports nothing under the key as absent', () => {
+    expect(classifySearchCacheLookup({ ...base, entry: undefined })).toBe('absent')
+  })
+
+  it('reports an entry the index moved past as a revision mismatch, not a miss', () => {
+    expect(classifySearchCacheLookup({ ...base, entry: { revision: 6, timestamp: 900 } })).toBe(
+      'revision-mismatch'
+    )
+  })
+
+  it('reports an entry older than the TTL as expired', () => {
+    expect(
+      classifySearchCacheLookup({ ...base, now: 7_000, entry: { revision: 7, timestamp: 900 } })
+    ).toBe('expired')
+  })
+
+  /**
+   * An entry can be both. Calling it expired would hide an invalidation behind the TTL and make
+   * the policy look like it costs nothing — which is the reading this whole breakdown exists to
+   * prevent.
+   */
+  it('attributes a stale-and-expired entry to the revision, not the clock', () => {
+    expect(
+      classifySearchCacheLookup({ ...base, now: 7_000, entry: { revision: 6, timestamp: 900 } })
+    ).toBe('revision-mismatch')
+  })
+
+  it('treats an entry exactly at the TTL boundary as expired', () => {
+    expect(
+      classifySearchCacheLookup({ ...base, now: 5_900, entry: { revision: 7, timestamp: 900 } })
+    ).toBe('expired')
+    expect(
+      classifySearchCacheLookup({ ...base, now: 5_899, entry: { revision: 7, timestamp: 900 } })
+    ).toBe('hit')
+  })
+})
+
+describe('search cache telemetry', () => {
+  it('reports nothing rather than dividing by zero before any lookup', () => {
+    const snapshot = new SearchCacheTelemetry().snapshot()
+
+    expect(snapshot.lookups).toBe(0)
+    expect(snapshot.hitRate).toBe(0)
+    expect(snapshot.hitAgeMs).toEqual({ p50: null, p95: null })
+    expect(snapshot.savedLatencyMs).toEqual({ p50: null, p95: null, total: 0 })
+    // Every reason present at zero, so a report can be read as a distribution from the first run.
+    expect(Object.values(snapshot.misses)).toEqual([0, 0, 0])
+    expect(Object.values(snapshot.invalidations)).toEqual([0, 0, 0, 0])
+  })
+
+  it('counts hits and misses against the same lookup total', () => {
+    const telemetry = new SearchCacheTelemetry()
+
+    telemetry.recordHit(100, 40)
+    telemetry.recordMiss('absent')
+    telemetry.recordMiss('revision-mismatch')
+    const snapshot = telemetry.snapshot()
+
+    expect(snapshot.lookups).toBe(3)
+    expect(snapshot.hits).toBe(1)
+    expect(snapshot.hitRate).toBeCloseTo(1 / 3)
+    expect(snapshot.misses).toEqual({ absent: 1, 'revision-mismatch': 1, expired: 0 })
+  })
+
+  /**
+   * The distinction this whole file exists for. Two runs with the same hit rate mean opposite
+   * things depending on which column the misses land in, and a single `misses` counter would
+   * make them indistinguishable.
+   */
+  it('separates a cache nobody used from a cache that was denied', () => {
+    const unused = new SearchCacheTelemetry()
+    for (let i = 0; i < 10; i += 1) unused.recordMiss('absent')
+
+    const denied = new SearchCacheTelemetry()
+    for (let i = 0; i < 10; i += 1) denied.recordMiss('revision-mismatch')
+
+    expect(unused.snapshot().hitRate).toBe(denied.snapshot().hitRate)
+    expect(unused.snapshot().misses.absent).toBe(10)
+    expect(unused.snapshot().misses['revision-mismatch']).toBe(0)
+    expect(denied.snapshot().misses['revision-mismatch']).toBe(10)
+    expect(denied.snapshot().misses.absent).toBe(0)
+  })
+
+  it('counts invalidations by entries dropped, not by calls', () => {
+    const telemetry = new SearchCacheTelemetry()
+
+    telemetry.recordInvalidation('index-commit', 12)
+    telemetry.recordInvalidation('index-commit', 3)
+    telemetry.recordInvalidation('lru-evict', 1)
+    const snapshot = telemetry.snapshot()
+
+    expect(snapshot.invalidations['index-commit']).toBe(15)
+    expect(snapshot.entriesDropped).toBe(16)
+  })
+
+  /**
+   * `handleSearchIndexCommit` clears unconditionally, so it fires on an empty cache constantly
+   * while the file watcher runs. Counting those would inflate `index-commit` with events that
+   * dropped nothing and make it look like the dominant cause when it dropped no entries at all.
+   */
+  it('ignores a clear that dropped no entries', () => {
+    const telemetry = new SearchCacheTelemetry()
+
+    telemetry.recordInvalidation('index-commit', 0)
+    telemetry.recordInvalidation('pin-toggle', -1)
+    telemetry.recordInvalidation('privacy-cleanup', Number.NaN)
+
+    expect(telemetry.snapshot().entriesDropped).toBe(0)
+    expect(telemetry.snapshot().invalidations['index-commit']).toBe(0)
+  })
+
+  it('reports the age of served entries so the TTL can be judged', () => {
+    const telemetry = new SearchCacheTelemetry()
+
+    for (const age of [10, 20, 30, 40, 4900]) telemetry.recordHit(age, 5)
+    const { hitAgeMs } = telemetry.snapshot()
+
+    expect(hitAgeMs.p50).toBe(30)
+    expect(hitAgeMs.p95).toBe(4900)
+  })
+
+  /**
+   * Saved latency is the duration the served result originally took. A snapshot stored without
+   * one contributes nothing rather than a zero — counting it as zero saved would pull the
+   * percentiles toward a saving that did not happen.
+   */
+  it('leaves durations it does not have out of the percentiles', () => {
+    const telemetry = new SearchCacheTelemetry()
+
+    telemetry.recordHit(10, 200)
+    telemetry.recordHit(10, null)
+    telemetry.recordHit(10, 400)
+    const { savedLatencyMs, hits } = telemetry.snapshot()
+
+    expect(hits).toBe(3)
+    expect(savedLatencyMs.total).toBe(600)
+    expect(savedLatencyMs.p50).toBe(400)
+  })
+
+  it('refuses values that would corrupt the percentiles', () => {
+    const telemetry = new SearchCacheTelemetry()
+
+    telemetry.recordHit(Number.NaN, Number.POSITIVE_INFINITY)
+    telemetry.recordHit(-5, 100)
+    const snapshot = telemetry.snapshot()
+
+    expect(snapshot.hits).toBe(2)
+    expect(snapshot.hitAgeMs.p50).toBeNull()
+    expect(snapshot.savedLatencyMs.total).toBe(100)
+  })
+
+  it('bounds its samples so a long session cannot grow it without limit', () => {
+    const telemetry = new SearchCacheTelemetry()
+
+    for (let i = 0; i < 1_500; i += 1) telemetry.recordHit(i, i)
+    const snapshot = telemetry.snapshot()
+
+    // Counts stay exact; only the percentile window slides to the most recent 1000, which after
+    // 1500 pushes holds 500..1499 — so the median is 1000, not 750.
+    expect(snapshot.hits).toBe(1_500)
+    expect(snapshot.hitAgeMs.p50).toBe(1_000)
+    expect(snapshot.hitAgeMs.p95).toBe(1_450)
+  })
+
+  it('clears every counter on reset', () => {
+    const telemetry = new SearchCacheTelemetry()
+
+    telemetry.recordHit(10, 10)
+    telemetry.recordMiss('expired')
+    telemetry.recordInvalidation('pin-toggle', 2)
+    telemetry.reset()
+
+    expect(telemetry.snapshot()).toEqual(new SearchCacheTelemetry().snapshot())
+  })
+})

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-cache-telemetry.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-cache-telemetry.ts
@@ -1,0 +1,164 @@
+/**
+ * Counters for the SearchCore query cache (#346).
+ *
+ * That issue asks whether the cache earns its complexity, and says to remove it if not. The
+ * number that would answer it does not exist: nothing counts a lookup. This records the lookups
+ * and, more importantly, *why* the misses happened.
+ *
+ * The reason breakdown is the decisive part rather than one column among several. A cache whose
+ * entries are thrown away by unrelated indexing has a low hit rate for a reason that has nothing
+ * to do with users repeating queries, and removing it on that number would be acting on an
+ * artefact of the invalidation policy. `search-core.contracts.test.ts:822` already encodes that
+ * policy as the contract: a commit from a provider the query never reached still evicts.
+ *
+ * No query text, no key, no item content -- only counts and durations. The cache key is a hash
+ * already, and even that is not recorded, so nothing here can reconstruct what was searched.
+ */
+
+/** Why a lookup did not produce a usable entry. */
+export type SearchCacheMissReason =
+  /** Nothing under this key — a first-time query, or the entry was already dropped. */
+  | 'absent'
+  /** The entry was there but the index moved on. This one is the cache being denied, not unused. */
+  | 'revision-mismatch'
+  | 'expired'
+
+/** Why entries were dropped, counted per entry rather than per call. */
+export type SearchCacheInvalidationReason =
+  /** A `searchCache.clear()` from any index commit, whatever source it came from. */
+  'index-commit' | 'privacy-cleanup' | 'pin-toggle' | 'lru-evict'
+
+export interface SearchCacheTelemetrySnapshot {
+  lookups: number
+  hits: number
+  misses: Record<SearchCacheMissReason, number>
+  invalidations: Record<SearchCacheInvalidationReason, number>
+  /** Entries dropped in total, so `invalidations` can be read as a distribution. */
+  entriesDropped: number
+  hitRate: number
+  /** Age of the entries that were served, in ms. Says whether the 5s TTL is the binding limit. */
+  hitAgeMs: { p50: number | null; p95: number | null }
+  /**
+   * Wall time the served result originally took to produce, in ms.
+   *
+   * This is what a hit saved, and it is the only defensible reading of "saved latency" here: the
+   * alternative would be timing the work that a hit did not do.
+   */
+  savedLatencyMs: { p50: number | null; p95: number | null; total: number }
+}
+
+const MISS_REASONS: SearchCacheMissReason[] = ['absent', 'revision-mismatch', 'expired']
+const INVALIDATION_REASONS: SearchCacheInvalidationReason[] = [
+  'index-commit',
+  'privacy-cleanup',
+  'pin-toggle',
+  'lru-evict'
+]
+
+/**
+ * Samples are capped so a long-running session cannot grow this without bound.
+ *
+ * Dropping the oldest keeps the percentiles describing recent behaviour, which is what a
+ * measurement session wants; the counts above stay exact regardless.
+ */
+const MAX_SAMPLES = 1_000
+
+function percentile(sorted: readonly number[], fraction: number): number | null {
+  if (sorted.length === 0) return null
+  const index = Math.min(sorted.length - 1, Math.floor(fraction * sorted.length))
+  return sorted[index] ?? null
+}
+
+export type SearchCacheLookupOutcome = 'hit' | SearchCacheMissReason
+
+/**
+ * Decides what a lookup was, from the entry and the state it is checked against.
+ *
+ * Extracted from `SearchCore.executeSearch` because the branch that matters -- telling
+ * `revision-mismatch` from `expired` -- had no way to be asserted while it sat inline in a
+ * 2200-line method. Those two are the whole point of the breakdown: one says an index commit
+ * denied the entry, the other says the user waited longer than the TTL.
+ */
+export function classifySearchCacheLookup(input: {
+  entry: { revision: number; timestamp: number } | undefined
+  currentRevision: number
+  now: number
+  ttlMs: number
+}): SearchCacheLookupOutcome {
+  const { entry, currentRevision, now, ttlMs } = input
+  if (!entry) return 'absent'
+  // Revision first: an entry can be both stale and expired, and reporting it as expired would
+  // hide the invalidation policy behind the TTL.
+  if (entry.revision !== currentRevision) return 'revision-mismatch'
+  if (now - entry.timestamp >= ttlMs) return 'expired'
+  return 'hit'
+}
+
+export class SearchCacheTelemetry {
+  private lookups = 0
+  private hits = 0
+  private readonly misses = new Map<SearchCacheMissReason, number>()
+  private readonly invalidations = new Map<SearchCacheInvalidationReason, number>()
+  private hitAges: number[] = []
+  private savedLatencies: number[] = []
+
+  recordHit(ageMs: number, originalDurationMs: number | null | undefined): void {
+    this.lookups += 1
+    this.hits += 1
+    push(this.hitAges, ageMs)
+    // A snapshot stored before durations were recorded has nothing to contribute; counting it as
+    // zero saved would drag the percentiles toward a saving that did not happen. `push` rejects
+    // the null on its own, so there is no second guard here -- an unreachable branch would look
+    // load-bearing to the next reader and no test could hold it.
+    push(this.savedLatencies, originalDurationMs)
+  }
+
+  recordMiss(reason: SearchCacheMissReason): void {
+    this.lookups += 1
+    this.misses.set(reason, (this.misses.get(reason) ?? 0) + 1)
+  }
+
+  /** `count` is entries dropped, so a `clear()` of an empty cache contributes nothing. */
+  recordInvalidation(reason: SearchCacheInvalidationReason, count: number): void {
+    if (!Number.isFinite(count) || count <= 0) return
+    this.invalidations.set(reason, (this.invalidations.get(reason) ?? 0) + count)
+  }
+
+  snapshot(): SearchCacheTelemetrySnapshot {
+    const ages = [...this.hitAges].sort((a, b) => a - b)
+    const saved = [...this.savedLatencies].sort((a, b) => a - b)
+    return {
+      lookups: this.lookups,
+      hits: this.hits,
+      misses: Object.fromEntries(
+        MISS_REASONS.map((reason) => [reason, this.misses.get(reason) ?? 0])
+      ) as Record<SearchCacheMissReason, number>,
+      invalidations: Object.fromEntries(
+        INVALIDATION_REASONS.map((reason) => [reason, this.invalidations.get(reason) ?? 0])
+      ) as Record<SearchCacheInvalidationReason, number>,
+      entriesDropped: [...this.invalidations.values()].reduce((total, value) => total + value, 0),
+      hitRate: this.lookups === 0 ? 0 : this.hits / this.lookups,
+      hitAgeMs: { p50: percentile(ages, 0.5), p95: percentile(ages, 0.95) },
+      savedLatencyMs: {
+        p50: percentile(saved, 0.5),
+        p95: percentile(saved, 0.95),
+        total: saved.reduce((sum, value) => sum + value, 0)
+      }
+    }
+  }
+
+  reset(): void {
+    this.lookups = 0
+    this.hits = 0
+    this.misses.clear()
+    this.invalidations.clear()
+    this.hitAges = []
+    this.savedLatencies = []
+  }
+}
+
+function push(samples: number[], value: number | null | undefined): void {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return
+  samples.push(value)
+  if (samples.length > MAX_SAMPLES) samples.shift()
+}

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
@@ -95,6 +95,8 @@ import {
   type SearchRequestContext,
   type SearchSession
 } from './search-session'
+import type { SearchCacheTelemetrySnapshot } from './search-cache-telemetry'
+import { classifySearchCacheLookup, SearchCacheTelemetry } from './search-cache-telemetry'
 
 interface SearchCacheEntry {
   result: CachedSearchResultSnapshot
@@ -184,6 +186,14 @@ export class SearchEngineCore
   private readonly maintenanceTaskId = 'search-engine.maintenance'
   private readonly providerHealthService = new ProviderHealthService()
   private searchCache = new Map<string, SearchCacheEntry>()
+  /**
+   * Counts what the cache actually does, so #346's keep-or-remove decision has a number.
+   *
+   * Nothing measured a lookup before this. The reason breakdown matters more than the hit rate:
+   * entries here are thrown away by any index commit, including from providers the query never
+   * reached, so a low hit rate may say more about the invalidation policy than about users.
+   */
+  private readonly cacheTelemetry = new SearchCacheTelemetry()
   private searchFirstResultMetrics = new Map<string, SearchFirstResultMetrics>()
   private readonly indexCommitStreams = new Set<StreamContext<CoreBoxSearchIndexCommitPayload>>()
   private indexCommitUnsubscribe: (() => void) | null = null
@@ -218,7 +228,10 @@ export class SearchEngineCore
           oldestKey = key
         }
       }
-      if (oldestKey) this.searchCache.delete(oldestKey)
+      if (oldestKey) {
+        this.searchCache.delete(oldestKey)
+        this.cacheTelemetry.recordInvalidation('lru-evict', 1)
+      }
     }
 
     this.searchCache.set(cacheKey, {
@@ -410,8 +423,19 @@ export class SearchEngineCore
     await this.searchUsageService.flush()
   }
 
+  /**
+   * Read-only counters for the query cache (#346).
+   *
+   * Counts and durations only -- no query text, no cache key, no item content -- so a report
+   * built from this cannot reconstruct what anyone searched for.
+   */
+  public getSearchCacheTelemetry(): SearchCacheTelemetrySnapshot {
+    return this.cacheTelemetry.snapshot()
+  }
+
   public completePrivacyRetentionCleanup(): void {
     this.searchUsageService.invalidateRetentionCaches()
+    this.cacheTelemetry.recordInvalidation('privacy-cleanup', this.searchCache.size)
     this.searchCache.clear()
     this.recommendationEngine?.invalidateCache()
   }
@@ -429,6 +453,7 @@ export class SearchEngineCore
   }
 
   private handleSearchIndexCommit(payload: CoreBoxSearchIndexCommitPayload): void {
+    this.cacheTelemetry.recordInvalidation('index-commit', this.searchCache.size)
     this.searchCache.clear()
     for (const context of this.indexCommitStreams) {
       if (context.isCancelled()) {
@@ -893,11 +918,19 @@ export class SearchEngineCore
 
     const searchRevision = searchIndexCommitHub.getRevision()
     const cachedEntry = this.searchCache.get(cacheKey)
-    if (
-      cachedEntry &&
-      cachedEntry.revision === searchRevision &&
-      Date.now() - cachedEntry.timestamp < SEARCH_CACHE_TTL_MS
-    ) {
+    const cacheCheckedAt = Date.now()
+    const cachedAgeMs = cachedEntry ? cacheCheckedAt - cachedEntry.timestamp : 0
+    // The reason is the point, not the hit rate: `revision-mismatch` means an index commit denied
+    // the entry, which is a different story from a query nobody repeated (#346).
+    const cacheOutcome = classifySearchCacheLookup({
+      entry: cachedEntry,
+      currentRevision: searchRevision,
+      now: cacheCheckedAt,
+      ttlMs: SEARCH_CACHE_TTL_MS
+    })
+    if (cacheOutcome !== 'hit') this.cacheTelemetry.recordMiss(cacheOutcome)
+    if (cacheOutcome === 'hit' && cachedEntry) {
+      this.cacheTelemetry.recordHit(cachedAgeMs, cachedEntry.result.duration)
       const cachedResult = materializeCachedSearchResult(cachedEntry.result, sessionId)
       cachedResult.items = fileFilterService.filterSearchItems(cachedResult.items ?? [])
       const cachedItems = cachedResult.items.length
@@ -2077,6 +2110,7 @@ export class SearchEngineCore
         const { sourceId, itemId, sourceType } = data
         const isPinned = await instance.dbUtils.togglePin(sourceId, itemId, sourceType)
         instance.invalidatePinnedCache()
+        instance.cacheTelemetry.recordInvalidation('pin-toggle', instance.searchCache.size)
         instance.searchCache.clear()
         instance.recommendationEngine?.invalidateCache()
         return { success: true, isPinned }


### PR DESCRIPTION
Toward #346.

That issue asks whether the query cache earns its complexity and says to remove it if not. **The number that would answer it did not exist** — nothing counted a lookup. This is acceptance criterion 1, and the prerequisite for every other one.

## The reason breakdown is the point, not the hit rate

Two prior investigations on this issue established that entries are dropped by **any** index commit, including from providers the query never reached — `search-core.contracts.test.ts:822` writes that down as the contract. So a hit rate near zero can mean *"nobody repeats queries"* or *"the cache was never given a chance"*, and those call for opposite decisions.

| | |
|---|---|
| misses | `absent` / `revision-mismatch` / `expired` |
| invalidations | `index-commit` / `privacy-cleanup` / `pin-toggle` / `lru-evict` |

**Invalidations count entries dropped, not calls.** `handleSearchIndexCommit` clears unconditionally and fires constantly while the file watcher runs, so counting calls would make `index-commit` look dominant on events that dropped nothing.

**Saved latency is the duration the served result originally took** — the only defensible reading here, since the alternative is timing work a hit did not do. A snapshot with no duration contributes nothing rather than a zero, which would drag the percentiles toward a saving that did not happen.

No query text, no cache key, no item content. Counts and durations only.

## What the plants found in my own first version

The classification came out of `executeSearch` into its own function because of this:

> **reporting every revision mismatch as `expired` passed all 656 search-engine tests** while it sat inline in a 2200-line method.

Six cases now cover it, including the entry that is *both* stale and expired — calling that one `expired` would hide an invalidation behind the TTL and make the policy look free.

```
revision/expired order swapped        1 of 16 fail
TTL boundary >= becomes >             1 of 16
samples unbounded                     1 of 16
accept null/NaN/negative samples      2 of 16
count invalidation calls not entries  1 of 16
```

A first plant also showed a **dead branch in my own code**: `recordHit` guarded a null duration that `push` already rejects, so no test could hold it and the next reader would have read it as load-bearing. Removed rather than left in.

## What this does not do

No behaviour change, no decision. The keep-or-remove threshold is still #346's to set, and the measurement run needs a real session. What this makes possible is that the run produces a distribution rather than a single misleading ratio.

`search-engine` 75 files / 662 tests pass. `typecheck:node` clean, lint clean.

Refs #346