### PR TITLE
ref(plugin): extract the feature admission rules from addFeature

### DIFF
--- a/apps/core-app/src/main/modules/plugin/plugin-feature-admission.test.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-feature-admission.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DISALLOWED_FEATURE_WORDS,
+  validatePluginFeatureAdmission
+} from './plugin-feature-admission'
+
+/**
+ * The rules a plugin feature has to clear before it reaches the list (#339).
+ *
+ * `addFeature` had six assertions and all of them checked the success path; the only rejection
+ * covered was the duplicate id. The word list in particular — which stops a plugin from calling
+ * its feature 官方 or talex — had no test of any kind, because reaching it meant constructing a
+ * plugin against a 3800-line class.
+ */
+function feature(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'demo-feature',
+    name: 'Demo',
+    desc: 'A demo feature',
+    commands: [{ type: 'over', value: ['demo'] }],
+    ...overrides
+  }
+}
+
+describe('feature id', () => {
+  it('admits word characters and hyphens', () => {
+    for (const id of ['demo', 'demo-feature', 'demo_feature', 'Demo123', '_x', '9'])
+      expect(validatePluginFeatureAdmission(feature({ id })), id).toEqual({ admitted: true })
+  })
+
+  /**
+   * Ids end up in routes and payload keys. A dot or a slash would be read as structure by
+   * something downstream, and an empty id matches every lookup that uses `startsWith`.
+   */
+  it('refuses anything that would be read as structure', () => {
+    for (const id of ['demo.feature', 'demo/feature', 'demo feature', '', '../escape', 'a:b'])
+      expect(validatePluginFeatureAdmission(feature({ id })), id).toEqual({
+        admitted: false,
+        reason: 'invalid-id'
+      })
+  })
+
+  it('refuses a missing or non-string id rather than coercing it', () => {
+    for (const id of [undefined, null, 42, {}])
+      expect(validatePluginFeatureAdmission(feature({ id }))).toEqual({
+        admitted: false,
+        reason: 'invalid-id'
+      })
+  })
+})
+
+describe('disallowed words', () => {
+  it('refuses every word on the list, in the name and in the description', () => {
+    for (const word of DISALLOWED_FEATURE_WORDS) {
+      for (const field of ['name', 'desc'] as const) {
+        const result = validatePluginFeatureAdmission(feature({ [field]: `A ${word} thing` }))
+        expect(result.admitted, `${field}: ${word}`).toBe(false)
+        // The reported word is the first entry the text contains, which is not always the one
+        // written -- see the redundancy case below.
+        expect(result, `${field}: ${word}`).toMatchObject({ reason: 'disallowed-words' })
+      }
+    }
+  })
+
+  /**
+   * Five entries can never be reported, because a shorter entry earlier in the list already
+   * matches everything they do. Recorded rather than removed: the list is a policy statement and
+   * trimming it is the owner's call, but a test that expected each entry to report itself would
+   * have been wrong about five of them.
+   */
+  it('has entries that a shorter entry already covers', () => {
+    const shadowed = DISALLOWED_FEATURE_WORDS.filter((word, index) =>
+      DISALLOWED_FEATURE_WORDS.some(
+        (other, otherIndex) => otherIndex < index && word.includes(other)
+      )
+    )
+
+    expect(shadowed).toEqual(['官方认证', '互动式', '触控技术', '互动体验', '互动设计'])
+    expect(validatePluginFeatureAdmission(feature({ name: '官方认证' }))).toEqual({
+      admitted: false,
+      reason: 'disallowed-words',
+      word: '官方'
+    })
+  })
+
+  /**
+   * The two kinds of claim the list exists to stop, spelled out so a future edit that drops one
+   * group fails here rather than silently allowing it.
+   */
+  it('covers first-party claims and superlative claims alike', () => {
+    for (const word of ['官方', 'talex', 'touch', '官方认证'])
+      expect(DISALLOWED_FEATURE_WORDS).toContain(word)
+    for (const word of ['第一', '首发', '排行', '权威性'])
+      expect(DISALLOWED_FEATURE_WORDS).toContain(word)
+  })
+
+  /**
+   * Substring matching, so `touch` also refuses `touchpad`. That is the existing behaviour rather
+   * than an intent, and it is written down here so a change to word-boundary matching is a
+   * deliberate decision with a failing test, not a quiet one.
+   */
+  it('matches as a substring, so ordinary words containing one are refused too', () => {
+    expect(validatePluginFeatureAdmission(feature({ name: 'Touchpad settings' }))).toEqual({
+      admitted: true
+    })
+    expect(validatePluginFeatureAdmission(feature({ name: 'touchpad settings' }))).toEqual({
+      admitted: false,
+      reason: 'disallowed-words',
+      word: 'touch'
+    })
+  })
+
+  it('admits a name and description with none of them', () => {
+    expect(
+      validatePluginFeatureAdmission(feature({ name: 'Weather', desc: 'Shows weather' }))
+    ).toEqual({ admitted: true })
+  })
+
+  /**
+   * `desc` is declared required on `IPluginFeature`, but the object comes from a plugin's own
+   * manifest. The original read `desc.includes(...)` directly, which throws on an absent one —
+   * a plugin omitting it crashed the check instead of failing it.
+   */
+  it('treats a missing name or description as empty rather than throwing', () => {
+    expect(() => validatePluginFeatureAdmission(feature({ desc: undefined }))).not.toThrow()
+    expect(validatePluginFeatureAdmission(feature({ desc: undefined }))).toEqual({ admitted: true })
+    expect(validatePluginFeatureAdmission(feature({ name: undefined, desc: undefined }))).toEqual({
+      admitted: true
+    })
+    expect(validatePluginFeatureAdmission(feature({ name: 42, desc: null }))).toEqual({
+      admitted: true
+    })
+  })
+})
+
+describe('commands', () => {
+  it('refuses a feature with nothing to trigger it', () => {
+    for (const commands of [[], undefined, null, 'over', {}])
+      expect(validatePluginFeatureAdmission(feature({ commands }))).toEqual({
+        admitted: false,
+        reason: 'no-commands'
+      })
+  })
+
+  it('admits a feature with at least one', () => {
+    expect(validatePluginFeatureAdmission(feature({ commands: [{ type: 'over' }] }))).toEqual({
+      admitted: true
+    })
+  })
+})
+
+/**
+ * The id is checked before the words, and the words before the commands. Order is asserted
+ * because the refusal reason is what `addFeature` logs, and a feature failing three rules should
+ * report the first one every time rather than whichever check happened to run.
+ */
+describe('refusal order', () => {
+  it('reports the id first when several rules fail', () => {
+    expect(
+      validatePluginFeatureAdmission({ id: 'bad id', name: '官方', desc: '', commands: [] })
+    ).toEqual({ admitted: false, reason: 'invalid-id' })
+  })
+
+  it('reports the words before the missing commands', () => {
+    expect(
+      validatePluginFeatureAdmission({ id: 'ok', name: '官方', desc: '', commands: [] })
+    ).toEqual({ admitted: false, reason: 'disallowed-words', word: '官方' })
+  })
+})

