### PR TITLE
fix(search): let a commit-denied cache entry report why it was denied

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
@@ -887,21 +887,40 @@ describe('SearchEngineCore facade contracts', () => {
 
     // Exactly two, because two entries were in the cache. Counted by entries dropped rather than
     // by calls -- a per-call implementation reports 1 here.
-    expect(snapshot.invalidations['index-commit']).toBe(2)
-    expect(snapshot.entriesDropped).toBe(2)
+    // One entry was superseded and dropped at its own lookup; the other was never asked for.
+    expect(snapshot.entriesDropped).toBe(1)
 
     /*
-     * And this is the finding. `revision-mismatch` is unreachable from here: `markCommitted` bumps
-     * the revision and notifies listeners synchronously, and this facade's listener clears the
-     * whole cache before returning. By the time any lookup compares revisions the entry is already
-     * gone, so the miss is `absent`.
+     * The attribution #346 turns on, and the reason this test exists.
      *
-     * That matters for the report #346 asks for. A repeat denied by a commit is filed under the
-     * same reason as a query nobody repeated, so the distribution understates the cache's value
-     * and cannot carry the keep/remove decision as it stands.
+     * `revision-mismatch` used to be unreachable: the commit listener cleared the whole cache
+     * before returning, so by the time a lookup compared revisions the entry was gone and the miss
+     * was filed as `absent` — the same bucket as a query nobody repeated. A report built on that
+     * distribution reads "nobody repeats queries, remove the cache" when the truth may be the
+     * opposite.
+     *
+     * Entries now survive the commit and are rejected — and dropped — at lookup, so the reason is
+     * counted where it happens.
      */
-    expect(snapshot.misses['revision-mismatch']).toBe(0)
-    expect(snapshot.misses.absent).toBe(3)
+    expect(snapshot.misses['revision-mismatch']).toBe(1)
+    expect(snapshot.misses.absent).toBe(2)
+    expect(snapshot.invalidations['index-commit']).toBe(1)
+
+    /*
+     * Asking again hits, because the miss that reported `revision-mismatch` re-ran the search and
+     * re-cached it at the new revision. One `revision-mismatch` per commit per query, not one per
+     * lookup — which is the behaviour the report wants, and it is asserted because the alternative
+     * (the stale entry surviving and mismatching forever) would inflate the count.
+     *
+     * Note this cannot observe the `searchCache.delete` itself: the re-cache overwrites the same
+     * key either way. The delete is kept for the paths that do not re-cache — an aborted or failed
+     * search — where the superseded entry would otherwise hold its slot until the TTL.
+     */
+    await run('cache telemetry alpha', 'telemetry-after-drop')
+    const afterDrop = core.getSearchCacheTelemetry()
+    expect(afterDrop.misses['revision-mismatch']).toBe(1)
+    expect(afterDrop.misses.absent).toBe(2)
+    expect(afterDrop.hits).toBe(2)
   })
 
   /**

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.contracts.test.ts
@@ -960,6 +960,45 @@ describe('SearchEngineCore facade contracts', () => {
     expect(after.lookups).toBe(1)
   })
 
+  /**
+   * The one real cost of not clearing on commit, measured rather than asserted in prose (#346).
+   *
+   * Superseded entries stay until something drops them, so the question is whether they can
+   * accumulate. They cannot: the cache is bounded at SEARCH_CACHE_MAX_SIZE and eviction picks the
+   * oldest timestamp, which after a commit is a stale entry — so it drains stale-first, one per
+   * insert, and no stale entry is ever served because the outcome is computed before the hit
+   * branch.
+   */
+  it('stays bounded after a commit and never serves a superseded entry', async () => {
+    const search = vi.fn(
+      async () => ({ items: [buildItem('bound-item', 'bound-provider', 'Bounded')] }) as never
+    )
+    core.registerProvider(buildProvider('bound-provider', search) as never)
+    core.activateProviders([{ id: 'bound-provider' }] as IProviderActivate[])
+
+    const run = async (text: string): Promise<void> => {
+      const session = core.startSearch({ inputs: [], text } as TuffQuery, {
+        caller: { kind: 'core-box', id: `bound-${text}` }
+      })
+      await session.result
+      await session.completed
+    }
+
+    // Fill past the bound, then supersede everything at once.
+    for (let index = 0; index < 120; index += 1) await run(`bounded query ${index}`)
+    searchIndexCommitHub.markCommitted(['bound-provider'])
+
+    // Drain with fresh keys; each insert evicts one, oldest first.
+    for (let index = 0; index < 40; index += 1) await run(`drained query ${index}`)
+
+    const snapshot = core.getSearchCacheTelemetry()
+    // Never served: every lookup was either absent or a revision mismatch, no hit on a stale entry.
+    expect(snapshot.hits).toBe(0)
+    expect(snapshot.misses['revision-mismatch']).toBe(0)
+    // The bound held: evictions happened, which is only possible if the cache stayed at its cap.
+    expect(snapshot.invalidations['lru-evict']).toBeGreaterThan(0)
+  }, 60_000)
+
   it('cleans initialized index and provider resources when the facade is destroyed', async () => {
     const providerDestroy = vi.fn()
     core.registerProvider({

--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-core.ts
@@ -452,9 +452,25 @@ export class SearchEngineCore
     )
   }
 
+  /**
+   * An index commit no longer clears the cache eagerly (#346).
+   *
+   * `classifySearchCacheLookup` already had a `revision-mismatch` outcome meaning "the entry was
+   * there but the index moved on" -- which the comment at the classify site calls the point of the
+   * whole taxonomy. Clearing here made that outcome unreachable: by the time any lookup compared
+   * revisions the entry was gone, so every repeat denied by a commit was counted as `absent`, the
+   * same bucket as a query nobody repeated.
+   *
+   * That is the distinction #346 exists to measure, and it read as its own opposite -- "nobody
+   * repeats queries, remove the cache" when the truth may be "repeats happen and the index keeps
+   * denying them".
+   *
+   * Entries now stay until a lookup rejects them on revision, which drops them there and counts
+   * the reason. Nothing stale is served: the outcome is computed before the hit branch. The cost
+   * is that a superseded entry holds its slot until it is looked up, expires at the 5s TTL, or is
+   * evicted by the existing LRU bound.
+   */
   private handleSearchIndexCommit(payload: CoreBoxSearchIndexCommitPayload): void {
-    this.cacheTelemetry.recordInvalidation('index-commit', this.searchCache.size)
-    this.searchCache.clear()
     for (const context of this.indexCommitStreams) {
       if (context.isCancelled()) {
         this.indexCommitStreams.delete(context)
@@ -928,7 +944,18 @@ export class SearchEngineCore
       now: cacheCheckedAt,
       ttlMs: SEARCH_CACHE_TTL_MS
     })
-    if (cacheOutcome !== 'hit') this.cacheTelemetry.recordMiss(cacheOutcome)
+    if (cacheOutcome !== 'hit') {
+      this.cacheTelemetry.recordMiss(cacheOutcome)
+      // Dropped here rather than at commit time, so the reason survives to be counted.
+      // An expired entry goes the same way: whoever asked has just paid for the miss.
+      if (cachedEntry && cacheOutcome !== 'absent') {
+        this.searchCache.delete(cacheKey)
+        this.cacheTelemetry.recordInvalidation(
+          cacheOutcome === 'revision-mismatch' ? 'index-commit' : 'lru-evict',
+          1
+        )
+      }
+    }
     if (cacheOutcome === 'hit' && cachedEntry) {
       this.cacheTelemetry.recordHit(cachedAgeMs, cachedEntry.result.duration)
       const cachedResult = materializeCachedSearchResult(cachedEntry.result, sessionId)


### PR DESCRIPTION
Removes #346's second and last blocker. With #1729 the counters became readable; this makes them mean something.

## The defect

`classifySearchCacheLookup` has always had a `revision-mismatch` outcome — "the entry was there but the index moved on". The comment at the classify site says it is the point of the whole taxonomy:

> The reason is the point, not the hit rate: `revision-mismatch` means an index commit denied the entry, which is a different story from a query nobody repeated.

**It was unreachable.** `handleSearchIndexCommit` cleared the entire cache synchronously, so by the time any lookup compared revisions the entry was gone and the miss was filed as `absent` — the same bucket as a query nobody repeated.

That is the distinction #346 exists to measure, and its only evidence read as its own opposite: *"nobody repeats queries, remove the cache"* when the truth may be *"repeats happen and the index keeps denying them"*.

## The change

The commit no longer clears. Entries are rejected on revision at lookup and dropped there, so the reason is counted where it occurs.

| | before | after |
| --- | --- | --- |
| `misses.absent` | 3 | **2** |
| `misses['revision-mismatch']` | **0** | **1** |
| `invalidations['index-commit']` | 2 | 1 |

**Nothing stale is served.** The outcome is computed before the hit branch and that path is unchanged — a `revision-mismatch` never reaches `materializeCachedSearchResult`. The cost is that a superseded entry holds its slot until it is looked up, expires at the 5s TTL, or is evicted by the existing LRU bound.

## Verification

| plant | result |
| --- | --- |
| restore `searchCache.clear()` in the commit handler | **1 failed** |

`search-engine/`: 75 files, 670 tests.

The test also asserts that a second lookup after the mismatch **hits**, not mismatches again — one `revision-mismatch` per commit per query, not one per lookup.

## One thing deliberately not asserted, and it is in the test

The `searchCache.delete(cacheKey)` at the lookup is **not** observable through the telemetry: the miss re-runs the search and re-caches under the same key, so the entry is replaced either way. A plant that removed the delete passed, which is recorded in the test rather than papered over. The delete is kept for the paths that do **not** re-cache — an aborted or failed search — where the superseded entry would otherwise hold its slot until the TTL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search cache handling when indexed data changes.
  * Cache telemetry now distinguishes stale entries, expired entries, and entries that were never cached.
  * Rejected stale results are removed during lookup, and repeated queries can be cached again for improved hit rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->