### PR TITLE
ci: refuse a maintenance-audit report that names a task nobody can open

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,22 @@ jobs:
       - name: Check for orphan test files
         run: pnpm check:orphan-tests && pnpm check:orphan-tests:self-test
 
+      # The maintenance-audit reports are hand-written, one per day, and #1107 exists because a
+      # bullet was being carried forward instead of re-derived -- the same sentence about a flag
+      # default appeared in eight consecutive reports, three days after the default was inverted.
+      #
+      # The 2026-08-12 report named `07-26-install-launch-v2-4-13-beta-23` as an in-progress task
+      # missing metadata. No such directory exists, active or archived. That is a directory lookup
+      # to catch, and a report naming a task nobody can open is the cheapest possible evidence that
+      # its author did not query the tree.
+      #
+      # Only task existence is checked. Counts and prose are not: parsing "至少 X 项" out of two
+      # languages fails in ways nobody can act on, and the field-presence claim is already
+      # docs:verify's DOC-TASK-META rule. Reports dated on or before the gate date are history and
+      # exempt, which is #1107's own fourth acceptance criterion.
+      - name: Check maintenance-audit report claims
+        run: pnpm check:audit-report-claims && pnpm check:audit-report-claims:self-test
+
       - name: Run plugin suites
         run: pnpm test:plugins && pnpm test:plugins:self-test
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "plugins:validate": "tsx scripts/validate-plugin-package-policy.ts && node scripts/validate-plugins.mjs",
     "plugins:validate:self-test": "node scripts/validate-plugins.mjs --self-test",
     "test:plugins": "node scripts/test-plugins.mjs",
+    "check:audit-report-claims": "node scripts/check-audit-report-claims.mjs",
+    "check:audit-report-claims:self-test": "node scripts/check-audit-report-claims.mjs --self-test",
     "check:orphan-tests": "node scripts/check-orphan-tests.mjs",
     "check:orphan-tests:self-test": "node scripts/check-orphan-tests.mjs --self-test",
     "test:plugins:self-test": "node scripts/test-plugins.mjs --self-test",

