### PR TITLE
chore(trellis): record why 13 planning tasks are not being worked

### DIFF
--- a/.trellis/tasks/07-28-rust-native-protocol-screenshot/task.json
+++ b/.trellis/tasks/07-28-rust-native-protocol-screenshot/task.json
@@ -25,5 +25,8 @@
   "parent": null,
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "blocker": "Deferred by docs/plan-prd/TODO.md:9 -- remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (release/runtime blockers: #326 OTA, #482 release notes) and lane 2 (search and cross-platform remediation: #334, #351) are both open.",
+    "nextAction": "Release condition: reopen when lanes 1 and 2 close. No bounded child is named yet because the ordering, not the scope, is what is blocking (#309)."
+  }
 }

--- a/.trellis/tasks/07-29-screenshot-annotation-editor/task.json
+++ b/.trellis/tasks/07-29-screenshot-annotation-editor/task.json
@@ -22,5 +22,8 @@
   "parent": "07-28-rust-screenshot-mvp",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "blocker": "Deferred by docs/plan-prd/TODO.md:9 -- remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (release/runtime blockers: #326 OTA, #482 release notes) and lane 2 (search and cross-platform remediation: #334, #351) are both open.",
+    "nextAction": "Release condition: reopen when lanes 1 and 2 close. No bounded child is named yet because the ordering, not the scope, is what is blocking (#309)."
+  }
 }

--- a/.trellis/tasks/07-29-screenshot-image-pin-history/task.json
+++ b/.trellis/tasks/07-29-screenshot-image-pin-history/task.json
@@ -22,5 +22,8 @@
   "parent": "07-28-rust-screenshot-mvp",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "blocker": "Deferred by docs/plan-prd/TODO.md:9 -- remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (release/runtime blockers: #326 OTA, #482 release notes) and lane 2 (search and cross-platform remediation: #334, #351) are both open.",
+    "nextAction": "Release condition: reopen when lanes 1 and 2 close. No bounded child is named yet because the ordering, not the scope, is what is blocking (#309)."
+  }
 }

--- a/.trellis/tasks/07-29-screenshot-long-capture/task.json
+++ b/.trellis/tasks/07-29-screenshot-long-capture/task.json
@@ -22,5 +22,8 @@
   "parent": "07-28-rust-screenshot-mvp",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "blocker": "Deferred by docs/plan-prd/TODO.md:9 -- remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (release/runtime blockers: #326 OTA, #482 release notes) and lane 2 (search and cross-platform remediation: #334, #351) are both open.",
+    "nextAction": "Release condition: reopen when lanes 1 and 2 close. No bounded child is named yet because the ordering, not the scope, is what is blocking (#309)."
+  }
 }

--- a/.trellis/tasks/07-29-screenshot-ocr-qr-color/task.json
+++ b/.trellis/tasks/07-29-screenshot-ocr-qr-color/task.json
@@ -22,5 +22,8 @@
   "parent": "07-28-rust-screenshot-mvp",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "blocker": "Deferred by docs/plan-prd/TODO.md:9 -- remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (release/runtime blockers: #326 OTA, #482 release notes) and lane 2 (search and cross-platform remediation: #334, #351) are both open.",
+    "nextAction": "Release condition: reopen when lanes 1 and 2 close. No bounded child is named yet because the ordering, not the scope, is what is blocking (#309)."
+  }
 }

--- a/.trellis/tasks/07-29-screenshot-packaged-evidence/task.json
+++ b/.trellis/tasks/07-29-screenshot-packaged-evidence/task.json
@@ -22,5 +22,8 @@
   "parent": "07-28-rust-screenshot-mvp",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "blocker": "Deferred by docs/plan-prd/TODO.md:9 -- remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (release/runtime blockers: #326 OTA, #482 release notes) and lane 2 (search and cross-platform remediation: #334, #351) are both open.",
+    "nextAction": "Release condition: reopen when lanes 1 and 2 close. No bounded child is named yet because the ordering, not the scope, is what is blocking (#309)."
+  }
 }

--- a/.trellis/tasks/08-05-ai-toolchain-suite/task.json
+++ b/.trellis/tasks/08-05-ai-toolchain-suite/task.json
@@ -27,5 +27,8 @@
   "parent": null,
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "blocker": "Deferred by docs/plan-prd/TODO.md:9 -- remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (release/runtime blockers: #326 OTA, #482 release notes) and lane 2 (search and cross-platform remediation: #334, #351) are both open. TODO.md:37 additionally names AI/Assistant/OmniPanel polish as paused until its execution lane is reached.",
+    "nextAction": "Release condition: reopen when lanes 1 and 2 close. No bounded child is named yet because the ordering, not the scope, is what is blocking (#309)."
+  }
 }

--- a/.trellis/tasks/08-05-reco-behavior-learning/task.json
+++ b/.trellis/tasks/08-05-reco-behavior-learning/task.json
@@ -22,5 +22,8 @@
   "parent": "08-05-search-audit-remediation",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "blocker": "Deferred by docs/plan-prd/TODO.md:9 -- remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (release/runtime blockers: #326 OTA, #482 release notes) and lane 2 (search and cross-platform remediation: #334, #351) are both open.",
