### PR TITLE
ref(plugin): move the plugin HTTP client out of plugin.ts

### DIFF
--- a/apps/core-app/src/main/modules/plugin/plugin-http-client.test.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-http-client.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const requestMock = vi.fn()
+
+vi.mock('../network', () => ({
+  getNetworkService: () => ({ request: requestMock })
+}))
+
+const { createPluginHttpClient, normalizeNetworkMethod, normalizeResponseType } =
+  await import('./plugin-http-client')
+
+/**
+ * The method allowlist is why this is worth reading on its own (#339).
+ *
+ * A plugin supplies `method` as a free string on the config object, and this is the last thing
+ * between that string and the network service. While it lived among four thousand lines of
+ * `plugin.ts` nothing tested it; the narrowing is the reason the extraction was worth doing, so
+ * it gets asserted here rather than assumed.
+ */
+describe('plugin http method narrowing', () => {
+  it('passes the methods the network service is allowed to see', () => {
+    for (const method of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'])
+      expect(normalizeNetworkMethod(method)).toBe(method)
+  })
+
+  it('accepts the same methods in any casing and with stray whitespace', () => {
+    expect(normalizeNetworkMethod('post')).toBe('POST')
+    expect(normalizeNetworkMethod('  delete  ')).toBe('DELETE')
+    expect(normalizeNetworkMethod('PaTcH')).toBe('PATCH')
+  })
+
+  /**
+   * The failure mode worth guarding: falling back to `GET` rather than forwarding whatever the
+   * plugin wrote. `TRACE` and `CONNECT` are real HTTP methods deliberately left out of the set,
+   * so they are the cases that show the rule is an allowlist and not a syntax check.
+   */
+  it('falls back to GET for anything outside the set', () => {
+    for (const method of ['TRACE', 'CONNECT', 'PROPFIND', 'GET ', '', 'not a method', 'GET;POST'])
+      expect(normalizeNetworkMethod(method), method).toBe('GET')
+  })
+
+  it('falls back to GET when the plugin supplies no method or a non-string', () => {
+    expect(normalizeNetworkMethod(undefined)).toBe('GET')
+    expect(normalizeNetworkMethod(42 as never)).toBe('GET')
+    expect(normalizeNetworkMethod(null as never)).toBe('GET')
+  })
+})
+
+describe('response type mapping', () => {
+  // The plugin-facing name is `arraybuffer`; the network service takes `arrayBuffer`. Getting this
+  // wrong hands binary responses back parsed as JSON.
+  it('renames arraybuffer to the network service spelling', () => {
+    expect(normalizeResponseType('arraybuffer')).toBe('arrayBuffer')
+  })
+
+  it('leaves the names both sides already agree on alone', () => {
+    expect(normalizeResponseType('json')).toBe('json')
+    expect(normalizeResponseType('text')).toBe('text')
+    expect(normalizeResponseType(undefined)).toBeUndefined()
+  })
+})
+
+describe('createPluginHttpClient', () => {
+  beforeEach(() => {
+    requestMock.mockReset()
+    requestMock.mockResolvedValue({
+      data: { ok: true },
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'application/json' },
+      url: 'https://example.test/resolved'
+    })
+  })
+
+  it('forwards the config to the network service under its own field names', async () => {
+    const signal = new AbortController().signal
+    const client = createPluginHttpClient()
+
+    await client.request({
+      url: 'https://example.test',
+      method: 'post',
+      headers: { 'x-test': '1' },
+      params: { page: 2 },
+      data: { body: true },
+      signal,
+      timeoutMs: 1_500,
+      responseType: 'arraybuffer'
+    })
+
+    // `params` becomes `query` and `data` becomes `body`; a rename missed here sends the query
+    // string as a request body.
+    expect(requestMock).toHaveBeenCalledWith({
+      method: 'POST',
+      url: 'https://example.test',
+      headers: { 'x-test': '1' },
+      query: { page: 2 },
+      body: { body: true },
+      signal,
+      timeoutMs: 1_500,
+      responseType: 'arrayBuffer'
+    })
+  })
+
+  it('prefers timeoutMs over the older timeout field', async () => {
+    const client = createPluginHttpClient()
+
+    await client.request({ url: 'https://example.test', timeout: 900, timeoutMs: 100 })
+    expect(requestMock.mock.calls[0]?.[0].timeoutMs).toBe(100)
+
+    await client.request({ url: 'https://example.test', timeout: 900 })
+    expect(requestMock.mock.calls[1]?.[0].timeoutMs).toBe(900)
+
+    await client.request({ url: 'https://example.test' })
+    expect(requestMock.mock.calls[2]?.[0].timeoutMs).toBeUndefined()
+  })
+
+  it('returns the response with the config that produced it', async () => {
+    const client = createPluginHttpClient()
+    const config = { url: 'https://example.test', method: 'GET' }
+
+    const response = await client.request(config)
+
+    expect(response).toEqual({
+      data: { ok: true },
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'application/json' },
+      config,
+      // The URL the service actually reached, not the one asked for — this is how a redirect is
+      // visible to the plugin.
+      url: 'https://example.test/resolved'
+    })
+  })
+
+  it('pins the method on every verb helper regardless of what the config asked for', async () => {
+    const client = createPluginHttpClient()
+
+    await client.get('https://example.test', { method: 'DELETE' } as never)
+    await client.post('https://example.test', { a: 1 }, { method: 'DELETE' } as never)
+    await client.put('https://example.test', { a: 1 })
+    await client.patch('https://example.test', { a: 1 })
+    await client.delete('https://example.test', { method: 'POST' } as never)
+
+    expect(requestMock.mock.calls.map((call) => call[0].method)).toEqual([
+      'GET',
+      'POST',
+      'PUT',
+      'PATCH',
+      'DELETE'
+    ])
+  })
+
+  it('sends the body only for the verbs that carry one', async () => {
+    const client = createPluginHttpClient()
+
+    await client.get('https://example.test')
+    await client.delete('https://example.test')
+    await client.post('https://example.test', { a: 1 })
+
+    expect(requestMock.mock.calls[0]?.[0].body).toBeUndefined()
+    expect(requestMock.mock.calls[1]?.[0].body).toBeUndefined()
+    expect(requestMock.mock.calls[2]?.[0].body).toEqual({ a: 1 })
+  })
+
+  it('lets a network failure reach the plugin rather than resolving with a fabricated response', async () => {
+    requestMock.mockRejectedValueOnce(new Error('offline'))
+    const client = createPluginHttpClient()
+
+    await expect(client.get('https://example.test')).rejects.toThrow('offline')
+  })
+})

