### PR TITLE
feat(search): give the query cache counters a reader

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
@@ -904,6 +904,43 @@ describe('SearchEngineCore facade contracts', () => {
     expect(snapshot.misses.absent).toBe(3)
   })
 
+  /**
+   * The counters are readable from outside the process now (#346).
+   *
+   * `getSearchCacheTelemetry` had one reference — its own declaration — so the report that issue
+   * asks for could not be produced from a real session. This asserts the transport handler is
+   * registered and returns the live snapshot, not a fresh one.
+   */
+  it('exposes the cache counters over the transport', async () => {
+    const search = vi.fn(
+      async () => ({ items: [buildItem('tel-item', 'tel-provider', 'Telemetry')] }) as never
+    )
+    core.registerProvider(buildProvider('tel-provider', search) as never)
+    core.activateProviders([{ id: 'tel-provider' }] as IProviderActivate[])
+
+    const handler = [...state.transportHandlers.entries()].find(([event]) => {
+      const transportEvent = event as { toEventName?: () => string }
+      return transportEvent.toEventName?.() === CoreBoxEvents.search.cacheTelemetry.toEventName()
+    })?.[1] as (() => Promise<{ lookups: number; hits: number }>) | undefined
+
+    expect(handler, 'cacheTelemetry handler is registered').toBeTypeOf('function')
+
+    const before = await handler!()
+    expect(before.lookups).toBe(0)
+
+    const session = core.startSearch(
+      { inputs: [], text: 'telemetry over transport' } as TuffQuery,
+      {
+        caller: { kind: 'core-box', id: 'tel-1' }
+      }
+    )
+    await session.result
+    await session.completed
+
+    const after = await handler!()
+    expect(after.lookups).toBe(1)
+  })
+
   it('cleans initialized index and provider resources when the facade is destroyed', async () => {
     const providerDestroy = vi.fn()
     core.registerProvider({

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
@@ -2014,6 +2014,12 @@ export class SearchEngineCore
       return await instance.indexingRuntime!.getDiagnostics()
     })
 
+    // The counters had no reader at all: `getSearchCacheTelemetry` was referenced only by its own
+    // declaration, so the measurement #346 asks for could not be taken from a real session.
+    transport.on(CoreBoxEvents.search.cacheTelemetry, async () => {
+      return instance.getSearchCacheTelemetry()
+    })
+
     transport.on(CoreBoxEvents.item.execute, async (payload) => {
       const { item, searchResult, actionId } = payload as {
         item: TuffItem

--- a/packages/utils/transport/events/index.ts
+++ b/packages/utils/transport/events/index.ts
@@ -112,6 +112,7 @@ import type {
   CoreBoxGetBoundsResponse,
   CoreBoxHideRequest,
   CoreBoxIndexingDiagnosticsResponse,
+  CoreBoxSearchCacheTelemetryResponse,
   CoreBoxInputChangeRequest,
   CoreBoxInputVisibilityResponse,
   CoreBoxIsPinnedRequest,
@@ -1162,6 +1163,23 @@ export const CoreBoxEvents = {
       .module('search')
       .event('indexing-diagnostics')
       .define<void, CoreBoxIndexingDiagnosticsResponse>(),
+
+    /**
+     * Read the query cache counters (#346).
+     *
+     * `SearchCore.getSearchCacheTelemetry()` existed with exactly one reference -- its own
+     * declaration. The counters incremented into a snapshot nobody could obtain, which reads the
+     * same as counters that were never wired, and it is why the measurement that issue is named
+     * for could not be taken.
+     *
+     * Host-only, like `indexingDiagnostics`: neither is in `plugin-facing-events.ts`, so a plugin
+     * surface cannot read it. The payload is counts and durations only -- no query text, no cache
+     * key, no item content.
+     */
+    cacheTelemetry: defineEvent('core-box')
+      .module('search')
+      .event('cache-telemetry')
+      .define<void, CoreBoxSearchCacheTelemetryResponse>(),
   },
 
   /**

--- a/packages/utils/transport/events/types/core-box.ts
+++ b/packages/utils/transport/events/types/core-box.ts
@@ -285,6 +285,37 @@ export interface CoreBoxNoResultsPayload {
   shouldShrink?: boolean
 }
 
+/**
+ * Query-cache counters for the CoreBox search cache (#346).
+ *
+ * Mirrors `SearchCacheTelemetrySnapshot` in the main process. The definition lives here because a
+ * shared package cannot import from the app, and the transport contract needs the shape.
+ *
+ * Counts and durations only -- no query text, no cache key, no item content -- so a report built
+ * from this cannot reconstruct what anyone searched for.
+ */
+export type CoreBoxSearchCacheMissReason = 'absent' | 'revision-mismatch' | 'expired'
+
+export type CoreBoxSearchCacheInvalidationReason =
+  | 'index-commit'
+  | 'privacy-cleanup'
+  | 'pin-toggle'
+  | 'lru-evict'
+
+export interface CoreBoxSearchCacheTelemetryResponse {
+  lookups: number
+  hits: number
+  misses: Record<CoreBoxSearchCacheMissReason, number>
+  invalidations: Record<CoreBoxSearchCacheInvalidationReason, number>
+  /** Entries dropped in total, so `invalidations` can be read as a distribution. */
+  entriesDropped: number
+  hitRate: number
+  /** Age of the entries that were served, in ms — says whether the 5s TTL is the binding limit. */
+  hitAgeMs: { p50: number | null, p95: number | null }
+  /** Wall time the served result originally took to produce, in ms: what a hit saved. */
+  savedLatencyMs: { p50: number | null, p95: number | null, total: number }
+}
+
 export type CoreBoxIndexingDiagnosticsResponse
   = IndexedSourceDiagnosticsSnapshot
 


### PR DESCRIPTION
Unblocks the measurement #346 is named for.

## The blocker

`SearchCore.getSearchCacheTelemetry()` had **exactly one reference in the repository — its own declaration.** No channel, no dashboard, no test until #1712 added an in-process one. The counters incremented into a snapshot nobody could obtain, which reads exactly like counters that were never wired.

Everything #346's first bullet asks for already exists in `search-cache-telemetry.ts`: `lookups`, `hits`, `misses` by reason, `invalidations` by reason, `entriesDropped`, `hitRate`, `hitAgeMs` p50/p95, `savedLatencyMs` p50/p95/total, and no query text anywhere. It just could not be read from a running session.

## The change

`CoreBoxEvents.search.cacheTelemetry`, modelled on `indexingDiagnostics` two lines above it — the same shape of read, registered the same way.

**Host-only by construction**: neither event appears in `packages/utils/transport/security/plugin-facing-events.ts`, and `TuffMainTransport.on()` binds to the plugin channel only for allowlisted names (#688). So no plugin surface can read it.

The response type is mirrored in `packages/utils/transport/events/types/core-box.ts` rather than imported from the app, because a shared package cannot depend on it — same reason `CoreBoxIndexingDiagnosticsResponse` lives there.

## Verification

| | result |
| --- | --- |
| baseline | 1 passed |
| remove the registration | **1 failed** |

The test asserts two things: the handler is registered, and `lookups` moves 0 → 1 across a search — i.e. it returns the **live** snapshot rather than a fresh object.

`search-engine/`: 75 files, 670 tests. `packages/utils`: 187 files, 1348 tests.

## What #346 still needs after this

Both remaining blockers are recorded on the issue and neither is code:

1. **The reason taxonomy is still wrong.** `revision-mismatch` is unreachable — `markCommitted` notifies listeners synchronously and this facade's listener clears the whole cache before returning, so a repeat denied by a commit is filed as `absent`, the same bucket as a query nobody repeated. A report built on that distribution understates the cache and cannot carry the keep/remove decision. #1712 pins this in a test.
2. **The keep/remove threshold** is a product judgement.

This PR only makes the numbers obtainable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search cache telemetry reporting, including lookup counts, hits and misses, invalidations, evictions, hit rate, cache age, and estimated latency savings.
  * Added categorized details for cache misses and invalidations to support clearer performance monitoring.

* **Tests**
  * Added coverage confirming telemetry is available through the search transport and updates after searches complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->