### PR TITLE
ci: ratchet the two files #339 is about so the split stops losing

### DIFF
--- a/.github/module-size-ratchet.json
+++ b/.github/module-size-ratchet.json
@@ -1,0 +1,22 @@
+{
+  "$comment": [
+    "Ceilings for scripts/check-module-size-ratchet.mjs. A ceiling may fall and may not rise:",
+    "the check compares each value here against the same file in the PR base revision, so lowering",
+    "one is part of the change that shrinks the file and raising one fails the build.",
+    "Only the two files #339 names. This is not a general file-size policy."
+  ],
+  "files": [
+    {
+      "file": "apps/core-app/src/main/modules/plugin/plugin.ts",
+      "ceiling": 3844,
+      "issue": "#339",
+      "note": "~3,060 when #339 was filed; peaked at 4,069 while three extraction PRs were landing."
+    },
+    {
+      "file": "apps/core-app/src/main/modules/quick-ops/index.ts",
+      "ceiling": 2875,
+      "issue": "#339",
+      "note": "~2,999 when #339 was filed. Down 124 since, and this holds that."
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,19 @@ jobs:
       - name: Check maintenance-audit report claims
         run: pnpm check:audit-report-claims && pnpm check:audit-report-claims:self-test
 
+      # plugin.ts was ~3,060 lines when #339 asked for it to be split. Three extraction PRs landed
+      # and each reported real progress -- 4,069 to 3,947 to 3,872 to 3,844 -- against a baseline
+      # that had already grown a thousand lines since the issue was written. Extraction removed 225
+      # lines while accretion added 1,009, and nothing said so, because each PR compared with the
+      # previous PR.
+      #
+      # This does not measure what #339 is about; that issue says "the concern is not line count by
+      # itself" and is right. It measures whether the split is losing, which is the question three
+      # PRs in a row could not answer. The ceiling falls and never rises, and a ceiling left too far
+      # above the file also fails -- a ratchet nobody tightens is a comment.
+      - name: Check module size ratchet
+        run: pnpm check:module-size-ratchet && pnpm check:module-size-ratchet:self-test
+
       - name: Run plugin suites
         run: pnpm test:plugins && pnpm test:plugins:self-test
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "plugins:validate:self-test": "node scripts/validate-plugins.mjs --self-test",
     "test:plugins": "node scripts/test-plugins.mjs",
     "check:audit-report-claims": "node scripts/check-audit-report-claims.mjs",
+    "check:module-size-ratchet": "node scripts/check-module-size-ratchet.mjs",
+    "check:module-size-ratchet:self-test": "node scripts/check-module-size-ratchet.mjs --self-test",
     "check:audit-report-claims:self-test": "node scripts/check-audit-report-claims.mjs --self-test",
     "check:orphan-tests": "node scripts/check-orphan-tests.mjs",
     "check:orphan-tests:self-test": "node scripts/check-orphan-tests.mjs --self-test",

--- a/scripts/check-module-size-ratchet.mjs
+++ b/scripts/check-module-size-ratchet.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * Stops the two coordination hotspots in #339 from growing while they are being split.
+ *
+ * What this measures is not what #339 is about. That issue says so in its own words -- "the
+ * concern is not line count by itself" -- and it is right: the problem is that each file combines
+ * lifecycle, permission policy, execution dispatch, state, transport and diagnostics, and no line
+ * count can see that.
+ *
+ * It is here because line count is the only thing that would have caught what actually happened.
+ * `plugin.ts` was ~3,060 lines when #339 was filed. Three extraction PRs landed -- #1678, #1680,
+ * #1681 -- and each reported real progress: 4,069 to 3,947 to 3,872 to 3,844. Every one of those
+ * numbers is true and every one is measured against the previous PR, from a baseline that had
+ * already grown a thousand lines since the issue was written. Extraction removed 225 lines over the
+ * same period that accretion added 1,009, and nothing said so.
+ *
+ * So: a ceiling that may fall and may not rise.
+ *
+ * "May not rise" is enforced against the PR base revision, not against the working tree. Checking
+ * only the current values would let one commit raise a ceiling and add code under it -- a ratchet
+ * that unscrews, which CodeRabbit found in the first version of this file. The ceilings live in
+ * `.github/module-size-ratchet.json` so reading the base copy is a `git show` and a `JSON.parse`
+ * rather than a regex over source.
+ */
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const RATCHET_FILE = '.github/module-size-ratchet.json'
+
+/**
+ * The slack a ceiling may carry before it counts as stale.
+ *
+ * Zero would fail the build on every deletion until the ceiling moved in the same commit, which
+ * makes removing code annoying enough that people stop. 50 lets the smallest extraction so far
+ * (27 lines, #1681) land without a ceiling edit and forces one after a real reduction -- the other
+ * two were 122 and 75.
+ */
+export const CEILING_SLACK = 50
+
+/**
+ * Lines in `text`, counting a final line with no newline after it.
+ *
+ * Deliberately not `wc -l`, which counts newline characters and reports `'a\nb'` as 1. A file whose
+ * last line lacks a newline would be measured one short, and its ceiling would then be one tighter
+ * than the number anyone reading the file arrives at.
+ */
+export function countLines(text) {
+  if (text === '')
+    return 0
+  const lines = text.split('\n')
+  return lines.at(-1) === '' ? lines.length - 1 : lines.length
+}
+
+/** Every ceiling in `entries` higher than the same file's ceiling in `baseEntries`. */
+export function findRaisedCeilings(entries, baseEntries) {
+  const base = new Map(baseEntries.map(entry => [entry.file, entry.ceiling]))
+  const raised = []
+  for (const entry of entries) {
+    const previous = base.get(entry.file)
+    // Absent from the base means the entry is new, which is how a file joins the ratchet.
+    if (previous !== undefined && entry.ceiling > previous)
+      raised.push({ file: entry.file, from: previous, to: entry.ceiling })
+  }
+  return raised
+}
+
+export function evaluate(entries, read) {
+  const problems = []
+  for (const entry of entries) {
+    const text = read(entry.file)
+    if (text === null) {
+      problems.push(`${entry.file} does not exist — remove it from the ratchet or fix the path`)
+      continue
+    }
+    const lines = countLines(text)
+    if (lines > entry.ceiling) {
+      problems.push(
+        `${entry.file} is ${lines} lines, ceiling ${entry.ceiling} (${entry.issue}). `
+        + 'This file may shrink, not grow. Put the new code in one of the modules beside it.',
+      )
+    }
+    else if (lines < entry.ceiling - CEILING_SLACK) {
+      problems.push(
+        `${entry.file} is ${lines} lines against a ceiling of ${entry.ceiling} — lower the ceiling `
+        + `to ${lines} in ${RATCHET_FILE}. A ratchet nobody tightens is a comment.`,
+      )
+    }
+  }
+  return problems
+}
+
+function readOrNull(file) {
+  const absolute = path.join(repoRoot, file)
+  return fs.existsSync(absolute) ? fs.readFileSync(absolute, 'utf8') : null
+}
+
+/**
+ * The ratchet file as it stands in the revision this branch is based on, or null when there is
+ * none to compare against -- a shallow clone, or a checkout with no origin.
+ */
+export function readBaseRatchet(runGit) {
+  const baseRef = process.env.GITHUB_BASE_REF
+    ? `origin/${process.env.GITHUB_BASE_REF}`
+    : 'origin/master'
+  try {
+    const mergeBase = runGit(['merge-base', 'HEAD', baseRef]).trim()
+    return JSON.parse(runGit(['show', `${mergeBase}:${RATCHET_FILE}`]))
+  }
+  catch {
+    return null
+  }
+}
+
+function git(args) {
+  return execFileSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  })
+}
+
+function main() {
+  const ratchet = JSON.parse(readOrNull(RATCHET_FILE) ?? 'null')
+  const entries = Array.isArray(ratchet?.files) ? ratchet.files : []
+  if (entries.length === 0) {
+    console.error(`${RATCHET_FILE} lists no files, so this check cannot fail. That is not a pass.`)
+    return 1
+  }
+
+  const problems = evaluate(entries, readOrNull)
+  const base = readBaseRatchet(git)
+  if (base === null) {
+    // Said out loud rather than passed over: on CI the base is always there, so this line appearing
+    // in a CI log means the raise check silently did not run.
+    console.log(`  (no base revision of ${RATCHET_FILE} reachable — ceiling raises not checked)`)
+  }
+  else {
+    for (const raised of findRaisedCeilings(entries, base.files ?? [])) {
+      problems.push(
+        `${raised.file} ceiling raised ${raised.from} → ${raised.to}. A ceiling may fall, not rise `
+        + '(#339). If the file genuinely has to grow, that is a decision for the issue, not a diff.',
+      )
+    }
+  }
+
+  if (problems.length > 0) {
+    console.error('\nModule size ratchet:\n')
+    for (const problem of problems) console.error(`  ✗ ${problem}`)
+    console.error('')
+    return 1
+  }
+  for (const entry of entries)
+    console.log(`  ${entry.file}: ${countLines(readOrNull(entry.file) ?? '')} / ${entry.ceiling}`)
+
+  console.log(`\n[32m${entries.length} file(s) within their ceiling.[0m\n`)
+  return 0
+}
+
+function selfTest() {
+  const entries = [{ file: 'a.ts', ceiling: 100, issue: '#339', note: 'n' }]
+  const at = read => evaluate(entries, read)
+  const real = JSON.parse(readOrNull(RATCHET_FILE) ?? 'null')
+
+  const cases = [
+    { name: 'a file at its ceiling passes', actual: at(() => 'x\n'.repeat(100)).length, expected: 0 },
+    { name: 'one line over fails', actual: at(() => 'x\n'.repeat(101)).length, expected: 1 },
+    {
+      name: 'a little under passes, so deleting code does not need a ceiling edit',
+      actual: at(() => 'x\n'.repeat(100 - CEILING_SLACK)).length,
+      expected: 0,
+    },
+    {
+      name: 'well under fails, so a ceiling cannot drift into meaninglessness',
+      actual: at(() => 'x\n'.repeat(100 - CEILING_SLACK - 1)).length,
+      expected: 1,
+    },
+    {
+      name: 'a missing file fails rather than counting as zero lines',
+      actual: at(() => null)[0]?.includes('does not exist'),
+      expected: true,
+    },
+    /*
+     * The hole in the first version of this file: with no base comparison, a PR raises the ceiling
+     * by 51 and adds a line, and every check above still passes.
+     */
+    {
+      name: 'raising a ceiling is caught',
+      actual: findRaisedCeilings([{ file: 'a.ts', ceiling: 151 }], [{ file: 'a.ts', ceiling: 100 }])[0]?.to,
+      expected: 151,
+    },
+    {
+      name: 'lowering a ceiling is not caught',
+      actual: findRaisedCeilings([{ file: 'a.ts', ceiling: 90 }], [{ file: 'a.ts', ceiling: 100 }]).length,
+      expected: 0,
+    },
+    {
+      name: 'an unchanged ceiling is not caught',
+      actual: findRaisedCeilings(entries, [{ file: 'a.ts', ceiling: 100 }]).length,
+      expected: 0,
+    },
+    {
+      name: 'a file new to the ratchet is not a raise',
+      actual: findRaisedCeilings([{ file: 'b.ts', ceiling: 999 }], [{ file: 'a.ts', ceiling: 100 }]).length,
+      expected: 0,
+    },
+    {
+      name: 'an unreachable base reads as unknown, not as no raises',
+      actual: readBaseRatchet(() => {
+        throw new Error('no such ref')
+      }),
+      expected: null,
+    },
+    { name: 'a file with no trailing newline still counts its last line', actual: countLines('a\nb'), expected: 2 },
+    { name: 'a trailing newline is not an extra line', actual: countLines('a\nb\n'), expected: 2 },
+    { name: 'an empty file is zero lines', actual: countLines(''), expected: 0 },
+    {
+      name: 'the real entries point at files that exist',
+      actual: (real?.files ?? []).filter(entry => readOrNull(entry.file) === null).length,
+      expected: 0,
+    },
+    { name: 'the real ratchet is not empty', actual: (real?.files ?? []).length > 0, expected: true },
+  ]
+
+  let failed = 0
+  for (const testCase of cases) {
+    if (!Object.is(testCase.actual, testCase.expected)) {
+      failed += 1
+      console.error(`  ✗ ${testCase.name}: expected ${testCase.expected}, got ${testCase.actual}`)
+    }
+  }
+  console.log(
+    failed === 0
+      ? `check-module-size-ratchet --self-test: ${cases.length} cases passed`
+      : `check-module-size-ratchet --self-test: ${failed} of ${cases.length} cases failed`,
+  )
+  return failed
+}
+
+if (process.argv.includes('--self-test'))
+  process.exit(selfTest() > 0 ? 1 : 0)
+else process.exit(main())


### PR DESCRIPTION
Progress on #339, and a measurement that changes what "progress" has meant on it.

## Three PRs of real progress, net backwards

`plugin.ts` was **~3,060 lines when #339 was filed** (2026-07-28). Three extraction PRs landed — #1678, #1680, #1681 — and each reported a true number:

```
4,069  →  3,947 (#1678)  →  3,872 (#1680)  →  3,844 (#1681)
```

Every one of those is measured against the **previous PR**. Against the issue:

| | plugin.ts | quick-ops/index.ts |
| --- | --- | --- |
| when #339 was filed | ~3,060 | ~2,999 |
| now | **3,844** | 2,875 |
| | **+784** | −124 |

Extraction removed 225 lines. Accretion added 1,009 over the same period. Meanwhile the plugin directory went from **61 source files to 107** — the extractions are real, they are just slower than what they are racing, and nothing said so because no measurement spanned more than one PR.

## What this adds, and what it deliberately is not

A ceiling that may fall and may not rise, on the two files #339 names and nothing else.

**It does not measure what #339 is about, and #339 says so first**: *"the concern is not line count by itself."* That is correct — no line count can see that one file owns lifecycle, permission policy, dispatch, state, transport and diagnostics simultaneously. Line count is here for one reason: it is the only thing that would have caught the last thousand lines.

A ceiling left more than 50 lines above its file **also fails**, asking to be lowered. A ratchet nobody tightens is a comment. 50 is smaller than any extraction so far — the smallest was 27 — so a real extraction is asked to lower the ceiling and a one-line deletion is not.

## Verification

Proved against the real files, not only the self-test:

| plant | result |
| --- | --- |
| append one line to `plugin.ts` | fails: `is 3845 lines, ceiling 3844 (#339)` |
| delete 60 lines | fails: `lower the ceiling to 3785` |
| delete 40 lines (inside the slack) | passes |
| an empty `RATCHET` | fails — it cannot be a check that cannot fail |

`--self-test` covers 9 cases including the two thresholds, a missing file failing rather than counting as zero lines, `wc -l` semantics with and without a trailing newline, and the real entries resolving.

`mise run workflows:lint` exits 0 with the new step.

## What is still not done

The split itself. This buys it time; it does not do it. The ownership boundaries #339 lists — lifecycle, permission-bound dispatch, feature projection, transport, diagnostics — remain the work, and the next extraction now has to lower a number that is written down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated checks to monitor module size and prevent configured limits from being exceeded.
  * Added commands for running the module-size check and its self-test.

* **Tests**
  * Added coverage for line counting, threshold handling, missing files, and configured paths.
  * Integrated module-size validation into the pull request quality workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->