--- a/apps/core-app/src/main/modules/plugin/plugin-http-client.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-http-client.ts
@@ -1,0 +1,137 @@
+import type {
+  NetworkMethod,
+  NetworkRequestOptions,
+  NetworkResponseType
+} from '@talex-touch/utils/network'
+import { getNetworkService } from '../network'
+
+/**
+ * The HTTP client handed to plugins.
+ *
+ * Lifted out of `plugin.ts` for #339. That file is a multi-owner coordination hotspot -- 4068
+ * lines when this moved, up 976 since the issue was filed -- and this is one of the parts with a
+ * boundary of its own: it takes a request config, hands it to the network service, and hands the
+ * response back. It reads no plugin state and touches nothing on `TouchPlugin`.
+ *
+ * The narrowing that matters is `ALLOWED_HTTP_METHODS`. A plugin supplies `method` as a free
+ * string, and anything outside the set becomes `GET` rather than reaching the network service --
+ * so the allowlist is the reason this file is worth being able to read on its own.
+ */
+
+export type PluginHttpResponseType = Extract<NetworkResponseType, 'json' | 'text'> | 'arraybuffer'
+export interface PluginHttpRequestConfig {
+  url: string
+  method?: string
+  headers?: Record<string, string>
+  params?: Record<string, string | number | boolean | null | undefined>
+  data?: unknown
+  signal?: AbortSignal
+  timeout?: number
+  timeoutMs?: number
+  responseType?: PluginHttpResponseType
+}
+
+export interface PluginHttpResponse<T = unknown> {
+  data: T
+  status: number
+  statusText: string
+  headers: Record<string, string>
+  config: PluginHttpRequestConfig
+  url: string
+}
+
+export interface PluginHttpClient {
+  request: <T = unknown>(config: PluginHttpRequestConfig) => Promise<PluginHttpResponse<T>>
+  get: <T = unknown>(
+    url: string,
+    config?: Omit<PluginHttpRequestConfig, 'url' | 'method' | 'data'>
+  ) => Promise<PluginHttpResponse<T>>
+  post: <T = unknown>(
+    url: string,
+    data?: unknown,
+    config?: Omit<PluginHttpRequestConfig, 'url' | 'method' | 'data'>
+  ) => Promise<PluginHttpResponse<T>>
+  put: <T = unknown>(
+    url: string,
+    data?: unknown,
+    config?: Omit<PluginHttpRequestConfig, 'url' | 'method' | 'data'>
+  ) => Promise<PluginHttpResponse<T>>
+  patch: <T = unknown>(
+    url: string,
+    data?: unknown,
+    config?: Omit<PluginHttpRequestConfig, 'url' | 'method' | 'data'>
+  ) => Promise<PluginHttpResponse<T>>
+  delete: <T = unknown>(
+    url: string,
+    config?: Omit<PluginHttpRequestConfig, 'url' | 'method' | 'data'>
+  ) => Promise<PluginHttpResponse<T>>
+}
+
+export const ALLOWED_HTTP_METHODS = new Set<NetworkMethod>([
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'HEAD',
+  'OPTIONS'
+])
+
+export function normalizeNetworkMethod(method?: string): NetworkMethod {
+  const normalized = typeof method === 'string' ? method.trim().toUpperCase() : 'GET'
+  if (ALLOWED_HTTP_METHODS.has(normalized as NetworkMethod)) {
+    return normalized as NetworkMethod
+  }
+  return 'GET'
+}
+
+export function normalizeResponseType(
+  responseType: PluginHttpResponseType | undefined
+): NetworkRequestOptions['responseType'] {
+  if (responseType === 'arraybuffer') {
+    return 'arrayBuffer'
+  }
+  return responseType
+}
+
+export function createPluginHttpClient(): PluginHttpClient {
+  const networkService = getNetworkService()
+
+  const send = async <T>(config: PluginHttpRequestConfig): Promise<PluginHttpResponse<T>> => {
+    const method = normalizeNetworkMethod(config.method)
+    const timeoutMs =
+      typeof config.timeoutMs === 'number'
+        ? config.timeoutMs
+        : typeof config.timeout === 'number'
+          ? config.timeout
+          : undefined
+    const response = await networkService.request<T>({
+      method,
+      url: config.url,
+      headers: config.headers,
+      query: config.params,
+      body: config.data,
+      signal: config.signal,
+      timeoutMs,
+      responseType: normalizeResponseType(config.responseType)
+    })
+
+    return {
+      data: response.data,
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+      config,
+      url: response.url
+    }
+  }
+
+  return {
+    request: send,
+    get: (url, config = {}) => send({ ...config, url, method: 'GET' }),
+    post: (url, data, config = {}) => send({ ...config, url, method: 'POST', data }),
+    put: (url, data, config = {}) => send({ ...config, url, method: 'PUT', data }),
+    patch: (url, data, config = {}) => send({ ...config, url, method: 'PATCH', data }),
+    delete: (url, config = {}) => send({ ...config, url, method: 'DELETE' })
+  }
+}

