### PR TITLE
fix(ocr): pair the Windows COM apartment with an owner (#344)

### DIFF
--- a/packages/test/src/native/tuff-native-ocr.test.ts
+++ b/packages/test/src/native/tuff-native-ocr.test.ts
@@ -110,4 +110,35 @@ describe('tuff-native ocr smoke & contract', () => {
     expect(Array.isArray(result.blocks)).toBe(true)
     expect((result.blocks || []).length).toBeGreaterThan(0)
   })
+
+  it('survives repeated and concurrent calls on reused threads', async () => {
+    const support = nativeOcr.getNativeOcrSupport()
+    if (!support.supported) {
+      expect(
+        REQUIRE_OCR,
+        `native OCR reported unsupported on ${process.platform} (${support.reason})`,
+      ).toBe(false)
+      return
+    }
+
+    // Windows initialises a COM apartment per call. It used to do so with nothing paired to it,
+    // so every reused N-API worker thread accumulated a reference (#344). One call cannot show
+    // that; a sequence on the same pool can, and the concurrent round additionally lands calls on
+    // threads another call already initialised -- the RPC_E_CHANGED_MODE path.
+    const fixturePath = fileURLToPath(new URL('./fixtures/tuff-ocr-fixture.png', import.meta.url))
+    const image = readFileSync(fixturePath)
+    const recognize = async (): Promise<string> => {
+      const result = await nativeOcr.recognizeImageText({ image })
+      return result.text.toLowerCase()
+    }
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(await recognize()).toContain('tuff')
+    }
+
+    const concurrent = await Promise.all(Array.from({ length: 4 }, () => recognize()))
+    for (const text of concurrent) {
+      expect(text).toContain('tuff')
+    }
+  })
 })

--- a/packages/tuff-native/native/src/platform/windows/winrt_ocr.cpp
+++ b/packages/tuff-native/native/src/platform/windows/winrt_ocr.cpp
@@ -146,6 +146,47 @@ std::array<double, 4> MergeWordBoundingBox(const winrt::Windows::Media::Ocr::Ocr
   return {minX, minY, std::max(0.0, maxX - minX), std::max(0.0, maxY - minY)};
 }
 
+/**
+ * Owns the COM apartment for one OCR call, and only when this call created it.
+ *
+ * `init_apartment` ran per call with nothing paired to it. Every N-API worker thread is reused,
+ * so each call left another reference behind; and a caller that had already initialised the
+ * thread single-threaded made the call throw RPC_E_CHANGED_MODE with no handling at all (#344).
+ *
+ * The two failure modes need opposite treatment, which is why this cannot be a bare
+ * init/uninit pair. CoInitializeEx returns S_FALSE when the apartment already exists in the same
+ * mode -- that is a success and still takes a reference, so it must be released. RPC_E_CHANGED_MODE
+ * takes no reference, so releasing on that path would tear down an apartment owned by someone
+ * else, on a thread this addon does not own.
+ */
+class ApartmentScope {
+ public:
+  ApartmentScope() {
+    try {
+      winrt::init_apartment(winrt::apartment_type::multi_threaded);
+      owned_ = true;
+    } catch (const winrt::hresult_error& ex) {
+      if (ex.code() != RPC_E_CHANGED_MODE) {
+        throw;
+      }
+      // The thread already has an apartment in another mode. WinRT still marshals across it, so
+      // the OCR proceeds -- it simply is not ours to release.
+    }
+  }
+
+  ApartmentScope(const ApartmentScope&) = delete;
+  ApartmentScope& operator=(const ApartmentScope&) = delete;
+
+  ~ApartmentScope() {
+    if (owned_) {
+      winrt::uninit_apartment();
+    }
+  }
+
+ private:
+  bool owned_ = false;
+};
+
 } // namespace
 
 bool PerformPlatformOcr(const OcrOptions& options, OcrResult& result, OcrError& error) {
@@ -154,7 +195,8 @@ bool PerformPlatformOcr(const OcrOptions& options, OcrResult& result, OcrError& 
   const auto startedAt = std::chrono::steady_clock::now();
 
   try {
-    winrt::init_apartment(winrt::apartment_type::multi_threaded);
+    // Destroyed on every exit from this try block, including the throwing ones below.
+    const ApartmentScope apartment;
 
     winrt::Windows::Graphics::Imaging::SoftwareBitmap bitmap{nullptr};
     if (!BuildBitmapFromBytes(options.image, bitmap, error)) {


### PR DESCRIPTION
Closes #344.

## What was there

One line, no partner:

```cpp
bool PerformPlatformOcr(...) {
  try {
    winrt::init_apartment(winrt::apartment_type::multi_threaded);   // ← the only occurrence
```

`grep` for `uninit_apartment`, `CoUninitialize`, `RPC_E_CHANGED_MODE` or `S_FALSE` in that file returns nothing else. So every OCR request initialised an apartment on whatever N-API worker thread it landed on and left the reference behind, and a caller that had already initialised that thread single-threaded produced `RPC_E_CHANGED_MODE`, which fell through to the generic catch and surfaced as a recognition failure.

## Why it cannot be a bare init/uninit pair

The two non-obvious returns from `CoInitializeEx` need **opposite** treatment, which is the whole reason this needs an owner rather than a symmetric pair:

| result | took a reference? | correct action |
|---|---|---|
| `S_OK` | yes | release it |
| `S_FALSE` — already initialised, same mode | **yes** | release it |
| `RPC_E_CHANGED_MODE` — already initialised, other mode | **no** | **must not** release |

Releasing on the third would tear down an apartment owned by someone else, on a thread this addon does not own. `ApartmentScope` records whether the constructor actually acquired one and releases only then; on `RPC_E_CHANGED_MODE` it proceeds unowned rather than failing the request, because WinRT still marshals across it.

Destruction is by scope, so it also runs on the throwing exits — bitmap build failure, no engine, empty text, and all three catch blocks — which a manual uninit at the end of the happy path would have missed.

## Verified where it matters, not where it is convenient

`tuff-native-ocr.test.ts` runs on `windows-2022` inside `native-protocol.yml` with `TUFF_NATIVE_OCR_REQUIRED=1` (added in #1517), so it **cannot pass by skipping** — the flag turns the early return into a failure naming the platform.

The new case exercises exactly the two conditions the fix is about: five sequential calls, which is what accumulates references on a reused pool, then four concurrent ones, which land on threads a previous call already initialised.

## Not verifiable locally

This file only compiles on Windows. Six tests pass on macOS, which exercises the Apple Vision path and proves the test itself is sound, but says nothing about the C++ above. **The Windows leg of `native-protocol.yml` is the verification** — it builds this addon and then runs OCR through it, so a compile error or a broken apartment shows up there rather than in review.
