### PR TITLE
fix(deps): move the root electron floor onto the patched line

### DIFF
--- a/.github/prod-audit-allowlist.json
+++ b/.github/prod-audit-allowlist.json
@@ -5,22 +5,14 @@
     "advisory no longer appears also fails, so the list cannot only grow and cannot silently pre-approve",
     "a re-introduction. Removing an entry is the fix in that case.",
     "This list is the state on 2026-08-11, not an endorsement of it. #328 owns clearing it.",
-    "2026-08-12: the eight nuxt-closure reasons said core-app's vue-sonner optional peer. Measured wrong — moving vue-sonner to devDependencies changed the --prod audit by zero advisories. The real path is apps/nexus's @sentry/nuxt. An exception list is only worth its reasons."
+    "2026-08-12: the eight nuxt-closure reasons said core-app's vue-sonner optional peer. Measured wrong \u2014 moving vue-sonner to devDependencies changed the --prod audit by zero advisories. The real path is apps/nexus's @sentry/nuxt. An exception list is only worth its reasons."
   ],
   "advisories": [
     {
       "id": "GHSA-279x-mwfv-vcqv",
       "module": "@nuxt/devtools",
       "severity": "critical",
-      "reason": "Reaches --prod under the same @sentry/nuxt closure as nuxt: @sentry/nuxt -> nuxt -> @nuxt/devtools@2.7.0. The patched range starts at 3.3.1, which needs @nuxt/kit ^4.5.1, i.e. the Nuxt 4.5 line — blocked behind the unhead 2 -> 3 migration (#1098).",
-      "owner": "#328",
-      "expires": "2026-11-09"
-    },
-    {
-      "id": "GHSA-9f4c-93c8-jc8g",
-      "module": "electron",
-      "severity": "high",
-      "reason": "Patched line is >=41.10.3 against the 40.x the app is on. A major Electron upgrade, not a dependency bump.",
+      "reason": "Reaches --prod under the same @sentry/nuxt closure as nuxt: @sentry/nuxt -> nuxt -> @nuxt/devtools@2.7.0. The patched range starts at 3.3.1, which needs @nuxt/kit ^4.5.1, i.e. the Nuxt 4.5 line \u2014 blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
     },
@@ -44,7 +36,7 @@
       "id": "GHSA-9473-5f9j-94wq",
       "module": "nuxt",
       "severity": "high",
-      "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction — a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
+      "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction \u2014 a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
     },
@@ -52,7 +44,7 @@
       "id": "GHSA-9pgf-384g-p7mv",
       "module": "nuxt",
       "severity": "high",
-      "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction — a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
+      "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction \u2014 a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
     },
@@ -60,7 +52,7 @@
       "id": "GHSA-hxcr-hm88-mpq6",
       "module": "nuxt",
       "severity": "high",
-      "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction — a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
+      "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction \u2014 a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
     },
@@ -68,7 +60,7 @@
       "id": "GHSA-hxvh-4h3w-prp9",
       "module": "nuxt",
       "severity": "high",
-      "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction — a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
+      "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction \u2014 a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
     },
@@ -76,7 +68,7 @@
       "id": "GHSA-wm8w-6qjm-cv43",
       "module": "nuxt",
       "severity": "high",
-      "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction — a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
+      "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction \u2014 a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
     }

--- a/apps/core-app/src/main/modules/notification.system-replace.test.ts
+++ b/apps/core-app/src/main/modules/notification.system-replace.test.ts
@@ -41,8 +41,22 @@ const { FakeNotification } = vi.hoisted(() => {
   return { FakeNotification }
 })
 
