### PR TITLE
ci(macos): launch the packaged app, not just verify its signature

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -681,13 +681,67 @@ jobs:
           # shape here: a launcher that is alive after 45s started. Any other code means it exited.
           if [ "$CODE" -eq 124 ]; then STATE=alive; else STATE=dead; fi
           echo "exit=$CODE state=$STATE"
-          node scripts/classify-linux-launch.mjs /tmp/launch.log "$CODE" "$STATE"
+          node scripts/classify-app-launch.mjs /tmp/launch.log "$CODE" "$STATE"
 
       - name: Upload Linux launch log
         if: always() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v7
         with:
           name: linux-launch-log-${{ github.run_id }}
+          path: /tmp/launch.log
+          if-no-files-found: ignore
+
+      # The Linux half of this landed as #1736 and the reasoning is identical here: the verification
+      # step above counts artifacts, and a file that exists and a file that runs are different
+      # claims. macOS had one thing Linux did not -- a signing check -- which verifies the bundle is
+      # signed correctly and says nothing about whether it starts.
+      #
+      # The binary is launched directly out of Contents/MacOS rather than through `open`, because
+      # `open` returns as soon as LaunchServices accepts the request and would report success for a
+      # bundle that died a second later. A locally built bundle carries no quarantine attribute, so
+      # this is not sidestepping Gatekeeper -- there is nothing to sidestep.
+      - name: "Smoke: launch the packaged macOS app"
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+          APP=$(find apps/core-app/dist -type d -name "*.app" -prune -print | head -1)
+          if [ -z "$APP" ]; then
+            echo "No .app bundle to launch. The verification step above should already have failed."
+            exit 1
+          fi
+          BIN="$APP/Contents/MacOS/$(basename "$APP" .app)"
+          if [ ! -x "$BIN" ]; then
+            echo "Expected an executable at $BIN"
+            ls -la "$APP/Contents/MacOS" || true
+            exit 1
+          fi
+          echo "Launching $BIN"
+
+          set +e
+          # No coreutils `timeout` on the macOS runner. A background process plus a poll does the
+          # same job and, unlike `timeout`, distinguishes "still running" from "exited with 124".
+          "$BIN" > /tmp/launch.log 2>&1 &
+          PID=$!
+          sleep 45
+          if kill -0 "$PID" 2>/dev/null; then
+            STATE=alive
+            CODE=0
+            kill "$PID" 2>/dev/null || true
+          else
+            wait "$PID"
+            CODE=$?
+            STATE=dead
+          fi
+          set -e
+          echo "exit=$CODE state=$STATE"
+          node scripts/classify-app-launch.mjs /tmp/launch.log "$CODE" "$STATE"
+
+      - name: Upload macOS launch log
+        if: always() && matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-launch-log-${{ github.run_id }}
           path: /tmp/launch.log
           if-no-files-found: ignore
 

