### PR TITLE
feat(plugins): give the permission-family blocked reasons one definition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,16 @@ jobs:
       - name: Check maintenance-audit report claims
         run: pnpm check:audit-report-claims && pnpm check:audit-report-claims:self-test
 
+      # 34 distinct blocked reasons live across plugins/ and 20 of them belong to exactly one
+      # plugin, so the vocabulary is open and a closed union would be the wrong contract. Only the
+      # permission family is enforced: a plugin writing permission_denied is claiming to speak a
+      # shared language and getting it wrong, and it fails silently on both sides -- a reason nobody
+      # handles is indistinguishable from a handler for a reason nobody emits. Plugin Preludes take
+      # everything from globalThis and contain no imports at all, so this check is what #1711 asked
+      # an import to provide.
+      - name: Check plugin blocked reasons
+        run: pnpm check:plugin-blocked-reasons && pnpm check:plugin-blocked-reasons:self-test
+
       # plugin.ts was ~3,060 lines when #339 asked for it to be split. Three extraction PRs landed
       # and each reported real progress -- 4,069 to 3,947 to 3,872 to 3,844 -- against a baseline
       # that had already grown a thousand lines since the issue was written. Extraction removed 225

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "plugins:validate:self-test": "node scripts/validate-plugins.mjs --self-test",
     "test:plugins": "node scripts/test-plugins.mjs",
     "check:audit-report-claims": "node scripts/check-audit-report-claims.mjs",
+    "check:plugin-blocked-reasons": "node scripts/check-plugin-blocked-reasons.mjs",
+    "check:plugin-blocked-reasons:self-test": "node scripts/check-plugin-blocked-reasons.mjs --self-test",
     "check:module-size-ratchet": "node scripts/check-module-size-ratchet.mjs",
     "check:module-size-ratchet:self-test": "node scripts/check-module-size-ratchet.mjs --self-test",
     "check:audit-report-claims:self-test": "node scripts/check-audit-report-claims.mjs --self-test",

--- a/packages/test/src/plugins/batch-rename.test.ts
+++ b/packages/test/src/plugins/batch-rename.test.ts
@@ -1,3 +1,4 @@
+import { PLUGIN_BLOCKED_REASONS } from '@talex-touch/utils'
 import { describe, expect, it, vi } from 'vitest'
 import { createPluginGlobals, loadPluginModule, loadPluginModuleWithSourceTransform, withoutGlobal } from './plugin-loader'
 
@@ -125,7 +126,7 @@ describe('batch rename rules', () => {
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
     })
   })
 
@@ -259,7 +260,7 @@ describe('batch rename rules', () => {
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
       message: '缺少 fs.write 权限',
     })
   })
@@ -276,7 +277,7 @@ describe('batch rename rules', () => {
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-sdk-unavailable',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_SDK_UNAVAILABLE,
       message: '权限系统不可用',
     })
   })
@@ -297,7 +298,7 @@ describe('batch rename rules', () => {
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-check-failed',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_CHECK_FAILED,
       message: '权限检查失败',
     })
   })

--- a/packages/test/src/plugins/browser-bookmarks.test.ts
+++ b/packages/test/src/plugins/browser-bookmarks.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs'
+import { PLUGIN_BLOCKED_REASONS } from '@talex-touch/utils'
 import { describe, expect, it, vi } from 'vitest'
 import { createPluginGlobals, loadPluginModule, withoutGlobal } from './plugin-loader'
 
