### PR TITLE
ref(plugin): move the Electron wrappers out of plugin.ts

### DIFF
--- a/apps/core-app/src/main/modules/plugin/plugin-safe-api.test.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-safe-api.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const validateExternalUrlMock = vi.fn()
+const openExternalMock = vi.fn()
+const clipboardMock = {
+  readText: vi.fn(() => 'text'),
+  writeText: vi.fn(),
+  readImage: vi.fn(() => 'image'),
+  writeImage: vi.fn(),
+  clear: vi.fn(),
+  has: vi.fn(() => true)
+}
+
+vi.mock('electron', () => ({
+  clipboard: clipboardMock,
+  dialog: {
+    showMessageBox: vi.fn(async () => ({ response: 0 })),
+    showOpenDialog: vi.fn(async () => ({ canceled: true, filePaths: [] })),
+    showSaveDialog: vi.fn(async () => ({ canceled: true }))
+  },
+  shell: { openExternal: openExternalMock }
+}))
+
+vi.mock('../../utils/external-url-policy', () => ({
+  validateExternalUrl: validateExternalUrlMock
+}))
+
+const {
+  createRemovedChannelError,
+  createSafePluginClipboardApi,
+  createSafePluginDialogApi,
+  createSafePluginOpenUrl,
+  withPluginSdkapiPayload
+} = await import('./plugin-safe-api')
+
+function fakeLogger(): { warn: ReturnType<typeof vi.fn> } {
+  return { warn: vi.fn() }
+}
+
+/**
+ * The reason this file exists (#339).
+ *
+ * A plugin passes a URL straight from its own code and this wrapper is the last thing before
+ * `shell.openExternal`. `external-url-policy` has its own tests; what had none was the wrapper
+ * deciding whether to call it, because it sat among four thousand lines of `plugin.ts` with no
+ * export to reach it by.
+ */
+describe('createSafePluginOpenUrl', () => {
+  beforeEach(() => {
+    validateExternalUrlMock.mockReset()
+    openExternalMock.mockReset()
+  })
+
+  it('opens the URL the policy returned, not the one the plugin passed', async () => {
+    // The policy may normalise; opening the raw input would defeat any normalisation it did.
+    validateExternalUrlMock.mockReturnValue({
+      allowed: true,
+      url: 'https://example.test/normalised'
+    })
+
+    await createSafePluginOpenUrl('touch-demo', fakeLogger() as never)('https://example.test')
+
+    expect(openExternalMock).toHaveBeenCalledWith('https://example.test/normalised')
+  })
+
+  it('never reaches the shell when the policy refuses', async () => {
+    validateExternalUrlMock.mockReturnValue({
+      allowed: false,
+      reason: 'protocol-not-allowed',
+      protocol: 'file:'
+    })
+    const logger = fakeLogger()
+
+    await expect(
+      createSafePluginOpenUrl('touch-demo', logger as never)('file:///etc/passwd')
+    ).rejects.toThrow('PLUGIN_OPEN_URL_BLOCKED:protocol-not-allowed')
+
+    expect(openExternalMock).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledOnce()
+  })
+
+  /**
+   * The thrown message carries the reason, and the log carries the reason and protocol. Neither
+   * carries the URL — a blocked `file://` or a credential-bearing link would otherwise end up in
+   * the plugin log verbatim.
+   */
+  it('keeps the refused URL out of the error and the log', async () => {
+    validateExternalUrlMock.mockReturnValue({
+      allowed: false,
+      reason: 'protocol-not-allowed',
+      protocol: 'file:'
+    })
+    const logger = fakeLogger()
+    const secret = 'file:///Users/someone/.ssh/id_rsa'
+
+    await expect(
+      createSafePluginOpenUrl('touch-demo', logger as never)(secret)
+    ).rejects.not.toThrow(secret)
+
+    expect(JSON.stringify(logger.warn.mock.calls)).not.toContain(secret)
+  })
+
+  it('rethrows a shell failure rather than reporting success', async () => {
+    validateExternalUrlMock.mockReturnValue({ allowed: true, url: 'https://example.test' })
+    openExternalMock.mockRejectedValue(new Error('no handler'))
+    const logger = fakeLogger()
+
+    await expect(
+      createSafePluginOpenUrl('touch-demo', logger as never)('https://example.test')
+    ).rejects.toThrow('no handler')
+
+    expect(logger.warn).toHaveBeenCalledOnce()
+  })
+})
+
+describe('createSafePluginClipboardApi', () => {
+  it('exposes exactly the six clipboard methods plus copyAndPaste', () => {
+    const copyAndPaste = vi.fn()
+    const api = createSafePluginClipboardApi(copyAndPaste as never)
+
+    // A named set is only worth having if something notices when it grows. `writeBookmark`,
+    // `readBuffer` and `writeBuffer` are real Electron clipboard methods deliberately left out.
+    expect(Object.keys(api).sort()).toEqual([
+      'clear',
+      'copyAndPaste',
+      'has',
+      'readImage',
+      'readText',
+      'writeImage',
+      'writeText'
+    ])
+  })
+
+  it('forwards to Electron rather than reimplementing anything', () => {
+    const api = createSafePluginClipboardApi(vi.fn() as never)
+
+    expect(api.readText()).toBe('text')
+    api.writeText('hello')
+    expect(clipboardMock.writeText).toHaveBeenCalledWith('hello')
+  })
+})
+
+describe('createSafePluginDialogApi', () => {
+  it('exposes exactly the three dialog methods', () => {
+    // `showErrorBox` and `showCertificateTrustDialog` are the omissions that matter here.
+    expect(Object.keys(createSafePluginDialogApi()).sort()).toEqual([
+      'showMessageBox',
+      'showOpenDialog',
+      'showSaveDialog'
+    ])
+  })
+})
+
+describe('withPluginSdkapiPayload', () => {
+  it('stamps the sdkapi onto an object payload', () => {
+    expect(withPluginSdkapiPayload({ a: 1 }, 260615)).toEqual({ a: 1, _sdkapi: 260615 })
+  })
+
+  /**
+   * Arrays, primitives and null are returned untouched. Spreading an array would turn it into an
+   * object keyed by index, which reaches the handler as a shape nothing downstream expects.
+   */
+  it('leaves anything that is not a plain object alone', () => {
+    for (const payload of [[1, 2], 'text', 42, null, undefined])
+      expect(withPluginSdkapiPayload(payload, 260615)).toBe(payload)
+  })
+
+  it('leaves the payload alone when there is no sdkapi to stamp', () => {
+    const payload = { a: 1 }
+
+    expect(withPluginSdkapiPayload(payload, undefined)).toBe(payload)
+    expect(withPluginSdkapiPayload(payload, '260615' as never)).toBe(payload)
+  })
+
+  it('overwrites an _sdkapi the plugin supplied itself', () => {
+    expect(withPluginSdkapiPayload({ _sdkapi: 1 }, 260615)).toEqual({ _sdkapi: 260615 })
+  })
+})
+
+describe('createRemovedChannelError', () => {
+  it('names the capability and points at the replacement', () => {
+    const error = createRemovedChannelError('channel.raw')
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toContain('channel.raw')
+    expect(error.message).toContain('typed transport')
+  })
+})

