### PR TITLE
fix(ci): the size ratchet was a check against writing things down

### DIFF
--- a/.github/module-size-ratchet.json
+++ b/.github/module-size-ratchet.json
@@ -7,30 +7,35 @@
     "2026-08-12: extended to #343 for the same reason as #339. Both issues say line count is not",
     "the point and both are right; both also grew while asking to be split -- plugin.ts +784,",
     "app-provider.ts +377, file-provider.ts +694. Nothing measured that, because every report",
-    "compared against the previous PR rather than against the issue."
+    "compared against the previous PR rather than against the issue.",
+    "2026-08-12 (later): ceilings are CODE lines now -- comments and blanks excluded -- and were",
+    "lowered accordingly. Counting raw lines made this a check against writing things down: of",
+    "app-provider.ts's +377 since #343 was filed, +131 was comments. A ceiling that fails the next",
+    "person who explains a decision, in files whose problem is unexplained decisions, is worse than",
+    "no ceiling."
   ],
   "files": [
     {
       "file": "apps/core-app/src/main/modules/plugin/plugin.ts",
-      "ceiling": 3844,
+      "ceiling": 3249,
       "issue": "#339",
       "note": "~3,060 when #339 was filed; peaked at 4,069 while three extraction PRs were landing."
     },
     {
       "file": "apps/core-app/src/main/modules/quick-ops/index.ts",
-      "ceiling": 2875,
+      "ceiling": 2594,
       "issue": "#339",
       "note": "~2,999 when #339 was filed. Down 124 since, and this holds that."
     },
     {
       "file": "apps/core-app/src/main/modules/box-tool/addon/apps/app-provider.ts",
-      "ceiling": 4600,
+      "ceiling": 3950,
       "issue": "#343",
       "note": "~4,223 when #343 was filed, which is exactly the number that issue cites. +377 since."
     },
     {
       "file": "apps/core-app/src/main/modules/box-tool/addon/files/file-provider.ts",
-      "ceiling": 4298,
+      "ceiling": 3703,
       "issue": "#343",
       "note": "~3,604 when #343 was filed. +694 since — the largest growth of the four files here."
     }

--- a/scripts/check-module-size-ratchet.mjs
+++ b/scripts/check-module-size-ratchet.mjs
@@ -52,31 +52,72 @@ export const CEILING_SLACK = 50
  * explained a decision in a file whose whole problem is that its decisions are unexplained.
  *
  * Not `wc -l` either, which counts newline characters and reports `'a\nb'` as 1.
+ *
+ * A character scan rather than a per-line one. The line version got four shapes wrong, all found
+ * by CodeRabbit: a one-line block comment with code after it lost that code, a block opened after
+ * code mid-line was not seen, a generator method `*gen()` read as a comment continuation, and so
+ * did a wrapped expression beginning with `*`. (Those shapes cannot be written literally in this
+ * comment -- the first one closes it. The self-test carries them as strings.) Measured on all four guarded files the two agree exactly -- 3249, 2594, 3950,
+ * 3703 -- so none of those shapes is present today, and no ceiling moved for this. They would have
+ * bitten the first time one appeared, which is reason enough.
+ *
+ * Quotes are tracked so a `/*` inside a string is not read as a comment.
  */
 export function countLines(text) {
-  let count = 0
+  const lines = []
+  let current = ''
+  let index = 0
   let inBlockComment = false
-  for (const raw of text.split('\n')) {
-    const line = raw.trim()
-    if (!line)
+  let quote = null
+
+  while (index < text.length) {
+    const char = text[index]
+    const next = text[index + 1]
+
+    if (char === '\n') {
+      lines.push(current)
+      current = ''
+      index += 1
       continue
+    }
     if (inBlockComment) {
-      if (line.includes('*/'))
+      if (char === '*' && next === '/') {
         inBlockComment = false
+        index += 2
+      }
+      else { index += 1 }
       continue
     }
-    if (line.startsWith('/*')) {
-      if (!line.includes('*/'))
-        inBlockComment = true
+    if (quote) {
+      current += char
+      if (char === '\\') {
+        current += next ?? ''
+        index += 2
+        continue
+      }
+      if (char === quote)
+        quote = null
+      index += 1
       continue
     }
-    // `*` catches continuation lines of a block comment that this loop already skipped past, and
-    // costs nothing real: a statement never starts with a bare asterisk.
-    if (line.startsWith('//') || line.startsWith('*'))
+    if (char === '/' && next === '*') {
+      inBlockComment = true
+      index += 2
       continue
-    count += 1
+    }
+    if (char === '/' && next === '/') {
+      while (index < text.length && text[index] !== '\n') index += 1
+      continue
+    }
+    if (char === '"' || char === '\'' || char === '`')
+      quote = char
+
+    current += char
+    index += 1
   }
-  return count
+  lines.push(current)
+
+  return lines.filter(line => line.trim() !== '').length
 }
 
 /** Every ceiling in `entries` higher than the same file's ceiling in `baseEntries`. */
@@ -250,6 +291,13 @@ function selfTest() {
     { name: 'code after a block comment closes is counted again', actual: countLines('/*\n */\nb'), expected: 1 },
     { name: 'a trailing comment on a code line does not remove the line', actual: countLines('a // why'), expected: 1 },
     { name: 'a file that is entirely comment is zero code', actual: countLines('// a\n// b\n'), expected: 0 },
+    /* The four shapes the per-line version got wrong. None occurs in the guarded files today. */
+    { name: 'code after a closing block comment on the same line still counts', actual: countLines('/* why */ b'), expected: 1 },
+    { name: 'a block comment opened after code still ends the comment correctly', actual: countLines('a /*\nmore */\nb'), expected: 2 },
+    { name: 'a generator method is code, not a comment continuation', actual: countLines('  *gen() {\n  }'), expected: 2 },
+    { name: 'a wrapped expression beginning with * is code', actual: countLines('const x = 1\n  * 2'), expected: 2 },
+    { name: 'a block comment inside a string is not a comment', actual: countLines('const s = "/*"\nconst t = 1'), expected: 2 },
+    { name: 'an escaped quote does not end the string', actual: countLines('const s = "a\\"/*"\nconst t = 1'), expected: 2 },
     { name: 'a file with no trailing newline still counts its last line', actual: countLines('a\nb'), expected: 2 },
     { name: 'a trailing newline is not an extra line', actual: countLines('a\nb\n'), expected: 2 },
     { name: 'an empty file is zero lines', actual: countLines(''), expected: 0 },

--- a/scripts/check-module-size-ratchet.mjs
+++ b/scripts/check-module-size-ratchet.mjs
@@ -1,18 +1,19 @@
 #!/usr/bin/env node
 /**
- * Stops the two coordination hotspots in #339 from growing while they are being split.
+ * Stops the four files #339 and #343 name from growing while they are being split.
  *
- * What this measures is not what #339 is about. That issue says so in its own words -- "the
- * concern is not line count by itself" -- and it is right: the problem is that each file combines
- * lifecycle, permission policy, execution dispatch, state, transport and diagnostics, and no line
- * count can see that.
+ * What this measures is not what either issue is about, and both say so first: #339 writes "the
+ * concern is not line count by itself" and #343 writes "the goal is not arbitrary line-count
+ * reduction". Both are right -- the problem is that one file owns lifecycle, permission policy,
+ * dispatch, state, transport and diagnostics at once, and no count can see that.
  *
  * It is here because line count is the only thing that would have caught what actually happened.
  * `plugin.ts` was ~3,060 lines when #339 was filed. Three extraction PRs landed -- #1678, #1680,
  * #1681 -- and each reported real progress: 4,069 to 3,947 to 3,872 to 3,844. Every one of those
  * numbers is true and every one is measured against the previous PR, from a baseline that had
  * already grown a thousand lines since the issue was written. Extraction removed 225 lines over the
- * same period that accretion added 1,009, and nothing said so.
+ * same period that accretion added 1,009, and nothing said so. #343's two files did the same:
+ * +377 and +694 against figures that issue quoted correctly.
  *
  * So: a ceiling that may fall and may not rise.
  *
@@ -42,17 +43,40 @@ const RATCHET_FILE = '.github/module-size-ratchet.json'
 export const CEILING_SLACK = 50
 
 /**
- * Lines in `text`, counting a final line with no newline after it.
+ * Code lines in `text` -- comments and blank lines excluded.
  *
- * Deliberately not `wc -l`, which counts newline characters and reports `'a\nb'` as 1. A file whose
- * last line lacks a newline would be measured one short, and its ceiling would then be one tighter
- * than the number anyone reading the file arrives at.
+ * The first version counted raw lines, which made this a check against *writing things down*.
+ * Measured on the four files it guards, comments and blanks are 10-15% of each; on the growth that
+ * put them here it is worse -- of `app-provider.ts`'s +377 since #343 was filed, **+131 is
+ * comments**, 35% of the increase. A ceiling on raw lines would have failed the next person who
+ * explained a decision in a file whose whole problem is that its decisions are unexplained.
+ *
+ * Not `wc -l` either, which counts newline characters and reports `'a\nb'` as 1.
  */
 export function countLines(text) {
-  if (text === '')
-    return 0
-  const lines = text.split('\n')
-  return lines.at(-1) === '' ? lines.length - 1 : lines.length
+  let count = 0
+  let inBlockComment = false
+  for (const raw of text.split('\n')) {
+    const line = raw.trim()
+    if (!line)
+      continue
+    if (inBlockComment) {
+      if (line.includes('*/'))
+        inBlockComment = false
+      continue
+    }
+    if (line.startsWith('/*')) {
+      if (!line.includes('*/'))
+        inBlockComment = true
+      continue
+    }
+    // `*` catches continuation lines of a block comment that this loop already skipped past, and
+    // costs nothing real: a statement never starts with a bare asterisk.
+    if (line.startsWith('//') || line.startsWith('*'))
+      continue
+    count += 1
+  }
+  return count
 }
 
 /** Every ceiling in `entries` higher than the same file's ceiling in `baseEntries`. */
@@ -79,13 +103,13 @@ export function evaluate(entries, read) {
     const lines = countLines(text)
     if (lines > entry.ceiling) {
       problems.push(
-        `${entry.file} is ${lines} lines, ceiling ${entry.ceiling} (${entry.issue}). `
+        `${entry.file} is ${lines} code lines, ceiling ${entry.ceiling} (${entry.issue}). `
         + 'This file may shrink, not grow. Put the new code in one of the modules beside it.',
       )
     }
     else if (lines < entry.ceiling - CEILING_SLACK) {
       problems.push(
-        `${entry.file} is ${lines} lines against a ceiling of ${entry.ceiling} — lower the ceiling `
+        `${entry.file} is ${lines} code lines against a ceiling of ${entry.ceiling} — lower the ceiling `
         + `to ${lines} in ${RATCHET_FILE}. A ratchet nobody tightens is a comment.`,
       )
     }
@@ -214,6 +238,18 @@ function selfTest() {
       }),
       expected: null,
     },
+    /*
+     * Added when the counter switched from raw lines to code lines. The four files this guards are
+     * 10-15% comment, and 35% of app-provider.ts's growth since #343 was filed is comment -- so a
+     * raw count made this a check against explaining a decision.
+     */
+    { name: 'a line comment is not code', actual: countLines('a\n// why\nb'), expected: 2 },
+    { name: 'a block comment is not code, however long', actual: countLines('a\n/*\n * why\n */\nb'), expected: 2 },
+    { name: 'a one-line block comment is not code', actual: countLines('a\n/* why */\nb'), expected: 2 },
+    { name: 'a blank line is not code', actual: countLines('a\n\n\nb'), expected: 2 },
+    { name: 'code after a block comment closes is counted again', actual: countLines('/*\n */\nb'), expected: 1 },
+    { name: 'a trailing comment on a code line does not remove the line', actual: countLines('a // why'), expected: 1 },
+    { name: 'a file that is entirely comment is zero code', actual: countLines('// a\n// b\n'), expected: 0 },
     { name: 'a file with no trailing newline still counts its last line', actual: countLines('a\nb'), expected: 2 },
     { name: 'a trailing newline is not an extra line', actual: countLines('a\nb\n'), expected: 2 },
     { name: 'an empty file is zero lines', actual: countLines(''), expected: 0 },


### PR DESCRIPTION
A defect in the ratchet I added in #1722/#1723, found by discharging a caveat I had attached to my own #343 comment.

## The problem

It counted **raw lines**. On the four files it guards, comments and blanks are 10-15%:

| file | raw | code | comment + blank |
| --- | ---: | ---: | ---: |
| `plugin.ts` | 3,844 | 3,249 | 15% |
| `quick-ops/index.ts` | 2,875 | 2,594 | 10% |
| `app-provider.ts` | 4,600 | 3,950 | 14% |
| `file-provider.ts` | 4,298 | 3,703 | 14% |

And on the *growth* that put them under the ratchet it is much worse. `app-provider.ts` is +377 since #343 was filed, and **+131 of that is comments** — 35% of the increase.

So the ceiling would have failed the next person who wrote down why a decision was made, in files whose stated problem is that their decisions are unexplained. That is the opposite of what both issues want.

Ceilings are code lines now, lowered to match: 3844→3249, 2875→2594, 4600→3950, 4298→3703. Lowering is what a ratchet permits, so the base-revision check from #1722 is satisfied by the same edit.

## How it was found

Not by review. My #343 comment carried a caveat: the +1,071 might be legitimate streaming work from #318's `scanDirectoryBatches` / paged reconciliation, in which case "simplification is losing" would not hold. Discharging it:

| | added code | mentions batching / paging / ack |
| --- | ---: | ---: |
| `file-provider.ts` | 612 | 58 (9.5%) |
| `app-provider.ts` | 385 | 40 (10.4%) |

So the hedge was mostly wrong — a tenth, not the bulk. But the same pass produced the comment counts, and those were a defect in my own check rather than in the codebase.

## Verification

Seven new self-test cases for the counter: a line comment, a block comment across lines, a one-line block comment, blank lines, code resuming after a block closes, a trailing comment not removing its line, and an all-comment file counting zero. 15 → **22 cases**.

And on the real file rather than a fixture:

| appended to `app-provider.ts` | exit |
| --- | --- |
| six comment lines (two `//`, a four-line block) | **0** |
| one line of code | **1** — `is 3951 code lines, ceiling 3950` |

The stale header — "the two coordination hotspots in #339" — now names four files and both issues, matching the fix CodeRabbit asked for in the JSON on #1723.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module size tracking by counting nonblank, non-comment code lines.
  * Added support for correctly ignoring block comments and blank lines.
  * Updated size thresholds and messages to reflect code-line counts.
* **Tests**
  * Expanded validation coverage for comments, blank lines, and block comments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->