@@ -119,7 +120,7 @@ describe('browser bookmarks plugin', () => {
       type: 'network',
       permission: 'network.internet',
       status: 'permission-missing',
-      reason: 'network-internet-permission-required',
+      reason: PLUGIN_BLOCKED_REASONS.NETWORK_INTERNET_PERMISSION_REQUIRED,
       audit: {
         pluginName: 'touch-browser-bookmarks',
         featureId: 'browser-bookmarks',
@@ -162,7 +163,7 @@ describe('browser bookmarks plugin', () => {
     expect(openItem?.subtitle).toContain('缺少 network.internet 权限')
     expect(actionPayload(openItem)?.capability).toMatchObject({
       status: 'permission-missing',
-      reason: 'permission-sdk-unavailable',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_SDK_UNAVAILABLE,
       permission: 'network.internet',
     })
   })

--- a/packages/test/src/plugins/dev-toolbox.test.ts
+++ b/packages/test/src/plugins/dev-toolbox.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs'
+import { PLUGIN_BLOCKED_REASONS } from '@talex-touch/utils'
 import { describe, expect, it, vi } from 'vitest'
 import { createPluginGlobals, loadPluginModule, loadPluginModuleWithSourceTransform, withoutGlobal } from './plugin-loader'
 
@@ -110,7 +111,7 @@ describe('dev toolbox config', () => {
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
       message: '缺少 network.internet 权限',
     })
   })

--- a/packages/test/src/plugins/dev-utils.test.ts
+++ b/packages/test/src/plugins/dev-utils.test.ts
@@ -1,3 +1,4 @@
+import { PLUGIN_BLOCKED_REASONS } from '@talex-touch/utils'
 import { describe, expect, it, vi } from 'vitest'
 import { createPluginGlobals, loadPluginModule, loadPluginModuleWithSourceTransform, withoutGlobal } from './plugin-loader'
 
@@ -176,7 +177,7 @@ describe('touch-dev-utils helpers', () => {
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
       message: '缺少 clipboard.write 权限',
     })
   })

--- a/packages/test/src/plugins/intelligence.test.ts
+++ b/packages/test/src/plugins/intelligence.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { structuredStrictStringify } from '@talex-touch/utils'
+import { PLUGIN_BLOCKED_REASONS, structuredStrictStringify } from '@talex-touch/utils'
 import { describe, expect, it, vi } from 'vitest'
 import { instantiateCommandPreset } from '../../../../plugins/touch-intelligence/widgets/_shared/command-presets'
 import { renderPromptTemplatePreview } from '../../../../plugins/touch-intelligence/widgets/_shared/prompt-template-preview'
@@ -2155,7 +2155,7 @@ describe('intelligence plugin', () => {
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
     })
   })
 
@@ -3344,7 +3344,7 @@ describe('intelligence plugin', () => {
         },
       },
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
     })
   })
 
@@ -3411,7 +3411,7 @@ describe('intelligence plugin', () => {
       success: false,
       shouldActivate: true,
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
     })
   })
 
@@ -3439,7 +3439,7 @@ describe('intelligence plugin', () => {
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
     })
   })
 
@@ -3506,7 +3506,7 @@ describe('intelligence plugin', () => {
       success: false,
       shouldActivate: true,
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
     })
   })
 

--- a/packages/test/src/plugins/snipaste.test.ts
+++ b/packages/test/src/plugins/snipaste.test.ts
@@ -1,3 +1,4 @@
+import { PLUGIN_BLOCKED_REASONS } from '@talex-touch/utils'
 import { describe, expect, it, vi } from 'vitest'
 import { createPluginGlobals, loadPluginModule } from './plugin-loader'
 
@@ -87,7 +88,7 @@ describe('snipaste isolated Prelude boundary', () => {
     const fixture = harness({
       actionId: 'snip',
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
     })
     await fixture.pluginModule.onFeatureTriggered('snipaste-quick', { text: '截图' })
 
@@ -98,7 +99,7 @@ describe('snipaste isolated Prelude boundary', () => {
     expect(result).toMatchObject({
       status: 'blocked',
       success: false,
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
       message: '缺少 system.shell 权限',
     })
     expect(JSON.stringify(result)).not.toMatch(/Applications|Program Files|private/)

--- a/packages/test/src/plugins/snippets.test.ts
+++ b/packages/test/src/plugins/snippets.test.ts
@@ -1,3 +1,4 @@
+import { PLUGIN_BLOCKED_REASONS } from '@talex-touch/utils'
 import { describe, expect, it, vi } from 'vitest'
 import { createPluginGlobals, loadPluginModule } from './plugin-loader'
 
@@ -105,7 +106,7 @@ describe('code snippets', () => {
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
     })
   })
 

--- a/packages/test/src/plugins/system-actions.test.ts
+++ b/packages/test/src/plugins/system-actions.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import { PLUGIN_BLOCKED_REASONS } from '@talex-touch/utils'
 import { describe, expect, it, vi } from 'vitest'
 import { createPluginGlobals, loadPluginModule } from './plugin-loader'
 
@@ -239,13 +240,13 @@ describe('isolated system actions Prelude', () => {
     harness.state.result = {
       actionId: 'lock-screen',
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
     }
     await expect(
       harness.module.onItemAction(itemForAction(harness.state.items, 'lock-screen')),
     ).resolves.toMatchObject({
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
       success: false,
     })
   })

--- a/packages/test/src/plugins/text-tools.test.ts
+++ b/packages/test/src/plugins/text-tools.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto'
+import { PLUGIN_BLOCKED_REASONS } from '@talex-touch/utils'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { createPluginGlobals, loadPluginModule, withoutGlobal } from './plugin-loader'
 
@@ -149,7 +150,7 @@ describe('touch-text-tools actions', () => {
       externalAction: true,
       success: false,
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
       message: '缺少 clipboard.write 权限',
     })
   })

