### PR TITLE
ci: re-derive flag defaults in maintenance-audit reports

### DIFF
--- a/scripts/check-audit-report-claims.mjs
+++ b/scripts/check-audit-report-claims.mjs
@@ -76,6 +76,71 @@ export function referencedTasks(markdown) {
   return [...new Set([...markdown.matchAll(TASK_REFERENCE)].map(match => match[1]))]
 }
 
+/** Where the runtime boolean flags are declared, as `parseEnvBoolean('NAME', true)`. */
+const FLAG_SOURCE = 'apps/core-app/src/main/db/runtime-flags.ts'
+const FLAG_DECLARATION = /parseEnvBoolean\(\s*'([A-Z][A-Z0-9_]*)'\s*,\s*(true|false)\s*\)/g
+
+/**
+ * Phrases asserting a default, in either language, mapped to what they assert.
+ *
+ * The vocabulary is deliberately the same as `packages/utils/__tests__/split-flag-docs.test.ts`,
+ * which owns `docs/` and `.trellis/spec` and *excludes* `docs/engineering/reports/` on the grounds
+ * that a dated report records what was true on its date and rewriting it falsifies the record.
+ * That exclusion is right, and it is also the hole #1107 is about: the reports written *after* the
+ * flip carried the stale claim forward. This closes it from the other side -- only reports dated
+ * after GATE_FROM are read, so history stays untouched and the next report has to be re-derived.
+ */
+const DEFAULT_CLAIMS = [
+  { pattern: /默认\s*\*{0,2}(?:关闭|off)/i, asserts: false },
+  { pattern: /defaults?\s+\*{0,2}off/i, asserts: false },
+  { pattern: /default[- ]off/i, asserts: false },
+  // `\b` only on the ASCII `on`, which needs it so `only` does not match. Putting it after a CJK
+  // alternation instead silently disables that branch -- `启` is not a `\w` character, so there is
+  // no boundary between it and the end of a line, and `默认开启` never matched. The "correct claim
+  // passes" cases went green on a pattern that could not fire; the inverted case is what caught it.
+  { pattern: /默认\s*\*{0,2}(?:开启|启用)/, asserts: true },
+  { pattern: /默认\s*\*{0,2}on\b/i, asserts: true },
+  { pattern: /defaults?\s+\*{0,2}on\b/i, asserts: true },
+  { pattern: /default[- ]on\b/i, asserts: true },
+]
+
+export function parseFlagDefaults(source) {
+  const defaults = new Map()
+  for (const match of source.matchAll(FLAG_DECLARATION))
+    defaults.set(match[1], match[2] === 'true')
+  return defaults
+}
+
+/**
+ * A report line naming a flag and asserting a default that the source contradicts.
+ *
+ * Line granularity, because these reports are one finding per bullet and the bullet that started
+ * #1107 carried both on the same line. A wider window would pair a flag in one bullet with a
+ * default claim in the next.
+ *
+ * The declared name is `TUFF_X`; reports also write the exported constant `X`. Both are matched, so
+ * `DB_SEARCH_SPLIT_ENABLED / TUFF_DB_SEARCH_SPLIT_ENABLED 默认关闭` is caught either way.
+ */
+export function findFlagClaims(reports, flagDefaults, readReport) {
+  const wrong = []
+  for (const report of reports) {
+    const lines = readReport(report).split('\n')
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index] ?? ''
+      for (const [flag, actual] of flagDefaults) {
+        const short = flag.startsWith('TUFF_') ? flag.slice(5) : flag
+        if (!line.includes(flag) && !line.includes(short))
+          continue
+        for (const claim of DEFAULT_CLAIMS) {
+          if (claim.pattern.test(line) && claim.asserts !== actual)
+            wrong.push({ report, line: index + 1, flag, claimed: claim.asserts, actual })
+        }
+      }
+    }
+  }
+  return wrong
+}
+
 export function gatedReports(names, gateFrom) {
   return names
     .map(name => ({ name, date: REPORT_NAME.exec(name)?.[1] }))
@@ -138,10 +203,41 @@ function main() {
     return 1
   }
 
+  const flagSource = path.join(repoRoot, FLAG_SOURCE)
+  if (!fs.existsSync(flagSource)) {
+    console.error(`${FLAG_SOURCE} is missing; flag defaults cannot be re-derived.`)
+    return 1
+  }
+  const flagDefaults = parseFlagDefaults(fs.readFileSync(flagSource, 'utf8'))
+  if (flagDefaults.size === 0) {
+    console.error(
+      `No parseEnvBoolean declarations found in ${FLAG_SOURCE}. An empty flag map asserts nothing,`
+      + ' so this is an error rather than a pass.',
+    )
+    return 1
+  }
+
+  const wrongFlags = findFlagClaims(reports, flagDefaults, readReport)
+  if (wrongFlags.length > 0) {
+    console.error('Maintenance-audit report states a flag default the source contradicts:\n')
+    for (const entry of wrongFlags) {
+      console.error(
+        `  ${REPORT_DIR}/${entry.report}:${entry.line}  ->  ${entry.flag} `
+        + `claimed default ${entry.claimed ? 'on' : 'off'}, actually ${entry.actual ? 'on' : 'off'}`,
+      )
+    }
+    console.error(
+      `\nRe-derived from ${FLAG_SOURCE}. #1107 exists because one such sentence appeared in eight`
+      + ' consecutive reports, three days after the default was inverted -- carried forward rather'
+      + ' than re-checked. Reports dated on or before the gate are history and are not read.',
+    )
+    return 1
+  }
+
   const checked = reports.reduce((total, report) => total + referencedTasks(readReport(report)).length, 0)
   console.log(
     `check-audit-report-claims: ${checked} task reference(s) across ${reports.length} report(s) `
-    + `all resolve; ${slugs.size} slugs known.`,
+    + `all resolve; ${slugs.size} slugs known; ${flagDefaults.size} flag default(s) re-derived.`,
   )
   return 0
 }
