### PR TITLE
ci: extend the size ratchet to the two files #343 is about

### DIFF
--- a/.github/module-size-ratchet.json
+++ b/.github/module-size-ratchet.json
@@ -3,7 +3,11 @@
     "Ceilings for scripts/check-module-size-ratchet.mjs. A ceiling may fall and may not rise:",
     "the check compares each value here against the same file in the PR base revision, so lowering",
     "one is part of the change that shrinks the file and raising one fails the build.",
-    "Only the two files #339 names. This is not a general file-size policy."
+    "Only the two files #339 names. This is not a general file-size policy.",
+    "2026-08-12: extended to #343 for the same reason as #339. Both issues say line count is not",
+    "the point and both are right; both also grew while asking to be split -- plugin.ts +784,",
+    "app-provider.ts +377, file-provider.ts +694. Nothing measured that, because every report",
+    "compared against the previous PR rather than against the issue."
   ],
   "files": [
     {
@@ -17,6 +21,18 @@
       "ceiling": 2875,
       "issue": "#339",
       "note": "~2,999 when #339 was filed. Down 124 since, and this holds that."
+    },
+    {
+      "file": "apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.ts",
+      "ceiling": 4600,
+      "issue": "#343",
+      "note": "~4,223 when #343 was filed, which is exactly the number that issue cites. +377 since."
+    },
+    {
+      "file": "apps/core-app/src/main/modules/box-tool/addon/files/file-provider.ts",
+      "ceiling": 4298,
+      "issue": "#343",
+      "note": "~3,604 when #343 was filed. +694 since — the largest growth of the four files here."
     }
   ]
 }

--- a/.github/module-size-ratchet.json
+++ b/.github/module-size-ratchet.json
@@ -3,7 +3,7 @@
     "Ceilings for scripts/check-module-size-ratchet.mjs. A ceiling may fall and may not rise:",
     "the check compares each value here against the same file in the PR base revision, so lowering",
     "one is part of the change that shrinks the file and raising one fails the build.",
-    "Only the two files #339 names. This is not a general file-size policy.",
+    "Only the files #339 and #343 name -- two each. This is not a general file-size policy.",
     "2026-08-12: extended to #343 for the same reason as #339. Both issues say line count is not",
     "the point and both are right; both also grew while asking to be split -- plugin.ts +784,",
     "app-provider.ts +377, file-provider.ts +694. Nothing measured that, because every report",


### PR DESCRIPTION
Same measurement as #339 on a different pair of files, and the same result.

## #343's own numbers were right, and both files have grown since

| file | in #343 | at the commit before it was filed | today |
| --- | ---: | ---: | ---: |
| `app-provider.ts` | ~4,223 | **4,223** | **4,600** (+377) |
| `file-provider.ts` | ~3,604 | **3,604** | **4,298** (+694) |

**+1,071 lines together**, over the two weeks the issue has been asking for them to be simplified. The issue's figures match git exactly at its own baseline, so this is not a stale premise — it is an accurate one that has got worse.

## Same framing as #339, for the same reason

#343 says *"The goal is not arbitrary line-count reduction. The goal is one discoverable owner for scan/watch/reconcile, persistence, search projection, asset/icon work, and lifecycle disposal."* That is right, and no line count can see any of it.

The ratchet does not measure that. It measures whether the simplification is losing, which is a question nothing was answering — and the answer for two weeks was yes.

## Verification

`file-provider.ts` with one line appended:

```
✗ .../file-provider.ts is 4299 lines, ceiling 4298 (#343).
```

Exit 1; restoring exits 0. The raise-a-ceiling guard from #1722 applies to these entries too — a PR that lifts 4298 to 4400 fails against the base revision.

Four files in the ratchet now, self-test 15 cases green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated module-size tracking documentation with growth details for provider modules.
  * Added size limits associated with issue `#343`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->