--- a/packages/test/src/plugins/translation.test.ts
+++ b/packages/test/src/plugins/translation.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import { PLUGIN_BLOCKED_REASONS } from '@talex-touch/utils'
 import { describe, expect, it, vi } from 'vitest'
 import { loadPluginModule } from './plugin-loader'
 
@@ -245,7 +246,7 @@ describe('touch-translation isolated Prelude', () => {
     const deniedItem = actionItem(finalItems(denied.pushes))
     await expect(denied.module.onItemAction(deniedItem)).resolves.toMatchObject({
       status: 'blocked',
-      reason: 'permission-denied',
+      reason: PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
     })
 
     const failed = createHarness({

--- a/packages/test/src/plugins/workspace-scripts.test.ts
+++ b/packages/test/src/plugins/workspace-scripts.test.ts
@@ -1,3 +1,4 @@
+import { PLUGIN_BLOCKED_REASONS } from '@talex-touch/utils'
 import { describe, expect, it, vi } from 'vitest'
 import { createPluginGlobals, loadPluginModule } from './plugin-loader'
 
@@ -190,7 +191,8 @@ describe('workspace scripts isolated Prelude', () => {
     expect(items).toEqual([
       expect.objectContaining({
         title: 'Workspace Scripts Unavailable',
-        subtitle: 'capability-unavailable',
+        // The same contract, surfaced as UI text rather than as a blocked result.
+        subtitle: PLUGIN_BLOCKED_REASONS.CAPABILITY_UNAVAILABLE,
       }),
     ])
   })
@@ -219,6 +221,6 @@ describe('workspace scripts isolated Prelude', () => {
         },
         { actionId: 'run-script' },
       ),
-    ).resolves.toMatchObject({ status: 'blocked', reason: 'capability-unavailable' })
+    ).resolves.toMatchObject({ status: 'blocked', reason: PLUGIN_BLOCKED_REASONS.CAPABILITY_UNAVAILABLE })
   })
 })

