### PR TITLE
fix(utils): exclude ~/Library and %APPDATA% at the home level

### DIFF
--- a/packages/utils/__tests__/file-filter-traversal-anchor.test.ts
+++ b/packages/utils/__tests__/file-filter-traversal-anchor.test.ts
@@ -85,3 +85,71 @@ describe('#1727 system-dir anchoring', () => {
     expect(reason('/Users/x/Pictures/Photos Library.photoslibrary')).toBe('bundle-internal')
   })
 })
+
+/**
+ * #1727's second acceptance criterion, which the root anchor above did not meet.
+ *
+ * `~/Library` and `%APPDATA%` are system locations under the user's home, not at the root, so
+ * anchoring the name list to the filesystem root stopped excluding them. The claim that
+ * `PATH_PATTERNS.SYSTEM_PATHS` still covered them was off by one separator: its macOS pattern is
+ * `/^\/Users\/[^\/]+\/Library\//`, which needs a slash after `Library` and therefore matches
+ * everything inside `~/Library` while missing `~/Library` itself.
+ *
+ * The leak is one directory level — on one Mac, all 111 subdirectories stayed excluded and six
+ * direct files did not — and it is reachable only through a custom scan root, since the six default
+ * roots never contain `~/Library`. Small, but it is a stated criterion and the comment asserting it
+ * was wrong.
+ */
+describe('#1727 home-anchored system dirs', () => {
+  const CANDIDATES = ['Library', 'AppData', 'LocalAppData']
+  const active = CANDIDATES.filter(name => SYSTEM_BLACKLISTED_DIRS.has(name))
+
+  it('gates on the platform list rather than a hardcoded name', () => {
+    // Pins the intent per platform, and keeps the loops below from passing by being empty.
+    const expected
+      = process.platform === 'darwin'
+        ? ['Library']
+        : process.platform === 'win32'
+          ? ['AppData', 'LocalAppData']
+          : []
+    expect(active).toEqual(expected)
+  })
+
+  it('excludes them one level under a home directory', () => {
+    for (const name of active) {
+      for (const home of ['/Users/someone', '/home/someone', 'C:/Users/someone'])
+        expect(reason(`${home}/${name}`), `${home}/${name}`).toBe('system-path')
+    }
+  })
+
+  /** The #1728 fix this must not undo: the same name deeper down is the user's own folder. */
+  it('still indexes the same name below the home level', () => {
+    for (const name of active) {
+      const deep = `/Users/someone/Documents/${name}`
+      expect(reason(deep), deep).not.toBe('system-path')
+    }
+  })
+
+  it('leaves names the platform does not claim alone', () => {
+    for (const name of CANDIDATES.filter(n => !SYSTEM_BLACKLISTED_DIRS.has(n)))
+      expect(reason(`/home/someone/${name}`), name).not.toBe('system-path')
+  })
+
+  /**
+   * The shape rule is three segments *and* a `Users`/`home` container. Without the second half any
+   * three-segment path would qualify. `/opt/...` is not usable as the counter-example here — it is
+   * already `system-path` through `PATH_PATTERNS.SYSTEM_PATHS`, which is correct and would have made
+   * this pass for the wrong reason.
+   */
+  it('does not treat an arbitrary three-segment path as a home child', () => {
+    for (const name of active) {
+      for (const p of [`/data/vendor/${name}`, `/Volumes/Ext/${name}`])
+        expect(reason(p), p).not.toBe('system-path')
+    }
+  })
+
+  it('keeps excluding what was already excluded inside them', () => {
+    if (process.platform === 'darwin')
+      expect(reason('/Users/x/Library/Caches')).toBe('system-path')
+  })
+})

--- a/packages/utils/common/file-filter-service.ts
+++ b/packages/utils/common/file-filter-service.ts
@@ -54,6 +54,19 @@ const LOWERCASE_INTERNAL_DATABASE_EXTENSIONS = lowerCaseSet(
 );
 const LOWERCASE_SYSTEM_DIRS = lowerCaseSet(SYSTEM_BLACKLISTED_DIRS);
 const LOWERCASE_TEMP_DIRS = lowerCaseSet(TEMP_BLACKLISTED_DIRS);