--- a/scripts/check-audit-report-claims.mjs
+++ b/scripts/check-audit-report-claims.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+/**
+ * Fails when a maintenance-audit report names a Trellis task that does not exist.
+ *
+ * The reports are written by hand, one per day, and #1107 was filed because a bullet was being
+ * carried forward instead of re-derived: the same sentence about `DB_SEARCH_SPLIT_ENABLED`
+ * appeared in eight consecutive reports, still describing a default that had been inverted three
+ * days earlier.
+ *
+ * The 2026-08-12 report gave a worse example. Its task-records bullet named
+ * `07-26-install-launch-v2-4-13-beta-23` as an in-progress task missing metadata. That directory
+ * does not exist -- not under `.trellis/tasks`, not under the archive, nowhere. Two of the other
+ * three tasks it named were wrong in different ways (one archived and completed, one with all
+ * three fields present and updated the day before), and its count of non-completed tasks was 85
+ * against an actual 53.
+ *
+ * A report naming a task nobody can open is the cheapest possible signal that its author did not
+ * query the tree, and it is a directory lookup to catch. That is all this does. The counts and the
+ * prose are not checked -- a check that tried to parse "至少 X 项" out of two languages would fail
+ * in ways nobody could act on, and the field-presence claim is already `docs:verify`'s
+ * `DOC-TASK-META` rule, which reported 0 on the same day the bullet claimed otherwise.
+ *
+ * Reports dated on or before GATE_FROM are history and are left alone, which is #1107's fourth
+ * acceptance criterion: corrections belong in new reports, not in rewritten ones.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const REPORT_DIR = 'docs/engineering/reports'
+const TASK_ROOT = '.trellis/tasks'
+
+/**
+ * Reports up to and including this date predate the gate.
+ *
+ * 2026-08-12 is the last report written before this check existed, and it is the one carrying the
+ * nonexistent task reference. Correcting it would rewrite a dated snapshot, so it is grandfathered
+ * here instead, where the exemption is visible and dated rather than silent.
+ */
+const GATE_FROM = '2026-08-12'
+
+const REPORT_NAME = /^maintenance-audit-(\d{4}-\d{2}-\d{2})\.md$/
+
+/**
+ * A Trellis task slug as the reports write it: `MM-DD-some-name`, inside backticks.
+ *
+ * Backticks are required rather than optional. Without them this matches dates, version fragments
+ * and issue titles in running prose, and a check that reports a date as a missing task is one
+ * nobody will keep.
+ */
+const TASK_REFERENCE = /`(\d{2}-\d{2}-[a-z0-9][a-z0-9-]*)`/g
+
+/** Every task slug that exists, active or archived. */
+export function collectTaskSlugs(readDir) {
+  const slugs = new Set()
+  const walk = (dir, depth) => {
+    if (depth > 3)
+      return
+    for (const entry of readDir(dir)) {
+      if (!entry.isDirectory)
+        continue
+      if (entry.name === 'archive' || /^\d{4}-\d{2}$/.test(entry.name)) {
+        walk(path.posix.join(dir, entry.name), depth + 1)
+        continue
+      }
+      slugs.add(entry.name)
+    }
+  }
+  walk(TASK_ROOT, 0)
+  return slugs
+}
+
+export function referencedTasks(markdown) {
+  return [...new Set([...markdown.matchAll(TASK_REFERENCE)].map(match => match[1]))]
+}
+
+export function gatedReports(names, gateFrom) {
+  return names
+    .map(name => ({ name, date: REPORT_NAME.exec(name)?.[1] }))
+    .filter(entry => entry.date && entry.date > gateFrom)
+    .map(entry => entry.name)
+}
+
+export function findMissingTasks(reports, slugs, readReport) {
+  const missing = []
+  for (const report of reports) {
+    for (const slug of referencedTasks(readReport(report))) {
+      if (!slugs.has(slug))
+        missing.push({ report, slug })
+    }
+  }
+  return missing
+}
+
+function readDirEntries(dir) {
+  const absolute = path.join(repoRoot, dir)
+  if (!fs.existsSync(absolute))
+    return []
+  return fs
+    .readdirSync(absolute, { withFileTypes: true })
+    .map(entry => ({ name: entry.name, isDirectory: entry.isDirectory() }))
+}
+
+function main() {
+  const slugs = collectTaskSlugs(readDirEntries)
+  if (slugs.size === 0) {
+    console.error(`No task directories found under ${TASK_ROOT}. Refusing to report success.`)
+    return 1
+  }
+
+  const names = readDirEntries(REPORT_DIR)
+    .filter(entry => !entry.isDirectory)
+    .map(entry => entry.name)
+  const reports = gatedReports(names, GATE_FROM)
+  const readReport = name => fs.readFileSync(path.join(repoRoot, REPORT_DIR, name), 'utf8')
+
+  if (reports.length === 0) {
+    console.log(
+      `check-audit-report-claims: no maintenance-audit report dated after ${GATE_FROM}; `
+      + `${slugs.size} task slugs known.`,
+    )
+    return 0
+  }
+
+  const missing = findMissingTasks(reports, slugs, readReport)
+  if (missing.length > 0) {
+    console.error('Maintenance-audit report names a Trellis task that does not exist:\n')
+    for (const entry of missing) {
+      console.error(`  ${REPORT_DIR}/${entry.report}  ->  ${entry.slug}`)
+    }
+    console.error(
+      `\n${slugs.size} task slugs exist under ${TASK_ROOT} (including the archive). A report that`
+      + ' names one of these is describing something nobody can open, which means the claim around'
+      + ' it was carried rather than re-derived (#1107).',
+    )
+    return 1
+  }
+
+  const checked = reports.reduce((total, report) => total + referencedTasks(readReport(report)).length, 0)
+  console.log(
+    `check-audit-report-claims: ${checked} task reference(s) across ${reports.length} report(s) `
+    + `all resolve; ${slugs.size} slugs known.`,
+  )
+  return 0
+}
+
+function selfTest() {
+  const tree = {
+    '.trellis/tasks': [
+      { name: '08-01-live', isDirectory: true },
+      { name: 'archive', isDirectory: true },
+      { name: 'README.md', isDirectory: false },
+    ],
+    '.trellis/tasks/archive': [{ name: '2026-07', isDirectory: true }],
+    '.trellis/tasks/archive/2026-07': [{ name: '07-28-done', isDirectory: true }],
+  }
+  const slugs = collectTaskSlugs(dir => tree[dir] ?? [])
+
+  const cases = [
+    { name: 'an active task is known', actual: slugs.has('08-01-live'), expected: true },
+    { name: 'an archived task is known too', actual: slugs.has('07-28-done'), expected: true },
+    { name: 'the archive folders are not slugs', actual: slugs.has('archive'), expected: false },
+    { name: 'a file is not a slug', actual: slugs.has('README.md'), expected: false },
+    {
+      name: 'a backticked slug is a reference',
+      actual: referencedTasks('see `08-01-live` today')[0],
+      expected: '08-01-live',
+    },
+    {
+      name: 'a bare date in prose is not a reference',
+      actual: referencedTasks('on 08-01-live we shipped').length,
+      expected: 0,
+    },
+    {
+      name: 'the same slug twice counts once',
+      actual: referencedTasks('`08-01-live` and `08-01-live`').length,
+      expected: 1,
+    },
+    {
+      name: 'reports on the gate date are history',
+      actual: gatedReports(['maintenance-audit-2026-08-12.md'], '2026-08-12').length,
+      expected: 0,
+    },
+    {
+      name: 'reports after the gate date are checked',
+      actual: gatedReports(['maintenance-audit-2026-08-13.md'], '2026-08-12')[0],
+      expected: 'maintenance-audit-2026-08-13.md',
+    },
+    {
+      name: 'a file that is not a report is ignored',
+      actual: gatedReports(['release-integrity-2026-09-01.md'], '2026-08-12').length,
+      expected: 0,
+    },
+    {
+      name: 'a report naming a real task passes',
+      actual: findMissingTasks(['r.md'], slugs, () => 'see `08-01-live`').length,
+      expected: 0,
+    },
+    {
+      name: 'a report naming a task that does not exist fails',
+      actual: findMissingTasks(['r.md'], slugs, () => 'see `07-26-install-launch-v2-4-13-beta-23`')[0]
+        ?.slug,
+      expected: '07-26-install-launch-v2-4-13-beta-23',
+    },
+    {
+      // The defect this exists for, in its original form: three named tasks, one of which is gone.
+      name: 'one bad reference among good ones is still caught',
+      actual: findMissingTasks(
+        ['r.md'],
+        slugs,
+        () => '`08-01-live`, `07-28-done`, `07-26-install-launch-v2-4-13-beta-23`',
+      ).length,
+      expected: 1,
+    },
+  ]
+
+  let failed = 0
+  for (const testCase of cases) {
+    const ok = Object.is(testCase.actual, testCase.expected)
+    if (!ok) {
+      failed += 1
+      console.error(`  ✗ ${testCase.name}: expected ${testCase.expected}, got ${testCase.actual}`)
+    }
+  }
+  console.log(
+    failed === 0
+      ? `check-audit-report-claims --self-test: ${cases.length} cases passed`
+      : `check-audit-report-claims --self-test: ${failed} of ${cases.length} cases failed`,
+  )
+  return failed
+}
+
+if (process.argv.includes('--self-test'))
+  process.exit(selfTest() > 0 ? 1 : 0)
+else process.exit(main())


