### PR TITLE
ci(linux): launch the packaged app instead of only counting it

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -650,9 +650,16 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
-          set -uo pipefail
+          # -e is on so a failed apt-get stops here. Without it the step would carry on and the
+          # launch would exit for a provisioning reason -- a missing xvfb-run gives an exit code
+          # with no output, which classifies as unknown-exit and is reported as a *product*
+          # failure. Misattributing CI breakage to the app is the one outcome this check must not
+          # produce. Found by CodeRabbit on #1736.
+          set -euo pipefail
           sudo apt-get update -qq
+          # t64 names are the 24.04 spelling; the fallback covers an older image if the runner moves.
           sudo apt-get install -y -qq xvfb libgbm1 libnss3 libasound2t64 libgtk-3-0t64 || sudo apt-get install -y -qq xvfb libgbm1 libnss3 libasound2 libgtk-3-0
+          command -v xvfb-run >/dev/null || { echo "xvfb-run missing after install"; exit 1; }
 
           APPIMAGE=$(find apps/core-app/dist -name "*.AppImage" -type f | head -1)
           if [ -z "$APPIMAGE" ]; then

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -635,6 +635,55 @@ jobs:
           echo ""
           echo "✓ Build completed successfully"
 
+      # #213 has been open since 2025-11-14 on "Ubuntu 24.04 启动不了". The step above counts
+      # .AppImage and .deb files and asserts the count is non-zero -- but a file that exists and a
+      # file that runs are different claims, and only the first was ever checked. Nothing in this
+      # repository has ever started the Linux artifact, which is why the thread spent nine months
+      # asking the reporter for logs nobody here could produce.
+      #
+      # The runner is already ubuntu-24.04, pinned in the matrix: the reproduction environment was
+      # here the whole time. This launches the AppImage under a virtual X server and reads why it
+      # stopped, if it stopped. AppImage rather than .deb on purpose -- electron-builder ships a
+      # .deb with an AppArmor profile that exempts it from the 24.04 userns restriction, and an
+      # AppImage cannot carry one, so the AppImage is the artifact the report is most likely about.
+      - name: "Smoke: launch the packaged Linux app"
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          set -uo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq xvfb libgbm1 libnss3 libasound2t64 libgtk-3-0t64 || sudo apt-get install -y -qq xvfb libgbm1 libnss3 libasound2 libgtk-3-0
+
+          APPIMAGE=$(find apps/core-app/dist -name "*.AppImage" -type f | head -1)
+          if [ -z "$APPIMAGE" ]; then
+            echo "No .AppImage to launch. The verification step above should already have failed."
+            exit 1
+          fi
+          chmod +x "$APPIMAGE"
+          echo "Launching $APPIMAGE"
+
+          # --appimage-extract-and-run avoids needing FUSE, which the runner does not have. It
+          # changes how the file is mounted, not how the app sandboxes, so the thing #213 is about
+          # is still exercised.
+          set +e
+          timeout --signal=TERM 45s xvfb-run -a --server-args="-screen 0 1280x1024x24" "$APPIMAGE" --appimage-extract-and-run --disable-gpu > /tmp/launch.log 2>&1
+          CODE=$?
+          set -e
+
+          # 124 is timeout's own code for "still running when I killed it", which is the success
+          # shape here: a launcher that is alive after 45s started. Any other code means it exited.
+          if [ "$CODE" -eq 124 ]; then STATE=alive; else STATE=dead; fi
+          echo "exit=$CODE state=$STATE"
+          node scripts/classify-linux-launch.mjs /tmp/launch.log "$CODE" "$STATE"
+
+      - name: Upload Linux launch log
+        if: always() && matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v7
+        with:
+          name: linux-launch-log-${{ github.run_id }}
+          path: /tmp/launch.log
+          if-no-files-found: ignore
+
       - name: Verify macOS Release Signing
         if: matrix.os == 'macos-latest'
         shell: bash

