### PR TITLE
fix(deps): move three dependencies onto their patched lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "eslint": "^9.39.4",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
-    "markdown-it": "14.1.0",
+    "markdown-it": "14.2.0",
     "markdownlint": "0.39.0",
     "marked": "catalog:",
     "remark-mdc": "3.11.1",

--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -91,7 +91,7 @@
     "@talex-touch/utils": "workspace:^",
     "@vue/reactivity": "^3.5.27",
     "@vueuse/core": "^14.3.0",
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.13",
     "gsap": "^3.15.0",
     "marked": "catalog:",
     "mermaid": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ catalogs:
       specifier: ^17.0.6
       version: 17.0.6
     mermaid:
-      specifier: ^11.16.0
-      version: 11.16.0
+      specifier: ^11.16.1
+      version: 11.16.1
     ogl:
       specifier: ^1.0.11
       version: 1.0.11
@@ -256,8 +256,8 @@ importers:
         specifier: ^16.4.0
         version: 16.4.0
       markdown-it:
-        specifier: 14.1.0
-        version: 14.1.0
+        specifier: 14.2.0
+        version: 14.2.0
       markdownlint:
         specifier: 0.39.0
         version: 0.39.0
@@ -655,7 +655,7 @@ importers:
         version: 3.10.1
       mermaid:
         specifier: 'catalog:'
-        version: 11.16.0
+        version: 11.16.1
       nitropack:
         specifier: 2.13.4
         version: 2.13.4(@libsql/client@0.17.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@libsql/client@0.17.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1))(encoding@0.1.13)(oxc-parser@0.133.0)
@@ -1147,8 +1147,8 @@ importers:
         specifier: ^14.3.0
         version: 14.3.0(vue@3.5.39(typescript@5.9.3))
       dompurify:
-        specifier: ^3.4.11
-        version: 3.4.12
+        specifier: ^3.4.13
+        version: 3.4.13
       gsap:
         specifier: ^3.15.0
         version: 3.15.0
@@ -1157,7 +1157,7 @@ importers:
         version: 17.0.6
       mermaid:
         specifier: 'catalog:'
-        version: 11.16.0
+        version: 11.16.1
       shiki:
         specifier: ^4.4.2
         version: 4.4.2
@@ -8007,8 +8007,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -10251,8 +10251,8 @@ packages:
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
 
-  markdown-it@14.1.0:
-    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
 
   markdown-table@3.0.4:
@@ -10354,8 +10354,8 @@ packages:
     resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
     engines: {node: '>=18.0.0'}
 
-  mermaid@11.16.0:
-    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -21519,7 +21519,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -24097,7 +24097,7 @@ snapshots:
 
   mark.js@8.11.1: {}
 
-  markdown-it@14.1.0:
+  markdown-it@14.2.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
@@ -24281,7 +24281,7 @@ snapshots:
 
   meriyah@6.1.4: {}
 
-  mermaid@11.16.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.4
@@ -24295,7 +24295,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       es-toolkit: 1.49.0
       katex: 0.16.45
       khroma: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,7 +48,7 @@ catalog:
   jszip: ^3.10.1
   markdown-it: 14.1.0
   marked: ^17.0.6
-  mermaid: ^11.16.0
+  mermaid: ^11.16.1
   next-auth: ~4.24.15
   ogl: ^1.0.11
   openapi-typescript: ^7.13.0


### PR DESCRIPTION
Toward #483.

That issue's baseline was **51 alerts (3 critical, 20 high, 25 moderate, 3 low)** on 2026-08-04. Measured today against `master` after the app-shell-v2 merge: **27 open (1 critical, 8 high, 14 medium, 4 low)**.

Three of the 27 were one patch position away, and the manifests now say so rather than leaving it to resolution:

| | | |
|---|---|---|
| `markdown-it` | `14.1.0` → `14.2.0` | root devDependency, previously pinned exactly |
| `dompurify` | `^3.4.11` → `^3.4.13` | `packages/tuffex` |
| `mermaid` | `^11.16.0` → `^11.16.1` | workspace catalog |

**The last two already permitted the patched version** — `^3.4.11` admits 3.4.13 — but pnpm keeps a satisfying resolution rather than moving to the newest, so the lockfile sat on 3.4.12 and 11.16.0. Refreshing alone would have fixed it silently and let the next resolution drift back; raising the declared floor records the security requirement where someone reading the manifest can see it.

Lockfile now carries exactly one version of each. Production audit gate unchanged at 8 Critical/High, 8 allowlisted.

The full 27-alert triage goes on the issue.

Refs #483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Markdown rendering, HTML sanitization, and Mermaid diagram components to newer patch versions.
  * Includes routine dependency updates with no changes to public APIs or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->