### PR TITLE
fix(sentry): install the renderer IPC bridge in the preload

### DIFF
--- a/apps/core-app/src/preload/index.ts
+++ b/apps/core-app/src/preload/index.ts
@@ -1,5 +1,20 @@
 import type { LoadingEvent, LoadingMode, StartupContext } from '@talex-touch/utils/preload'
 import type { StartupInfo } from '../shared/types/startup-info'
+/**
+ * Installs the IPC bridge `@sentry/electron/renderer` looks for on `window.__SENTRY_IPC__` (#1718).
+ *
+ * Imported for the side effect, which is the whole module. Without it the renderer SDK takes a
+ * documented fallback -- `fetch('sentry-ipc://envelope/…')` per envelope, plus a
+ * `window.__SENTRY_RENDERER_ID__` global -- and announces the switch through a `debug.log` nobody
+ * reads. The fallback works here (`preInitBeforeReady()` runs at `main/index.ts:252`, ahead of
+ * `app.whenReady()` at 257, so the SDK's `registerSchemesAsPrivileged` lands in time), so this is
+ * not a rescue. It is picking the intended path deliberately instead of arriving at the other one
+ * by omission.
+ *
+ * `preload-sentry-bridge.test.ts` asserts this import, because losing it is silent: the SDK falls
+ * back rather than failing, and the call site cannot tell the difference.
+ */
+import '@sentry/electron/preload'
 import { hasWindow } from '@talex-touch/utils/env'
 import { PRELOAD_LOADING_CHANNEL } from '@talex-touch/utils/preload'
 import { isCoreBox, isMainWindow } from '@talex-touch/utils/renderer/hooks/arg-mapper'