+    "nextAction": "Release condition: reopen when lanes 1 and 2 close. No bounded child is named yet because the ordering, not the scope, is what is blocking (#309)."
+  }
 }

--- a/.trellis/tasks/08-05-reco-calendar-signal/task.json
+++ b/.trellis/tasks/08-05-reco-calendar-signal/task.json
@@ -22,5 +22,8 @@
   "parent": "08-05-search-audit-remediation",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "blocker": "Deferred by docs/plan-prd/TODO.md:9 -- remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (release/runtime blockers: #326 OTA, #482 release notes) and lane 2 (search and cross-platform remediation: #334, #351) are both open.",
+    "nextAction": "Release condition: reopen when lanes 1 and 2 close. No bounded child is named yet because the ordering, not the scope, is what is blocking (#309)."
+  }
 }

--- a/.trellis/tasks/08-05-reco-file-activity-signals/task.json
+++ b/.trellis/tasks/08-05-reco-file-activity-signals/task.json
@@ -22,5 +22,8 @@
   "parent": "08-05-search-audit-remediation",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "blocker": "Deferred by docs/plan-prd/TODO.md:9 -- remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (release/runtime blockers: #326 OTA, #482 release notes) and lane 2 (search and cross-platform remediation: #334, #351) are both open.",
+    "nextAction": "Release condition: reopen when lanes 1 and 2 close. No bounded child is named yet because the ordering, not the scope, is what is blocking (#309)."
+  }
 }

--- a/.trellis/tasks/08-05-reco-signal-substrate/task.json
+++ b/.trellis/tasks/08-05-reco-signal-substrate/task.json
@@ -22,5 +22,8 @@
   "parent": "08-05-search-audit-remediation",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "blocker": "Deferred by docs/plan-prd/TODO.md:9 -- remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (release/runtime blockers: #326 OTA, #482 release notes) and lane 2 (search and cross-platform remediation: #334, #351) are both open.",
+    "nextAction": "Release condition: reopen when lanes 1 and 2 close. No bounded child is named yet because the ordering, not the scope, is what is blocking (#309)."
+  }
 }

--- a/.trellis/tasks/08-05-reco-system-state-signals/task.json
+++ b/.trellis/tasks/08-05-reco-system-state-signals/task.json
@@ -22,5 +22,8 @@
   "parent": "08-05-search-audit-remediation",
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "blocker": "Deferred by docs/plan-prd/TODO.md:9 -- remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (release/runtime blockers: #326 OTA, #482 release notes) and lane 2 (search and cross-platform remediation: #334, #351) are both open.",
+    "nextAction": "Release condition: reopen when lanes 1 and 2 close. No bounded child is named yet because the ordering, not the scope, is what is blocking (#309)."
+  }
 }

--- a/.trellis/tasks/08-05-tuffex-ai-suite/task.json
+++ b/.trellis/tasks/08-05-tuffex-ai-suite/task.json
@@ -27,5 +27,8 @@
   "parent": null,
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "blocker": "Deferred by docs/plan-prd/TODO.md:9 -- remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (release/runtime blockers: #326 OTA, #482 release notes) and lane 2 (search and cross-platform remediation: #334, #351) are both open. TODO.md:37 additionally names AI/Assistant/OmniPanel polish as paused until its execution lane is reached.",
+    "nextAction": "Release condition: reopen when lanes 1 and 2 close. No bounded child is named yet because the ordering, not the scope, is what is blocking (#309)."
+  }
 }


### PR DESCRIPTION
#309's third criterion. 14 active tasks had no `meta.nextAction`, `blocker` or `evidence` at all.

They are planned, not empty — each has `prd`, `implement` and `check` artifacts. What they do not say is **why they are sitting still**, which is the difference between a backlog and an ambiguous active list.

## 13 of the 14, and the exception is the point

My own earlier comment on #309 proposed one blanket deferral, grouped as "six screenshot, six recommendation/AI, one OTA". **That would have been wrong.** The OTA one is `07-17-unify-ota-update-flow`, and OTA is TODO.md's **lane 1** — the highest-priority release blocker, not something deferred.

Marking a release blocker as deferred is precisely the untruthful record #309 exists to remove. It is left untouched here and reported on the issue for the maintainer, because *why a lane-1 blocker is not moving* is their information, not something I can derive.

## The wording is a citation, not a judgement

Following the precedent already in the tree (`07-13-search-crossplatform-audit`, `07-13-catalog-service-mvp`):

> Deferred by `docs/plan-prd/TODO.md:9` — remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (#326, #482) and lane 2 (#334, #351) are both open.

Every clause is checkable. The two AI suites additionally cite `TODO.md:37`, which names AI/Assistant/OmniPanel polish as paused **by name** — the screenshot cluster is not named there, so it is not claimed to be.

`nextAction` says no bounded child is named because *the ordering is what blocks, not the scope*. That is the honest answer and it is falsifiable; an invented child would not be.

## Verification

- 13/13 pass `task.py validate`.
- `docs:verify` passes, including its `DOC-TASK-META` rule.
- `git status` shows exactly 13 changed files — no collateral edits in a tree several agents write to.

Refs #309