--- a/scripts/classify-linux-launch.mjs
+++ b/scripts/classify-linux-launch.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+/**
+ * Says why the packaged Linux app did not start, from what it printed (#213).
+ *
+ * #213 has been open since 2025-11-14. The reporter answered three times -- "还没兼容吗" -- and never
+ * sent the one diagnostic bit the thread was waiting on. Nine months of waiting on a person is a
+ * signal about the process, not about them: nothing in this repository has ever started the Linux
+ * artifact. `build-and-release.yml` counts `.AppImage` and `.deb` files and asserts the count is
+ * non-zero. A file that exists and a file that runs are different claims, and only the first one
+ * was ever checked.
+ *
+ * The build already runs on `ubuntu-24.04` -- pinned in the matrix, the exact platform in the
+ * report -- so the reproduction environment was there the whole time. All that was missing was
+ * launching the thing.
+ *
+ * This does the reading half. A launch failure prints many lines and one of them says why; a step
+ * that only reports "exit 1" turns a specific, fixable cause into an unspecific one, which is how
+ * this issue spent nine months on "please send logs".
+ *
+ * Ordering matters: a missing shared library and a denied sandbox both end in a non-zero exit, and
+ * the sandbox message is the one #213 is about, so it is matched first.
+ */
+import fs from 'node:fs'
+import process from 'node:process'
+
+/**
+ * Ubuntu 24.04 sets `kernel.apparmor_restrict_unprivileged_userns=1`, which stops Electron from
+ * creating its sandbox. `.deb` installs carry an AppArmor profile -- electron-builder's
+ * `FpmTarget` falls back to a built-in `apparmor-profile.tpl` even when `appArmorProfile` is unset,
+ * so this repo gets one without configuring it. An AppImage is a file the user runs, not a package
+ * that installs anything, so it gets no profile and no exemption.
+ *
+ * That asymmetry is the whole reason the thread needed to know which artifact was used.
+ */
+const SANDBOX_PATTERNS = [
+  /SUID sandbox helper binary was found, but is not configured correctly/i,
+  /setuid_sandbox_host\.cc/i,
+  /Failed to move to new namespace/i,
+  /clone\(\) returned -1/i,
+  /No usable sandbox/i,
+  /namespace sandbox/i,
+  /apparmor_restrict_unprivileged_userns/i,
+]
+
+/** A runner missing an Electron runtime dependency, which is a CI problem and not a product one. */
+const MISSING_LIBRARY_PATTERNS = [
+  /error while loading shared libraries: (lib[\w.+-]+)/i,
+  /cannot open shared object file/i,
+]
+
+/** No X server. Also a CI problem: the step is supposed to provide one. */
+const NO_DISPLAY_PATTERNS = [
+  /Missing X server or \$DISPLAY/i,
+  /cannot open display/i,
+  /Unable to open X display/i,
+]
+
+export function classifyLaunch({ output, exitCode, stayedAlive }) {
+  const text = String(output ?? '')
+
+  // Checked before the exit code, not after. A sandbox refusal can appear on a run that was killed
+  // by the timeout rather than exiting, and reporting that one as "started" would be the same
+  // false pass this whole check exists to remove.
+  if (SANDBOX_PATTERNS.some(pattern => pattern.test(text)))
+    return { verdict: 'sandbox-denied', product: true }
+
+  if (NO_DISPLAY_PATTERNS.some(pattern => pattern.test(text)))
+    return { verdict: 'no-display', product: false }
+
+  for (const pattern of MISSING_LIBRARY_PATTERNS) {
+    const match = pattern.exec(text)
+    if (match)
+      return { verdict: 'missing-library', product: false, detail: match[1] }
+  }
+
+  if (stayedAlive)
+    return { verdict: 'ok', product: false }
+
+  return { verdict: 'unknown-exit', product: true, detail: `exit ${exitCode}` }
+}
+
+const DESCRIPTIONS = {
+  'sandbox-denied': 'The app could not create its sandbox. This is #213: Ubuntu 24.04 restricts '
+    + 'unprivileged user namespaces, a .deb carries an AppArmor profile and an AppImage cannot.',
+  'no-display': 'No X server was available. The smoke step is supposed to provide one, so this is '
+    + 'a problem with the step rather than with the build.',
+  'missing-library': 'The runner is missing an Electron runtime dependency. A CI environment gap, '
+    + 'not a product defect -- add the package rather than changing the app.',
+  'unknown-exit': 'The app exited without printing anything this recognises. The captured output '
+    + 'is the only evidence; read it rather than assuming a cause.',
+  'ok': 'The packaged app started and was still running when the window opened.',
+}
+
+function main(argv) {
+  const outputPath = argv[0]
+  const exitCode = Number(argv[1] ?? 0)
+  const stayedAlive = argv[2] === 'alive'
+
+  if (!outputPath || !fs.existsSync(outputPath)) {
+    console.error(`classify-linux-launch: no captured output at ${outputPath ?? '<missing>'}.`)
+    console.error('Refusing to report a verdict with nothing to read -- an empty log is not a pass.')
+    return 1
+  }
+
+  const output = fs.readFileSync(outputPath, 'utf8')
+  const result = classifyLaunch({ output, exitCode, stayedAlive })
+
+  console.log(`verdict: ${result.verdict}`)
+  console.log(DESCRIPTIONS[result.verdict])
+  if (result.detail)
+    console.log(`detail: ${result.detail}`)
+
+  if (result.verdict === 'ok')
+    return 0
+
+  console.error('\n--- captured output ---')
+  console.error(output.trim().split('\n').slice(-40).join('\n'))
+  return 1
+}
+
+function selfTest() {
+  const cases = [
+    {
+      name: 'a clean start is ok',
+      actual: classifyLaunch({ output: 'ready', exitCode: 0, stayedAlive: true }).verdict,
+      expected: 'ok',
+    },
+    // The message #213 is about, in the two spellings Electron actually prints.
+    {
+      name: 'the SUID helper message is the sandbox verdict',
+      actual: classifyLaunch({
+        output: 'The SUID sandbox helper binary was found, but is not configured correctly',
+        exitCode: 1,
+        stayedAlive: false,
+      }).verdict,
+      expected: 'sandbox-denied',
+    },
+    {
+      name: 'the setuid_sandbox_host trace is the sandbox verdict',
+      actual: classifyLaunch({
+        output: 'FATAL:setuid_sandbox_host.cc(158)',
+        exitCode: 133,
+        stayedAlive: false,
+      }).verdict,
+      expected: 'sandbox-denied',
+    },
+    {
+      name: 'the namespace failure is the sandbox verdict',
+      actual: classifyLaunch({
+        output: 'Failed to move to new namespace: PID namespaces supported',
+        exitCode: 1,
+        stayedAlive: false,
+      }).verdict,
+      expected: 'sandbox-denied',
+    },
+    {
+      name: 'the sysctl name itself is the sandbox verdict',
+      actual: classifyLaunch({
+        output: 'kernel.apparmor_restrict_unprivileged_userns is 1',
+        exitCode: 1,
+        stayedAlive: false,
+      }).verdict,
+      expected: 'sandbox-denied',
+    },
+    // The ordering case. A run killed by the timeout is "alive", and reporting a sandbox refusal
+    // as a successful start is the false pass this exists to prevent.
+    {
+      name: 'a sandbox refusal outranks having stayed alive',
+      actual: classifyLaunch({
+        output: 'No usable sandbox! Update your kernel',
+        exitCode: 0,
+        stayedAlive: true,
+      }).verdict,
+      expected: 'sandbox-denied',
+    },
+    { name: 'a sandbox failure is a product problem', actual: classifyLaunch({ output: 'No usable sandbox', exitCode: 1, stayedAlive: false }).product, expected: true },
+    {
+      name: 'a missing library is a CI problem, not a product one',
+      actual: classifyLaunch({
+        output: 'error while loading shared libraries: libgbm.so.1',
+        exitCode: 127,
+        stayedAlive: false,
+      }).product,
+      expected: false,
+    },
+    {
+      name: 'the missing library is named',
+      actual: classifyLaunch({
+        output: 'error while loading shared libraries: libgbm.so.1: cannot open shared object file',
+        exitCode: 127,
+        stayedAlive: false,
+      }).detail,
+      expected: 'libgbm.so.1',
+    },
+    {
+      name: 'a missing display blames the step, not the build',
+      actual: classifyLaunch({
+        output: 'Missing X server or $DISPLAY',
+        exitCode: 1,
+        stayedAlive: false,
+      }).product,
+      expected: false,
+    },
+    {
+      name: 'the sandbox check wins over a missing library on the same run',
+      actual: classifyLaunch({
+        output: 'error while loading shared libraries: libx.so\nNo usable sandbox!',
+        exitCode: 1,
+        stayedAlive: false,
+      }).verdict,
+      expected: 'sandbox-denied',
+    },
+    {
+      name: 'an unrecognised exit says so instead of guessing',
+      actual: classifyLaunch({ output: 'segfault', exitCode: 139, stayedAlive: false }).verdict,
+      expected: 'unknown-exit',
+    },
+    { name: 'an unrecognised exit carries the code', actual: classifyLaunch({ output: 'x', exitCode: 139, stayedAlive: false }).detail, expected: 'exit 139' },
+    { name: 'an unrecognised exit is treated as a product problem', actual: classifyLaunch({ output: 'x', exitCode: 139, stayedAlive: false }).product, expected: true },
+    { name: 'empty output with a live process is still ok', actual: classifyLaunch({ output: '', exitCode: 0, stayedAlive: true }).verdict, expected: 'ok' },
+    { name: 'empty output with a dead process is not ok', actual: classifyLaunch({ output: '', exitCode: 1, stayedAlive: false }).verdict, expected: 'unknown-exit' },
+    { name: 'null output does not throw', actual: classifyLaunch({ output: null, exitCode: 0, stayedAlive: true }).verdict, expected: 'ok' },
+    { name: 'matching is case-insensitive', actual: classifyLaunch({ output: 'NO USABLE SANDBOX', exitCode: 1, stayedAlive: false }).verdict, expected: 'sandbox-denied' },
+    { name: 'every verdict has a description', actual: Object.keys(DESCRIPTIONS).length, expected: 5 },
+  ]
+
+  let failed = 0
+  for (const testCase of cases) {
+    if (!Object.is(testCase.actual, testCase.expected)) {
+      failed += 1
+      console.error(`  x ${testCase.name}: expected ${testCase.expected}, got ${testCase.actual}`)
+    }
+  }
+  console.log(
+    failed === 0
+      ? `classify-linux-launch --self-test: ${cases.length} cases passed`
+      : `classify-linux-launch --self-test: ${failed} of ${cases.length} cases failed`,
+  )
+  return failed
+}
+
+if (process.argv.includes('--self-test'))
+  process.exit(selfTest() > 0 ? 1 : 0)
+else process.exit(main(process.argv.slice(2)))


