### PR TITLE
test(search): pin that a re-sent item reorders instead of duplicating

### DIFF
--- a/apps/core-app/src/renderer/src/modules/box/adapter/hooks/useSearch.rank.test.ts
+++ b/apps/core-app/src/renderer/src/modules/box/adapter/hooks/useSearch.rank.test.ts
@@ -243,6 +243,46 @@ describe('useSearch rendered ranking', () => {
     expect(hook.res.value.map((item) => item.id)).toEqual(['file-high', 'app-low'])
   })
 
+  /**
+   * The question #348 turns on, asked of the renderer rather than assumed.
+   *
+   * That issue says renderer merging is append-only and "a later semantic score cannot reorder
+   * already rendered items". The merge is by id and the rank is by score, so re-sending an item
+   * with a higher score should move it -- but nothing had exercised that, because the backend
+   * excludes already-rendered ids from semantic recall and so never re-sends one.
+   *
+   * If this passes, the renderer needs no contract work and the whole of #348 is one policy line
+   * in `search-core.ts`.
+   */
+  it('reorders an already rendered item when a later batch re-sends it with a higher score', async () => {
+    const hook = useSearch(createBoxOptions(), createClipboardOptions())
+    await flushPromises()
+
+    const stream = await runFirstBatch(hook, 'rescore', [
+      buildItem('app-top', 'app-provider', { final: 900 }),
+      buildItem('file-buried', 'file-provider', { final: 10 })
+    ])
+    expect(hook.res.value.map((item) => item.id)).toEqual(['app-top', 'file-buried'])
+
+    // The same id, not a new one -- this is what a semantic re-score would look like on the wire.
+    await pushDeferredBatch(stream, [buildItem('file-buried', 'file-provider', { final: 950 })])
+
+    expect(hook.res.value.map((item) => item.id)).toEqual(['file-buried', 'app-top'])
+  })
+
+  /** And the item is replaced, not duplicated, when the same id arrives twice. */
+  it('does not duplicate an item that is re-sent', async () => {
+    const hook = useSearch(createBoxOptions(), createClipboardOptions())
+    await flushPromises()
+
+    const stream = await runFirstBatch(hook, 'no duplicate', [
+      buildItem('file-once', 'file-provider', { final: 10 })
+    ])
+    await pushDeferredBatch(stream, [buildItem('file-once', 'file-provider', { final: 20 })])
+
+    expect(hook.res.value.filter((item) => item.id === 'file-once')).toHaveLength(1)
+  })
+
   it('keeps pinned items on top regardless of score', async () => {
     const hook = useSearch(createBoxOptions(), createClipboardOptions())
     await flushPromises()


### PR DESCRIPTION
Turns #348 from a design discussion into a one-line decision, by testing the thing that issue assumed was missing.

## What #348 assumed

> renderer merging is append-only. A later semantic score cannot reorder already rendered items

and proposed defining "a typed mid-session replace/reorder event or extend the session snapshot/update contract with revisioned ordering semantics".

## What is actually there

`useSearch.ts` merges by id and re-ranks by score, with its own comment saying so — *"so a later batch competes with the earlier ones instead of being appended below them"*. `previousRank` gives the stability #348 asks for under "bound visual churn", and `applyRenderedItemQuota` reserves a per-source floor.

It was never exercised for the case that matters, because `search-core.ts:786` passes `excludeIds = new Set(baseItems.map(i => i.id))` to `semanticRecall` — the backend never re-sends an item already on screen, so the renderer's reordering has nothing to react to.

So the capability was real, untested, and about to be rebuilt beside itself.

## What this adds

Two tests, no behaviour change:

- an item re-sent with a higher score moves to the top (`file-buried` at 10, then re-sent at 950, ends above `app-top` at 900)
- the same id arriving twice yields one row, not two

| plant | result |
| --- | --- |
| drop `if (b.score !== a.score) return b.score - a.score` from the sort | **3 failed** |
| make the merge skip ids it already has | **1 failed** |

`box/adapter/` passes: 10 files, 87 tests.

## Why it matters for #348

With this pinned, that issue reduces to one question in `search-core.ts`: **should semantic recall score the items already on screen instead of excluding them?** That is a cost decision — the exclusion keeps the embedding scan small — and if the answer is yes, the renderer needs no changes at all.

Worth knowing while deciding: semantic recall is also gated by `DEFERRED_SEMANTIC_MAX_BASE_ITEMS = 20`, with the comment *"Only worth the embedding scan when the primary results are sparse."* So it does not run at all once there are 20 primary results — the case where reordering would matter most.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that re-sent search items are correctly reordered when their score improves.
  * Confirmed that re-sending an existing item does not create duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->