--- a/apps/core-app/src/main/modules/plugin/plugin-feature-admission.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin-feature-admission.ts
@@ -1,0 +1,85 @@
+/**
+ * Whether a plugin feature is allowed onto the list.
+ *
+ * Lifted out of `TouchPlugin.addFeature` for #339. The word list below is a policy -- it stops a
+ * plugin from calling its feature 官方 or talex, which is a naming-authority claim, not a
+ * spelling rule -- and it had no test of any kind. `addFeature`'s six existing assertions all
+ * check the success path; the one rejection covered is the duplicate id, which is checked against
+ * plugin state and so stays on the class.
+ *
+ * A policy that lives inside a method on a 3800-line class can only be exercised by constructing
+ * a plugin, which is why nothing did.
+ */
+
+/** Feature ids are used in routes and payload keys, so anything outside this is refused. */
+const FEATURE_ID_PATTERN = /^[\w-]+$/
+
+/**
+ * Words a feature's name or description may not contain.
+ *
+ * Two groups, and they are not the same kind of rule. `官方` / `touch` / `talex` / `官方认证`
+ * claim first-party status. The rest -- `第一`, `首发`, `排行`, `权威性` -- are superlative and
+ * ranking claims. Both are substring matches, so `touch` also refuses `touchpad`; that is the
+ * existing behaviour and it is asserted below rather than quietly narrowed here.
+ */
+export const DISALLOWED_FEATURE_WORDS: readonly string[] = Object.freeze([
+  '官方',
+  'touch',
+  'talex',
+  '第一',
+  '权利',
+  '权威性',
+  '官方认证',
+  '触控',
+  '联系',
+  '互动',
+  '互动式',
+  '触控技术',
+  '互动体验',
+  '互动设计',
+  '创意性',
+  '创造性',
+  '首发',
+  '首部',
+  '首款',
+  '首张',
+  '排行',
+  '排名系统'
+])
+
+export type FeatureAdmissionRefusal = 'invalid-id' | 'disallowed-words' | 'no-commands'
+
+export type FeatureAdmissionResult =
+  | { admitted: true }
+  | { admitted: false; reason: FeatureAdmissionRefusal; word?: string }
+
+/**
+ * Checks a feature against the rules that need nothing but the feature itself.
+ *
+ * The duplicate-id rule is deliberately not here: it reads `this.features`, so moving it would
+ * mean handing plugin state to a pure function purely to keep the checks together.
+ */
+export function validatePluginFeatureAdmission(feature: {
+  id?: unknown
+  name?: unknown
+  desc?: unknown
+  commands?: unknown
+}): FeatureAdmissionResult {
+  const id = typeof feature.id === 'string' ? feature.id : ''
+  if (!FEATURE_ID_PATTERN.test(id)) return { admitted: false, reason: 'invalid-id' }
+
+  // Coerced rather than assumed. `desc` is declared required on IPluginFeature, but the object
+  // arrives from a plugin's own manifest, and `undefined.includes` would throw here rather than
+  // refuse the feature.
+  const name = typeof feature.name === 'string' ? feature.name : ''
+  const desc = typeof feature.desc === 'string' ? feature.desc : ''
+  const word = DISALLOWED_FEATURE_WORDS.find(
+    (entry) => name.includes(entry) || desc.includes(entry)
+  )
+  if (word !== undefined) return { admitted: false, reason: 'disallowed-words', word }
+
+  if (!Array.isArray(feature.commands) || feature.commands.length < 1)
+    return { admitted: false, reason: 'no-commands' }
+
+  return { admitted: true }
+}