### PR DESCRIPTION
#213 has been open since **2025-11-14**. The reporter replied three times — "还没兼容吗" — and never sent the diagnostic the thread was waiting on.

Nine months of waiting on a person is a signal about the process, not about them. So I stopped waiting and checked what this repository actually knows about the Linux build.

## Nothing here has ever started it

`build-and-release.yml` counts `.AppImage` and `.deb` files and asserts the count is non-zero. **A file that exists and a file that runs are different claims, and only the first was ever checked.**

Positive control on that scan, because "no matches" is exactly what a broken scan reports: zero hits for `xvfb`, `smoke` or `launch` across every workflow, on a `run:`-grep that returns plenty.

And the reproduction environment was already here — the build matrix pins `image: ubuntu-24.04`, the exact platform in the report. All that was missing was launching the thing.

## AppImage, not `.deb`, deliberately

electron-builder's `FpmTarget` falls back to a built-in `apparmor-profile.tpl` when `appArmorProfile` is unset, so this repo's `.deb` carries a profile that exempts it from 24.04's `kernel.apparmor_restrict_unprivileged_userns` **without anyone configuring it**. An AppImage is a file the user runs, not a package that installs anything, so it gets no profile.

That asymmetry is precisely what the thread has been asking the reporter to disambiguate for nine months. It is cheaper to test the hypothesis than to keep asking.

