### PR TITLE
test(main): derive the privileged-scheme file list instead of naming two

### DIFF
--- a/apps/core-app/src/main/csp-bypass.contract.test.ts
+++ b/apps/core-app/src/main/csp-bypass.contract.test.ts
@@ -9,6 +9,7 @@
  * only "no bypassCSP" would pass just as well on a build where tfile: had silently stopped
  * loading.
  */
+import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -57,5 +58,38 @@ describe('privileged schemes do not bypass the page CSP', () => {
     // Positive control for the absence check: atom is handled here, so the scan can see handlers.
     expect(PROTOCOL_HANDLER).toContain("protocol.handle('atom'")
     expect(PROTOCOL_HANDLER).not.toContain("protocol.handle('stream'")
+  })
+
+  /**
+   * The two assertions above read two named files. That covers every call site today only because
+   * there happens to be exactly one, in `index.ts` -- a second one added anywhere else under
+   * `src/main` would carry `bypassCSP` past this suite unseen (#689).
+   *
+   * So the file list is derived rather than written down. If a new call site appears, either it is
+   * covered by the scan below or this test names it.
+   *
+   * What this cannot see: a scheme a dependency registers at runtime. `@sentry/electron/main`
+   * registers `sentry-ipc` with `bypassCSP: true` from inside `Sentry.init`, and no source scan of
+   * this repository will ever show it. Recorded here rather than asserted, because asserting on a
+   * dependency's internals breaks on its next release and says nothing about our own code.
+   */
+  it('每一个仓库内的 registerSchemesAsPrivileged 调用点都不带 bypassCSP', () => {
+    const mainRoot = __dirname
+    const files = execFileSync('git', ['grep', '-l', 'registerSchemesAsPrivileged', '--', '*.ts'], {
+      cwd: mainRoot,
+      encoding: 'utf8'
+    })
+      .split('\n')
+      .filter((entry) => entry && !entry.endsWith('.test.ts'))
+
+    // An empty list would make every assertion below vacuous, and is itself the failure: the call
+    // has to live somewhere for `tfile:` to work at all.
+    expect(files, 'no registerSchemesAsPrivileged call site found under src/main').not.toEqual([])
+    expect(files).toContain('index.ts')
+
+    for (const file of files) {
+      const source = readFileSync(path.join(mainRoot, file), 'utf8')
+      expect(privilegedSchemeBlock(source), file).not.toContain('bypassCSP')
+    }
   })
 })


### PR DESCRIPTION
Progress on #689, plus a finding about where the renderer's `connect-src` can actually go.

## The guard

`csp-bypass.contract.test.ts` read `index.ts` and `protocol-handler.ts` **by name**. That covers every call site today only because there happens to be exactly one — a second `registerSchemesAsPrivileged` anywhere else under `src/main` would carry `bypassCSP` past the suite unseen.

The list is derived by grep now, and an empty result is a failure rather than a pass: the call has to live somewhere for `tfile:` to work at all.

| plant | result |
| --- | --- |
| a second call site with `bypassCSP: true` in a new file | **1 failed** — only the new assertion, so the named-file checks would indeed have missed it |
| `bypassCSP` put back on `tfile` | 2 failed |
| grep pointed at a pattern matching nothing | 1 failed (not a vacuous pass) |

`csp-bypass.contract.test.ts` + `csp-policy.test.ts`: 15 tests, green.

## What no source scan here can see

`@sentry/electron/main` registers `sentry-ipc` with `privileges: { bypassCSP: true, corsEnabled: true, supportFetchAPI: true, secure: true }` from inside `Sentry.init` (`esm/main/ipc.js:179`). No scan of this repository will ever show it.

Recorded in the test as a comment rather than asserted — asserting on a dependency's internals breaks on its next release and says nothing about our own code. Exploitability looks low: the `sentry-ipc` handler accepts envelope POSTs and returns an empty 200, so it serves no content a `<script src>` could execute. Worth knowing rather than worth alarm.