### PR TITLE
test(search): read the query cache counters end to end

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
@@ -840,6 +840,64 @@ describe('SearchEngineCore facade contracts', () => {
     expect(search).toHaveBeenCalledTimes(2)
   })
 
+  /**
+   * The first end-to-end read of the cache counters (#346).
+   *
+   * `search-cache-telemetry.test.ts` covers the counter object thoroughly, and
+   * `getSearchCacheTelemetry` had exactly one reference in the repository -- its own declaration.
+   * So every `recordHit` / `recordMiss` / `recordInvalidation` call site in search-core was
+   * unverified: the counters incremented into a snapshot nobody obtained, which reads the same as
+   * counters that were never wired at all.
+   *
+   * The reason distribution is the part #346 turns on. A miss attributed to `absent` says "nobody
+   * repeated this query", which argues for removing the cache; one attributed to
+   * `revision-mismatch` says "the index denied a repeat that would otherwise have hit", which
+   * argues the opposite. This records which reason an index commit actually produces.
+   */
+  it('attributes a repeat denied by an index commit, and pins which reason it used', async () => {
+    const search = vi.fn(
+      async () =>
+        ({ items: [buildItem('telemetry-item', 'telemetry-provider', 'Telemetry')] }) as never
+    )
+    const query = { inputs: [], text: 'cache telemetry contract' } as TuffQuery
+    core.registerProvider(buildProvider('telemetry-provider', search) as never)
+    core.activateProviders([{ id: 'telemetry-provider' }] as IProviderActivate[])
+
+    const run = async (id: string): Promise<void> => {
+      const session = core.startSearch(query, { caller: { kind: 'core-box', id } })
+      await session.result
+      await session.completed
+    }
+
+    await run('telemetry-cold')
+    await run('telemetry-warm')
+    searchIndexCommitHub.markCommitted(['telemetry-provider'])
+    await run('telemetry-after-commit')
+
+    const snapshot = core.getSearchCacheTelemetry()
+
+    // The counters reach the snapshot at all: three lookups, and the middle one served.
+    expect(snapshot.lookups).toBe(3)
+    expect(snapshot.hits).toBe(1)
+    expect(snapshot.hitRate).toBeCloseTo(1 / 3, 5)
+
+    // The commit is counted as an invalidation, by entries dropped rather than by calls.
+    expect(snapshot.invalidations['index-commit']).toBeGreaterThan(0)
+
+    /*
+     * And this is the finding. `revision-mismatch` is unreachable from here: `markCommitted` bumps
+     * the revision and notifies listeners synchronously, and this facade's listener clears the
+     * whole cache before returning. By the time any lookup compares revisions the entry is already
+     * gone, so the miss is `absent`.
+     *
+     * That matters for the report #346 asks for. A repeat denied by a commit is filed under the
+     * same reason as a query nobody repeated, so the distribution understates the cache's value
+     * and cannot carry the keep/remove decision as it stands.
+     */
+    expect(snapshot.misses['revision-mismatch']).toBe(0)
+    expect(snapshot.misses.absent).toBe(2)
+  })
+
   it('cleans initialized index and provider resources when the facade is destroyed', async () => {
     const providerDestroy = vi.fn()
     core.registerProvider({

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
@@ -859,30 +859,36 @@ describe('SearchEngineCore facade contracts', () => {
       async () =>
         ({ items: [buildItem('telemetry-item', 'telemetry-provider', 'Telemetry')] }) as never
     )
-    const query = { inputs: [], text: 'cache telemetry contract' } as TuffQuery
     core.registerProvider(buildProvider('telemetry-provider', search) as never)
     core.activateProviders([{ id: 'telemetry-provider' }] as IProviderActivate[])
 
-    const run = async (id: string): Promise<void> => {
-      const session = core.startSearch(query, { caller: { kind: 'core-box', id } })
+    const run = async (text: string, id: string): Promise<void> => {
+      const session = core.startSearch({ inputs: [], text } as TuffQuery, {
+        caller: { kind: 'core-box', id }
+      })
       await session.result
       await session.completed
     }
 
-    await run('telemetry-cold')
-    await run('telemetry-warm')
+    // Two distinct queries, so the commit drops two entries. One entry cannot tell "counted per
+    // entry dropped" from "counted per call", and both readings are one line apart in the source.
+    await run('cache telemetry alpha', 'telemetry-alpha-cold')
+    await run('cache telemetry beta', 'telemetry-beta-cold')
+    await run('cache telemetry alpha', 'telemetry-alpha-warm')
     searchIndexCommitHub.markCommitted(['telemetry-provider'])
-    await run('telemetry-after-commit')
+    await run('cache telemetry alpha', 'telemetry-alpha-after-commit')
 
     const snapshot = core.getSearchCacheTelemetry()
 
-    // The counters reach the snapshot at all: three lookups, and the middle one served.
-    expect(snapshot.lookups).toBe(3)
+    // The counters reach the snapshot at all: four lookups, and the third one served.
+    expect(snapshot.lookups).toBe(4)
     expect(snapshot.hits).toBe(1)
-    expect(snapshot.hitRate).toBeCloseTo(1 / 3, 5)
+    expect(snapshot.hitRate).toBeCloseTo(1 / 4, 5)
 
-    // The commit is counted as an invalidation, by entries dropped rather than by calls.
-    expect(snapshot.invalidations['index-commit']).toBeGreaterThan(0)
+    // Exactly two, because two entries were in the cache. Counted by entries dropped rather than
+    // by calls -- a per-call implementation reports 1 here.
+    expect(snapshot.invalidations['index-commit']).toBe(2)
+    expect(snapshot.entriesDropped).toBe(2)
 
     /*
      * And this is the finding. `revision-mismatch` is unreachable from here: `markCommitted` bumps
@@ -895,7 +901,7 @@ describe('SearchEngineCore facade contracts', () => {
      * and cannot carry the keep/remove decision as it stands.
      */
     expect(snapshot.misses['revision-mismatch']).toBe(0)
-    expect(snapshot.misses.absent).toBe(2)
+    expect(snapshot.misses.absent).toBe(3)
   })
 
   it('cleans initialized index and provider resources when the facade is destroyed', async () => {


### PR DESCRIPTION
Progress on #346, and it surfaced why that issue cannot be answered as written.

## The counters were unreadable

`getSearchCacheTelemetry()` has **exactly one reference in the repository — its own declaration**. Nothing calls it: no IPC channel, no dashboard, no test. (Positive control: the same search finds `recordSearchMetrics` in four files, so it does work.)

So while `search-cache-telemetry.test.ts` covers the counter object thoroughly — 16 cases including percentile corruption and sample bounding — every `recordHit` / `recordMiss` / `recordInvalidation` call site in `search-core.ts` was unverified. Counters incrementing into a snapshot nobody obtains read exactly like counters that were never wired.

This adds the first end-to-end read: a cold query, a warm repeat, an index commit, a third query, then the snapshot.

## And it pins the thing #346 turns on

The miss taxonomy is the whole point of the instrumentation — the comment at the classify site says so: *"The reason is the point, not the hit rate: `revision-mismatch` means an index commit denied the entry, which is a different story from a query nobody repeated."*

**`revision-mismatch` is unreachable.** `markCommitted` bumps the revision and notifies listeners synchronously; this facade's listener clears the entire cache before returning. By the time any lookup compares revisions, the entry is already gone, so the miss is `absent`.

The test asserts that directly (`misses['revision-mismatch']` is 0, `misses.absent` is 2), and the causal plant is removing the `searchCache.clear()` on index commit — which turns the test red, because `revision-mismatch` then becomes reachable. The classifier is fine; the clear is what makes the distinction unobservable.

This is not cosmetic. A repeat denied by an index commit lands under the same reason as a query nobody repeated. A report built on that distribution reads "nobody repeats queries, remove the cache" when the truth might be "repeats happen and the index keeps denying them". #346's keep/remove decision cannot rest on it as it stands.

## Verification

| plant | result |
| --- | --- |
| remove `recordHit` | 1 failed |
| remove `recordMiss` | 1 failed |
| remove `searchCache.clear()` on index commit | 1 failed |

`src/main/modules/box-tool/search-engine/` passes: 75 files, 667 tests. `search-core.ts` is restored byte-for-byte after the plants — `git diff` on it is empty, and this PR touches only the test file.

## What remains on #346

The report it asks for still cannot be produced. Two blockers, in order: the snapshot has no reader outside a test, and the reason distribution mis-attributes commit-denied repeats. Both are recorded on the issue; neither is fixed here, because how to surface the snapshot is a product decision and changing the invalidation order is a behaviour change that wants its own justification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for search-cache telemetry across cold, warm, and post-index-commit searches.
  * Verifies cache lookups, hits, hit rates, and invalidation behavior.
  * Confirms searches after an index update are correctly recorded as cache misses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->