### PR TITLE
feat(ai): tell an MCP server going away apart from a tool failing

### DIFF
--- a/apps/core-app/src/main/modules/ai/intelligence-mcp-failure.test.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-mcp-failure.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createMcpFailure,
+  isMcpServerUnavailable,
+  MCP_FAILURE_REASON_KEY,
+  MCP_FAILURE_REASONS,
+  readMcpFailureReason
+} from './intelligence-mcp-failure'
+
+/**
+ * The distinction #971 asks for: "server went away" versus "the tool itself failed".
+ *
+ * `intelligence-mcp-registry` already knew it — a per-session `closed` flag, refused at three
+ * separate points — and threw a plain `Error` at every one of them. The only thing separating a
+ * dead transport from a tool error was the message text, so the confirmation card and the result
+ * card had nothing to branch on.
+ */
+describe('mcp failure reason', () => {
+  it('carries the reason as a readable own property', () => {
+    const error = createMcpFailure('server-unavailable', 'MCP profile x is disconnected')
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toBe('MCP profile x is disconnected')
+    expect(readMcpFailureReason(error)).toBe('server-unavailable')
+  })
+
+  /**
+   * The error crosses to the renderer, where it arrives copied field by field rather than as an
+   * Error. So the reason has to be readable off a plain object.
+   *
+   * This does not distinguish `Object.assign` from a subclass -- a plant that switched to a
+   * subclass kept all five cases green, because an own field on a subclass instance spreads the
+   * same way. That is recorded rather than papered over: the test pins the property being own and
+   * enumerable, which is what callers depend on, not the construction.
+   */
+  it('survives being flattened the way a transport hop flattens it', () => {
+    const error = createMcpFailure('tool-failed', 'search returned an error')
+    const copied = { ...error, message: error.message }
+
+    expect(readMcpFailureReason(copied)).toBe('tool-failed')
+    expect(Object.hasOwn(error, MCP_FAILURE_REASON_KEY)).toBe(true)
+  })
+
+  it('separates the two reasons rather than collapsing them', () => {
+    expect(isMcpServerUnavailable(createMcpFailure('server-unavailable', 'gone'))).toBe(true)
+    expect(isMcpServerUnavailable(createMcpFailure('tool-failed', 'bad input'))).toBe(false)
+  })
+
+  /**
+   * `undefined` rather than a default. "We do not know" and "the tool failed" lead to different
+   * UI — a retry prompt versus the tool's own error — so an unmarked error must not read as one
+   * of the two.
+   */
+  it('reports nothing for an error that was never marked', () => {
+    const unmarked = [new Error('plain'), null, undefined, 'string', {}, { mcpFailureReason: 'x' }]
+    for (const value of unmarked) expect(readMcpFailureReason(value), String(value)).toBeUndefined()
+
+    expect(isMcpServerUnavailable(new Error('plain'))).toBe(false)
+  })
+
+  it('has exactly the two reasons the callers branch on', () => {
+    expect([...MCP_FAILURE_REASONS]).toEqual(['server-unavailable', 'tool-failed'])
+  })
+})

--- a/apps/core-app/src/main/modules/ai/intelligence-mcp-failure.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-mcp-failure.ts
@@ -1,0 +1,56 @@
+/**
+ * Why an MCP call failed, in a form a caller can branch on (#971).
+ *
+ * `intelligence-mcp-registry` already knows the difference — it keeps a `closed` flag per session
+ * and refuses a dead transport at three separate points — but every one of those throws a plain
+ * `Error` whose only distinguishing feature is its message. So a tool-call failure reaches the
+ * confirmation card and the result card with no way to tell "the server went away" from "the tool
+ * itself returned an error", which is the distinction that issue asks for.
+ *
+ * Attached rather than subclassed, matching how the repo already carries codes on errors -- e.g.
+ * `Object.assign(new Error('quota'), { storageCode: … })` in plugin-sqlite-worker.
+ *
+ * Not because a subclass would lose the field: an own field on a subclass instance is copied by
+ * a spread just the same, and a plant proved the test cannot tell the two apart. What a subclass
+ * loses across the transport hop is `instanceof`, and nothing here relies on it:
+ * `readMcpFailureReason` reads the property, so it works on the error, on a spread of it, and on
+ * whatever reaches the renderer. The reason to prefer `Object.assign` is that it needs no class.
+ */
+
+export const MCP_FAILURE_REASONS = [
+  /** The profile is gone, the session is closed, or it closed while connecting. */
+  'server-unavailable',
+  /** The server answered and the tool reported an error. Not a transport problem. */
+  'tool-failed'
+] as const
+
+export type McpFailureReason = (typeof MCP_FAILURE_REASONS)[number]
+
+/** The own property carrying the reason. Named so it cannot collide with an SDK field. */
+export const MCP_FAILURE_REASON_KEY = 'mcpFailureReason' as const
+
+export interface McpFailureError extends Error {
+  [MCP_FAILURE_REASON_KEY]: McpFailureReason
+}
+
+export function createMcpFailure(reason: McpFailureReason, message: string): McpFailureError {
+  return Object.assign(new Error(message), { [MCP_FAILURE_REASON_KEY]: reason })
+}
+
+/**
+ * Reads the reason off anything.
+ *
+ * Returns `undefined` rather than a default, because "we do not know" and "the tool failed" lead
+ * to different UI: one is a retry prompt, the other is the tool's own error worth showing.
+ */
+export function readMcpFailureReason(error: unknown): McpFailureReason | undefined {
+  if (!error || typeof error !== 'object') return undefined
+  const value = (error as Record<string, unknown>)[MCP_FAILURE_REASON_KEY]
+  return (MCP_FAILURE_REASONS as readonly string[]).includes(value as string)
+    ? (value as McpFailureReason)
+    : undefined
+}
+
+export function isMcpServerUnavailable(error: unknown): boolean {
+  return readMcpFailureReason(error) === 'server-unavailable'
+}

