### PR TITLE
fix(deps): patch socket.io-parser off GHSA-2m8v-j782-fhvr

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
       "serialize-javascript": "7.0.7",
       "shell-quote": "1.9.0",
       "simple-git": "3.36.0",
+      "socket.io-parser@^4.0.0": "4.2.7",
       "srvx": "0.11.21",
       "svgo": "4.0.2",
       "tar": "7.5.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,7 @@ overrides:
   serialize-javascript: 7.0.7
   shell-quote: 1.9.0
   simple-git: 3.36.0
+  socket.io-parser@^4.0.0: 4.2.7
   srvx: 0.11.21
   svgo: 4.0.2
   tar: 7.5.21
@@ -12255,8 +12256,8 @@ packages:
     resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
     engines: {node: '>=10.0.0'}
 
-  socket.io-parser@4.2.6:
-    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
     engines: {node: '>=10.0.0'}
 
   socks-proxy-agent@8.0.5:
@@ -26891,13 +26892,13 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@10.2.2)
       engine.io-client: 6.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      socket.io-parser: 4.2.6
+      socket.io-parser: 4.2.7
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.6:
+  socket.io-parser@4.2.7:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@10.2.2)


### PR DESCRIPTION
Progress on #483.

`socket.io-parser@4.2.6` sits inside `>= 4.0.0, < 4.2.7`. 4.2.7 is a patch on the same line. It arrives through `@nuxt/content@3.15.0 > socket.io-client@4.8.3`, but the fix is not blocked on the Nuxt upgrade in #1098 — the override moves the leaf, not the closure.

One of the two open High alerts that are **not** part of that closure. The other one is `sharp`, and it should not be forced:

| consumer | declares |
| --- | --- |
| `astro@6.4.8` | `sharp: ^0.34.0` |
| `miniflare@4.20260702.0` | `sharp: 0.34.5` (exact) |

The patched `0.35.0` is outside both. An override there would be overriding a *constraint* rather than a stale resolution, which is a different and much riskier act — and `sharp@0.35.3` already exists in the tree for the packages that ask for it, so the two majors coexisting is correct, not an oversight.

`check:prod-audit` and its 15-case self-test stay green.