### PR TITLE
fix(windows): add the two missing PowerShell hardening flags

### DIFF
--- a/apps/core-app/src/main/modules/system/desktop-shortcut.ts
+++ b/apps/core-app/src/main/modules/system/desktop-shortcut.ts
@@ -37,6 +37,9 @@ export async function sendPlatformShortcut(shortcut: DesktopShortcut): Promise<v
 
   if (process.platform === 'win32') {
     await execFileAsync('powershell', [
+      // `-NoLogo` only suppresses the banner; it is not `-NoProfile`, so a user's profile script
+      // still ran inside this invocation (#350).
+      '-NoProfile',
       '-NoLogo',
       '-NonInteractive',
       '-Command',

--- a/apps/core-app/src/main/service/device-idle-service.ts
+++ b/apps/core-app/src/main/service/device-idle-service.ts
@@ -253,6 +253,9 @@ export class DeviceIdleService {
       if (process.platform === 'win32') {
         const { stdout } = await execFileAsync('powershell', [
           '-NoProfile',
+          // Idle detection runs on a schedule rather than on user action, so a prompt here waits
+          // on a user who is by definition not looking (#350).
+          '-NonInteractive',
           '-Command',
           'Get-CimInstance -ClassName Win32_Battery | Select-Object -ExpandProperty EstimatedChargeRemaining | Select-Object -First 1'
         ])


### PR DESCRIPTION
Toward #350.

Found while rebuilding this issue's call inventory, which turned out to be **three times larger** than the one recorded on it — 19 real invocation sites, not 7. Full corrected inventory goes on the issue.

## The two fixed here

**`desktop-shortcut.ts:39`** passed `-NoLogo`. That suppresses the banner and **is not `-NoProfile`**, so a user's profile script ran inside every shortcut invocation.

**`device-idle-service.ts:254`** passed `-NoProfile` without `-NonInteractive`. Idle detection runs on a schedule rather than on user action, so a prompt there waits on a user who is by definition not looking — **the worst place in the inventory for that flag to be missing.**

Both are argument-array additions with no security trade-off, which is why they are here and `-ExecutionPolicy` is not. Seven sites still lack that one, and choosing a policy value is a deliberate decision rather than a sweep.

## On verification

Neither path can be exercised off Windows. This is a flag change verified by reading and by the suites covering the surrounding code — `service` + `system`, 12 files / 84 tests — not by running PowerShell. Saying so explicitly because "tests pass" would otherwise imply more than it does here.

`typecheck:node` clean, lint clean.

Refs #350