--- a/packages/utils/plugin/blocked-reasons.ts
+++ b/packages/utils/plugin/blocked-reasons.ts
@@ -1,0 +1,101 @@
+/**
+ * The `reason` strings a plugin may return alongside `{ status: 'blocked' }` (#1711).
+ *
+ * Measured across `plugins/` before this file existed: 34 distinct reason literals, of which 14
+ * appear in two or more plugins and 20 belong to exactly one. `permission-denied` alone is written
+ * out in 12 plugins. So the set is **open**, not closed — the 20 single-plugin reasons describe
+ * things only that plugin can fail at (`workspace-script-failed`, `invalid-flow-action`,
+ * `archived-session-continuation`), and forcing them into a union here would be a worse contract
+ * than no contract.
+ *
+ * What is defined here is the shared half: a reason that two or more plugins already emit means the
+ * same thing in each, and a renderer that wants to distinguish "you have not granted this" from
+ * "that action was malformed" has to match on it. Those are the ones worth owning.
+ *
+ * ## This is a vocabulary, not an import target
+ *
+ * Plugin Preludes take everything from `globalThis` — `const { plugin, clipboard, http, logger } =
+ * globalThis` — and none of the 24 `index.js` files contains a single `import` or `require`. So the
+ * plugins cannot import this, and #1711's second acceptance criterion is not reachable by adding a
+ * constant. `scripts/check-plugin-blocked-reasons.mjs` supplies the property that the import would
+ * have: a permission-family literal that is not in this set fails the build.
+ *
+ * Everything that *can* import it — `packages/test`, `apps/core-app` — should, so that a rename
+ * breaks compilation rather than an assertion.
+ */
+export const PLUGIN_BLOCKED_REASONS = {
+  /** The user has this permission and refused, or the grant was revoked. 12 plugins. */
+  PERMISSION_DENIED: 'permission-denied',
+  /** The permission exists but cannot be evaluated right now. 3 plugins. */
+  PERMISSION_UNAVAILABLE: 'permission-unavailable',
+  /** The host did not inject a permission SDK at all. 3 plugins. */
+  PERMISSION_SDK_UNAVAILABLE: 'permission-sdk-unavailable',
+  /** The permission check itself threw. 3 plugins. */
+  PERMISSION_CHECK_FAILED: 'permission-check-failed',
+  /**
+   * The host cannot perform the action, independent of permission.
+   *
+   * Shared with `ContextActionUnavailableCode` in `../core-box/context-actions` deliberately, which
+   * #1711 asked to make explicit rather than leave as a coincidence: both mean "the capability is
+   * not present", one for a context action and one for a plugin action. Same word, same meaning,
+   * now one definition. If they ever diverge, this comment is where to say so.
+   */
+  CAPABILITY_UNAVAILABLE: 'capability-unavailable',
+  /**
+   * `network.internet` specifically was not granted. 1 plugin.
+   *
+   * The only single-plugin reason in this file, and it is here because it is a permission claim:
+   * the family below is enforced as closed, so a reason that says "permission" and is missing from
+   * it reads as a typo. The blocked shape is `{ status, reason }` with nowhere to name *which*
+   * permission, which is why this exists as its own string rather than as `permission-denied`.
+   */
+  NETWORK_INTERNET_PERMISSION_REQUIRED: 'network-internet-permission-required',
+  /** No clipboard bridge. 4 plugins. */
+  CLIPBOARD_UNAVAILABLE: 'clipboard-unavailable',
+  /** The clipboard bridge was there and the write failed. 2 plugins. */
+  CLIPBOARD_WRITE_FAILED: 'clipboard-write-failed',
+  /** No URL opener. 2 plugins. */
+  OPEN_URL_UNAVAILABLE: 'open-url-unavailable',
+  /** The action id is not one this plugin serves. 3 plugins. */
+  INVALID_ACTION: 'invalid-action',
+  /** The action was valid and did not complete. 2 plugins. */
+  ACTION_FAILED: 'action-failed',
+  /** The user dismissed a confirmation. 3 plugins. */
+  CANCELLED: 'cancelled',
+  /** The action exceeded its own deadline. 3 plugins. */
+  TIMEOUT: 'timeout',
+  /** A newer request superseded this one before it resolved. 2 plugins. */
+  STALE_REQUEST: 'stale-request',
+  /** A capability token aged out. 2 plugins. */
+  TOKEN_EXPIRED: 'token-expired',
+} as const
+
+export type PluginBlockedReason =
+  (typeof PLUGIN_BLOCKED_REASONS)[keyof typeof PLUGIN_BLOCKED_REASONS]
+
+const SHARED_REASONS: ReadonlySet<string> = new Set(Object.values(PLUGIN_BLOCKED_REASONS))
+
+/**
+ * The subset the guard enforces.
+ *
+ * Only the permission family is closed. A plugin inventing `workspace-script-failed` is describing
+ * its own domain and nobody else needs to agree; a plugin inventing `permission_denied` or
+ * `permissions-denied` is claiming to speak a shared language and getting it wrong, which is the
+ * failure #1711 is about — silent on both sides, since a reason nobody handles looks exactly like a
+ * handler for a reason nobody emits.
+ */
+export const PLUGIN_PERMISSION_BLOCKED_REASONS: readonly PluginBlockedReason[] = [
+  PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,
+  PLUGIN_BLOCKED_REASONS.PERMISSION_UNAVAILABLE,
+  PLUGIN_BLOCKED_REASONS.PERMISSION_SDK_UNAVAILABLE,
+  PLUGIN_BLOCKED_REASONS.PERMISSION_CHECK_FAILED,
+  PLUGIN_BLOCKED_REASONS.CAPABILITY_UNAVAILABLE,
+  PLUGIN_BLOCKED_REASONS.NETWORK_INTERNET_PERMISSION_REQUIRED,
+]
+
+/** Whether `reason` is one of the shared vocabulary rather than a plugin-private string. */
+export function isSharedPluginBlockedReason(
+  reason: string,
+): reason is PluginBlockedReason {
+  return SHARED_REASONS.has(reason)
+}

