### PR TITLE
docs(spec): write down what makes a guard able to fail

### DIFF
--- a/.trellis/spec/guides/guard-thinking-guide.md
+++ b/.trellis/spec/guides/guard-thinking-guide.md
@@ -1,0 +1,84 @@
+# Guard Thinking Guide
+
+> **Purpose**: Write checks that fail when the thing they protect is broken, not when its spelling changes.
+
+---
+
+## The Problem
+
+**A guard that cannot fail is worse than no guard**, because it also removes the suspicion that would have made someone look.
+
+Every example below is from this repository, and each one passed CI while the property it named was broken:
+
+| The guard asserted | What actually had to hold | How it broke |
+|---|---|---|
+| `artifactName` contains `${arch}` | the produced filenames can be classified by the release pipeline | `Tuff-2.4.14-arm64.zip` satisfied the check and `inferCoreArtifactIdentity` returned `null` for it |
+| the implicit-any count equals the pinned number | the compiler rejects implicit any | the number was correct for seven PRs while the compiler flag stayed off |
+| `main.ts` contains `.catch(` | the CSP violation reporter does not reject unhandled | the substring matched unrelated code 200 lines further down |
+| `actionlint` exits 0 | workflows are actually analysed | without `shellcheck` on `PATH` it silently skips every `run:` block and reports 0 findings where CI reports 32 |
+| the OCR test passes | native OCR ran | it returns early when support is absent, so a run that never reached the engine looked identical to a passing one |
+
+The shape is always the same: **the assertion names a proxy for the property, and the proxy is satisfiable without the property.**
+
+---
+
+## The Questions
+
+### 1. If this were broken, would my check fail?
+
+Not "does my check pass" — write the broken version and run it. If it still passes, the check is decorative.
+
+This is the whole of mutation testing, and it costs one minute: change the implementation to the failure you are guarding against, run the test, expect red, revert.
+
+### 2. Am I asserting the config, or the result of the config?
+
+Prefer running the real consumer over reading the text that feeds it.
+
+```js
+// Proxy: satisfied by a name the pipeline cannot parse
+expect(artifactName).toContain('${arch}')
+
+// Property: the same function the release pipeline calls
+expect(inferCoreArtifactIdentity(expandedName)).toEqual({ platform: 'darwin', arch })
+```
+
+### 3. Can this pass because nothing ran?
+
+A skip, an early return, an absent binary, and a satisfied assertion all produce a green tick.
+
+If the code under test can decline to run, the guard needs a way to demand it — an env flag the CI job sets, an explicit assertion that the precondition held, or a positive control proving the search or the tool was live.
+
+### 4. Does the number this pins have a floor?
+
+A ratchet is for debt that will never reach zero but must not grow. **If the number can reach zero, the instrument is a switch, not a ratchet** — turn on the compiler flag, the lint rule, the config, and delete the counter.
+
+Keeping a ratchet at zero means maintaining a second, weaker, hand-updated copy of a rule the tool already enforces.
+
+### 5. Where does this fail, and is that early enough?
+
+A check that fires during manifest validation, after signing and notarisation, is technically a check. It is also a check that costs a full release cycle to learn from. Prefer the earliest layer that can see the property.
+
+---
+
+## Absence Scans Need a Positive Control
+
+"No references found" is the easiest wrong answer to produce. A misspelled pattern, a wrong directory, a flag that means something else, and a genuinely empty result all print nothing.
+
+Before believing an absence, prove the scan works by finding something you know is there.
+
+```bash
+rg -n "Windows OCR recognized no text" packages   # known to exist — non-empty proves the scan runs
+rg -n "No text recognized" .                      # the actual question
+```
+
+Two ways this has gone wrong here: `rg -r` is `--replace`, not "recursive", so `rg -rn pattern` silently rewrites the output; and a `^src/` anchor quietly excluded every path that did not start with `src/`, under-reporting a per-file breakdown by two.
+
+---
+
+## When You Cannot Verify Locally
+
+Say so, and name what would verify it.
+
+A guard for Windows COM behaviour cannot be proven on macOS. What can be done is to place the test where the platform runs it — and then read the job log to confirm it *ran*, rather than trusting the green tick.
+
+Recording the limit is not a weaker result. It is the difference between "verified" and "assumed", and the next person needs to know which one they inherited.

--- a/.trellis/spec/guides/index.md
+++ b/.trellis/spec/guides/index.md
@@ -24,6 +24,7 @@ These guides help you **ask the right questions before coding**.
 | [Code Reuse Thinking Guide](./code-reuse-thinking-guide.md) | Identify patterns and reduce duplication | When you notice repeated patterns |
 | [Cross-Layer Thinking Guide](./cross-layer-thinking-guide.md) | Think through data flow across layers | Features spanning multiple layers |
 | [Multi-Session Collaboration Guide](./multi-session-collab-guide.md) | Work safely while other sessions write the repo | Shared-file commits, CDP driving, parallel agent dispatch |
+| [Guard Thinking Guide](./guard-thinking-guide.md) | Write checks that fail when the thing they protect breaks | Adding a test, a CI gate, a ratchet, or any absence scan |
 
 ---
 


### PR DESCRIPTION
Five checks in this repository passed CI while the property they named was broken. Each was found by accident, weeks or hours apart, rather than by anything that would have caught the next one.

| The guard asserted | What had to hold | How it broke |
|---|---|---|
| `artifactName` contains `${arch}` | the produced filenames can be classified by the release pipeline | `Tuff-2.4.14-arm64.zip` satisfied it; `inferCoreArtifactIdentity` returned `null` (#311) |
| the implicit-any count equals the pin | the compiler rejects implicit any | correct for seven PRs while the flag stayed off (#548) |
| `main.ts` contains `.catch(` | the CSP reporter does not reject unhandled | matched unrelated code 200 lines below (#689) |
| `actionlint` exits 0 | workflows are analysed | without `shellcheck` it skips every `run:` block — 0 findings locally, 32 on CI (#482) |
| the OCR test passes | native OCR ran | early return on unsupported platforms is indistinguishable from success (#1517) |

They share one shape: **the assertion names a proxy for the property, and the proxy is satisfiable without the property.**

## What this adds

A thinking guide, in the same style and place as the existing three — questions to ask before writing a check, not a policy to enforce after:

1. If this were broken, would my check fail? (write the broken version and run it)
2. Am I asserting the config, or the result of the config?
3. Can this pass because nothing ran?
4. Does the number this pins have a floor? — if it can reach zero, the instrument is a switch, not a ratchet
5. Where does this fail, and is that early enough? — a check that fires after signing and notarisation costs a release cycle to learn from

Plus the two rules that keep surfacing on their own: absence scans need a positive control before "nothing found" is believable, and saying "not verified locally" is a result rather than a weaker one.

## Why a guide rather than a lint rule

None of these five is mechanically detectable — each needs someone to ask what the assertion is standing in for. The repo already keeps that kind of knowledge in `.trellis/spec/guides/`, so this goes there rather than becoming a check that would itself need a guard.

Documentation only. `docs:verify` passes.