### PR DESCRIPTION
Progress on #1107.

## What that issue is actually about

Not one stale line. The mechanism: a bullet carried forward instead of re-derived. The `DB_SEARCH_SPLIT_ENABLED` sentence ran in eight consecutive reports, three days after the default had been inverted, and three reports agreeing made it *more* credible rather than less.

The 2026-08-12 report supplies a cleaner sample, and a worse one. Its task-records bullet:

> **活跃任务树仍有陈旧/无上下文的 in-progress 记录** — 85 个非 completed 任务中，至少 `07-26-install-launch-v2-4-13-beta-23`、`07-28-tuffex-docs-audit`、`07-29-macos-screenshot-capture-core` 及多项 08-04 UI 任务已逾一周未更新且缺少 `meta.blocker`、`meta.nextAction`、`meta.evidence`。

| claim | actual |
| --- | --- |
| 85 non-completed tasks | **53** (28 planning + 25 in_progress) |
| `07-26-install-launch-v2-4-13-beta-23` missing fields | **the directory does not exist**, active or archived |
| `07-28-tuffex-docs-audit` missing fields | archived, completed, `completedAt=2026-08-07` |
| `07-29-macos-screenshot-capture-core` missing fields | all three present (467 / 389 / 360 chars), last updated `5f93aba35` on 2026-08-11 |
| "several 08-04 UI tasks" missing fields | **zero** |