@@ -215,6 +311,39 @@ function selfTest() {
       expected: 1,
     },
   ]
+
+  // Flag-default half. The real declaration shape, plus a decoy that is not one.
+  const flagSource = [
+    'export const DB_AUX_ENABLED = parseEnvBoolean(\'TUFF_DB_AUX_ENABLED\', true)',
+    'export const DB_SEARCH_SPLIT_ENABLED = parseEnvBoolean(\'TUFF_DB_SEARCH_SPLIT_ENABLED\', true)',
+    'export const LEGACY = parseEnvBoolean(\'TUFF_LEGACY\', false)',
+    'function parseEnvBoolean(name: string, defaultValue: boolean): boolean {',
+  ].join('\n')
+  const flags = parseFlagDefaults(flagSource)
+  const claim = text => findFlagClaims(['r.md'], flags, () => text)
+
+  cases.push(
+    { name: 'a default-on flag is parsed', actual: flags.get('TUFF_DB_SEARCH_SPLIT_ENABLED'), expected: true },
+    { name: 'a default-off flag is parsed', actual: flags.get('TUFF_LEGACY'), expected: false },
+    { name: 'the helper signature is not a declaration', actual: flags.has('name'), expected: false },
+    // The sentence from #1107, verbatim in shape: eight reports carried it after the flip.
+    { name: 'the bullet that started #1107 is caught', actual: claim('- `DB_SEARCH_SPLIT_ENABLED` / `TUFF_DB_SEARCH_SPLIT_ENABLED` 默认关闭，但环境变量仍可启用').length, expected: 1 },
+    { name: 'the exported short name alone is enough', actual: claim('`DB_SEARCH_SPLIT_ENABLED` 默认关闭').length, expected: 1 },
+    { name: 'the English spelling is caught', actual: claim('`TUFF_DB_SEARCH_SPLIT_ENABLED` defaults off today').length, expected: 1 },
+    { name: 'a hyphenated default-off is caught', actual: claim('TUFF_DB_SEARCH_SPLIT_ENABLED is a default-off safety gate').length, expected: 1 },
+    { name: 'bold markup between the words is caught', actual: claim('TUFF_DB_SEARCH_SPLIT_ENABLED 默认**关闭**').length, expected: 1 },
+    { name: 'the correct claim passes', actual: claim('`TUFF_DB_SEARCH_SPLIT_ENABLED` 默认开启').length, expected: 0 },
+    { name: 'the correct English claim passes', actual: claim('TUFF_DB_SEARCH_SPLIT_ENABLED defaults on').length, expected: 0 },
+    { name: 'a genuinely default-off flag described as off passes', actual: claim('`TUFF_LEGACY` 默认关闭').length, expected: 0 },
+    { name: 'that same flag described as on is caught', actual: claim('`TUFF_LEGACY` 默认开启').length, expected: 1 },
+    { name: 'a flag with no default claim is left alone', actual: claim('`TUFF_DB_SEARCH_SPLIT_ENABLED` still needs writer ownership').length, expected: 0 },
+    { name: 'a default claim with no flag is left alone', actual: claim('the search split 默认关闭').length, expected: 0 },
+    // Line granularity: a flag in one bullet must not pair with a claim in the next.
+    { name: 'a claim on a different line does not pair', actual: claim('- `TUFF_LEGACY` needs work\n- something else 默认开启').length, expected: 0 },
+    { name: 'the line number is reported', actual: claim('x\n`TUFF_LEGACY` 默认开启')[0]?.line, expected: 2 },
+    { name: 'what was claimed and what is true are both reported', actual: `${claim('`TUFF_LEGACY` 默认开启')[0]?.claimed}/${claim('`TUFF_LEGACY` 默认开启')[0]?.actual}`, expected: 'true/false' },
+    { name: 'an empty source yields an empty map', actual: parseFlagDefaults('nothing here').size, expected: 0 },
+  )
 
   let failed = 0
   for (const testCase of cases) {


### PR DESCRIPTION
#1107's second acceptance criterion, plus the spot-check for the third (in the issue comment, since criterion 4 forbids rewriting dated reports).

## The two mechanisms now split the surface instead of overlapping

`packages/utils/__tests__/split-flag-docs.test.ts` owns `docs/` and `.trellis/spec`, and **deliberately excludes `docs/engineering/reports/`** — a dated report records what was true on its date, and rewriting it falsifies the record rather than correcting it.

That exclusion is right, and it is also exactly the hole #1107 is about: the reports written *after* the flip carried the claim forward. This closes it from the other side. Only reports dated after `GATE_FROM` are read, so history stays untouched and the next report has to be re-derived.

## General, not one flag

The five `parseEnvBoolean('NAME', bool)` declarations in `runtime-flags.ts` are parsed, and any default claim on the same line as a flag name is compared against them. Both the `TUFF_` name and the exported short name match, because the #1107 bullet wrote both.

Line granularity on purpose: these reports are one finding per bullet, and a wider window would pair a flag in one bullet with a default claim in the next.

## The `on` patterns were broken and passing

`/默认\s*\*{0,2}(?:开启|启用|on)\b/` puts `\b` after a CJK alternation. `启` is not a `\w` character, so there is no boundary between it and end-of-line, and **that branch never fired**. Every "a correct claim passes" case was green on a pattern that could not match.

What caught it was the inverted case — a genuinely default-off flag described as *on*. That is the argument for asserting both directions rather than only the failure direction: a guard that only ever checks "the bad thing is caught" cannot tell a working matcher from a dead one.

## Verification

- 31 self-test cases, up from 13.
- **Negative control**: a post-gate report carrying #1107's sentence verbatim reports the flag, the line, what was claimed and what is true.
- Positive control on the parser: the `parseEnvBoolean` *helper signature* in the same file is not mistaken for a declaration.

## Stated limitation

**This is inert today.** No report is dated after 2026-08-12, the grandfather date, so the flag map is built and nothing is checked against it. It fires on the next report written. That is the same trade #1107's fourth criterion asks for, but it is worth saying plainly rather than letting a green check imply the reports were verified.

Refs #1107