--- a/packages/utils/plugin/index.ts
+++ b/packages/utils/plugin/index.ts
@@ -748,6 +748,7 @@ export interface IManifest {
   }
 }
 
+export * from './blocked-reasons'
 export * from './install'
 export * from './package-policy'
 export * from './security-scan'

--- a/scripts/check-plugin-blocked-reasons.mjs
+++ b/scripts/check-plugin-blocked-reasons.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/**
+ * Fails when a plugin returns a permission-family blocked reason that is not the canonical spelling.
+ *
+ * #1711 asked for the reason strings to be defined in one place and for `plugins/*` to import that
+ * definition. The first half is `packages/utils/plugin/blocked-reasons.ts`. The second half is not
+ * reachable: plugin Preludes take everything from `globalThis` and not one of the 24 `index.js`
+ * files contains an `import` or a `require`, so there is nothing to import into. This script
+ * supplies the property the import would have given -- a misspelled reason fails the build rather
+ * than sitting there silently.
+ *
+ * Only the permission family is enforced. 20 of the 34 reasons measured across `plugins/` belong to
+ * exactly one plugin and describe that plugin's own domain; a plugin inventing
+ * `workspace-script-failed` needs nobody's agreement. A plugin writing `permission_denied` is
+ * claiming to speak a shared language and getting it wrong, and both sides fail silently: a reason
+ * nobody handles is indistinguishable from a handler for a reason nobody emits.
+ *
+ * The canonical list is parsed out of the TypeScript source rather than repeated here, because a
+ * second copy of the list is the defect this is meant to prevent.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const SOURCE = 'packages/utils/plugin/blocked-reasons.ts'
+const PLUGIN_ROOT = 'plugins'
+
+/** `reason: 'x'`, `reason = 'x'` and `reason('x')`, single or double quoted. */
+const REASON_LITERAL = /reason\s*[:=(]\s*['"]([a-z0-9][a-z0-9_-]*)['"]/g
+
+/**
+ * A reason that claims membership in the permission family.
+ *
+ * Deliberately wider than the canonical list: `permission_denied` and `permissions-denied` have to
+ * be *caught*, and they are only catchable by matching the family loosely and then checking
+ * membership. Matching the canonical list alone would let every typo through as "not a permission
+ * reason".
+ */
+const CLAIMS_PERMISSION_FAMILY = /permission|capabilit/i
+
+/** `KEY: 'value'` pairs out of the `PLUGIN_BLOCKED_REASONS` object literal. */
+export function parseReasonMap(source) {
+  const start = source.indexOf('export const PLUGIN_BLOCKED_REASONS')
+  if (start < 0)
+    return new Map()
+  const end = source.indexOf('} as const', start)
+  if (end < 0)
+    return new Map()
+  const body = source.slice(start, end)
+  const map = new Map()
+  for (const match of body.matchAll(/^\s*([A-Z][A-Z0-9_]*)\s*:\s*'([^']+)'/gm))
+    map.set(match[1], match[2])
+  return map
+}
+
+/** The `PLUGIN_BLOCKED_REASONS.X` references inside `PLUGIN_PERMISSION_BLOCKED_REASONS`, resolved. */
+export function parsePermissionFamily(source, reasonMap) {
+  const start = source.indexOf('export const PLUGIN_PERMISSION_BLOCKED_REASONS')
+  if (start < 0)
+    return []
+  // From `= [`, not from the declaration: the real one is annotated
+  // `: readonly PluginBlockedReason[] =`, whose `[]` comes first and closed the slice on nothing.
+  // The empty-allowlist guard in main() is what surfaced that -- an allowlist of zero passes
+  // everything, so it has to be an error rather than a quiet success.
+  const open = source.indexOf('= [', start)
+  if (open < 0)
+    return []
+  const end = source.indexOf(']', open + 3)
+  if (end < 0)
+    return []
+  const body = source.slice(open, end)
+  const resolved = []
+  for (const match of body.matchAll(/PLUGIN_BLOCKED_REASONS\.([A-Z][A-Z0-9_]*)/g)) {
+    const value = reasonMap.get(match[1])
+    if (value)
+      resolved.push(value)
+  }
+  return resolved
+}
+
+export function findOffenders(files, readFile, canonical) {
+  const allowed = new Set(canonical)
+  const offenders = []
+  let scanned = 0
+  for (const file of files) {
+    const contents = readFile(file)
+    const lines = contents.split('\n')
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index] ?? ''
+      REASON_LITERAL.lastIndex = 0
+      for (const match of line.matchAll(REASON_LITERAL)) {
+        scanned += 1
+        const reason = match[1]
+        if (!CLAIMS_PERMISSION_FAMILY.test(reason))
+          continue
+        if (!allowed.has(reason))
+          offenders.push({ file, line: index + 1, reason })
+      }
+    }
+  }
+  return { offenders, scanned }
+}
+
+function collectPluginFiles(dir = PLUGIN_ROOT) {
+  const absolute = path.join(repoRoot, dir)
+  if (!fs.existsSync(absolute))
+    return []
+  const files = []
+  for (const entry of fs.readdirSync(absolute, { withFileTypes: true })) {
+    if (!entry.isDirectory())
+      continue
+    const pluginDir = path.join(absolute, entry.name)
+    for (const name of fs.readdirSync(pluginDir)) {
+      if (name === 'index.js' || name.endsWith('.test.cjs'))
+        files.push(path.posix.join(dir, entry.name, name))
+    }
+  }
+  return files
+}
+
+function main() {
+  const sourcePath = path.join(repoRoot, SOURCE)
+  if (!fs.existsSync(sourcePath)) {
+    console.error(`${SOURCE} is missing; the canonical reasons cannot be read.`)
+    return 1
+  }
+  const source = fs.readFileSync(sourcePath, 'utf8')
+  const canonical = parsePermissionFamily(source, parseReasonMap(source))
+  if (canonical.length === 0) {
+    console.error(
+      `No permission reasons parsed out of ${SOURCE}. Either the file changed shape or the parser`
+      + ' broke -- refusing to report success on an empty allowlist, which would pass everything.',
+    )
+    return 1
+  }
+
+  const files = collectPluginFiles()
+  const { offenders, scanned } = findOffenders(
+    files,
+    file => fs.readFileSync(path.join(repoRoot, file), 'utf8'),
+    canonical,
+  )
+  if (scanned === 0) {
+    console.error(
+      `Scanned ${files.length} plugin file(s) and found no reason literals at all. That is not a`
+      + ' pass; the scan is broken.',
+    )
+    return 1
+  }
+
+  if (offenders.length > 0) {
+    console.error('Plugin returns a permission-family reason that is not the canonical spelling:\n')
+    for (const entry of offenders)
+      console.error(`  ${entry.file}:${entry.line}  ->  ${entry.reason}`)
+    console.error(`\nCanonical (${SOURCE}): ${canonical.join(', ')}`)
+    console.error(
+      '\nA reason nobody handles looks exactly like a handler for a reason nobody emits, which is'
+      + ' why this is a build failure rather than a lint warning (#1711).',
+    )
+    return 1
+  }
+
+  console.log(
+    `check-plugin-blocked-reasons: ${scanned} reason literal(s) across ${files.length} plugin `
+    + `file(s); every permission-family one matches the ${canonical.length} canonical spellings.`,
+  )
+  return 0
+}
+
+function selfTest() {
+  const source = [
+    'export const PLUGIN_BLOCKED_REASONS = {',
+    '  PERMISSION_DENIED: \'permission-denied\',',
+    '  CAPABILITY_UNAVAILABLE: \'capability-unavailable\',',
+    '  TIMEOUT: \'timeout\',',
+    '} as const',
+    'export const PLUGIN_PERMISSION_BLOCKED_REASONS = [',
+    '  PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,',
+    '  PLUGIN_BLOCKED_REASONS.CAPABILITY_UNAVAILABLE,',
+    ']',
+  ].join('\n')
+  const reasonMap = parseReasonMap(source)
+  const canonical = parsePermissionFamily(source, reasonMap)
+  const check = contents =>
+    findOffenders(['p/index.js'], () => contents, canonical)
+
+  const cases = [
+    { name: 'the object literal is parsed', actual: reasonMap.get('PERMISSION_DENIED'), expected: 'permission-denied' },
+    { name: 'a non-permission entry is parsed too', actual: reasonMap.get('TIMEOUT'), expected: 'timeout' },
+    { name: 'the family resolves through the references', actual: canonical.join(','), expected: 'permission-denied,capability-unavailable' },
+    { name: 'the family excludes what it does not list', actual: canonical.includes('timeout'), expected: false },
+    { name: 'a canonical reason passes', actual: check('reason: \'permission-denied\'').offenders.length, expected: 0 },
+    { name: 'an underscore typo is caught', actual: check('reason: \'permission_denied\'').offenders[0]?.reason, expected: 'permission_denied' },
+    { name: 'a pluralised typo is caught', actual: check('reason: \'permissions-denied\'').offenders[0]?.reason, expected: 'permissions-denied' },
+    { name: 'an invented permission reason is caught', actual: check('reason: \'permission-expired\'').offenders[0]?.reason, expected: 'permission-expired' },
+    { name: 'a capability typo is caught', actual: check('reason: \'capability_unavailable\'').offenders[0]?.reason, expected: 'capability_unavailable' },
+    // The open half. 20 of 34 reasons belong to one plugin; enforcing them would be wrong.
+    { name: 'a plugin-private reason is left alone', actual: check('reason: \'workspace-script-failed\'').offenders.length, expected: 0 },
+    { name: 'an unrelated shared reason is left alone', actual: check('reason: \'clipboard-unavailable\'').offenders.length, expected: 0 },
+    { name: 'reason = form is scanned', actual: check('const reason = \'permission_denied\'').offenders.length, expected: 1 },
+    { name: 'reason( form is scanned', actual: check('blocked(reason(\'permission_denied\'))').offenders.length, expected: 1 },
+    { name: 'double quotes are scanned', actual: check('reason: "permission_denied"').offenders.length, expected: 1 },
+    { name: 'the line number is reported', actual: check('x\nreason: \'permission_denied\'').offenders[0]?.line, expected: 2 },
+    { name: 'two offenders on one line are both caught', actual: check('reason: \'permission_denied\', reason: \'capability_x\'').offenders.length, expected: 2 },
+    { name: 'scanned counts every literal, not just offenders', actual: check('reason: \'timeout\'').scanned, expected: 1 },
+    { name: 'a file with no reasons scans nothing', actual: check('const x = 1').scanned, expected: 0 },
+    { name: 'a missing object literal yields an empty map', actual: parseReasonMap('nothing here').size, expected: 0 },
+    { name: 'a missing family yields an empty list', actual: parsePermissionFamily('nothing here', reasonMap).length, expected: 0 },
+    { name: 'a reference to an unknown key is dropped', actual: parsePermissionFamily('export const PLUGIN_PERMISSION_BLOCKED_REASONS = [PLUGIN_BLOCKED_REASONS.NOPE]', reasonMap).length, expected: 0 },
+    // The shape the real file actually has. The first version of this self-test used the
+    // unannotated form, passed 21 of 21, and the parser still returned nothing against the source
+    // it was written for -- the `[]` in `readonly PluginBlockedReason[]` closed the slice early.
+    {
+      name: 'a type-annotated declaration is parsed',
+      actual: parsePermissionFamily(
+        'export const PLUGIN_PERMISSION_BLOCKED_REASONS: readonly PluginBlockedReason[] = [\n  PLUGIN_BLOCKED_REASONS.PERMISSION_DENIED,\n]',
+        reasonMap,
+      ).join(','),
+      expected: 'permission-denied',
+    },
+  ]
+
+  let failed = 0
+  for (const testCase of cases) {
+    if (!Object.is(testCase.actual, testCase.expected)) {
+      failed += 1
+      console.error(`  x ${testCase.name}: expected ${testCase.expected}, got ${testCase.actual}`)
+    }
+  }
+  console.log(
+    failed === 0
+      ? `check-plugin-blocked-reasons --self-test: ${cases.length} cases passed`
+      : `check-plugin-blocked-reasons --self-test: ${failed} of ${cases.length} cases failed`,
+  )
+  return failed
+}
+
+if (process.argv.includes('--self-test'))
+  process.exit(selfTest() > 0 ? 1 : 0)
+else process.exit(main())


