### PR TITLE
fix(release): make the macOS artifacts identifiable, not just distinct (#311)

### DIFF
--- a/apps/core-app/electron-builder.yml
+++ b/apps/core-app/electron-builder.yml
@@ -136,9 +136,12 @@ mac:
   # have no certificate and are not producing releases.
   forceCodeSigning: false
   hardenedRuntime: true
-  # ${arch} is load-bearing now that two architectures are built: without it the arm64 and x64
-  # dmgs resolve to the same filename and one silently overwrites the other.
-  artifactName: ${productName}-${version}-${arch}.${ext}
+  # Both parts are load-bearing. ${arch}: without it the arm64 and x64 builds resolve to the same
+  # filename and one silently overwrites the other. `macos`: inferCoreArtifactIdentity recognises
+  # a mac artifact by `macos`/`darwin` in the name or a `.dmg`/`.app.zip` suffix, so a plain
+  # `-arm64.zip` counted as a core package it could not identify, and manifest validation rejects
+  # an artifact whose platform cannot be inferred (#311).
+  artifactName: ${productName}-${version}-macos-${arch}.${ext}
 dmg:
 linux:
   target:

--- a/scripts/check-macos-release-targets.test.mjs
+++ b/scripts/check-macos-release-targets.test.mjs
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { inferCoreArtifactIdentity } from './lib/release-artifacts.mjs'
 
 /**
  * The macOS release contract in electron-builder.yml (#594, #786).
@@ -79,6 +80,33 @@ describe('macOS release targets', () => {
     // interpolate it away and the assertion would pass against any artifactName at all.
     // eslint-disable-next-line no-template-curly-in-string
     expect(match[1]).toContain('${arch}')
+  })
+
+  it('produces names the release manifest can identify', () => {
+    // The substring assertion above is not enough on its own. `${productName}-${version}-${arch}`
+    // satisfies it and still yields `Tuff-2.4.14-arm64.zip`, which inferCoreArtifactIdentity
+    // cannot place: it recognises a mac artifact by `macos`/`darwin` in the name or a `.dmg` /
+    // `.app.zip` suffix, and that name has none of them. isCorePackageFileName still returns true,
+    // so it reaches manifest validation as an artifact whose platform cannot be inferred and is
+    // rejected there -- after the release has been built. Asserting through the real inference
+    // closes the gap between "the template looks right" and "the output is usable".
+    const template = mac.match(/artifactName:\s*(.+)/)[1].trim()
+    for (const arch of ['arm64', 'x64']) {
+      for (const ext of ['dmg', 'zip']) {
+        /* eslint-disable no-template-curly-in-string -- electron-builder's placeholder syntax,
+           matched literally; backticks here would interpolate them away. */
+        const name = template
+          .replace('${productName}', 'Tuff')
+          .replace('${version}', '2.4.14')
+          .replace('${arch}', arch)
+          .replace('${ext}', ext)
+        /* eslint-enable no-template-curly-in-string */
+        expect(inferCoreArtifactIdentity(name), `${name} is not identifiable`).toEqual({
+          platform: 'darwin',
+          arch,
+        })
+      }
+    }
   })
 
   it('notarizes', () => {


### PR DESCRIPTION
Toward #311. **This fixes a defect I introduced in #1648**, found while checking whether that change had left #311 in a half-decided state.

## What #1648 did and what it broke

It set `artifactName: ${productName}-${version}-${arch}.${ext}` so the arm64 and x64 builds would stop resolving to the same filename. That part was necessary. It also made the macOS **zip** unidentifiable.

`inferCoreArtifactIdentity` places a mac artifact by `macos`/`darwin` appearing in the name, or a `.dmg` / `.app.zip` suffix. `Tuff-2.4.14-arm64.zip` has none of the four. Reproduced before touching anything:

```
Tuff-2.4.14-arm64.dmg  → darwin/arm64
Tuff-2.4.14-x64.dmg    → darwin/x64
Tuff-2.4.14-arm64.zip  → null   ← corePackage=true
Tuff-2.4.14-x64.zip    → null   ← corePackage=true
```

`isCorePackageFileName` still returns **true** for those zips, so they reach `update-validate-release-manifest.mjs` as core artifacts whose platform cannot be inferred — and `requireField(Boolean(inferredIdentity), …)` rejects them. The failure would have surfaced during a release, after the build.

The dmg was safe on its extension alone, and zips did not exist before #1648 because the target was `dir`. **So this is a defect that change created, not one it exposed.**

## The fix

`macos` in the name. All four combinations classify correctly.

Nothing else needed to move: the manifest validator already handles per-arch entries — `coreArchs` includes `x64`, `platform/arch` uniqueness is enforced for core artifacts, and `arch` is cross-checked against the artifact name.

## The guard is upgraded, not adjusted

The existing assertion was "artifactName contains `${arch}`". **The broken name satisfied it.** That is the failure mode this repo keeps hitting: a check that looks like it covers the property but tests a proxy for it.

It now expands the template for both architectures and both extensions and runs the **real** `inferCoreArtifactIdentity` over the results — the same function the release pipeline uses.

Mutation-checked: the previous name fails 1 test, dropping `${arch}` fails 2, restored is 9 passed. Scripts gate 23 files / 231 tests; release-acceptance 2 files / 11 tests.

## What this does not do

It does not decide #311's architecture policy. #1648 already added x64 in practice without the surrounding work that option 2 of that issue asks for — per-arch manifest entries and detached signatures are handled, but download-selection metadata, the OTA matrix, and a real Intel/Universal host verification are not. #311 stays open for those.