--- a/apps/core-app/src/main/modules/plugin/plugin-safe-api.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-safe-api.ts
@@ -1,0 +1,95 @@
+import type { ClipboardCopyAndPasteRequest } from '@talex-touch/utils/transport/events/types'
+import type { PluginLogger } from '@talex-touch/utils/plugin/node'
+import { clipboard, dialog, shell } from 'electron'
+import { validateExternalUrl } from '../../utils/external-url-policy'
+
+/**
+ * The wrappers a plugin reaches Electron through.
+ *
+ * Lifted out of `plugin.ts` for #339. The reason is `createSafePluginOpenUrl`, not the line
+ * count: a plugin passes a URL straight from its own code, and `validateExternalUrl` is the last
+ * thing before `shell.openExternal`. `external-url-policy` is tested; the wrapper that decides
+ * whether to call it was not, because it sat among four thousand lines with no export.
+ *
+ * The dialog and clipboard wrappers are here for the opposite reason -- they narrow Electron's
+ * surface to a named set, and a set is only worth having if something notices when it changes.
+ */
+
+export type PluginCopyAndPasteOptions = Omit<ClipboardCopyAndPasteRequest, '_sdkapi'>
+
+export type PluginClipboardApi = Pick<
+  Electron.Clipboard,
+  'readText' | 'writeText' | 'readImage' | 'writeImage' | 'clear' | 'has'
+> & {
+  copyAndPaste: (options: PluginCopyAndPasteOptions) => Promise<boolean>
+}
+
+export function createSafePluginDialogApi() {
+  return {
+    showMessageBox: (...args: Parameters<typeof dialog.showMessageBox>) =>
+      dialog.showMessageBox(...args),
+    showOpenDialog: (...args: Parameters<typeof dialog.showOpenDialog>) =>
+      dialog.showOpenDialog(...args),
+    showSaveDialog: (...args: Parameters<typeof dialog.showSaveDialog>) =>
+      dialog.showSaveDialog(...args)
+  }
+}
+
+export function createSafePluginClipboardApi(
+  copyAndPaste: PluginClipboardApi['copyAndPaste']
+): PluginClipboardApi {
+  return {
+    readText: (...args: Parameters<typeof clipboard.readText>) => clipboard.readText(...args),
+    writeText: (...args: Parameters<typeof clipboard.writeText>) => clipboard.writeText(...args),
+    readImage: (...args: Parameters<typeof clipboard.readImage>) => clipboard.readImage(...args),
+    writeImage: (...args: Parameters<typeof clipboard.writeImage>) => clipboard.writeImage(...args),
+    clear: (...args: Parameters<typeof clipboard.clear>) => clipboard.clear(...args),
+    has: (...args: Parameters<typeof clipboard.has>) => clipboard.has(...args),
+    copyAndPaste
+  }
+}
+
+export function createSafePluginOpenUrl(pluginName: string, logger: PluginLogger) {
+  return async (url: string): Promise<void> => {
+    const decision = validateExternalUrl(url)
+    if (!decision.allowed) {
+      const error = new Error(`PLUGIN_OPEN_URL_BLOCKED:${decision.reason}`)
+      logger.warn(`[Plugin ${pluginName}] openUrl blocked`, {
+        reason: decision.reason,
+        protocol: decision.protocol
+      })
+      throw error
+    }
+
+    try {
+      await shell.openExternal(decision.url)
+    } catch (error) {
+      logger.warn(`[Plugin ${pluginName}] openUrl failed`, {
+        error: error instanceof Error ? error.message : String(error)
+      })
+      throw error
+    }
+  }
+}
+
+export function withPluginSdkapiPayload(payload: unknown, sdkapi?: number): unknown {
+  if (
+    !payload ||
+    typeof payload !== 'object' ||
+    Array.isArray(payload) ||
+    typeof sdkapi !== 'number'
+  ) {
+    return payload
+  }
+
+  return {
+    ...(payload as Record<string, unknown>),
+    _sdkapi: sdkapi
+  }
+}
+
+export function createRemovedChannelError(capability: 'channel.raw'): Error {
+  return new Error(
+    `[Plugin API] ${capability} was removed by the core-app hard-cut. Migrate this plugin to typed transport send/on APIs.`
+  )
+}