+
+/**
+ * The system names that sit under a home directory instead of the filesystem root.
+ *
+ * Intersected with the platform's own list rather than written out, so a Linux user's
+ * `/home/me/Library` stays indexed -- `Library` is only a system location where the platform says
+ * it is. On Linux the intersection is empty, which is the correct answer, not a gap.
+ */
+const HOME_ANCHORED_SYSTEM_DIRS = new Set(
+  ["library", "appdata", "localappdata"].filter((name) =>
+    LOWERCASE_SYSTEM_DIRS.has(name),
+  ),
+);
 const LOWERCASE_SYSTEM_METADATA_NAMES = lowerCaseSet(
   SYSTEM_METADATA_FILE_NAMES,
 );
@@ -88,9 +101,15 @@ function pathSegments(value: string): string[] {
  * POSIX roots are one segment *and* a leading `/` -- the separator is what distinguishes `/usr`
  * from a relative `usr`, which `pathSegments` renders identically. Windows roots are two segments,
  * because the drive is one (`C:/Windows`); `C:Library` is drive-relative, stays a single segment
- * and is therefore not a root. `~/Library` and `%APPDATA%` keep their exclusion through the anchored patterns
- * in `PATH_PATTERNS.SYSTEM_PATHS` (`/^\/Users\/[^/]+\/Library\//`), which is where root-level
- * system paths were already handled -- this check was only ever adding the unanchored half.
+ * and is therefore not a root.
+ *
+ * `~/Library` and `%APPDATA%` are the exception #1727 called out: system locations that live under
+ * the user's home rather than at the root, so the root anchor above cannot reach them. The first
+ * version of this comment claimed `PATH_PATTERNS.SYSTEM_PATHS` covered them, and that was off by
+ * one separator -- `/^\/Users\/[^/]+\/Library\//` needs a slash *after* `Library`, so it excludes
+ * everything inside `~/Library` but not `~/Library` itself. Measured on one Mac: all 111
+ * subdirectories were still excluded, and six direct files were not. `isHomeDirectoryChild` closes
+ * that level.
  */
 function isFilesystemRootChild(
   normalizedPath: string,
@@ -100,6 +119,32 @@ function isFilesystemRootChild(
   // relative `usr` -- both are one segment. The original path has to carry the root marker.
   if (segments.length === 1) return normalizedPath.startsWith("/");
   return segments.length === 2 && /^[a-z]:$/i.test(segments[0] ?? "");
+}
+
+/**
+ * `/Users/<user>/X`, `/home/<user>/X` or `C:/Users/<user>/X` -- one level below a home directory.
+ *
+ * The home container is matched by name because this module has no filesystem and no `os.homedir`;
+ * it is a pure path classifier, and `file-scan-utils` only reaches for `node:fs` lazily precisely
+ * because some hosts do not have it. That makes this a shape rule, not a resolved-home check: a
+ * literal directory named `Users` two levels up is enough. The names it gates are drawn from the
+ * platform's own system list, so the false positive is confined to a folder named `Library` sitting
+ * directly under a folder named `Users` on macOS.
+ */
+function isHomeDirectoryChild(
+  normalizedPath: string,
+  segments: readonly string[],
+): boolean {
+  if (segments.length === 3) {
+    return (
+      normalizedPath.startsWith("/") && /^(?:users|home)$/i.test(segments[0] ?? "")
+    );
+  }
+  return (
+    segments.length === 4 &&
+    /^[a-z]:$/i.test(segments[0] ?? "") &&
+    /^users$/i.test(segments[1] ?? "")
+  );
 }
 
 function basename(value: string): string {
@@ -206,8 +251,15 @@ export class FileFilterService {
     if (options.customBlacklistedDirs?.has(directoryName))
       return "excluded-path";
     if (LOWERCASE_DEV_DIRS.has(lowerDirectoryName)) return "development-path";
-    if (isFilesystemRootChild(normalizePath(path), segments) && LOWERCASE_SYSTEM_DIRS.has(lowerDirectoryName))
+    const normalized = normalizePath(path);
+    if (
+      (isFilesystemRootChild(normalized, segments) &&
+        LOWERCASE_SYSTEM_DIRS.has(lowerDirectoryName)) ||
+      (isHomeDirectoryChild(normalized, segments) &&
+        HOME_ANCHORED_SYSTEM_DIRS.has(lowerDirectoryName))
+    ) {
       return "system-path";
+    }
     if (LOWERCASE_TEMP_DIRS.has(lowerDirectoryName)) return "cache-path";
 
     if (


### PR DESCRIPTION
Closes the second acceptance criterion of #1727, which my own #1728 broke.

## What was wrong

#1727 asked for two things: root-anchor the system-directory names so a user's `~/Documents/Library` is indexed, **and** keep `~/Library` and `%APPDATA%` excluded. #1728 delivered the first and left a comment asserting the second was still covered by `PATH_PATTERNS.SYSTEM_PATHS`.

It is off by one separator. The macOS pattern is `/^\/Users\/[^/]+\/Library\//` — it needs a slash *after* `Library`, so it excludes everything **inside** `~/Library` but not `~/Library` itself. Same shape on Windows: `/^[A-Z]:\\Users\\[^\\]+\\AppData\\/i`.

## Measured, not assumed

On one Mac, `~/Library` has **111 direct subdirectories and 6 direct files**. All 111 subdirectories are still excluded by the pattern; the 6 files are not. So the leak is exactly **one directory level** — one wasted `readdir` plus any stray files at that level — not an indexing blowup.

It is also reachable only through a custom scan root: `resolveFileProviderBaseWatchPaths` defaults to `documents · downloads · desktop · music · pictures · videos`, none of which contain `~/Library`. A user who sets the env override to `$HOME` reaches it.

Small. But it is a criterion the issue states explicitly, and the comment claiming it held was wrong.

## The fix

`isHomeDirectoryChild` matches one level below a `Users`/`home` container — 3 segments on POSIX, 4 with a drive letter. The names it gates are **intersected with the platform's own system list** rather than hardcoded, so:

| platform | gated names |
| --- | --- |
| macOS | `Library` |
| Windows | `AppData`, `LocalAppData` |
| Linux | *(none)* — `/home/me/Library` stays indexed, which is the correct answer, not a gap |

This module is a pure path classifier with no imports beyond its own constants — `file-scan-utils` reaches for `node:fs` lazily precisely because some hosts lack it — so this is a path-shape rule, not a resolved-home check. The residual false positive is a folder named `Library` directly under a folder named `Users` on macOS; that is recorded in the doc comment.

## Verification

- 13 cases in `file-filter-traversal-anchor.test.ts`, 1354 in the full `packages/utils` suite — all green.
- **Negative control**: reverting `file-filter-service.ts` to `HEAD` with the tests in place turns exactly one case red — `excludes them one level under a home directory`. The other three new cases pass on the broken code too, which is what they are for: they are guard rails against over-reach, not defect detectors.
- The counter-example case had to be rewritten. `/opt/vendor/Library` was already `system-path` via `PATH_PATTERNS.SYSTEM_PATHS`, so it would have passed for the wrong reason; it now uses `/data/vendor/…` and `/Volumes/Ext/…`, verified `INDEXED` first.
- Lint: 0 problems under `packages/utils/eslint.config.js`, the config `pnpm lint` actually applies to this package. Confirmed with a positive control (a planted redeclare was reported).

## Not in scope

#1727's third criterion — whether `build`, `dist`, `out`, `bin`, `cache`, `logs` should exclude a folder under `~/Documents` — is a policy decision, and a comment on the issue records that narrowing `DEV_BLACKLISTED_DIRS` would re-open #318's memory bound. The existing test pins today's answer rather than changing it.

Refs #1727

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file and folder filtering for system directories located directly beneath user home folders on macOS and Windows.
  * Preserved access to similarly named folders nested deeper within user-created paths.
  * Continued blocking protected system directories and unclaimed or invalid path patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->