--- a/apps/core-app/src/main/modules/plugin/plugin.ts
+++ b/apps/core-app/src/main/modules/plugin/plugin.ts
@@ -156,6 +156,7 @@ import { getNetworkService } from '../network'
 import { createPluginHttpClient } from './plugin-http-client'
 import { notificationModule } from '../notification'
 import { getPermissionModule } from '../permission'
+import { validatePluginFeatureAdmission } from './plugin-feature-admission'
 import { PluginFeature } from './plugin-feature'
 import {
   bundlePluginPreludeFromContent,
@@ -192,31 +193,6 @@ interface PluginStorageRoot {
   name: string
   path: string
 }
-
-const disallowedArrays = [
-  '官方',
-  'touch',
-  'talex',
-  '第一',
-  '权利',
-  '权威性',
-  '官方认证',
-  '触控',
-  '联系',
-  '互动',
-  '互动式',
-  '触控技术',
-  '互动体验',
-  '互动设计',
-  '创意性',
-  '创造性',
-  '首发',
-  '首部',
-  '首款',
-  '首张',
-  '排行',
-  '排名系统'
-]
 
 const pluginSystemLog = createLogger('PluginSystem').child('Plugin')
 const TRANSIENT_ISSUE_CODES = new Set([
@@ -620,24 +596,20 @@ export class TouchPlugin implements ITouchPlugin {
       return false
     }
 
-    const { id, name, desc, commands } = feature
-
-    const regex = /^[\w-]+$/
-    if (!regex.test(id)) {
-      pluginSystemLog.error(`[Plugin ${this.name}] Feature add error, id ${id} not valid.`)
+    const admission = validatePluginFeatureAdmission(feature)
+    if (!admission.admitted) {
+      if (admission.reason === 'invalid-id') {
+        pluginSystemLog.error(
+          `[Plugin ${this.name}] Feature add error, id ${feature.id} not valid.`
+        )
+      }
+      if (admission.reason === 'disallowed-words') {
+        pluginSystemLog.error(
+          `[Plugin ${this.name}] Feature add error, name or desc contains disallowed words.`
+        )
+      }
       return false
     }
-
-    if (
-      disallowedArrays.filter((item: string) => name.includes(item) || desc.includes(item)).length
-    ) {
-      pluginSystemLog.error(
-        `[Plugin ${this.name}] Feature add error, name or desc contains disallowed words.`
-      )
-      return false
-    }
-
-    if (commands.length < 1) return false
 
     const shouldInitializeIcon = !(feature instanceof PluginFeature)
     // 如果已经是 PluginFeature 实例，直接使用；否则创建新实例


### PR DESCRIPTION
Toward #339. Third cut, same file, same run.

```
4069 → 3947 (#1678) → 3872 (#1680) → 3844
```

## Why this piece

The word list. It stops a plugin from calling its feature **官方** or **talex** — a naming-authority claim, not a spelling rule — and **it had no test of any kind**.

`addFeature`'s six existing assertions all check the success path. The one rejection covered is the duplicate id, which reads plugin state and so stays on the class. A policy inside a method on a 3800-line class can only be exercised by constructing a plugin, which is why nothing did.

## Six plants, each caught

| plant | failing |
|---|---|
| open up the id pattern | 4 of 13 |
| drop `官方` from the list | 3 of 13 |
| stop refusing disallowed words | 4 of 13 |
| stop requiring a command | 1 of 13 |
| read `desc` without coercing it | 1 of 13 |
| drop the id check | 3 of 13 |

## Two things the tests found, recorded rather than changed

**`desc` is declared required on `IPluginFeature`**, but the object comes from a plugin's own manifest and the original read `desc.includes(...)` directly. A plugin omitting it **crashed the check instead of failing it**. Coerced now, with the throw asserted against.

**Five of the twenty-two words can never be reported.** `官方认证` contains `官方`; `触控技术` contains `触控`; `互动式` / `互动体验` / `互动设计` all contain `互动` — a shorter entry earlier in the list always matches first. The list is a policy statement and trimming it is the owner's call, so the redundancy is written down as a test instead.

My first version expected each entry to report itself and **was wrong about all five** — the test was corrected to match the implementation, not the other way round.

## Verification

`plugin` 92 of 93 files pass, 1255 tests. The remaining failure is `plugin-sqlite-worker.integration.test.ts` asking for a build artifact this checkout lacks — identical on the baseline, green in CI (#1604). `typecheck:node` clean, lint clean.

Refs #339