### PR TITLE
fix(search): await provider teardown instead of firing it

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-provider-registry.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-provider-registry.test.ts
@@ -165,6 +165,85 @@ describe('search provider registry', () => {
     vi.useRealTimers()
   })
 
+  /**
+   * `destroy()` fired provider teardown without awaiting it (#334).
+   *
+   * `ISearchProvider` has no disposal member at all, so the registry reaches for `onDestroy`
+   * structurally through a local type that declared it `() => void`. `AppProvider`'s is
+   * `async onDestroy(): Promise<void>` and awaits `prepareForSearchIndexShutdown()` -- so the
+   * registry resolved while the search index was still shutting down, and the `void` declaration
+   * meant TypeScript saw no floating promise to complain about.
+   */
+  it('waits for an async provider teardown before resolving', async () => {
+    let released!: () => void
+    const teardownFinished = vi.fn()
+    const provider = {
+      id: 'slow-teardown',
+      type: 'app' as never,
+      onSearch: vi.fn(async () => ({ items: [] })) as never,
+      onDestroy: vi.fn(async () => {
+        await new Promise<void>((resolve) => {
+          released = resolve
+        })
+        teardownFinished()
+      })
+    }
+
+    const registry = new SearchProviderRegistry({
+      beforeProvidersLoad: async () => undefined,
+      onProvidersReady: async () => undefined,
+      getSearchIndexService: () => null,
+      getTouchApp: () => null,
+      onProviderDeactivated: () => undefined
+    })
+    registry.register(provider as never)
+
+    const destroyed = registry.destroy()
+    let settled = false
+    void destroyed.then(() => {
+      settled = true
+    })
+
+    // The teardown has started and has not finished, so destroy() must not have resolved either.
+    await Promise.resolve()
+    expect(provider.onDestroy).toHaveBeenCalledTimes(1)
+    expect(teardownFinished).not.toHaveBeenCalled()
+    expect(settled).toBe(false)
+
+    released()
+    await destroyed
+    expect(teardownFinished).toHaveBeenCalledTimes(1)
+  })
+
+  /** A rejecting teardown is logged and the remaining providers are still torn down. */
+  it('keeps tearing down after one provider rejects', async () => {
+    const second = vi.fn(async () => undefined)
+    const registry = new SearchProviderRegistry({
+      beforeProvidersLoad: async () => undefined,
+      onProvidersReady: async () => undefined,
+      getSearchIndexService: () => null,
+      getTouchApp: () => null,
+      onProviderDeactivated: () => undefined
+    })
+    registry.register({
+      id: 'rejects',
+      type: 'app' as never,
+      onSearch: vi.fn(async () => ({ items: [] })) as never,
+      onDestroy: async () => {
+        throw new Error('teardown failed')
+      }
+    } as never)
+    registry.register({
+      id: 'after',
+      type: 'app' as never,
+      onSearch: vi.fn(async () => ({ items: [] })) as never,
+      onDestroy: second
+    } as never)
+
+    await expect(registry.destroy()).resolves.toBeUndefined()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+
   it('combines indexed sources and plugin search providers for settings config', () => {
     const snapshot = buildSearchProviderRegistrySnapshot({
       indexedSources: [createIndexedSource('file-provider')],

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-provider-registry.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-provider-registry.ts
@@ -54,8 +54,17 @@ export interface SearchProviderRegistrySnapshot {
   issues: SearchProviderRegistryIssue[]
 }
 
+/**
+ * `onDestroy` is not on `ISearchProvider` (#334), so the registry reaches for it structurally.
+ *
+ * It returns `void | Promise<void>` because implementations already return both: `AppProvider`'s is
+ * `async onDestroy(): Promise<void>` and awaits `prepareForSearchIndexShutdown()`, while
+ * `EverythingProvider`'s and `FileSystemWatcher`'s are synchronous. Declaring it `() => void` made
+ * the async one look settled at the call site, so `destroy()` resolved before the search index had
+ * finished shutting down, and TypeScript could not see the floating promise.
+ */
 type DestroyableSearchProvider = ISearchProvider<ProviderContext> & {
-  onDestroy?: () => void
+  onDestroy?: () => void | Promise<void>
 }
 
 const SEARCH_PROVIDER_ISSUE_CODES: Record<SearchProviderRegistryIssue['code'], true> = {
@@ -405,10 +414,12 @@ export class SearchProviderRegistry {
     this.clearOnboardingSubscription()
     const activeLoads = [...this.ensureLoadedOperations]
     if (activeLoads.length > 0) await Promise.allSettled(activeLoads)
+    // Sequential rather than Promise.all: teardown touches the shared index and the writer, and one
+    // that rejects must not abort the rest -- which is why the catch is inside the loop.
     for (const provider of this.providers.values()) {
       try {
         const destroyableProvider = provider as DestroyableSearchProvider
-        if (destroyableProvider.onDestroy) destroyableProvider.onDestroy()
+        if (destroyableProvider.onDestroy) await destroyableProvider.onDestroy()
         else provider.onDeactivate?.()
       } catch (error) {
         log.warn(`Provider '${provider.id}' cleanup failed`, { error })


### PR DESCRIPTION
A real defect behind #334's fourth and fifth bullets, found while verifying that issue's premises.

## What happens

`SearchProviderRegistry.destroy()` is `async` and does await in-flight loads:

```ts
const activeLoads = [...this.ensureLoadedOperations]
if (activeLoads.length > 0) await Promise.allSettled(activeLoads)
for (const provider of this.providers.values()) {
  const destroyableProvider = provider as DestroyableSearchProvider
  if (destroyableProvider.onDestroy) destroyableProvider.onDestroy()   // ← not awaited
  else provider.onDeactivate?.()
}
```

`AppProvider`'s implementation is **`async onDestroy(): Promise<void>`** and awaits `prepareForSearchIndexShutdown()`. So `destroy()` resolved while the search index was still shutting down.

**TypeScript could not see it.** `ISearchProvider` has no disposal member — #334's fourth bullet, verified: the interface is `id`, `type`, `name?`, `icon?`, `supportedInputTypes?`, `priority?`, `onSearch`, `onActivate?`, `onDeactivate?`, `onExecute?`, `onLoad?`, `info` and nothing else. The registry compensates with a local structural type that declared `onDestroy?: () => void`, so an async implementation looked settled at the call site and there was no floating promise to flag.

Implementations already return both shapes: `AppProvider` async, `EverythingProvider` and `FileSystemWatcher` synchronous.

## The change

`onDestroy?: () => void | Promise<void>` on the local type, and `await` at the call. Nothing else — adding a disposal member to `ISearchProvider` is the interface work #334 is actually about, and it belongs there rather than smuggled into a bug fix.

The loop stays sequential with the `catch` inside it: teardown touches the shared index and the writer, and one provider rejecting must not skip the rest.

## Verification

| | result |
| --- | --- |
| baseline | 9 passed |
| remove the `await` (i.e. today's master) | **1 failed** |
| restored | 9 passed |

Two tests: one holds a teardown open and asserts `destroy()` has not resolved while it is pending, then that it resolves after; one has the first provider reject and asserts the second is still torn down.

`search-engine/` passes: 75 files, 669 tests.

## What is still open on #334

The interface. Also worth recording from the same pass, because it is *good* news the issue does not know: its second bullet — "search execution uses a separate provider map in `search-core`" — **is no longer true**. `SearchCore.registerProvider` delegates straight to `this.providerRegistry.register(...)`, and the only container is the registry's own `providers` Map. The two control planes have been unified since it was filed.