### PR TITLE
docs: say which Linux artifact works on Ubuntu 24.04 (#213)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ The repository's latest stable release is `2.4.13` (see [GitHub Releases](https:
 
 Preview artifacts are produced for macOS, Windows, and Linux. A stable source version does not imply identical capability maturity or complete OTA acceptance across platforms; unsupported or degraded paths must remain explicit and fail closed. See the [current stability plan](./docs/plan-prd/TODO.md) and [cross-platform audit](./.trellis/tasks/07-13-search-crossplatform-audit/prd.md).
 
+On Ubuntu 24.04 and later, install from the `.deb` rather than the AppImage. 24.04 restricts
+unprivileged user namespaces by default, which Electron's sandbox needs; the `.deb` registers an
+AppArmor profile granting `userns` during installation, and an AppImage has no install step in
+which to do that. If you must use the AppImage, either allow it for that session with
+`sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`, or use the `.deb`. Tracked in
+[#213](https://github.com/talex-touch/tuff/issues/213), which is still waiting on a report that
+says which of the two was used.
+
 ## Highlights
 
 - Search applications, files, plugin actions, calculations, units, currencies, and time directly from CoreBox.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,6 +19,8 @@
 
 当前提供 macOS、Windows 和 Linux 预发布构建。稳定源码版本不代表三端能力成熟度一致，也不代表 OTA 验收已经完成；不支持或降级路径必须明确说明并保持 fail-closed。详情见[当前稳定化计划](./docs/plan-prd/TODO.md)与[跨平台审计](./.trellis/tasks/07-13-search-crossplatform-audit/prd.md)。
 
+Ubuntu 24.04 及以上请安装 `.deb` 而不是 AppImage。24.04 默认限制非特权用户命名空间，而 Electron 的沙箱需要它；`.deb` 会在安装时注册一份授予 `userns` 的 AppArmor 配置，AppImage 没有安装步骤，无处注册。若必须使用 AppImage，可用 `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0` 临时放开。相关追踪见 [#213](https://github.com/talex-touch/tuff/issues/213)，该 issue 仍在等待一份说明「用的是两者中哪一个」的复测报告。
+
 ## 🔷 项目简介
 
 Tuff (原 TalexTouch) 是一个基于 Electron, TypeScript 和 Vue.js 构建的、本地优先、AI 原生、可无限扩展的桌面指令中心。它旨在成为您工作流的无缝延伸，帮助您更快地查找任何内容、执行任何指令。

--- a/apps/nexus/content/docs/guide/start.en.mdc
+++ b/apps/nexus/content/docs/guide/start.en.mdc
@@ -9,6 +9,12 @@
 
 > Node.js 22 runtime ships inside every build—no extra tooling needed.
 
+> On Ubuntu 24.04 and later, choose the `.deb` rather than the AppImage. 24.04 restricts
+> unprivileged user namespaces by default and Electron's sandbox needs them; the `.deb` registers
+> an AppArmor profile granting `userns` during installation, and an AppImage has no install step
+> in which to do that. If you must use the AppImage, allow it for the session with
+> `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`.
+
 ## 2. First Launch
 1. Run the installer and allow CoreBox global shortcut.
 2. Sign in via Apple ID, GitHub, or email.

--- a/apps/nexus/content/docs/guide/start.zh.mdc
+++ b/apps/nexus/content/docs/guide/start.zh.mdc
@@ -9,6 +9,11 @@
 
 > 所有版本均已内置 Node.js 22 运行时，无需额外环境。
 
+> Ubuntu 24.04 及以上请选 `.deb` 而不是 AppImage。24.04 默认限制非特权用户命名空间，而 Electron
+> 的沙箱需要它；`.deb` 在安装时会注册一份授予 `userns` 的 AppArmor 配置，AppImage 没有安装步骤，
+> 无处注册。若必须用 AppImage，可用
+> `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0` 临时放开。
+
 ## 2. 初次启动
 1. 打开安装包，勾选「启用 CoreBox 全局快捷键」。
 2. 首次进入会弹出登录窗，支持 Apple ID / GitHub / 邮箱三种方式。


### PR DESCRIPTION
Toward #213, open since November 2025.

## What the issue thread looks like

Reported 2025-11-14 with a screenshot and environment. Asked "是不是不支持 ubuntu" in December, "还没兼容吗" in June, then left. Asked for logs in July. No reply since.

The answer to the most likely cause was in `node_modules` the whole time.

## What the packaging chain actually does

Read from `electron-builder 26.15.3`, which is what this repo pins:

- `FpmTarget.js:61-70` — `getResource(this.options.appArmorProfile, "apparmor-profile.tpl")`. With `appArmorProfile` unset, it falls back to a **default template**, and that template is `profile … flags=(unconfined) { userns, }` — precisely the capability 24.04 restricts.
- `templates/linux/after-install.tpl:29-57` — the `.deb` checks `apparmor_status --enabled`, dry-runs the profile through `apparmor_parser --skip-kernel-load --debug` (so 22.04, which has no `abi/4.0`, skips it cleanly instead of failing the install), then copies it to `/etc/apparmor.d/` and loads it.
- All of that is `FpmTarget`, which serves **deb and rpm**. AppImage uses a separate target and **has no install step**, so there is nowhere to register a profile.

So on Ubuntu 24.04 the `.deb` is expected to work and the AppImage is expected not to — and nothing in the repo told a user that.

## What this changes

Both READMEs and both start guides now say which artifact to take, why, and the one-line escape hatch for someone who must use the AppImage. Documentation only.

## What it does not do

**This is read from the packaging chain, not from a machine.** I have no Ubuntu 24.04 to test on, and the screenshot attached to #213 could not be fetched from here (the S3 asset host is unreachable in this environment). The issue stays open for the single fact that settles it — **which of the two artifacts the reporter used** — and I have narrowed it to that on the issue itself.

One thing I deliberately did not do: change any packaging config. `deb.appArmorProfile` exists and could be overridden, but the default is already correct for this case, and shipping a hand-written profile to the one platform that is already broken, with no runner to test it, is how you turn one bug into two.