--- a/apps/core-app/src/main/modules/ai/intelligence-mcp-registry.ts
+++ b/apps/core-app/src/main/modules/ai/intelligence-mcp-registry.ts
@@ -7,6 +7,7 @@ import { resolveRuntimeRootPath } from '../../utils/app-root-path'
 import { app } from 'electron'
 import { getSecureStoreValue, isSecureStoreAvailable } from '../../utils/secure-store'
 import { createLogger } from '../../utils/logger'
+import { createMcpFailure } from './intelligence-mcp-failure'
 
 const mcpLog = createLogger('Intelligence').child('McpRegistry')
 
@@ -203,7 +204,8 @@ export class IntelligenceMcpRegistry {
 
   async callTool(profileId: string, toolName: string, input: unknown): Promise<unknown> {
     const profile = this.getProfile(profileId)
-    if (!profile) throw new Error(`MCP profile ${profileId} is not available`)
+    if (!profile)
+      throw createMcpFailure('server-unavailable', `MCP profile ${profileId} is not available`)
 
     const session = await this.connectProfile(profile)
     const result = await this.withSessionRpc(profileId, session, () =>
@@ -214,7 +216,10 @@ export class IntelligenceMcpRegistry {
     )
 
     if (result.isError) {
-      throw new Error(normalizeTextContent(result.content ?? []) || `MCP tool ${toolName} failed`)
+      throw createMcpFailure(
+        'tool-failed',
+        normalizeTextContent(result.content ?? []) || `MCP tool ${toolName} failed`
+      )
     }
 
     if (result.structuredContent) return result.structuredContent
@@ -327,7 +332,10 @@ export class IntelligenceMcpRegistry {
       // Nothing to remove -- this session was never added to this.sessions. connectProfile
       // propagates the throw and clears its pending entry in the finally, so the next caller
       // starts a fresh connect rather than awaiting a dead one.
-      throw new Error(`MCP profile ${profile.id} closed during connect`)
+      throw createMcpFailure(
+        'server-unavailable',
+        `MCP profile ${profile.id} closed during connect`
+      )
     }
     session = {
       client,
@@ -345,7 +353,8 @@ export class IntelligenceMcpRegistry {
     session: ConnectedMcpSession,
     operation: () => Promise<T>
   ): Promise<T> {
-    if (session.closed) throw new Error(`MCP profile ${profileId} is disconnected`)
+    if (session.closed)
+      throw createMcpFailure('server-unavailable', `MCP profile ${profileId} is disconnected`)
     session.rpcCount += 1
     clearTimeout(session.idleTimer ?? undefined)
     session.idleTimer = null


### PR DESCRIPTION
Item 2 of #971 — "MCP 断连要在确认卡和结果卡上体现".

## What was actually wrong

`intelligence-mcp-registry.callTool` already **knew** the difference. It keeps a `closed` flag per session and refuses a dead transport at three separate points:

| line | condition | what it means |
| --- | --- | --- |
| 208 | profile is not available | the profile is gone |
| 335 | closed during connect | it went away mid-handshake |
| 357 | is disconnected | the session is closed |
| 219 | `result.isError` | the server answered; the **tool** failed |

All four threw a plain `Error`. The only thing separating "the server went away" from "the tool itself returned an error" was the message text, so the confirmation card and the result card had nothing to branch on.

The earlier pass on this issue deferred it as needing a semantics decision — "新错误码还是在既有错误上加字段". The repo has already answered that: `Object.assign(new Error('quota'), { storageCode })` in `plugin-sqlite-worker`. `INTELLIGENCE_ERROR_CODES` is a closed 10-member enum with a `isIntelligenceErrorCode` guard, and this is not one of its members — it is a property on a throw, not a transport-level code.

## The shape

An own enumerable property, because the error is copied field by field on the way to the renderer and has to stay readable there. `readMcpFailureReason` returns `undefined` for anything unmarked rather than a default: "we do not know" and "the tool failed" lead to different UI, so an unmarked error must not read as either.

No caller branches on it yet. This is the discriminator the UI work needs and could not have been built without — the card change is a renderer task with a real design surface, and it was blocked on there being something to read.

## Verification

Five cases, and each was planted against:

| plant | result |
| --- | --- |
| drop the `MCP_FAILURE_REASONS.includes` check | 1 failed |
| collapse the two reasons into "any reason" | 1 failed |
| remove `tool-failed` from the reason list | 2 failed |
| switch `Object.assign` → subclass | **5 passed — caught nothing** |

The fourth plant is recorded in both files rather than papered over. An own field on a subclass instance spreads exactly the same way, so the test cannot tell the two apart; what a subclass loses is `instanceof`, which nothing here relies on. The comment claiming otherwise was corrected. The test pins what callers depend on — the property being own and enumerable — not the construction.

`intelligence-mcp-registry.test.ts`, `.smoke.test.ts` and `mcp-server-admin.test.ts` pass (24 passed, 1 skipped). The wider `ai/` suite shows 20 files failing locally with `Electron failed to install correctly`; `node_modules/electron/dist` is empty in this checkout, so that is this machine, not this change.

## Still blocked on #971

Item 1 (`/name` reaching a local skill) needs `53b1ea472`'s local skill channel, and `readLocalSkill` / `skillDir` are still 0 files on master.