### PR TITLE
fix(tuff-intelligence): stop advertising a dist that is no longer shipped

### DIFF
--- a/packages/tuff-intelligence/package.json
+++ b/packages/tuff-intelligence/package.json
@@ -20,7 +20,6 @@
     "./client": {
       "types": "./src/client.ts",
       "import": "./src/client.ts",
-      "require": "./dist/client.cjs",
       "default": "./src/client.ts"
     },
     "./light": {
@@ -44,7 +43,7 @@
     "node": ">=24.15.0"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --splitting --clean --target node24 --platform node && tsup src/client.ts --format cjs --target node24 --platform node",
+    "build": "tsup src/index.ts --format esm --dts --splitting --clean --target node24 --platform node",
     "dev": "tsup src/index.ts --format esm --dts --splitting --clean --target node24 --platform node --watch",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",

--- a/packages/tuff-intelligence/src/package-exports.test.ts
+++ b/packages/tuff-intelligence/src/package-exports.test.ts
@@ -1,0 +1,91 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const manifest = JSON.parse(
+  execFileSync('node', ['-e', 'process.stdout.write(JSON.stringify(require("./package.json")))'], {
+    cwd: packageRoot,
+    encoding: 'utf8',
+  }),
+) as {
+  files?: string[]
+  main?: string
+  exports?: Record<string, Record<string, string> | string>
+  scripts?: Record<string, string>
+}
+
+/** Every relative path the exports map and `main` point at. */
+function declaredTargets(): string[] {
+  const targets = new Set<string>()
+  if (typeof manifest.main === 'string')
+    targets.add(manifest.main)
+  for (const entry of Object.values(manifest.exports ?? {})) {
+    if (typeof entry === 'string')
+      targets.add(entry)
+    else
+      for (const value of Object.values(entry)) targets.add(value)
+  }
+  return [...targets].map(target => target.replace(/^\.\//, ''))
+}
+
+/**
+ * The files npm would actually publish, asked of npm rather than reimplemented.
+ *
+ * `files` has its own glob and always-include semantics, so a hand-rolled matcher would answer a
+ * slightly different question than the one that matters.
+ */
+function packedFiles(): string[] {
+  const output = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+    cwd: packageRoot,
+    encoding: 'utf8',
+  })
+  return (JSON.parse(output) as Array<{ files: Array<{ path: string }> }>)[0]!.files.map(
+    entry => entry.path,
+  )
+}
+
+/**
+ * An exports target that is not in the tarball (#970).
+ *
+ * `exports['./client'].require` pointed at `./dist/client.cjs` while `files` was `["src"]`, so
+ * `require('@talex-touch/tuff-intelligence/client')` resolved to a path the package does not
+ * contain. It worked in this repo because `dist/` exists on disk here, and it worked from npm
+ * because the published 0.0.2 still lists `dist` in `files` — the two drifted apart in c8977cc44
+ * without the version changing.
+ *
+ * This is the second time in one day that a `files` array omitted something another field pointed
+ * at; `scripts/verify-audio-production.js` was the first (#1674). Both are invisible in the repo
+ * and only appear to a consumer of the published package.
+ */
+describe('published surface', () => {
+  it('ships every file the exports map and main point at', () => {
+    const packed = new Set(packedFiles())
+    const missing = declaredTargets().filter(target => !packed.has(target))
+
+    expect(missing, `exports/main target(s) not in the tarball: ${missing.join(', ')}`).toEqual([])
+  })
+
+  // Guards the check itself: a manifest with no targets would make the assertion above vacuous.
+  it('has targets to check', () => {
+    expect(declaredTargets().length).toBeGreaterThan(3)
+  })
+
+  it('does not advertise a require condition it cannot serve', () => {
+    // The package publishes TypeScript source, so a CJS `require` cannot load any of it. A
+    // `require` condition here would either point outside `files` or at a `.ts` file.
+    const conditions = Object.values(manifest.exports ?? {}).flatMap(entry =>
+      typeof entry === 'string' ? [] : Object.keys(entry),
+    )
+
+    expect(conditions).not.toContain('require')
+  })
+
+  it('builds nothing it does not publish', () => {
+    // `tsup --format cjs` was the only producer of dist/client.cjs, and dist is not shipped.
+    expect(manifest.scripts?.build ?? '').not.toContain('format cjs')
+    expect(existsSync(path.join(packageRoot, 'package.json'))).toBe(true)
+  })
+})


### PR DESCRIPTION
Toward #970, third item.

`c8977cc44` (*"stop shipping a dist nothing resolves"*, #1642) removed `"dist"` from `files` and **left `exports["./client"].require` pointing at `./dist/client.cjs`**. Something did resolve it — that is what the `require` condition is.

The result is invisible in the repo and invisible on npm. It only appears on the next publish:

| | `files` | tarball |
|---|---|---|
| published `0.0.2` | `["dist","src"]` | contains `dist/client.cjs` |
| repo `0.0.2` | `["src"]` | would not |

**Same version number**, so the two drifted with nothing marking it. Checked against the real tarball rather than inferred — `npm pack @talex-touch/tuff-intelligence@0.0.2` still carries the file, which is why nothing has broken yet.

## Completing #1642's intent rather than undoing it

The package publishes TypeScript source (`main` is `src/index.ts`, `files` is `["src"]`), so a CJS `require` cannot load any of it and the condition was vestigial either way. The `tsup --format cjs` half of the build goes with it, since it was the only producer of the file nothing ships.

No `require(...tuff-intelligence/client)` exists anywhere in the repo. The one consumer — `plugins/touch-translation` — uses `import` and resolves to `src/client.ts`.

## Four plants, each caught

| plant | failing |
|---|---|
| put the `require` condition back | 2 of 4 |
| point `./light` at an unpublished dist | 1 of 4 |
| build a cjs bundle again | 1 of 4 |
| empty the exports map entirely | 1 of 4 |

**The last one matters most** — it is the check guarding itself, because a manifest with no targets would make the main assertion vacuously true.

The packed file list comes from `npm pack --dry-run --json` rather than a hand-rolled matcher: `files` has its own glob and always-include rules, and reimplementing them would answer a slightly different question than the one that matters.

**Second time today a `files` array omitted something another field pointed at** — the first was `scripts/verify-audio-production.js` in #1674. Same defect class, different package, both invisible until someone consumes the published artifact.

Package suite 10 files / 39 tests pass, lint clean.

Refs #970