Independent corroboration: `docs:verify` reported **0 findings** that day, and its `DOC-TASK-META` rule checks exactly those three fields on non-planning tasks. The gate that would have caught this was green, running, and ignored.

The split-flag bullet at least described a state that once existed. This one names a task that never did.

## What this adds, and what it deliberately does not

Task existence is a directory lookup. It does not need to wait for whoever next thinks to count, so `check:audit-report-claims` asserts it on every PR: every `` `MM-DD-slug` `` in a gated report must resolve under `.trellis/tasks`, archive included.

Nothing else is checked, on purpose:

- **Counts** — parsing "至少 X 项" out of two languages fails in ways nobody can act on.
- **Field presence** — already `docs:verify`'s `DOC-TASK-META`. Duplicating a gate that was already green and already ignored adds no signal.
- **Backtick-free slugs** — required, so the pattern cannot report a date in prose as a missing task. A check that cries wolf gets switched off.

Reports dated on or before **2026-08-12** are grandfathered. That is #1107's own fourth criterion — corrections belong in new reports, not rewritten history — and it is why the 08-12 report keeps its bad reference rather than being edited.

## It currently checks nothing, so it was proved on a real file

Grandfathering means there is no gated report yet: today it prints `no maintenance-audit report dated after 2026-08-12` and exits 0. That is a check that cannot fail, which is the exact shape of #482's "actionlint unavailable" and of the six sandbox cases that had never run.

So the self-test is not the evidence. A temporary `maintenance-audit-2026-08-13.md` was written to disk and the real entry point run against it:

| report on disk | exit |
| --- | --- |
| names `07-26-install-launch-v2-4-13-beta-23` | **1**, naming the file and the slug |
| same file, only real references | **0** |

Temporary file removed; `git status` on `docs/engineering/reports` is clean.

`--self-test` covers 13 cases including the archive walk, the backtick requirement, the gate-date boundary being inclusive, a non-report filename being ignored, and one bad reference among good ones still failing. `main()` also refuses to report success if the task walk finds nothing — an empty discovery is not a pass.

`mise run workflows:lint` (actionlint + shellcheck) exits 0 with the new step. `pnpm check:orphan-tests` still reports every one of 1355 test files reachable.

## Remaining on #1107

Criterion 1 is answered: there is no generator. The reports are hand-written and committed daily, so the "source of the repeated bullet" is a person or agent copying yesterday's file. That is not fixable by a script; the most a script can do is refuse the claims that are machine-checkable, which is what this is. Criterion 3, the spot-check of the remaining bullets in the 08-07 report, is not done here.