### PR TITLE
docs(security): nanoid does move with the nuxt closure after all

### DIFF
--- a/.github/prod-audit-allowlist.json
+++ b/.github/prod-audit-allowlist.json
@@ -20,7 +20,7 @@
       "id": "GHSA-28wg-ghj8-5hjv",
       "module": "nanoid",
       "severity": "high",
-      "reason": "Reached from production by many roots, and blocked upstream rather than by the nuxt closure. `pnpm why nanoid -r --prod` puts nanoid@3.3.16 under postcss@8.5.23, and postcss is reached directly by @talex-touch/core-app, tuff-cli and tuff-cli-core through @vue/compiler-sfc, as well as by @nuxt/vite-builder and by vue-router. So it does NOT clear when #1098 moves the nuxt closure. It also cannot be bumped here: postcss@8.5.23 requires nanoid ^3.3.16 and the patched line is 5.1.16, which is ESM-only, so the postcss 8.x line will not adopt it. Moves when postcss does.",
+      "reason": "Only nanoid@5.1.6 is affected -- the advisory range is >= 4.0.0, < 5.1.16, so the nanoid@3.3.16 that postcss pulls is already on the patched 3.x line and is not covered. 5.1.6 arrives through @vue/devtools-core -> @nuxt/devtools@2.7.0 -> nuxt, so this does move when the nuxt closure moves in #1098. Corrected twice before landing here: #1691 reattributed it to the postcss/vue-router path and #1708 doubled down, both of which describe the 3.x copy the advisory does not cover.",
       "owner": "#328",
       "expires": "2026-11-09"
     },
@@ -28,7 +28,7 @@
       "id": "GHSA-2v37-7h3g-55p8",
       "module": "nanoid",
       "severity": "high",
-      "reason": "Reached from production by many roots, and blocked upstream rather than by the nuxt closure. `pnpm why nanoid -r --prod` puts nanoid@3.3.16 under postcss@8.5.23, and postcss is reached directly by @talex-touch/core-app, tuff-cli and tuff-cli-core through @vue/compiler-sfc, as well as by @nuxt/vite-builder and by vue-router. So it does NOT clear when #1098 moves the nuxt closure. It also cannot be bumped here: postcss@8.5.23 requires nanoid ^3.3.16 and the patched line is 5.1.16, which is ESM-only, so the postcss 8.x line will not adopt it. Moves when postcss does.",
+      "reason": "Only nanoid@5.1.6 is affected -- the advisory range is >= 4.0.0, < 5.1.16, so the nanoid@3.3.16 that postcss pulls is already on the patched 3.x line and is not covered. 5.1.6 arrives through @vue/devtools-core -> @nuxt/devtools@2.7.0 -> nuxt, so this does move when the nuxt closure moves in #1098. Corrected twice before landing here: #1691 reattributed it to the postcss/vue-router path and #1708 doubled down, both of which describe the 3.x copy the advisory does not cover.",
       "owner": "#328",
       "expires": "2026-11-09"
     },

--- a/.github/prod-audit-allowlist.json
+++ b/.github/prod-audit-allowlist.json
@@ -20,7 +20,7 @@
       "id": "GHSA-28wg-ghj8-5hjv",
       "module": "nanoid",
       "severity": "high",
-      "reason": "Two production roots, not one. `pnpm -C apps/nexus why nanoid --prod` shows @sentry/nuxt -> nuxt -> @nuxt/vite-builder -> postcss -> nanoid, and independently vue-router (a direct nexus production dependency) -> @vue-macros/common -> @vue/compiler-sfc -> postcss -> nanoid. So this does NOT clear when the nuxt closure moves in #1098 — the vue-router path survives it. Patched line needs postcss to move, which vue-router pulls on its own.",
+      "reason": "Reached from production by many roots, and blocked upstream rather than by the nuxt closure. `pnpm why nanoid -r --prod` puts nanoid@3.3.16 under postcss@8.5.23, and postcss is reached directly by @talex-touch/core-app, tuff-cli and tuff-cli-core through @vue/compiler-sfc, as well as by @nuxt/vite-builder and by vue-router. So it does NOT clear when #1098 moves the nuxt closure. It also cannot be bumped here: postcss@8.5.23 requires nanoid ^3.3.16 and the patched line is 5.1.16, which is ESM-only, so the postcss 8.x line will not adopt it. Moves when postcss does.",
       "owner": "#328",
       "expires": "2026-11-09"
     },
@@ -28,7 +28,7 @@
       "id": "GHSA-2v37-7h3g-55p8",
       "module": "nanoid",
       "severity": "high",
-      "reason": "Two production roots, not one. `pnpm -C apps/nexus why nanoid --prod` shows @sentry/nuxt -> nuxt -> @nuxt/vite-builder -> postcss -> nanoid, and independently vue-router (a direct nexus production dependency) -> @vue-macros/common -> @vue/compiler-sfc -> postcss -> nanoid. So this does NOT clear when the nuxt closure moves in #1098 — the vue-router path survives it. Patched line needs postcss to move, which vue-router pulls on its own.",
+      "reason": "Reached from production by many roots, and blocked upstream rather than by the nuxt closure. `pnpm why nanoid -r --prod` puts nanoid@3.3.16 under postcss@8.5.23, and postcss is reached directly by @talex-touch/core-app, tuff-cli and tuff-cli-core through @vue/compiler-sfc, as well as by @nuxt/vite-builder and by vue-router. So it does NOT clear when #1098 moves the nuxt closure. It also cannot be bumped here: postcss@8.5.23 requires nanoid ^3.3.16 and the patched line is 5.1.16, which is ESM-only, so the postcss 8.x line will not adopt it. Moves when postcss does.",
       "owner": "#328",
       "expires": "2026-11-09"
     },


### PR DESCRIPTION
**CodeRabbit caught an error in my reasoning on this PR's first commit, and it was right.** The PR now says the opposite of what it opened with.

## What the advisory actually covers

`GHSA-28wg-ghj8-5hjv` has vulnerable range **`>= 4.0.0, < 5.1.16`**. The lockfile has two copies:

```
nanoid@3.3.16   via postcss@8.5.23     ← NOT covered; 3.3.16 is the patched 3.x line
nanoid@5.1.6    via @vue/devtools-core → @nuxt/devtools@2.7.0 → nuxt   ← the affected one
```

So the exposure is entirely inside the nuxt closure, and **the original allowlist reason — "moves when that closure moves" — was correct.**

## Three revisions of the same field, and the first was right

| | |
|---|---|
| original | *"Transitive under the same @sentry/nuxt → nuxt closure. Moves when that closure moves."* — **correct** |
| #1691 | reattributed it to `vue-router → … → postcss` as an independent root — **wrong version** |
| this PR, first commit | doubled down: "blocked by postcss, cannot be bumped" — **same wrong version** |
| now | names the version, the range, and both bad corrections |

## What I got wrong twice

I traced the **package name** to a production root without checking **which installed version the advisory covers**. `pnpm why nanoid --prod` prints both copies; I read the tree and not the range. Two corrections built on the same omission.

The reason text now carries the version, the range and the history, so the next reader can see why it contradicts the previous two commits.

Gate unchanged: 8 Critical/High, 8 allowlisted, self-test 9 cases.

Refs #483, #1098

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified production security audit notes to distinguish affected and unaffected dependency versions.
  * Updated exception explanations to accurately reflect advisory coverage, remediation status, and dependency relationships.
  * Corrected outdated attribution details to improve the accuracy and transparency of audit records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->