### PR TITLE
test(indexing): hold the scan backpressure bound

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/file-indexed-source.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/file-indexed-source.test.ts
@@ -332,6 +332,120 @@ describe('fileIndexedSource', () => {
     expect(producerSignal?.aborted).toBe(true)
   })
 
+  /**
+   * The backpressure bound (#318).
+   *
+   * `enqueue` parks the producer while two batches sit unconsumed, and that constant is the
+   * memory bound the whole R3 risk rests on: peak retention is batch size x 2 regardless of how
+   * many files the tree holds. Nothing tested it. Someone could raise it to 1000, or delete the
+   * `while` and keep the `push`, and every structural argument in the code review would still
+   * read as true while a million-file root went back to being unbounded.
+   */
+  describe('scan backpressure', () => {
+    function trackedProducer(total: number): {
+      accepted: () => number
+      emitted: Promise<void>
+    } {
+      let accepted = 0
+      const emitted = Promise.withResolvers<void>()
+      fileProviderMock.scanIndexedSource.mockImplementation(
+        async (
+          _request: unknown,
+          options: { onRecordBatch: (batch: IndexedSourceRecordBatch) => Promise<void> }
+        ) => {
+          for (let index = 0; index < total; index += 1) {
+            await options.onRecordBatch({
+              sourceId: 'file-provider',
+              records: [],
+              done: index === total - 1
+            })
+            accepted += 1
+          }
+          emitted.resolve()
+          return { batches: [] }
+        }
+      )
+      return { accepted: () => accepted, emitted: emitted.promise }
+    }
+
+    /** Lets the parked producer run as far as it can before the assertion reads its counter. */
+    async function settle(): Promise<void> {
+      for (let index = 0; index < 20; index += 1) await Promise.resolve()
+    }
+
+    it('parks the producer once two batches are waiting', async () => {
+      const producer = trackedProducer(50)
+      const source = buildFileIndexedSource()
+
+      const iterator = source
+        .scan({ sourceId: 'file-provider', reason: IndexedSourceScanReasons.Scheduled })
+        [Symbol.asyncIterator]()
+      // Pulling one starts the producer; nothing else consumes after that.
+      await iterator.next()
+      await settle()
+
+      // One yielded plus two queued. A producer that buffered would be at 50.
+      expect(producer.accepted()).toBe(3)
+
+      await iterator.return?.()
+    })
+
+    it('releases exactly one batch per batch consumed, however large the tree', async () => {
+      const producer = trackedProducer(200)
+      const source = buildFileIndexedSource()
+
+      const iterator = source
+        .scan({ sourceId: 'file-provider', reason: IndexedSourceScanReasons.Scheduled })
+        [Symbol.asyncIterator]()
+
+      for (let consumed = 1; consumed <= 10; consumed += 1) {
+        await iterator.next()
+        await settle()
+        // The bound is a constant offset from what has been consumed, not a fraction of the tree.
+        expect(producer.accepted(), `after ${consumed} consumed`).toBe(consumed + 2)
+      }
+
+      await iterator.return?.()
+    })
+
+    /**
+     * The park is inside a loop that re-checks the abort signal, so a cancelled scan cannot leave
+     * the producer waiting on a consumer that will never pull again. Without that check this test
+     * hangs rather than fails, which is why it asserts the producer settled at all.
+     */
+    it('releases a parked producer when the consumer stops early', async () => {
+      const producer = trackedProducer(50)
+      const source = buildFileIndexedSource()
+
+      const iterator = source
+        .scan({ sourceId: 'file-provider', reason: IndexedSourceScanReasons.Scheduled })
+        [Symbol.asyncIterator]()
+      await iterator.next()
+      await settle()
+      expect(producer.accepted()).toBe(3)
+
+      await expect(iterator.return?.()).resolves.toEqual({ value: undefined, done: true })
+      expect(producer.accepted()).toBeLessThan(50)
+    })
+
+    it('does not park a scan that produces fewer batches than the bound', async () => {
+      const producer = trackedProducer(2)
+      const source = buildFileIndexedSource()
+
+      const batches: IndexedSourceRecordBatch[] = []
+      for await (const batch of source.scan({
+        sourceId: 'file-provider',
+        reason: IndexedSourceScanReasons.Scheduled
+      })) {
+        batches.push(batch)
+      }
+
+      expect(producer.accepted()).toBe(2)
+      expect(batches).toHaveLength(2)
+      expect(batches.at(-1)?.done).toBe(true)
+    })
+  })
+
   it('propagates a FileProvider scan failure without yielding a terminal batch', async () => {
     const source = buildFileIndexedSource()
     const scanError = new Error('file scan failed')


### PR DESCRIPTION
Toward #318.

The prior investigation on that issue concluded the memory bounds are structurally met, and named the one thing worth fixing before closing R3:

> **`queued.length >= 2` has no test.** That constant *is* the memory bound this issue exists to protect. Someone can change it to `1000` — or delete the `while` and keep the `push` — and nothing goes red.

This is that test.

## Why the constant is the whole risk

`enqueue` parks the producer while two batches sit unconsumed, so peak retention is **batch size × 2 regardless of how many files the tree holds**. Remove it and a million-file root goes back to being unbounded — while every structural argument in the code review still reads as true.

## Three plants, each caught

| plant | result |
|---|---|
| raise the bound from `2` to `1000` | fails |
| delete the park entirely, keep the `push` | fails |
| stop waking the producer after a consume | fails, `after 2 consumed: expected 3 to be 4` |

**The second case is asserted as a constant offset rather than a fixed number** — after N consumed the producer has accepted N + 2. That says *the retention does not scale with the tree*, which is the actual claim, rather than checking one number at one point.

The abort case matters for a different reason: the park sits inside a loop that re-checks the signal, so a consumer stopping early releases the producer instead of leaving it waiting for a pull that never comes. **Without that check the test hangs rather than fails**, so it asserts the producer settled at all.

## What this does not do

No benchmark. The prior comment argued a test is worth more here than one, and I agree with its reasoning: a benchmark tells you what today's number is, a test tells you when it changes. The synthetic-tree benchmark criterion stays open.

`search-engine` 75 files / 666 tests pass. `typecheck:node` clean, lint clean.

Refs #318