--- a/apps/core-app/src/main/modules/plugin/plugin.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin.ts
@@ -23,7 +23,6 @@ import type { IndexedSourceDescriptor, SearchProviderDescriptor } from '@talex-t
 import type { ITuffTransport, SendOptions, TuffEvent } from '@talex-touch/utils/transport'
 import type {
   ClipboardActionResult,
-  ClipboardCopyAndPasteRequest,
   QuickOpsAuditGetRequest,
   QuickOpsAuditGetResponse,
   QuickOpsBatteryStatusGetResponse,
@@ -128,7 +127,7 @@ import {
   PluginEvents,
   QuickOpsEvents
 } from '@talex-touch/utils/transport/events'
-import { app, clipboard, dialog, shell } from 'electron'
+import { app } from 'electron'
 import fse from 'fs-extra'
 import {
   PluginLogAppendEvent,
@@ -138,7 +137,13 @@ import {
 } from '../../core/eventbus/touch-event'
 import { TuffIconImpl } from '../../core/tuff-icon'
 import { deviceIdleService } from '../../service/device-idle-service'
-import { validateExternalUrl } from '../../utils/external-url-policy'
+import {
+  createRemovedChannelError,
+  createSafePluginClipboardApi,
+  createSafePluginDialogApi,
+  createSafePluginOpenUrl,
+  withPluginSdkapiPayload
+} from './plugin-safe-api'
 import { t as translate } from '../../utils/i18n-helper'
 import { createLogger } from '../../utils/logger'
 import { getStyles } from '../../utils/plugin-injection'
@@ -170,85 +175,6 @@ interface FeatureEventUtil {
 }
 
 type BoxItemWriteScope = 'root-results' | 'active-feature'
-
-type PluginCopyAndPasteOptions = Omit<ClipboardCopyAndPasteRequest, '_sdkapi'>
-
-type PluginClipboardApi = Pick<
-  Electron.Clipboard,
-  'readText' | 'writeText' | 'readImage' | 'writeImage' | 'clear' | 'has'
-> & {
-  copyAndPaste: (options: PluginCopyAndPasteOptions) => Promise<boolean>
-}
-
-function createSafePluginDialogApi() {
-  return {
-    showMessageBox: (...args: Parameters<typeof dialog.showMessageBox>) =>
-      dialog.showMessageBox(...args),
-    showOpenDialog: (...args: Parameters<typeof dialog.showOpenDialog>) =>
-      dialog.showOpenDialog(...args),
-    showSaveDialog: (...args: Parameters<typeof dialog.showSaveDialog>) =>
-      dialog.showSaveDialog(...args)
-  }
-}
-
-function createSafePluginClipboardApi(
-  copyAndPaste: PluginClipboardApi['copyAndPaste']
-): PluginClipboardApi {
-  return {
-    readText: (...args: Parameters<typeof clipboard.readText>) => clipboard.readText(...args),
-    writeText: (...args: Parameters<typeof clipboard.writeText>) => clipboard.writeText(...args),
-    readImage: (...args: Parameters<typeof clipboard.readImage>) => clipboard.readImage(...args),
-    writeImage: (...args: Parameters<typeof clipboard.writeImage>) => clipboard.writeImage(...args),
-    clear: (...args: Parameters<typeof clipboard.clear>) => clipboard.clear(...args),
-    has: (...args: Parameters<typeof clipboard.has>) => clipboard.has(...args),
-    copyAndPaste
-  }
-}
-
-function createSafePluginOpenUrl(pluginName: string, logger: PluginLogger) {
-  return async (url: string): Promise<void> => {
-    const decision = validateExternalUrl(url)
-    if (!decision.allowed) {
-      const error = new Error(`PLUGIN_OPEN_URL_BLOCKED:${decision.reason}`)
-      logger.warn(`[Plugin ${pluginName}] openUrl blocked`, {
-        reason: decision.reason,
-        protocol: decision.protocol
-      })
-      throw error
-    }
-
-    try {
-      await shell.openExternal(decision.url)
-    } catch (error) {
-      logger.warn(`[Plugin ${pluginName}] openUrl failed`, {
-        error: error instanceof Error ? error.message : String(error)
-      })
-      throw error
-    }
-  }
-}
-
-function withPluginSdkapiPayload(payload: unknown, sdkapi?: number): unknown {
-  if (
-    !payload ||
-    typeof payload !== 'object' ||
-    Array.isArray(payload) ||
-    typeof sdkapi !== 'number'
-  ) {
-    return payload
-  }
-
-  return {
-    ...(payload as Record<string, unknown>),
-    _sdkapi: sdkapi
-  }
-}
-
-function createRemovedChannelError(capability: 'channel.raw'): Error {
-  return new Error(
-    `[Plugin API] ${capability} was removed by the core-app hard-cut. Migrate this plugin to typed transport send/on APIs.`
-  )
-}
 
 interface StorageTreeNode {
   name: string


### PR DESCRIPTION
Toward #339. Second cut on the same file, same run.

```
4069 → 3947 (HTTP client, #1678) → 3872
```

## Why this piece

`createSafePluginOpenUrl`, not the seventy-odd lines. **A plugin passes a URL straight from its own code and that wrapper is the last thing before `shell.openExternal`.** `external-url-policy` has its own tests; what had none was the wrapper deciding whether to call it, because it sat in `plugin.ts` with no export to reach it by.

## Seven plants, each caught

| plant | failing |
|---|---|
| drop the policy check entirely | 2 of 12 |
| open the plugin's raw URL instead of the one the policy returned | 1 of 12 |
| log the refused URL | 1 of 12 |
| add `writeBookmark` to the clipboard set | 1 of 12 |
| add `showErrorBox` to the dialog set | 1 of 12 |
| stamp `_sdkapi` onto arrays too | 1 of 12 |
| stamp a non-numeric sdkapi | 1 of 12 |

Two of those are the same shape as the HTTP client's method allowlist: **a named subset of an Electron surface is only worth having if something notices when it grows.** `writeBookmark`, `readBuffer` and `showErrorBox` are real methods deliberately outside the sets, so the tests fail on a *widened* set rather than on a typo.

The "open the raw URL" plant is the subtle one — the policy may normalise, and calling `shell.openExternal(url)` instead of `shell.openExternal(decision.url)` silently discards whatever it did.

## One thing asserted rather than left to reading

The refused URL appears in neither the thrown message nor the log line — only the reason and the protocol. A blocked `file:///Users/.../.ssh/id_rsa` would otherwise land in the plugin log verbatim.

## Verification

`plugin` 91 of 92 files pass, 1242 tests. The remaining failure is `plugin-sqlite-worker.integration.test.ts` asking for a build artifact this checkout lacks — identical on the baseline, green in CI (#1604). `typecheck:node` clean, lint clean.

Refs #339