### PR TITLE
fix(utils): anchor the system-directory exclusion to the filesystem root

### DIFF
--- a/packages/utils/__tests__/file-filter-traversal-anchor.test.ts
+++ b/packages/utils/__tests__/file-filter-traversal-anchor.test.ts
@@ -42,6 +42,20 @@ describe('#1727 system-dir anchoring', () => {
     }
   })
 
+  /**
+   * `pathSegments` drops separators, so `usr` and `/usr` are both one segment. Without the root
+   * marker a caller passing a relative path — `scanDirectory` does not require an absolute one —
+   * would have it classified as a filesystem root. Found by CodeRabbit on #1728.
+   */
+  it('does not treat a relative path as the filesystem root', () => {
+    for (const name of systemNames) {
+      expect(reason(name), name).not.toBe('system-path')
+      expect(reason(`./${name}`), `./${name}`).not.toBe('system-path')
+      expect(reason(`a/${name}`), `a/${name}`).not.toBe('system-path')
+      expect(reason(`C:${name}`), `C:${name}`).not.toBe('system-path')
+    }
+  })
+
   it('keeps the root-anchored patterns doing their job below the root', () => {
     // From PATH_PATTERNS.SYSTEM_PATHS, which is where root-level system paths were always handled;
     // the name list was only ever adding the unanchored half. Platform-split for the same reason

--- a/packages/utils/__tests__/file-filter-traversal-anchor.test.ts
+++ b/packages/utils/__tests__/file-filter-traversal-anchor.test.ts
@@ -1,50 +1,73 @@
-import { fileFilterService } from '../common/file-filter-service'
 import { describe, expect, it } from 'vitest'
-const r = (p: string): string => String(fileFilterService.getTraversalExclusionReason(p, undefined as never) ?? '—')
+import { fileFilterService } from '../common/file-filter-service'
+import { SYSTEM_BLACKLISTED_DIRS } from '../common/file-scan-constants'
+
+const reason = (p: string): string =>
+  String(fileFilterService.getTraversalExclusionReason(p, undefined as never) ?? '—')
+
+/**
+ * The names are read from the runtime set rather than written down.
+ *
+ * `SYSTEM_BLACKLISTED_DIRS` is assembled per platform — macOS gets `MACOS_SYSTEM_DIRS`, Linux gets
+ * `LINUX_SYSTEM_DIRS`, and only the matching branch is present. The first version of this file
+ * asserted `/private` and `C:/Windows` directly; it passed on macOS and failed on Linux CI, because
+ * `private` is macOS-only and the Windows names are Windows-only. What #1727 changed is *where* a
+ * name matches, not *which* names are on the list, so the test asks the list.
+ */
+const systemNames = [...SYSTEM_BLACKLISTED_DIRS].filter(
+  (name): name is string => typeof name === 'string' && name.length > 0 && !name.includes('/'),
+)
 
 describe('#1727 system-dir anchoring', () => {
-  it('still excludes real system locations at the filesystem root', () => {
-    for (const p of ['/usr', '/var', '/tmp', '/private', '/dev', '/opt', '/etc', '/System', '/Library', '/Applications'])
-      expect(r(p), p).not.toBe('—')
-    // SYSTEM_BLACKLISTED_DIRS is platform-scoped -- on macOS it holds only MACOS_SYSTEM_DIRS, so
-    // Windows names are not in it here. The drive-letter branch of isFilesystemRootChild is still
-    // asserted, on a name this platform does have.
-    expect(r('C:/Library'), 'C:/Library').toBe('system-path')
-    expect(r('/Users/x/Documents/Application Support')).toBe('—')
+  it('has names to check, so the assertions below are not vacuous', () => {
+    expect(systemNames.length).toBeGreaterThan(0)
   })
 
-  it('still excludes system paths below the root, via the anchored patterns', () => {
-    for (const p of ['/private/var/folders/x', '/System/Library/Fonts', '/Users/x/Library/Caches'])
-      expect(r(p), p).toBe('system-path')
-  })
-
-  /** The six false positives measured on a real machine, minus the ones another list also owns. */
-  it('no longer excludes user folders named after system directories', () => {
-    for (const p of [
-      '/Users/x/Pictures/private',
-      '/Users/x/Documents/Library',
-      '/Users/x/Documents/etc',
-      '/Users/x/Music/var',
-      '/Users/x/Documents/usr',
-      '/Users/x/Documents/opt'
-    ]) expect(r(p), p).toBe('—')
+  it('still excludes every system name at the filesystem root', () => {
+    for (const name of systemNames) expect(reason(`/${name}`), `/${name}`).not.toBe('—')
   })
 
   /**
-   * Recorded, not fixed: `tmp` is on TEMP_BLACKLISTED_DIRS and `dev`/`bin`/`out`/`cache` on
-   * DEV_BLACKLISTED_DIRS, and both lists are still matched on the leaf name at any depth. So the
-   * observed Codex session tmp folders are still excluded -- by a different list, for a reason
-   * that is a policy call rather than an obvious defect.
+   * The defect: those names excluded a user's folder anywhere they appeared, before `readdir`, with
+   * no error and no `errorCount` — so the file simply never showed up in search. Six of 545
+   * directories under the default roots on one machine.
+   *
+   * Other lists own some of these names too, so this asserts only that `system-path` is no longer
+   * the reason — not that the folder is definitely indexed.
+   */
+  it('no longer reports system-path for a user folder of the same name', () => {
+    for (const name of systemNames) {
+      const deep = `/Users/someone/Documents/${name}`
+      expect(reason(deep), deep).not.toBe('system-path')
+    }
+  })
+
+  it('keeps the root-anchored patterns doing their job below the root', () => {
+    // From PATH_PATTERNS.SYSTEM_PATHS, which is where root-level system paths were always handled;
+    // the name list was only ever adding the unanchored half. Platform-split for the same reason
+    // as above.
+    const belowRoot
+      = process.platform === 'darwin'
+        ? ['/System/Library/Fonts', '/Users/x/Library/Caches']
+        : ['/usr/local/share', '/var/log']
+    for (const p of belowRoot) expect(reason(p), p).toBe('system-path')
+  })
+
+  /**
+   * Recorded, not fixed. `TEMP_BLACKLISTED_DIRS` and `DEV_BLACKLISTED_DIRS` are still matched on the
+   * leaf name at any depth, so the folders that prompted #1727 are still excluded — by a different
+   * list. Whether an ordinary word should exclude a folder under a user's documents is a policy
+   * question, and this pins the current answer rather than deciding it.
    */
   it('documents the two lists this change does not touch', () => {
-    expect(r('/Users/x/Documents/tmp')).toBe('cache-path')
-    expect(r('/Users/x/Downloads/cache')).toBe('development-path')
-    expect(r('/Users/x/Documents/build')).toBe('development-path')
+    expect(reason('/Users/x/Documents/tmp')).toBe('cache-path')
+    expect(reason('/Users/x/Downloads/cache')).toBe('development-path')
+    expect(reason('/Users/x/Documents/build')).toBe('development-path')
   })
 
   it('leaves the other reasons alone', () => {
-    expect(r('/Users/x/p/node_modules')).toBe('development-path')
-    expect(r('/Users/x/.config')).toBe('hidden-name')
-    expect(r('/Users/x/Pictures/Photos Library.photoslibrary')).toBe('bundle-internal')
+    expect(reason('/Users/x/p/node_modules')).toBe('development-path')
+    expect(reason('/Users/x/.config')).toBe('hidden-name')
+    expect(reason('/Users/x/Pictures/Photos Library.photoslibrary')).toBe('bundle-internal')
   })
 })

--- a/packages/utils/__tests__/file-filter-traversal-anchor.test.ts
+++ b/packages/utils/__tests__/file-filter-traversal-anchor.test.ts
@@ -1,0 +1,50 @@
+import { fileFilterService } from '../common/file-filter-service'
+import { describe, expect, it } from 'vitest'
+const r = (p: string): string => String(fileFilterService.getTraversalExclusionReason(p, undefined as never) ?? '—')
+
+describe('#1727 system-dir anchoring', () => {
+  it('still excludes real system locations at the filesystem root', () => {
+    for (const p of ['/usr', '/var', '/tmp', '/private', '/dev', '/opt', '/etc', '/System', '/Library', '/Applications'])
+      expect(r(p), p).not.toBe('—')
+    // SYSTEM_BLACKLISTED_DIRS is platform-scoped -- on macOS it holds only MACOS_SYSTEM_DIRS, so
+    // Windows names are not in it here. The drive-letter branch of isFilesystemRootChild is still
+    // asserted, on a name this platform does have.
+    expect(r('C:/Library'), 'C:/Library').toBe('system-path')
+    expect(r('/Users/x/Documents/Application Support')).toBe('—')
+  })
+
+  it('still excludes system paths below the root, via the anchored patterns', () => {
+    for (const p of ['/private/var/folders/x', '/System/Library/Fonts', '/Users/x/Library/Caches'])
+      expect(r(p), p).toBe('system-path')
+  })
+
+  /** The six false positives measured on a real machine, minus the ones another list also owns. */
+  it('no longer excludes user folders named after system directories', () => {
+    for (const p of [
+      '/Users/x/Pictures/private',
+      '/Users/x/Documents/Library',
+      '/Users/x/Documents/etc',
+      '/Users/x/Music/var',
+      '/Users/x/Documents/usr',
+      '/Users/x/Documents/opt'
+    ]) expect(r(p), p).toBe('—')
+  })
+
+  /**
+   * Recorded, not fixed: `tmp` is on TEMP_BLACKLISTED_DIRS and `dev`/`bin`/`out`/`cache` on
+   * DEV_BLACKLISTED_DIRS, and both lists are still matched on the leaf name at any depth. So the
+   * observed Codex session tmp folders are still excluded -- by a different list, for a reason
+   * that is a policy call rather than an obvious defect.
+   */
+  it('documents the two lists this change does not touch', () => {
+    expect(r('/Users/x/Documents/tmp')).toBe('cache-path')
+    expect(r('/Users/x/Downloads/cache')).toBe('development-path')
+    expect(r('/Users/x/Documents/build')).toBe('development-path')
+  })
+
+  it('leaves the other reasons alone', () => {
+    expect(r('/Users/x/p/node_modules')).toBe('development-path')
+    expect(r('/Users/x/.config')).toBe('hidden-name')
+    expect(r('/Users/x/Pictures/Photos Library.photoslibrary')).toBe('bundle-internal')
+  })
+})

--- a/packages/utils/common/file-filter-service.ts
+++ b/packages/utils/common/file-filter-service.ts
@@ -85,13 +85,20 @@ function pathSegments(value: string): string[] {
  * Measured on one default install: six of 545 directories under the default roots, five of them
  * real user content.
  *
- * POSIX roots are one segment (`/usr`). Windows roots are two, because the drive is a segment
- * (`C:/Windows`). `~/Library` and `%APPDATA%` keep their exclusion through the anchored patterns
+ * POSIX roots are one segment *and* a leading `/` -- the separator is what distinguishes `/usr`
+ * from a relative `usr`, which `pathSegments` renders identically. Windows roots are two segments,
+ * because the drive is one (`C:/Windows`); `C:Library` is drive-relative, stays a single segment
+ * and is therefore not a root. `~/Library` and `%APPDATA%` keep their exclusion through the anchored patterns
  * in `PATH_PATTERNS.SYSTEM_PATHS` (`/^\/Users\/[^/]+\/Library\//`), which is where root-level
  * system paths were already handled -- this check was only ever adding the unanchored half.
  */
-function isFilesystemRootChild(segments: readonly string[]): boolean {
-  if (segments.length === 1) return true;
+function isFilesystemRootChild(
+  normalizedPath: string,
+  segments: readonly string[],
+): boolean {
+  // `pathSegments` drops the separators, so the segment count alone cannot tell `/usr` from a
+  // relative `usr` -- both are one segment. The original path has to carry the root marker.
+  if (segments.length === 1) return normalizedPath.startsWith("/");
   return segments.length === 2 && /^[a-z]:$/i.test(segments[0] ?? "");
 }
 
@@ -199,7 +206,7 @@ export class FileFilterService {
     if (options.customBlacklistedDirs?.has(directoryName))
       return "excluded-path";
     if (LOWERCASE_DEV_DIRS.has(lowerDirectoryName)) return "development-path";
-    if (isFilesystemRootChild(segments) && LOWERCASE_SYSTEM_DIRS.has(lowerDirectoryName))
+    if (isFilesystemRootChild(normalizePath(path), segments) && LOWERCASE_SYSTEM_DIRS.has(lowerDirectoryName))
       return "system-path";
     if (LOWERCASE_TEMP_DIRS.has(lowerDirectoryName)) return "cache-path";
 

--- a/packages/utils/common/file-filter-service.ts
+++ b/packages/utils/common/file-filter-service.ts
@@ -73,6 +73,28 @@ function pathSegments(value: string): string[] {
   return normalizePath(value).split("/").filter(Boolean);
 }
 
+/**
+ * Whether `segments` names a directory sitting directly at the filesystem root (#1727).
+ *
+ * `SYSTEM_BLACKLISTED_DIRS` is a list of OS locations -- `usr`, `var`, `tmp`, `private`, `dev`,
+ * `Library`, `Windows.old` -- and every one of them is also an ordinary word someone may name a
+ * folder. Matched on the leaf name alone it excluded `~/Documents/tmp`, `~/Pictures/private` and
+ * `~/Documents/Library`, silently: the check runs before `readdir`, so nothing errors, nothing is
+ * counted, and the file simply never appears in search.
+ *
+ * Measured on one default install: six of 545 directories under the default roots, five of them
+ * real user content.
+ *
+ * POSIX roots are one segment (`/usr`). Windows roots are two, because the drive is a segment
+ * (`C:/Windows`). `~/Library` and `%APPDATA%` keep their exclusion through the anchored patterns
+ * in `PATH_PATTERNS.SYSTEM_PATHS` (`/^\/Users\/[^/]+\/Library\//`), which is where root-level
+ * system paths were already handled -- this check was only ever adding the unanchored half.
+ */
+function isFilesystemRootChild(segments: readonly string[]): boolean {
+  if (segments.length === 1) return true;
+  return segments.length === 2 && /^[a-z]:$/i.test(segments[0] ?? "");
+}
+
 function basename(value: string): string {
   const normalized = normalizePath(value).replace(/\/+$/, "");
   const separator = normalized.lastIndexOf("/");
@@ -177,7 +199,8 @@ export class FileFilterService {
     if (options.customBlacklistedDirs?.has(directoryName))
       return "excluded-path";
     if (LOWERCASE_DEV_DIRS.has(lowerDirectoryName)) return "development-path";
-    if (LOWERCASE_SYSTEM_DIRS.has(lowerDirectoryName)) return "system-path";
+    if (isFilesystemRootChild(segments) && LOWERCASE_SYSTEM_DIRS.has(lowerDirectoryName))
+      return "system-path";
     if (LOWERCASE_TEMP_DIRS.has(lowerDirectoryName)) return "cache-path";
 
     if (


### PR DESCRIPTION
Fixes the `system-path` half of #1727.

## The defect

`getTraversalExclusionReason` matched `SYSTEM_BLACKLISTED_DIRS` on the directory's **own name**, at any depth. That list names OS locations — on macOS `Library`, `Application Support`, `Applications`, `System`, `private`, `usr`, `bin`, `sbin`, `var`, `tmp`, `opt`, `etc`, `dev` — and every one is also a word someone may name a folder.

**Silently**: the check runs before `readdir`, so nothing errors, `errorCount` is not incremented, and the file never appears in search — indistinguishable from a file that does not exist.

Measured on one default install: 545 directories under the six default roots, **six excluded this way**, five of them real user content.

## Why anchoring rather than deleting

The correct behaviour was already implemented and already gated. `PATH_PATTERNS.SYSTEM_PATHS` holds root-anchored regexes (`/^\/System\//`, `/^\/private\//`, `/^\/Users\/[^/]+\/Library\//`, the Windows equivalents), and those already catch `/private/var/folders/x`, `/System/Library/Fonts`, `/usr/local/bin`, `~/Library/Caches` — while correctly not catching `~/Documents/tmp`.

Deleting the name check outright would lose the Windows root-only names that have no pattern (`Windows.old`, `Recovery`, `Boot`, `EFI`). Anchoring keeps them.

## Deliberately narrow

Two sibling lists are matched the same way and are **not** touched: `TEMP_BLACKLISTED_DIRS` (`tmp`, `cache`, `logs`) and `DEV_BLACKLISTED_DIRS` (`build`, `out`, `bin`, `target`, `dist`, `node_modules`). The observed Codex `tmp` folders are still excluded, now as `cache-path`. Whether an ordinary word should exclude a folder under `~/Documents` is a policy question, and a test pins the current answer rather than changing it.

## Verification

| plant | result |
| --- | --- |
| remove the anchor (today's master) | **3 failed** |
| make the anchor reject the filesystem root itself | **1 failed** |

`pnpm -C packages/utils` — the three affected files are 12 tests green. Running vitest from the repo root instead makes two unrelated suites fail on `ENOENT: plugin/sdk/channel-client.ts`; they resolve source paths relative to cwd.

`SYSTEM_BLACKLISTED_DIRS` is platform-scoped — on macOS only `MACOS_SYSTEM_DIRS` applies, which is worth knowing before writing tests against these lists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filesystem filtering so system-directory exclusions apply only to directories directly under a filesystem root.
  * Prevented similarly named folders within user directories from being incorrectly excluded.
  * Preserved existing exclusions for temporary, development, and other recognized system paths.
* **Tests**
  * Added coverage for POSIX and Windows root paths, nested directories, and exclusion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->