+/**
+ * `ipcMain` and `MessageChannelMain` are here because this factory replaces the whole `electron`
+ * module, and `packages/utils/transport/sdk/main-transport.ts` destructures both at import time.
+ *
+ * The mock got away without them while the workspace resolved two copies of electron: the utils
+ * package bound to one and this test mocked the other, so main-transport read the real module.
+ * Deduplicating electron (#328) put them on the same specifier and the omission became a
+ * collection failure -- `No "ipcMain" export is defined on the "electron" mock`.
+ */
 vi.mock('electron', () => ({
-  Notification: FakeNotification
+  Notification: FakeNotification,
+  ipcMain: { on: () => {}, off: () => {}, handle: () => {}, removeHandler: () => {} },
+  MessageChannelMain: class {
+    port1 = { on: () => {}, start: () => {}, close: () => {}, postMessage: () => {} }
+    port2 = { on: () => {}, start: () => {}, close: () => {}, postMessage: () => {} }
+  }
 }))
 
 vi.mock('../core/runtime-accessor', () => ({

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@sentry/vite-plugin": "^4.9.1",
-    "electron": "^41.10.1",
+    "electron": "^41.10.4",
     "vite-plugin-electron": "^0.29.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,8 +213,8 @@ importers:
         specifier: ^4.9.1
         version: 4.9.1(encoding@0.1.13)
       electron:
-        specifier: ^41.10.1
-        version: 41.10.2
+        specifier: ^41.10.4
+        version: 41.10.4
       vite-plugin-electron:
         specifier: ^0.29.1
         version: 0.29.1
@@ -8136,11 +8136,6 @@ packages:
   electron-winstaller@5.4.0:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
-
-  electron@41.10.2:
-    resolution: {integrity: sha512-vzSetbn05LPfg0gW0p9txpqmkkFyTXzdSHvKIXbtmsK362hkgUQJu+x19GSSS9v/VXeFi5UJI5TYJ1a+Os3CpA==}
-    engines: {node: '>= 22.12.0'}
-    hasBin: true
 
   electron@41.10.4:
     resolution: {integrity: sha512-YUE5aRDz1M1d+1BX1G7SESkXup+1fqvrQ64ztVa/b1N+yXxXRUnbRlRNk70FI/n3O65JiQV9G3M0dxn5XldowQ==}
@@ -21555,14 +21550,6 @@ snapshots:
       temp: 0.9.4
     optionalDependencies:
       '@electron/windows-sign': 1.2.2
-    transitivePeerDependencies:
-      - supports-color
-
-  electron@41.10.2:
-    dependencies:
-      '@electron-internal/extract-zip': 1.0.4
-      '@electron/get': 5.0.0
-      '@types/node': 24.13.2
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
Toward #328. **The last High advisory outside the nuxt closure, cleared by a patch bump.**

```
9 Critical/High, 9 allowlisted  →  8 Critical/High, 8 allowlisted
```

## The allowlist entry was wrong on both counts

> *"Patched line is >=41.10.3 against the 40.x the app is on. A major Electron upgrade, not a dependency bump."*

`apps/core-app` already declares `^41.10.4`. What pulled the unpatched copy was **the repo root's own `dependencies.electron` at `^41.10.1`**, which resolves to **41.10.2 — one patch below the floor**. The lockfile carried both versions, and it was the root's that the audit saw.

No major upgrade was needed at all. Root is at `^41.10.4` now, matching core-app; `electron@41.10.2` is gone from the lockfile and the advisory with it.

## The gate found the stale entry itself

With the advisory gone it reported:

```
✗ allowlist entry GHSA-9f4c-93c8-jc8g no longer matches a live advisory — remove it
```

That is what the two-way ratchet is for — the list cannot quietly outlive the problem it describes. Entry removed.

## Causality checked rather than assumed

My first negative control was useless: reverting `package.json` to `^41.10.1` leaves the lockfile on 41.10.4, because the wider range is already satisfied by what is there. So I could not tell whether the bump or the reinstall cleared it.

Restoring **both** files from origin and running `pnpm install --lockfile-only` with no manifest change:

```
origin (^41.10.1) + lockfile-only   →  9 advisories, 41.10.2 still present
^41.10.4 + lockfile-only            →  8 advisories, 41.10.2 gone
```

The bump is the cause.

## What remains

Eight, all one cluster: `@sentry/nuxt → nuxt` (nuxt ×5, nanoid ×2, `@nuxt/devtools` ×1). They move together and are blocked behind the unhead 2 → 3 migration tracked in #1098.

Refs #328