### PR TITLE
docs(ratchet): stop calling a decided default a debt (#806)

### DIFF
--- a/scripts/check-transparent-window-debt.mjs
+++ b/scripts/check-transparent-window-debt.mjs
@@ -8,14 +8,17 @@
  * `transparent: true` window with no `backgroundColor` renders black or invisible. There is no
  * fallback to catch it, and nothing in the tree detects a compositor.
  *
- * Six of the eight window option sets are in that shape today. Fixing them is a rendering change
- * on a platform this repo has no runner for, so it needs someone who can look at the result --
- * that is the decision on #806. What needs no decision is that a seventh should not appear while
- * that waits, because each one lands silently: it looks correct on macOS and Windows, which is
- * where it gets reviewed.
+ * Six of the eight window option sets are in that shape, and #806 decided they stay that way.
+ * Giving them all an opaque backgroundColor was the audit's suggestion and was rejected: most
+ * Linux desktops do composite, so a blanket default would flatten the launcher's translucency
+ * for all of them to protect the ones that cannot show it. What shipped instead is
+ * TUFF_OPAQUE_WINDOWS=1 -- a way out reachable from outside a window you cannot see.
  *
- * A ratchet, not a fix. The number below is a debt, and lowering it is the repair. It fails in
- * both directions so a repair moves the floor with it.
+ * So the number below is not debt awaiting repair, and lowering it is not the fix. It is a count
+ * of a deliberate default, held so a seventh cannot join it without the same consideration:
+ * each one lands silently, because it looks correct on macOS and Windows, which is where it gets
+ * reviewed. It fails in both directions so that a window genuinely gaining a backgroundColor
+ * moves the floor rather than leaving room for a new one.
  */
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
@@ -25,7 +28,7 @@ import { fileURLToPath } from 'node:url'
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const WINDOW_CONFIG = path.join(REPO_ROOT, 'apps/core-app/src/main/config/default.ts')
 
-/** Window option sets that are transparent with no `backgroundColor`, as of the pin. */
+/** Window option sets that are transparent with no `backgroundColor`, by design (#806). */
 export const KNOWN_TRANSPARENT_WITHOUT_BACKGROUND = 6
 
 /** Every exported `*WindowOption` in the config, with the two fields that matter. */
@@ -69,9 +72,10 @@ function main() {
 
   if (risky.length < KNOWN_TRANSPARENT_WITHOUT_BACKGROUND) {
     process.stderr.write(
-      `[check-transparent-window-debt] only ${risky.length} remain, down from `
-      + `${KNOWN_TRANSPARENT_WITHOUT_BACKGROUND}. Lower KNOWN_TRANSPARENT_WITHOUT_BACKGROUND to `
-      + `${risky.length} so the floor moves with the repair.\n`,
+      `[check-transparent-window-debt] only ${risky.length} are transparent without a `
+      + `backgroundColor, down from ${KNOWN_TRANSPARENT_WITHOUT_BACKGROUND}. If that was `
+      + `intended, lower KNOWN_TRANSPARENT_WITHOUT_BACKGROUND to ${risky.length} so the floor `
+      + `moves with it; #806 decided these six stay, so check that the change was deliberate.\n`,
     )
     process.exit(1)
   }


### PR DESCRIPTION
Follow-up to #806, found while auditing the repo's four ratchets after #548 retired one of them.

## The rationale outlived its decision

`check-transparent-window-debt.mjs` says:

> Fixing them is a rendering change on a platform this repo has no runner for, so it needs someone who can look at the result — **that is the decision on #806**. […] The number below is a debt, and **lowering it is the repair**.

**#806 is closed, and the decision went the other way.** Giving all six windows an opaque `backgroundColor` was the audit's suggestion and was explicitly rejected: most Linux desktops do composite, so a blanket default would flatten the launcher's translucency for all of them to protect the ones that cannot show it. What shipped instead is `TUFF_OPAQUE_WINDOWS=1` — a way out reachable from outside a window you cannot see.

So the file is telling its next reader to do the thing that was considered and turned down, and pointing at a closed issue as though the answer were still pending.

## What changes

Only the prose and one message. The pin stays at 6, both directions still fail, and the test passes unchanged.

The guard is still worth having — a seventh such window lands silently, because it looks correct on macOS and Windows, which is where it gets reviewed. But it is **holding a deliberate default**, not counting down to zero. The message printed when the count drops now asks whether the change was deliberate rather than instructing the reader to lower the pin as though a repair had happened.

## Why this came up

#548 ended by deleting its ratchet, on the principle that **a ratchet is for debt that will never reach zero; if the number can reach zero, the right instrument is a switch.** Applying that to the remaining three:

| ratchet | can it reach zero? | verdict |
|---|---|---|
| drizzle snapshot gap (24) | no — #1303 established that replaying the 23 hand-written migrations would fossilise a guess | correct use |
| transparent windows (6) | no — but not because it is hard; because #806 decided it should not | **correct guard, wrong description** — this PR |
| tuffex CSS budget | not checked here | open question |

Documentation only.
