### PR TITLE
ci(audit): check what an allowlist entry claims against what the audit reports

### DIFF
--- a/.github/prod-audit-allowlist.json
+++ b/.github/prod-audit-allowlist.json
@@ -5,13 +5,22 @@
     "advisory no longer appears also fails, so the list cannot only grow and cannot silently pre-approve",
     "a re-introduction. Removing an entry is the fix in that case.",
     "This list is the state on 2026-08-11, not an endorsement of it. #328 owns clearing it.",
-    "2026-08-12: the eight nuxt-closure reasons said core-app's vue-sonner optional peer. Measured wrong — moving vue-sonner to devDependencies changed the --prod audit by zero advisories. The real path is apps/nexus's @sentry/nuxt. An exception list is only worth its reasons."
+    "2026-08-12: the eight nuxt-closure reasons said core-app's vue-sonner optional peer. Measured wrong — moving vue-sonner to devDependencies changed the --prod audit by zero advisories. The real path is apps/nexus's @sentry/nuxt. An exception list is only worth its reasons.",
+    "2026-08-12: `module`, `severity` and `versions` are now checked against what the audit actually",
+    "reports, not just declared. `versions` is the installed version(s) the advisory hits. This is",
+    "here because the prose could be — and four times was — about a different dependency than the",
+    "entry allows: GHSA-2v37-7h3g-55p8 carried a verbatim copy of the neighbouring nanoid reason,",
+    "which described a range that entry did not have. Nothing could see that by reading. Now the",
+    "audit is asked instead."
   ],
   "advisories": [
     {
       "id": "GHSA-279x-mwfv-vcqv",
       "module": "@nuxt/devtools",
       "severity": "critical",
+      "versions": [
+        "2.7.0"
+      ],
       "reason": "Reaches --prod under the same @sentry/nuxt closure as nuxt: @sentry/nuxt -> nuxt -> @nuxt/devtools@2.7.0. The patched range starts at 3.3.1, which needs @nuxt/kit ^4.5.1, i.e. the Nuxt 4.5 line — blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
@@ -20,6 +29,9 @@
       "id": "GHSA-28wg-ghj8-5hjv",
       "module": "nanoid",
       "severity": "high",
+      "versions": [
+        "5.1.6"
+      ],
       "reason": "Only nanoid@5.1.6 is affected -- the advisory range is >= 4.0.0, < 5.1.16, so the nanoid@3.3.16 that postcss pulls is already on the patched 3.x line and is not covered. 5.1.6 arrives through @vue/devtools-core -> @nuxt/devtools@2.7.0 -> nuxt, so this does move when the nuxt closure moves in #1098. Corrected twice before landing here: #1691 reattributed it to the postcss/vue-router path and #1708 doubled down, both of which describe the 3.x copy the advisory does not cover.",
       "owner": "#328",
       "expires": "2026-11-09"
@@ -28,6 +40,9 @@
       "id": "GHSA-9473-5f9j-94wq",
       "module": "nuxt",
       "severity": "high",
+      "versions": [
+        "4.4.8"
+      ],
       "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction — a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
@@ -36,6 +51,9 @@
       "id": "GHSA-9pgf-384g-p7mv",
       "module": "nuxt",
       "severity": "high",
+      "versions": [
+        "4.4.8"
+      ],
       "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction — a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
@@ -44,6 +62,9 @@
       "id": "GHSA-hxcr-hm88-mpq6",
       "module": "nuxt",
       "severity": "high",
+      "versions": [
+        "4.4.8"
+      ],
       "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction — a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
@@ -52,6 +73,9 @@
       "id": "GHSA-hxvh-4h3w-prp9",
       "module": "nuxt",
       "severity": "high",
+      "versions": [
+        "4.4.8"
+      ],
       "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction — a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"
@@ -60,6 +84,9 @@
       "id": "GHSA-wm8w-6qjm-cv43",
       "module": "nuxt",
       "severity": "high",
+      "versions": [
+        "4.4.8"
+      ],
       "reason": "Reaches --prod through apps/nexus's production dependency @sentry/nuxt@10.65.0, which depends on nuxt by construction — a Sentry integration for Nuxt cannot not. Traced with `pnpm -C apps/nexus why nuxt --prod`: @sentry/nuxt -> nuxt -> @nuxt/devtools -> @nuxt/kit. Not reclassifiable: Sentry reporting is runtime behaviour, not a build input. Blocked behind the unhead 2 -> 3 migration (#1098).",
       "owner": "#328",
       "expires": "2026-11-09"

--- a/scripts/check-prod-audit.mjs
+++ b/scripts/check-prod-audit.mjs
@@ -29,7 +29,10 @@ const allowlistPath = path.join(repoRoot, '.github', 'prod-audit-allowlist.json'
 const BLOCKING = new Set(['critical', 'high'])
 
 /**
- * Reads the audit JSON into `{ id -> {module, severity} }` for the severities that block.
+ * Reads the audit JSON into `{ id -> {module, severity, versions} }` for the severities that block.
+ *
+ * `versions` is what the advisory actually hits in this tree, from its own findings. It is here so
+ * the allowlist can be checked against it rather than against prose -- see `evaluate`.
  *
  * Throws rather than returning empty when the payload has no advisory container at all. An audit
  * that failed to reach the registry and an audit that found nothing produce the same empty map,
@@ -50,7 +53,14 @@ export function collectBlockingAdvisories(payload) {
     const id = advisory?.github_advisory_id ?? String(advisory?.id ?? '')
     if (!id)
       continue
-    found.set(id, { module: advisory?.module_name ?? 'unknown', severity })
+    const versions = [
+      ...new Set(
+        (Array.isArray(advisory?.findings) ? advisory.findings : [])
+          .map(finding => String(finding?.version ?? ''))
+          .filter(Boolean),
+      ),
+    ].sort()
+    found.set(id, { module: advisory?.module_name ?? 'unknown', severity, versions })
   }
   return found
 }
@@ -75,8 +85,46 @@ export function evaluate(found, allowlist, today) {
       problems.push(`allowlist entry ${entry.id} needs reason, owner and expires`)
     else if (entry.expires < today)
       problems.push(`allowlist entry ${entry.id} expired on ${entry.expires}`)
-    if (!found.has(entry.id))
+    const live = found.get(entry.id)
+    if (!live) {
       problems.push(`allowlist entry ${entry.id} no longer matches a live advisory — remove it`)
+      continue
+    }
+
+    /*
+     * The declared package and versions are checked against what the audit reports (#328).
+     *
+     * Every other field can be right while the entry describes a different dependency entirely.
+     * That happened four times to one package here: #1691 attributed nanoid to a vue-router root,
+     * #1708 to postcss, and the corrected text was then pasted onto GHSA-2v37-7h3g-55p8, whose
+     * range is < 3.3.17 and whose only finding was the 3.3.16 that the pasted text called "already
+     * on the patched line and not covered". A reviewer cannot catch that by reading -- it reads
+     * perfectly, and it is about a package the sentence never names. The audit knows.
+     */
+    if (!Array.isArray(entry.versions) || entry.versions.length === 0) {
+      problems.push(
+        `allowlist entry ${entry.id} needs versions — the installed version(s) the advisory hits, `
+        + `which the audit reports as ${live.versions?.join(', ') || '(none)'}`,
+      )
+      continue
+    }
+    if (entry.module !== live.module) {
+      problems.push(
+        `allowlist entry ${entry.id} says module ${entry.module}, audit reports ${live.module}`,
+      )
+    }
+    if (entry.severity !== live.severity) {
+      problems.push(
+        `allowlist entry ${entry.id} says severity ${entry.severity}, audit reports ${live.severity}`,
+      )
+    }
+    const declared = [...entry.versions].sort().join(', ')
+    const actual = [...(live.versions ?? [])].sort().join(', ')
+    if (declared !== actual) {
+      problems.push(
+        `allowlist entry ${entry.id} says version(s) ${declared}, audit reports ${actual || '(none)'}`,
+      )
+    }
   }
 
   return problems
@@ -84,8 +132,21 @@ export function evaluate(found, allowlist, today) {
 
 function selfTest() {
   const today = '2026-08-11'
-  const live = new Map([['GHSA-aaaa', { module: 'left', severity: 'high' }]])
-  const good = { advisories: [{ id: 'GHSA-aaaa', reason: 'r', owner: '#328', expires: '2026-11-09' }] }
+  const live = new Map([
+    ['GHSA-aaaa', { module: 'left', severity: 'high', versions: ['1.2.3'] }],
+  ])
+  const entry = {
+    id: 'GHSA-aaaa',
+    module: 'left',
+    severity: 'high',
+    versions: ['1.2.3'],
+    reason: 'r',
+    owner: '#328',
+    expires: '2026-11-09',
+  }
+  const good = { advisories: [entry] }
+  /** The same entry with one field changed, which is how every real mistake here has looked. */
+  const withOnly = patch => ({ advisories: [{ ...entry, ...patch }] })
 
   const cases = [
     {
@@ -112,6 +173,54 @@ function selfTest() {
       name: 'an allowlist entry missing owner/reason/expiry fails',
       actual: evaluate(live, { advisories: [{ id: 'GHSA-aaaa' }] }, today).length > 0,
       expected: true,
+    },
+    /*
+     * The four checks below are the ones #328's nanoid entry needed and did not have. Its id,
+     * reason, owner and expiry were all fine; the sentence described a different package's
+     * advisory range, and nothing could see that.
+     */
+    {
+      name: 'an entry naming the wrong package fails',
+      actual: evaluate(live, withOnly({ module: 'right' }), today)[0],
+      expected: 'allowlist entry GHSA-aaaa says module right, audit reports left',
+    },
+    {
+      name: 'an entry naming a version the advisory does not hit fails',
+      actual: evaluate(live, withOnly({ versions: ['9.9.9'] }), today)[0],
+      expected: 'allowlist entry GHSA-aaaa says version(s) 9.9.9, audit reports 1.2.3',
+    },
+    {
+      name: 'an entry claiming a lower severity than the audit fails',
+      actual: evaluate(live, withOnly({ severity: 'moderate' }), today)[0],
+      expected: 'allowlist entry GHSA-aaaa says severity moderate, audit reports high',
+    },
+    {
+      name: 'an entry with no versions at all fails rather than being taken on trust',
+      actual: evaluate(live, withOnly({ versions: undefined }), today).length,
+      expected: 1,
+    },
+    {
+      name: 'version order does not matter, only the set',
+      actual: evaluate(
+        new Map([['GHSA-aaaa', { module: 'left', severity: 'high', versions: ['2.0.0', '1.2.3'] }]]),
+        withOnly({ versions: ['1.2.3', '2.0.0'] }),
+        today,
+      ).length,
+      expected: 0,
+    },
+    {
+      name: 'the findings a real audit reports become versions',
+      actual: collectBlockingAdvisories({
+        advisories: {
+          a: {
+            severity: 'high',
+            github_advisory_id: 'GHSA-v',
+            module_name: 'v',
+            findings: [{ version: '1.0.0' }, { version: '1.0.0' }, { version: '2.0.0' }],
+          },
+        },
+      }).get('GHSA-v').versions.join(','),
+      expected: '1.0.0,2.0.0',
     },
     {
       name: 'moderate and low advisories do not block',


### PR DESCRIPTION
Follow-on from #1719, closing the hole that let four wrong attributions through.

## What the gate could not see

It verified an entry has an `id`, a `reason`, an `owner`, an unexpired date, and a still-live advisory. **Every one of those can be right while the entry describes a different dependency.**

`GHSA-2v37-7h3g-55p8` carried a verbatim copy of the neighbouring nanoid entry's reason:

> Only nanoid@5.1.6 is affected — the advisory range is >= 4.0.0, < 5.1.16, so the nanoid@3.3.16 that postcss pulls is already on the patched 3.x line and is not covered.

That advisory's range is `< 3.3.17`, and `nanoid@3.3.16` was its **entire finding**. The sentence reads perfectly, cites a real range, and is about the other advisory. #1691 and #1708 were the same class and were caught by review; this one *survived* review because the text was correct somewhere else.

## The change

`module`, `severity` and a new `versions` are compared against the audit rather than taken on trust. `versions` is the installed version(s) the advisory actually hits, read from its `findings`.

```
allowlist entry GHSA-2v37-7h3g-55p8 says version(s) 5.1.6, audit reports 3.3.16
```

An entry now has to agree with arithmetic, not with a reader.

## Replayed against the real defect

Not against a fixture — against the 2026-08-12 entry and the 2026-08-12 audit:

| input | result |
| --- | --- |
| the entry as it was, versions per its own reason (`5.1.6`) vs a finding of `3.3.16` | **fails**, naming both |
| the same entry declaring `3.3.16` | passes — no false positive |

Self-test 9 → 15 cases, adding: wrong package, wrong version, understated severity, missing `versions` (not taken on trust), set-not-order equality for multi-version advisories, and findings de-duplication.

The seven live entries are populated from the audit and the gate is green:

```
Production audit: 7 Critical/High advisories, 7 allowlisted.
No unapproved Critical/High production advisories.
```

## Why this shape rather than more prose review

The existing stale-entry rule is the model: it caught its own case in #1719 the moment nanoid cleared, without anyone looking. `reason` stays free text and stays required — it is where the *why* lives — but the facts it asserts about are now held by the machine, because the one thing an allowlist has to be is auditable, and four rounds of careful reading did not achieve that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production security-audit validation by checking affected package versions alongside advisory modules and severity.
  * Detects stale, incomplete, or mismatched audit allowlist entries.
  * Expanded validation coverage for advisory extraction, missing versions, and consistent version ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->