--- a/apps/core-app/src/main/modules/plugin/plugin.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin.ts
@@ -3,11 +3,6 @@ import type { TuffItem } from '@talex-touch/utils/core-box'
 import type { ITouchEvent } from '@talex-touch/utils/eventbus'
 import type { LocalizedTextValue } from '@talex-touch/utils/i18n'
 import type {
-  NetworkMethod,
-  NetworkRequestOptions,
-  NetworkResponseType
-} from '@talex-touch/utils/network'
-import type {
   IFeatureLifeCycle,
   IPlatform,
   IPluginBuildInfo,
@@ -153,6 +148,7 @@ import { viewCacheManager } from '../box-tool/core-box/view-cache'
 import { getBoxItemManager } from '../box-tool/item-sdk'
 import { getSearchProviderUserConfigs } from '../box-tool/search-engine/search-provider-config'
 import { getNetworkService } from '../network'
+import { createPluginHttpClient } from './plugin-http-client'
 import { notificationModule } from '../notification'
 import { getPermissionModule } from '../permission'
 import { PluginFeature } from './plugin-feature'
@@ -333,124 +329,6 @@ export interface PluginLoadError {
 
 function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error))
-}
-
-type PluginHttpResponseType = Extract<NetworkResponseType, 'json' | 'text'> | 'arraybuffer'
-interface PluginHttpRequestConfig {
-  url: string
-  method?: string
-  headers?: Record<string, string>
-  params?: Record<string, string | number | boolean | null | undefined>
-  data?: unknown
-  signal?: AbortSignal
-  timeout?: number
-  timeoutMs?: number
-  responseType?: PluginHttpResponseType
-}
-
-interface PluginHttpResponse<T = unknown> {
-  data: T
-  status: number
-  statusText: string
-  headers: Record<string, string>
-  config: PluginHttpRequestConfig
-  url: string
-}
-
-interface PluginHttpClient {
-  request: <T = unknown>(config: PluginHttpRequestConfig) => Promise<PluginHttpResponse<T>>
-  get: <T = unknown>(
-    url: string,
-    config?: Omit<PluginHttpRequestConfig, 'url' | 'method' | 'data'>
-  ) => Promise<PluginHttpResponse<T>>
-  post: <T = unknown>(
-    url: string,
-    data?: unknown,
-    config?: Omit<PluginHttpRequestConfig, 'url' | 'method' | 'data'>
-  ) => Promise<PluginHttpResponse<T>>
-  put: <T = unknown>(
-    url: string,
-    data?: unknown,
-    config?: Omit<PluginHttpRequestConfig, 'url' | 'method' | 'data'>
-  ) => Promise<PluginHttpResponse<T>>
-  patch: <T = unknown>(
-    url: string,
-    data?: unknown,
-    config?: Omit<PluginHttpRequestConfig, 'url' | 'method' | 'data'>
-  ) => Promise<PluginHttpResponse<T>>
-  delete: <T = unknown>(
-    url: string,
-    config?: Omit<PluginHttpRequestConfig, 'url' | 'method' | 'data'>
-  ) => Promise<PluginHttpResponse<T>>
-}
-
-const ALLOWED_HTTP_METHODS = new Set<NetworkMethod>([
-  'GET',
-  'POST',
-  'PUT',
-  'PATCH',
-  'DELETE',
-  'HEAD',
-  'OPTIONS'
-])
-
-function normalizeNetworkMethod(method?: string): NetworkMethod {
-  const normalized = typeof method === 'string' ? method.trim().toUpperCase() : 'GET'
-  if (ALLOWED_HTTP_METHODS.has(normalized as NetworkMethod)) {
-    return normalized as NetworkMethod
-  }
-  return 'GET'
-}
-
-function normalizeResponseType(
-  responseType: PluginHttpResponseType | undefined
-): NetworkRequestOptions['responseType'] {
-  if (responseType === 'arraybuffer') {
-    return 'arrayBuffer'
-  }
-  return responseType
-}
-
-function createPluginHttpClient(): PluginHttpClient {
-  const networkService = getNetworkService()
-
-  const send = async <T>(config: PluginHttpRequestConfig): Promise<PluginHttpResponse<T>> => {
-    const method = normalizeNetworkMethod(config.method)
-    const timeoutMs =
-      typeof config.timeoutMs === 'number'
-        ? config.timeoutMs
-        : typeof config.timeout === 'number'
-          ? config.timeout
-          : undefined
-    const response = await networkService.request<T>({
-      method,
-      url: config.url,
-      headers: config.headers,
-      query: config.params,
-      body: config.data,
-      signal: config.signal,
-      timeoutMs,
-      responseType: normalizeResponseType(config.responseType)
-    })
-
-    return {
-      data: response.data,
-      status: response.status,
-      statusText: response.statusText,
-      headers: response.headers,
-      config,
-      url: response.url
-    }
-  }
-
-  return {
-    request: send,
-    get: (url, config = {}) => send({ ...config, url, method: 'GET' }),
-    post: (url, data, config = {}) => send({ ...config, url, method: 'POST', data }),
-    put: (url, data, config = {}) => send({ ...config, url, method: 'PUT', data }),
-    patch: (url, data, config = {}) => send({ ...config, url, method: 'PATCH', data }),
-    delete: (url, config = {}) => send({ ...config, url, method: 'DELETE' })
-  }
 }
 
 const TRANSLATION_RUNTIME_CAPABILITIES = Object.freeze([


### PR DESCRIPTION
Toward #339.

`plugin.ts` was **4068 lines, up 976 since that issue was filed**. It has been shrinking in the issue's name while growing faster than it shrank. This is the first commit that leaves it smaller than it found it.

```
4069 → 3947
```

## Why this piece

The HTTP client is one of the parts with a boundary of its own: it takes a request config, hands it to the network service, and hands the response back. **It reads no plugin state and touches nothing on `TouchPlugin`**, so it moves whole — types included — and the class keeps a single value import.

#339 says explicitly that no extraction is justified by a line count. This one isn't. The narrowing is:

> A plugin supplies `method` as a **free string**, and `ALLOWED_HTTP_METHODS` is the last thing between that string and the network service.

Nothing tested it in four thousand lines.

## Six plants, each caught

| plant | failing |
|---|---|
| drop the method allowlist entirely | 1 of 12 |
| add `TRACE` to the allowlist | 1 of 12 |
| stop renaming `arraybuffer` | 2 of 12 |
| swap `query` and `body` | 2 of 12 |
| ignore the legacy `timeout` field | 1 of 12 |
| let `delete` inherit the config's method | 1 of 12 |

`arraybuffer` → `arrayBuffer` is the one that reads as harmless. The plugin-facing name and the service's name differ by a capital B, and getting it wrong hands a binary response back parsed as JSON.

The allowlist cases use `TRACE` and `CONNECT` deliberately — real HTTP methods left out of the set, so the test shows the rule is an allowlist rather than a syntax check.

## Verification

`plugin` 90 of 91 files pass, 1230 tests. The one failure is `plugin-sqlite-worker.integration.test.ts` asking for a build artifact this checkout lacks — identical on the baseline, green in CI (#1604). `typecheck:node` clean under the package's own flags, lint clean.

Refs #339