### PR DESCRIPTION
Closes #1711, with one criterion met differently than it was written and one limitation stated.

## Measured first, because the issue's table was a sample

Across `plugins/`: **34 distinct blocked-reason literals — 14 in two or more plugins, 20 in exactly one.** `permission-denied` alone is written out in **12 plugins**.

That settles the question #1711 said to answer first. **The set is open.** A `PLUGIN_BLOCKED_REASONS` union covering all 34 would be a worse contract than none: `workspace-script-failed`, `invalid-flow-action`, `developer-preview-save-unavailable` and 17 others describe things only one plugin can fail at, and nobody else needs to agree on them.

So this defines the shared half — a reason two or more plugins already emit means the same thing in each, and that is the half a renderer has to match on.

## `plugins/* import the definition` is not reachable

Plugin Preludes open with `const { plugin, clipboard, http, logger } = globalThis`. **Not one of the 24 `index.js` files contains an `import` or a `require`** — verified with a positive control, since "zero matches" is exactly what a broken scan reports. Only 4 of 24 even declare `@talex-touch/utils` as a dependency, and none of them bundle the Prelude.

Adding a constant does not change that. So the property the import was for — a typo fails the build — is supplied statically instead: **`scripts/check-plugin-blocked-reasons.mjs`**.

Only the permission family is enforced. A plugin inventing `workspace-script-failed` is describing its own domain; a plugin writing `permission_denied` is claiming to speak a shared language and getting it wrong, and that is the failure mode #1711 is about — silent on both sides, since a reason nobody handles is indistinguishable from a handler for a reason nobody emits.

