### PR TITLE
test(indexing): pin the ack ordering the scan bound rests on (#480, #318)

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/addon/files/workers/file-scan-worker-client.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/workers/file-scan-worker-client.test.ts
@@ -268,3 +268,63 @@ describe('FileScanWorkerClient idle shutdown', () => {
     expect(worker.terminateCalls).toBe(1)
   })
 })
+
+describe('FileScanWorkerClient batch backpressure', () => {
+  function fileAt(path: string): ScannedFileInfo {
+    return {
+      path,
+      name: path.split('/').pop() ?? path,
+      extension: '',
+      size: 0,
+      ctime: new Date(0),
+      mtime: new Date(0)
+    }
+  }
+
+  function acksIn(messages: readonly unknown[]): number {
+    return messages.filter((message) => messageTypeOf(message) === 'batchAck').length
+  }
+
+  it('acknowledges a batch only after the consumer has finished with it', async () => {
+    // The worker registers an ack waiter, posts one batch, and awaits that ack before producing
+    // the next -- so exactly one batch is ever in flight, whatever the directory's size. That
+    // bound is only real if the client acks *after* yielding. Acking first would let the worker
+    // run ahead of the consumer and the queue would grow with the directory again, which is the
+    // shape #480 is about, and nothing here would fail.
+    const client = new FileScanWorkerClient()
+    const acksSeenWhileConsuming: number[] = []
+    const consumed: string[] = []
+
+    const run = (async () => {
+      for await (const batch of client.scanBatches(['/tmp'])) {
+        // The generator is suspended at its `yield` for the whole of this block.
+        acksSeenWhileConsuming.push(acksIn(workerMock.workers.at(-1)!.messages))
+        consumed.push(...batch.map((file) => file.path))
+        // A tick, so an ack posted eagerly would have landed before the next assertion.
+        await Promise.resolve()
+      }
+    })()
+
+    await Promise.resolve()
+    const worker = workerMock.workers.at(-1)!
+    const taskId = taskIdOf(worker.messages[0])
+
+    for (let sequence = 0; sequence < 3; sequence += 1) {
+      worker.emit('message', {
+        type: 'batch',
+        taskId,
+        sequence,
+        batch: [fileAt(`/tmp/${String(sequence)}`)]
+      })
+      await Promise.resolve()
+    }
+    worker.emit('message', { type: 'done', taskId, scannedCount: 3 })
+    await run
+
+    expect(consumed).toEqual(['/tmp/0', '/tmp/1', '/tmp/2'])
+    // Nth batch is consumed with N acks behind it, never N+1: the ack for the batch in hand has
+    // not been sent yet.
+    expect(acksSeenWhileConsuming).toEqual([0, 1, 2])
+    expect(acksIn(worker.messages)).toBe(3)
+  })
+})


### PR DESCRIPTION
Toward #480 and #318.

## The implementation #480 asks for is already there

Its three cited hot spots no longer say what it says. Re-located by meaning rather than line number:

| #480 says | what the code does now |
|---|---|
| `file-scan-worker.ts` scans a complete directory list | batches at `batchSize` (default 500), registers a `batchAckWaiters` entry, posts one batch, then `await acknowledged` before producing the next |
| `file-scan-worker-client.ts` accumulates it again | `async *scanBatches` — `pending.batches.shift()` then `yield`, draining rather than collecting |
| reconciliation holds disk and DB sets with an unbounded `LIKE` | iterates the batches and calls `getDbFilesByPaths(diskPaths)` for the current batch only; no `LIKE` |

So exactly **one batch is in flight at a time, whatever the directory's size**.

## But the bound rests on an ordering nothing asserted

```ts
yield next.batch
worker.postMessage({ type: 'batchAck', taskId, sequence: next.sequence })
```

`yield` suspends until the consumer resumes, so the ack goes out only after the batch has been dealt with. **Swap those two lines and the bound disappears** — the worker runs ahead of the consumer, the client's queue grows with the directory, and the OOM shape is back.

Every existing test in that file still passes with them swapped, because they cover worker lifecycle: idle shutdown, liveness while polling, in-flight scans failing on shutdown. None of them looks at batch flow.

## What this adds

One test asserting the ordering from the outside: the Nth batch is consumed with **N** acks behind it, never N+1, because the ack for the batch in hand has not been posted yet. The consumer awaits a tick inside the loop so an eagerly-posted ack would have landed before the assertion is read.

Mutation-checked: moving the `postMessage` above the `yield` fails it (1 failed / 7 passed), restoring gives 8 passed. 48 files / 325 tests pass across the files addon.

## Coordination

`test/318-scan-backpressure` is already pushed by a concurrent session and covers `search-engine/file-indexed-source.test.ts` — the consumer end of the same path. Different file, complementary assertion; I checked before writing rather than after.

## What is still missing on #480

The memory-budget evidence: no million-entry fixture, no `heapUsed`/`memoryUsage` measurement anywhere under that directory (positive control: the same scan finds `scanBatches` in those test files, so it is looking in the right place). I argued on the issue that measuring peak memory in CI is the wrong instrument — GC timing makes it flaky — and that asserting the invariant deterministically, as here, is what actually holds the bound. That is a change to the issue's acceptance criteria, so it is proposed there rather than assumed here.