## Why a classifier and not just an exit code

A launch failure prints twenty lines and one of them says why. A step that reports only `exit 1` converts a specific, fixable cause into an unspecific one — which is how this issue spent nine months on "please send logs".

`classify-linux-launch.mjs` separates:

| verdict | product problem? |
| --- | --- |
| `sandbox-denied` | **yes** — this is #213 |
| `unknown-exit` | **yes** — with the code, and the last 40 lines printed |
| `missing-library` | no — names the `.so`, it is a runner gap |
| `no-display` | no — the step failed to provide an X server |

A red build says which, so nobody has to guess whether CI or the product broke.

## The ordering is load-bearing, and self-tested

`timeout` returns **124** when the process was still running — that is the success shape. But a sandbox refusal can print *and* have the process linger, so a run can be both "alive" and broken. The sandbox check therefore runs **before** the alive check; reporting a refusal as a successful start would be exactly the false pass this exists to remove. That is an explicit self-test case.

19 self-test cases total, including both Electron spellings of the sandbox message, the `sysctl` name itself, and sandbox-outranks-missing-library on the same run.

## Verification

- 19/19 self-test cases pass.
- End to end: a real sandbox log → `sandbox-denied`, exit 1. A clean log → `ok`, exit 0. A **missing** log → exit 1, because an empty log is not a pass.
- `actionlint` delta **0** against HEAD (4 pre-existing SC2129 style notes at lines 170 and 1070, untouched).
- YAML re-parsed to confirm both steps register with the right `if:` conditions.
- The launch log is uploaded on failure, so the evidence outlives the run.

## What this does not do

It does not fix #213. It makes the answer arrive from CI instead of from a reporter who has not sent it in nine months. If it comes back `sandbox-denied`, that is the diagnosis confirmed and the fix is a separate change; if it comes back `ok`, the AppImage hypothesis is wrong and the thread needs to look elsewhere. **Either outcome is worth more than the current state, which is no information at all.**

Refs #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added automated Linux release launch checks to detect packaging and startup problems before release.
  * Improved diagnostics for sandbox restrictions, display failures, missing libraries, and unexpected exits.
  * Verified Linux AppImages can start in headless environments and remain responsive during validation.

* **Chores**
  * Linux launch logs are now preserved as build artifacts to support troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->