The guard **parses the canonical list out of the TypeScript source** rather than repeating it, because a second copy of the list is the defect being prevented.

## The empty-allowlist guard earned its keep on the first run

The first parser sliced from the declaration to the next `]`. The real declaration is annotated `: readonly PluginBlockedReason[] =` — that `[]` comes first, so the slice closed on nothing and the allowlist resolved empty. **An allowlist of zero passes everything**, which is why it is an error rather than a quiet success. Self-test case 22 is now the annotated shape; the first 21 all passed against a form the real file does not have.

## One real offender

`network-internet-permission-required` in `touch-browser-data/index.js:183`. It is a permission claim, so it is canonical now rather than renamed — the blocked shape is `{ status, reason }` with nowhere to say *which* permission.

## `capability-unavailable`

Shared with `ContextActionUnavailableCode` deliberately, which is criterion 4. Both mean "the capability is not present"; the doc comment says so and says where to record a divergence if they ever diverge.

## Verification

- Guard: 76 reason literals across 38 plugin files, all permission-family ones canonical. 22 self-test cases.
- **Negative control**: planting `permission_denied` in `touch-browser-open` makes it fail at `index.js:286`; reverting makes it pass.
- `packages/test`: 17 files, 159 tests green. `packages/utils`: 187 files, 1348 tests green.
- CI step added next to the other `check:*` gates; workflow re-parsed as YAML to confirm the step is registered.

## Stated limitation

21 assertions across 11 files now reference the constant, but **this fails the test, not the build**. `packages/test` has no `typecheck` script and its CI job runs `vitest run` only, so a wrong *key* becomes `undefined` and the assertion fails at runtime rather than at compile time. Criterion 3 asked for "a rename fails the build rather than the test"; what is actually delivered is that a rename fails *something*, loudly, in CI. Closing that properly means giving `packages/test` a typecheck job, which is its own change.

Closes #1711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized blocked-action reason handling for plugin operations.
  * Added validation to detect inconsistent permission and capability-blocking messages.
* **Bug Fixes**
  * Improved consistency of blocked-result reasons across plugin functionality.
* **Tests**
  * Added automated checks and self-tests for blocked-reason usage.
  * Updated plugin tests to verify standardized permission and capability reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->