--- a/apps/core-app/src/preload/preload-sentry-bridge.test.ts
+++ b/apps/core-app/src/preload/preload-sentry-bridge.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const PRELOAD = readFileSync(path.join(here, 'index.ts'), 'utf8')
+const MAIN_INDEX = readFileSync(path.join(here, '..', 'main', 'index.ts'), 'utf8')
+
+/**
+ * #1718. `@sentry/electron/renderer` looks for an IPC bridge on `window.__SENTRY_IPC__` that the
+ * preload installs. When it is absent the SDK does not fail — it takes a documented fallback,
+ * `fetch('sentry-ipc://envelope/…')` per envelope plus a `window.__SENTRY_RENDERER_ID__` global,
+ * and says so through a `debug.log` nobody reads.
+ *
+ * That is why this is a test rather than a comment: the call site cannot tell the two apart, so
+ * deleting the import looks exactly like keeping it.
+ *
+ * Source-level rather than behavioural. Importing the preload here would pull in `electron`, and
+ * the bridge's observable effect is a `contextBridge.exposeInMainWorld` call in a renderer realm
+ * this suite does not have. The same shape as `duplicate-instance-bootstrap.test.ts`, which asserts
+ * ordering in `main/index.ts` by reading it.
+ */
+describe('#1718 sentry preload bridge', () => {
+  it('reads a preload that is actually there, so the assertions below are not vacuous', () => {
+    expect(PRELOAD.length).toBeGreaterThan(0)
+    expect(PRELOAD).toContain('contextBridge')
+    expect(MAIN_INDEX).toContain('app.whenReady()')
+  })
+
+  it('imports @sentry/electron/preload for its side effect', () => {
+    // Bare import: `preload/default.js` calls `hookupIpc()` at module scope. A named import would
+    // be wrong here — there is nothing to name, and a bundler may drop it.
+    expect(PRELOAD).toMatch(/^import '@sentry\/electron\/preload'$/m)
+  })
+
+  /**
+   * The finding that made #1718 a deliberate choice rather than a rescue.
+   *
+   * The issue's open question was whether renderer envelopes arrive at all: the SDK registers
+   * `sentry-ipc` through `protocol.registerSchemesAsPrivileged`, which Electron ignores after
+   * `ready`. If `Sentry.init` ran late, the fallback would fail outright and renderer errors would
+   * go nowhere. It does not — `preInitBeforeReady()` precedes `app.whenReady()`, so the fallback
+   * was working and the bridge is an upgrade, not a fix.
+   *
+   * Pinned here because that ordering is a one-line edit away from being wrong, and both paths
+   * would still look identical from the renderer.
+   */
+  it('pre-initialises Sentry before app.whenReady, which is what makes the scheme privileged', () => {
+    // Anchored to the start of a line and to `.then(`, not to the bare call. The first version
+    // searched for `app.whenReady()` and matched the *comment* two lines above the pre-init, which
+    // failed on correct code — the ordering is right, the assertion was reading prose.
+    const preInit = MAIN_INDEX.indexOf('sentryModule.preInitBeforeReady()')
+    const whenReady = MAIN_INDEX.search(/^app\.whenReady\(\)\.then\(/m)
+    expect(preInit, 'sentryModule.preInitBeforeReady() not found').toBeGreaterThanOrEqual(0)
+    expect(whenReady, 'top-level app.whenReady().then( not found').toBeGreaterThanOrEqual(0)
+    expect(preInit).toBeLessThan(whenReady)
+  })
+})


### PR DESCRIPTION
Closes #1718.

## The open question first, because it decides what this is

#1718 flagged one thing it had not verified: `registerSchemesAsPrivileged` must run before `app.ready`, and if `Sentry.init` ran late then `fetch('sentry-ipc://…')` would fail outright — meaning **renderer errors reported nowhere at all**. That would have made this a live gap rather than a tidy-up.

**They arrive.** The chain is `sentryModule.preInitBeforeReady()` → `initializeSentry()` → `Sentry.init()` → the SDK's `protocol.registerSchemesAsPrivileged` (`@sentry/electron/esm/main/ipc.js:181`), and the entry point calls it at `main/index.ts:252` against `app.whenReady()` at **257**. Electron ignores the privileged-scheme call after `ready`; it is not being made after `ready`.

The issue asked for this to be answered from a packaged build rather than a dev run. The ordering is the same source in both, and it is the ordering that decides it — so this is answered statically, and the assertion below pins it.

So the fallback was working. This picks the intended path deliberately instead of arriving at the other one by omission.

## The change

One side-effect import. `@sentry/electron/preload` resolves to `preload/default.js`, which calls `hookupIpc()` **at module scope** — so a bare import is correct and a named import would be wrong. It sets `window.__SENTRY_IPC__` and exposes it through `contextBridge`, which is exactly what `@sentry/electron/renderer` probes for before falling back to a `fetch` per envelope plus a `window.__SENTRY_RENDERER_ID__` global.

## Why a test rather than a comment

The fallback is indistinguishable from success at the call site. Deleting the import does not throw, does not warn anywhere a person will see, and does not change what the renderer's `Sentry.init` returns — it just quietly moves to the other transport and says so via `debug.log`. That is the same failure shape #1718 itself names.

Source-level assertion, matching `duplicate-instance-bootstrap.test.ts`: importing the preload here would pull in `electron`, and the bridge's only observable effect is a `contextBridge` call in a renderer realm this suite does not have.

## Verification

- 3 cases green.
- **Negative control**: removing the import turns the bridge case red; restoring it turns it back.
- **The ordering assertion caught itself first.** It searched for `app.whenReady()` and matched the *comment* two lines above the pre-init (`// Pre-initialize Sentry before \`app.whenReady()\`…`), so it failed against code that was correct. It now anchors to `^app\.whenReady\(\)\.then\(`.
- `typecheck:node` (which owns `src/preload/**/*`) reports 3 errors, all pre-existing and all in `local-ai-cli/index.ts` — optional deps `node-pty` and `@anthropic-ai/claude-agent-sdk`. Nothing from preload.
- `check:orphan-tests` sees the new file: 1357 test files, every one reachable by a CI job.

## Acceptance

- [x] Determine whether renderer envelopes currently arrive — yes, via the ordering above
- [x] Import `@sentry/electron/preload` in the preload entry
- [x] Assert the chosen path so a future refactor cannot drop it silently

Closes #1718