### PR TITLE
fix(test): stop the browser-open leak scan reading its own random token

### DIFF
--- a/apps/core-app/src/main/modules/plugin/host/plugin-browser-open-capabilities.test.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-browser-open-capabilities.test.ts
@@ -159,9 +159,21 @@ describe('isolated browser-open capability', () => {
         }
       ]
     })
-    expect(JSON.stringify(result)).not.toMatch(
-      /Applications|Google Chrome\.app|path|executable|dev|ino/i
-    )
+    /*
+     * The token is masked out before the leak scan (#1714).
+     *
+     * `dev` and `ino` are three-character substrings matched case-insensitively, and the payload
+     * carries a 32-character random token. Over 2,000,000 generated tokens they collide 0.190% of
+     * the time -- about one CI run in 528 -- and one did: `bo_d3KUpqKSWdevwwQmuyCRtbewgZxrjzxJ`
+     * failed a PR whose only change was in another module.
+     *
+     * Masking rather than loosening the pattern: the token's shape is already asserted above by
+     * `toEqual`, so nothing is lost by taking its bytes out of a scan that is looking for
+     * filesystem paths and `fs.Stats` fields, which a token cannot be.
+     */
+    const withoutTokens = JSON.stringify(result).replace(/bo_[A-Za-z0-9_-]{32}/g, 'bo_<token>')
+
+    expect(withoutTokens).not.toMatch(/Applications|Google Chrome\.app|path|executable|dev|ino/i)
     expect(harness.spawn).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
Fixes #1714.

## The assertion scans a string containing its own random token

`lists only bounded display metadata and activation-local opaque tokens` is a **security** check: the capability must not surface filesystem paths or `fs.Stats` fields to a plugin.

```ts
expect(JSON.stringify(result)).not.toMatch(
  /Applications|Google Chrome\.app|path|executable|dev|ino/i
)
```

`result` contains a 32-character random token. `dev` and `ino` are three-character substrings, matched case-insensitively, over a 64-character alphabet. They collide.

**3,791 of 2,000,000 generated tokens match — 0.190%, about one CI run in 528.** `ino` accounts for most of it: three letters, either case, thirty positions.

One of them landed on #1712, whose only change was a test file in `search-engine/` — a different module. The token was `bo_d3KUpqKSWdevwwQmuyCRtbewgZxrjzxJ`, and the match was `…KSW`**`dev`**`wwQ…`.

## Fix

Mask the token to a placeholder before the scan. Not loosen the pattern: the token's shape is already asserted by the `toEqual` immediately above, so removing its bytes from a scan looking for paths and stat fields loses nothing a token could have carried.

## Verification, against the token that actually failed

#1714's third acceptance criterion asks for exactly this rather than fresh random tokens, because a fresh one has a 99.81% chance of proving nothing. Pinning `randomBytes` to the CI token:

| file | result |
| --- | --- |
| current `HEAD` | **1 failed** |
| this branch | 1 passed |

And the mask does not swallow a real leak — each of these still trips the scan with a token present in the payload:

| planted leak | flagged |
| --- | --- |
| `path` field | ✅ |
| `/Applications/Google Chrome.app` in a name | ✅ |
| `fs.Stats` `dev` / `ino` pair | ✅ |
| `executable` field | ✅ |
| clean payload + the colliding token | ✅ not flagged |

`src/main/modules/plugin/host/` passes: 46 files, 759 tests.

## Not done here

`dev` and `ino` as bare substrings remain loose — they would match `Devon`, `window`, or any future field name containing either. The fields they aim at are `fs.Stats` keys, so checking the object's keys would say what is meant. That is a redesign of the assertion and does not belong in a flake fix; it is recorded on #1714.