--- a/scripts/classify-app-launch.mjs
+++ b/scripts/classify-app-launch.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Says why the packaged Linux app did not start, from what it printed (#213).
+ * Says why a packaged app did not start, from what it printed (#213, #308).
  *
  * #213 has been open since 2025-11-14. The reporter answered three times -- "还没兼容吗" -- and never
  * sent the one diagnostic bit the thread was waiting on. Nine months of waiting on a person is a
@@ -55,6 +55,22 @@ const NO_DISPLAY_PATTERNS = [
   /Unable to open X display/i,
 ]
 
+/**
+ * macOS refusing to run the bundle at all (#308).
+ *
+ * A CI build is ad-hoc or Developer ID signed and never notarized, so Gatekeeper has an opinion.
+ * Launching `Contents/MacOS/<binary>` directly sidesteps the quarantine attribute -- a locally
+ * built bundle was never downloaded, so it has none -- but a *broken* signature still refuses, and
+ * that is a real product failure rather than a CI one. Kept separate from the sandbox family so a
+ * red build does not blame the wrong subsystem.
+ */
+const CODE_SIGNATURE_PATTERNS = [
+  /code signature[^\n]*not valid/i,
+  /cannot be opened because the developer cannot be verified/i,
+  /Library not loaded[\s\S]{0,200}code signature/i,
+  /killed: 9/i,
+]
+
 export function classifyLaunch({ output, exitCode, stayedAlive }) {
   const text = String(output ?? '')
 
@@ -63,6 +79,9 @@ export function classifyLaunch({ output, exitCode, stayedAlive }) {
   // false pass this whole check exists to remove.
   if (SANDBOX_PATTERNS.some(pattern => pattern.test(text)))
     return { verdict: 'sandbox-denied', product: true }
+
+  if (CODE_SIGNATURE_PATTERNS.some(pattern => pattern.test(text)))
+    return { verdict: 'code-signature', product: true }
 
   if (NO_DISPLAY_PATTERNS.some(pattern => pattern.test(text)))
     return { verdict: 'no-display', product: false }
@@ -88,6 +107,9 @@ const DESCRIPTIONS = {
     + 'not a product defect -- add the package rather than changing the app.',
   'unknown-exit': 'The app exited without printing anything this recognises. The captured output '
     + 'is the only evidence; read it rather than assuming a cause.',
+  'code-signature': 'macOS refused the bundle. The signature is broken or the binary was killed '
+    + 'by the kernel (SIGKILL 9 is what an invalid signature looks like from the shell), which is a '
+    + 'packaging defect rather than a runner gap.',
   'ok': 'The packaged app started and was still running when the window opened.',
 }
 
@@ -97,7 +119,7 @@ function main(argv) {
   const stayedAlive = argv[2] === 'alive'
 
   if (!outputPath || !fs.existsSync(outputPath)) {
-    console.error(`classify-linux-launch: no captured output at ${outputPath ?? '<missing>'}.`)
+    console.error(`classify-app-launch: no captured output at ${outputPath ?? '<missing>'}.`)
     console.error('Refusing to report a verdict with nothing to read -- an empty log is not a pass.')
     return 1
   }
@@ -221,7 +243,13 @@ function selfTest() {
     { name: 'empty output with a dead process is not ok', actual: classifyLaunch({ output: '', exitCode: 1, stayedAlive: false }).verdict, expected: 'unknown-exit' },
     { name: 'null output does not throw', actual: classifyLaunch({ output: null, exitCode: 0, stayedAlive: true }).verdict, expected: 'ok' },
     { name: 'matching is case-insensitive', actual: classifyLaunch({ output: 'NO USABLE SANDBOX', exitCode: 1, stayedAlive: false }).verdict, expected: 'sandbox-denied' },
-    { name: 'every verdict has a description', actual: Object.keys(DESCRIPTIONS).length, expected: 5 },
+    // macOS half (#308). Kept distinct from sandbox-denied so a red build names the right subsystem.
+    { name: 'an invalid signature is its own verdict', actual: classifyLaunch({ output: 'code signature in (...) not valid for use in process', exitCode: 1, stayedAlive: false }).verdict, expected: 'code-signature' },
+    { name: 'SIGKILL is what an invalid signature looks like from a shell', actual: classifyLaunch({ output: 'Killed: 9', exitCode: 137, stayedAlive: false }).verdict, expected: 'code-signature' },
+    { name: 'an unverified developer is the same verdict', actual: classifyLaunch({ output: 'cannot be opened because the developer cannot be verified', exitCode: 1, stayedAlive: false }).verdict, expected: 'code-signature' },
+    { name: 'a signature refusal is a product problem', actual: classifyLaunch({ output: 'Killed: 9', exitCode: 137, stayedAlive: false }).product, expected: true },
+    { name: 'a sandbox refusal still outranks a signature one', actual: classifyLaunch({ output: 'Killed: 9\nNo usable sandbox!', exitCode: 1, stayedAlive: false }).verdict, expected: 'sandbox-denied' },
+    { name: 'every verdict has a description', actual: Object.keys(DESCRIPTIONS).length, expected: 6 },
   ]
 
   let failed = 0
@@ -233,8 +261,8 @@ function selfTest() {
   }
   console.log(
     failed === 0
-      ? `classify-linux-launch --self-test: ${cases.length} cases passed`
-      : `classify-linux-launch --self-test: ${failed} of ${cases.length} cases failed`,
+      ? `classify-app-launch --self-test: ${cases.length} cases passed`
+      : `classify-app-launch --self-test: ${failed} of ${cases.length} cases failed`,
   )
   return failed
 }


### PR DESCRIPTION
The macOS half of what #1736 did for Linux. Same reasoning, one platform where the gap is more dangerous.

## Why macOS is the worse case

Linux only counted files. macOS counts files **and runs `Verify macOS Release Signing`** — which confirms the bundle is signed correctly and says nothing at all about whether it starts.

A correctly signed app that dies on launch passes that check. A green signing step reads like "the artifact was validated", and it validated one property that is not the one anybody cares about.

## The rename

`classify-linux-launch.mjs` → `classify-app-launch.mjs`. Renaming a file merged an hour ago is worth the churn: the name was wrong the moment a second caller existed, and a script called `classify-linux-launch` invoked from a macOS step is the kind of small lie that survives for years. No stale references remain — checked.

## macOS gets its own verdict, not the sandbox family

An invalid signature surfaces from a shell as `Killed: 9`. It shares nothing with a userns refusal except that both end in a dead process, and a red build naming the wrong subsystem is worse than no build.

| verdict | product problem? |
| --- | --- |
| `sandbox-denied` | yes — #213, Linux |
| `code-signature` | yes — #308, macOS: broken signature or SIGKILL |
| `unknown-exit` | yes — code + last 40 lines |
| `missing-library` | no — names the `.so` |
| `no-display` | no — the step failed to provide one |

A sandbox refusal still outranks a signature one when both appear. That is a self-test case, not an assumption.

## Two implementation notes, both about not measuring the wrong thing

**`open` is not used.** It returns as soon as LaunchServices accepts the request, so it reports success for a bundle that dies a second later — the exact false pass this check exists to remove. The binary is launched from `Contents/MacOS/` directly. That is not sidestepping Gatekeeper: a locally built bundle was never downloaded, so it carries no quarantine attribute and there is nothing to sidestep.

**No coreutils `timeout` on the macOS runner.** The process is backgrounded and polled with `kill -0`, which also distinguishes "still running" from "exited with 124" — something `timeout` conflates and which the Linux step has to infer.

## Verification

- **24 self-test cases**, up from 19.
- Verified locally against a real dyld signature failure (`code signature in (...) not valid`), a bare `Killed: 9`, a clean start, and a Linux sandbox log to confirm the rename caused no regression.
- Exit codes checked directly: signature failure → 1, clean start → 0, missing log → 1 (an empty log is not a pass).
- `actionlint` delta **0** against HEAD.
- YAML re-parsed: all four steps register with the right `if:` conditions.

## Scope

This does not close #308, which asks for interactive packaged CoreBox Everything acceptance on Windows — a different artifact and a different thing to verify. What it does is remove the same blind spot on the platform where a signing check was standing in for a launch check. Windows remains file-count-only; that is the next one, and it is harder because the artifact is an NSIS installer rather than a runnable bundle.

Refs #308