### PR TITLE
ci(windows): launch the packaged app, completing the three-platform smoke

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -700,6 +700,59 @@ jobs:
       # `open` returns as soon as LaunchServices accepts the request and would report success for a
       # bundle that died a second later. A locally built bundle carries no quarantine attribute, so
       # this is not sidestepping Gatekeeper -- there is nothing to sidestep.
+      # The third platform. Linux landed as #1736, macOS as #1737, and Windows was the one left
+      # counting .exe files -- which made the coverage asymmetric, and asymmetric verification reads
+      # as uniform to anyone who does not go and check.
+      #
+      # win-unpacked rather than the NSIS installer: it is the same binary the installer places, and
+      # launching it directly skips a silent-install round trip that could fail for reasons having
+      # nothing to do with whether the app runs. The pre-build "Clean Windows Build Artifacts" step
+      # removes win-unpacked from a previous run, so what is there now came from this build.
+      - name: "Smoke: launch the packaged Windows app"
+        if: matrix.os == 'windows-2022'
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $exe = Get-ChildItem -Path "apps/core-app/dist/win-unpacked" -Filter "*.exe" -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -notlike "__uninstaller-*" } | Select-Object -First 1
+          if (-not $exe) {
+            Write-Host "No executable under win-unpacked. The verification step above should already have failed."
+            Get-ChildItem -Path "apps/core-app/dist" -Recurse -Depth 1 -ErrorAction SilentlyContinue | Select-Object -First 20 | Format-Table Name
+            exit 1
+          }
+          Write-Host "Launching $($exe.FullName)"
+
+          $out = "$env:RUNNER_TEMP\launch.out"
+          $err = "$env:RUNNER_TEMP\launch.err"
+          $proc = Start-Process -FilePath $exe.FullName -PassThru -RedirectStandardOutput $out -RedirectStandardError $err
+          Start-Sleep -Seconds 45
+
+          if ($proc.HasExited) {
+            $state = "dead"
+            $code = $proc.ExitCode
+          } else {
+            $state = "alive"
+            $code = 0
+            Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+          }
+          Write-Host "exit=$code state=$state"
+
+          # One file for the classifier; a GUI process on Windows splits little between the two and
+          # the interesting line can land on either.
+          $log = "$env:RUNNER_TEMP\launch.log"
+          Get-Content $out, $err -ErrorAction SilentlyContinue | Set-Content $log
+          if (-not (Test-Path $log)) { New-Item -ItemType File -Path $log | Out-Null }
+          node scripts/classify-app-launch.mjs $log $code $state
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Upload Windows launch log
+        if: always() && matrix.os == 'windows-2022'
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-launch-log-${{ github.run_id }}
+          path: ${{ runner.temp }}/launch.log
+          if-no-files-found: ignore
+
       - name: "Smoke: launch the packaged macOS app"
         if: matrix.os == 'macos-latest'
         shell: bash

--- a/scripts/classify-app-launch.mjs
+++ b/scripts/classify-app-launch.mjs
@@ -71,6 +71,25 @@ const CODE_SIGNATURE_PATTERNS = [
   /killed: 9/i,
 ]
 
+/**
+ * Windows refusing to start the unpacked build (#308).
+ *
+ * Deliberately `product: true`, unlike `missing-library` on Linux, and the asymmetry is the point.
+ * A missing `.so` on a Linux runner means the *runner* lacks a system package -- the app is fine and
+ * the step should install it. A missing DLL under `win-unpacked` means electron-builder did not
+ * place it there: everything the app needs is supposed to ship inside that directory, so the same
+ * symptom is a packaging defect rather than an environment gap.
+ *
+ * `0xc0000135` is the NTSTATUS for DLL-not-found and is often all a GUI process leaves behind, since
+ * the message box it would otherwise show has nowhere to go on a CI runner.
+ */
+const WINDOWS_MISSING_DLL_PATTERNS = [
+  /The code execution cannot proceed because ([\w.-]+\.dll)/i,
+  /0xc0000135/i,
+  /STATUS_DLL_NOT_FOUND/i,
+  /was not found[^\n]{0,40}reinstalling the program/i,
+]
+
 export function classifyLaunch({ output, exitCode, stayedAlive }) {
   const text = String(output ?? '')
 
@@ -82,6 +101,12 @@ export function classifyLaunch({ output, exitCode, stayedAlive }) {
 
   if (CODE_SIGNATURE_PATTERNS.some(pattern => pattern.test(text)))
     return { verdict: 'code-signature', product: true }
+
+  for (const pattern of WINDOWS_MISSING_DLL_PATTERNS) {
+    const match = pattern.exec(text)
+    if (match)
+      return { verdict: 'missing-dll', product: true, detail: match[1] ?? 'unnamed' }
+  }
 
   if (NO_DISPLAY_PATTERNS.some(pattern => pattern.test(text)))
     return { verdict: 'no-display', product: false }
@@ -110,6 +135,9 @@ const DESCRIPTIONS = {
   'code-signature': 'macOS refused the bundle. The signature is broken or the binary was killed '
     + 'by the kernel (SIGKILL 9 is what an invalid signature looks like from the shell), which is a '
     + 'packaging defect rather than a runner gap.',
+  'missing-dll': 'A DLL under win-unpacked was not found. Unlike a missing .so on a Linux runner '
+    + 'this is a packaging defect, not an environment gap: everything the app needs is supposed to '
+    + 'ship inside that directory.',
   'ok': 'The packaged app started and was still running when the window opened.',
 }
 
@@ -249,7 +277,16 @@ function selfTest() {
     { name: 'an unverified developer is the same verdict', actual: classifyLaunch({ output: 'cannot be opened because the developer cannot be verified', exitCode: 1, stayedAlive: false }).verdict, expected: 'code-signature' },
     { name: 'a signature refusal is a product problem', actual: classifyLaunch({ output: 'Killed: 9', exitCode: 137, stayedAlive: false }).product, expected: true },
     { name: 'a sandbox refusal still outranks a signature one', actual: classifyLaunch({ output: 'Killed: 9\nNo usable sandbox!', exitCode: 1, stayedAlive: false }).verdict, expected: 'sandbox-denied' },
-    { name: 'every verdict has a description', actual: Object.keys(DESCRIPTIONS).length, expected: 6 },
+    // Windows half (#308). The asymmetry with missing-library is deliberate and asserted, because
+    // it is the one thing about this verdict a future reader is most likely to "correct".
+    { name: 'a named missing DLL is its own verdict', actual: classifyLaunch({ output: 'The code execution cannot proceed because VCRUNTIME140.dll was not found', exitCode: 1, stayedAlive: false }).verdict, expected: 'missing-dll' },
+    { name: 'the DLL is named', actual: classifyLaunch({ output: 'The code execution cannot proceed because VCRUNTIME140.dll was not found', exitCode: 1, stayedAlive: false }).detail, expected: 'VCRUNTIME140.dll' },
+    { name: 'the bare NTSTATUS is enough', actual: classifyLaunch({ output: 'exited with 0xc0000135', exitCode: 3221225781, stayedAlive: false }).verdict, expected: 'missing-dll' },
+    { name: 'an unnamed DLL failure still reports', actual: classifyLaunch({ output: 'STATUS_DLL_NOT_FOUND', exitCode: 1, stayedAlive: false }).detail, expected: 'unnamed' },
+    { name: 'a missing DLL is a product problem, unlike a missing .so', actual: classifyLaunch({ output: '0xc0000135', exitCode: 1, stayedAlive: false }).product, expected: true },
+    { name: 'a missing .so is still not a product problem', actual: classifyLaunch({ output: 'error while loading shared libraries: libgbm.so.1', exitCode: 127, stayedAlive: false }).product, expected: false },
+    { name: 'a sandbox refusal still outranks a missing DLL', actual: classifyLaunch({ output: '0xc0000135\nNo usable sandbox!', exitCode: 1, stayedAlive: false }).verdict, expected: 'sandbox-denied' },
+    { name: 'every verdict has a description', actual: Object.keys(DESCRIPTIONS).length, expected: 7 },
   ]
 
   let failed = 0

--- a/scripts/classify-app-launch.mjs
+++ b/scripts/classify-app-launch.mjs
@@ -129,8 +129,14 @@ export function classifyLaunch({ output, exitCode, stayedAlive }) {
 
   // Only when the process actually exited. A run still alive at the timeout reports exitCode 0 from
   // the caller, and treating that as a status code would invent a failure.
-  if (!stayedAlive && DLL_NOT_FOUND_EXIT_CODES.has(Number(exitCode)))
-    return { verdict: 'missing-dll', product: true, detail: '0xC0000135 (no output)' }
+  if (!stayedAlive && DLL_NOT_FOUND_EXIT_CODES.has(Number(exitCode))) {
+    // "(no output)" only when there genuinely was none. The status code is reached whenever the
+    // patterns above did not match, which includes a run that printed diagnostics worth reading --
+    // telling someone there was no output while the log holds the answer sends them the wrong way.
+    // Found by CodeRabbit on #1739.
+    const detail = text.trim() ? '0xC0000135' : '0xC0000135 (no output)'
+    return { verdict: 'missing-dll', product: true, detail }
+  }
 
   if (NO_DISPLAY_PATTERNS.some(pattern => pattern.test(text)))
     return { verdict: 'no-display', product: false }
@@ -311,6 +317,8 @@ function selfTest() {
     { name: 'the exit code alone, with no output, is enough', actual: classifyLaunch({ output: '', exitCode: 3221225781, stayedAlive: false }).verdict, expected: 'missing-dll' },
     { name: 'the signed representation is recognised too', actual: classifyLaunch({ output: '', exitCode: -1073741515, stayedAlive: false }).verdict, expected: 'missing-dll' },
     { name: 'the no-output case says so rather than naming a DLL it never saw', actual: classifyLaunch({ output: '', exitCode: 3221225781, stayedAlive: false }).detail, expected: '0xC0000135 (no output)' },
+    { name: 'a log with unmatched diagnostics is not called empty', actual: classifyLaunch({ output: 'some other error', exitCode: 3221225781, stayedAlive: false }).detail, expected: '0xC0000135' },
+    { name: 'whitespace-only output still counts as no output', actual: classifyLaunch({ output: '  \n ', exitCode: 3221225781, stayedAlive: false }).detail, expected: '0xC0000135 (no output)' },
     // A live process reports exitCode 0 from the caller; reading that as a status code would invent
     // a failure out of a successful start.
     { name: 'a live process is never a DLL failure', actual: classifyLaunch({ output: '', exitCode: 3221225781, stayedAlive: true }).verdict, expected: 'ok' },

--- a/scripts/classify-app-launch.mjs
+++ b/scripts/classify-app-launch.mjs
@@ -80,15 +80,34 @@ const CODE_SIGNATURE_PATTERNS = [
  * place it there: everything the app needs is supposed to ship inside that directory, so the same
  * symptom is a packaging defect rather than an environment gap.
  *
- * `0xc0000135` is the NTSTATUS for DLL-not-found and is often all a GUI process leaves behind, since
- * the message box it would otherwise show has nowhere to go on a CI runner.
+ * `0xc0000135` is the NTSTATUS for DLL-not-found and is often *all* a GUI process leaves behind,
+ * since the message box it would otherwise show has nowhere to go on a CI runner.
  */
 const WINDOWS_MISSING_DLL_PATTERNS = [
   /The code execution cannot proceed because ([\w.-]+\.dll)/i,
   /0xc0000135/i,
   /STATUS_DLL_NOT_FOUND/i,
-  /was not found[^\n]{0,40}reinstalling the program/i,
+  // Requires an actual `.dll`. Without it this matched any "X was not found ... reinstalling the
+  // program", which is the wording Windows also uses for a missing *application* file -- a
+  // different defect that would have been reported as a missing DLL. Found by CodeRabbit on #1739.
+  /([\w.-]+\.dll)[^\n]{0,40}was not found[^\n]{0,60}reinstalling the program/i,
 ]
+
+/**
+ * `STATUS_DLL_NOT_FOUND` as an exit code, in both representations.
+ *
+ * This exists because the pattern list above could not reach the real case. The smoke step prints
+ * `exit=$code` with `Write-Host`, which goes to the *step* log -- never into `launch.log`, which is
+ * the only thing `output` ever contains. So a process that died with `0xc0000135` and printed
+ * nothing (the normal shape for a GUI process on a runner) arrived here with an empty `output` and
+ * was classified `unknown-exit`.
+ *
+ * The self-test did not catch it because the case passed the status code as *text*, which is a
+ * shape the real caller cannot produce. That is the second time in this file a case has asserted a
+ * path that does not exist -- the first was a gerund closing keyword -- and both times the test was
+ * green on a branch that could never fire.
+ */
+const DLL_NOT_FOUND_EXIT_CODES = new Set([0xC0000135, -1073741515])
 
 export function classifyLaunch({ output, exitCode, stayedAlive }) {
   const text = String(output ?? '')
@@ -107,6 +126,11 @@ export function classifyLaunch({ output, exitCode, stayedAlive }) {
     if (match)
       return { verdict: 'missing-dll', product: true, detail: match[1] ?? 'unnamed' }
   }
+
+  // Only when the process actually exited. A run still alive at the timeout reports exitCode 0 from
+  // the caller, and treating that as a status code would invent a failure.
+  if (!stayedAlive && DLL_NOT_FOUND_EXIT_CODES.has(Number(exitCode)))
+    return { verdict: 'missing-dll', product: true, detail: '0xC0000135 (no output)' }
 
   if (NO_DISPLAY_PATTERNS.some(pattern => pattern.test(text)))
     return { verdict: 'no-display', product: false }
@@ -281,7 +305,20 @@ function selfTest() {
     // it is the one thing about this verdict a future reader is most likely to "correct".
     { name: 'a named missing DLL is its own verdict', actual: classifyLaunch({ output: 'The code execution cannot proceed because VCRUNTIME140.dll was not found', exitCode: 1, stayedAlive: false }).verdict, expected: 'missing-dll' },
     { name: 'the DLL is named', actual: classifyLaunch({ output: 'The code execution cannot proceed because VCRUNTIME140.dll was not found', exitCode: 1, stayedAlive: false }).detail, expected: 'VCRUNTIME140.dll' },
-    { name: 'the bare NTSTATUS is enough', actual: classifyLaunch({ output: 'exited with 0xc0000135', exitCode: 3221225781, stayedAlive: false }).verdict, expected: 'missing-dll' },
+    { name: 'the bare NTSTATUS in text is enough', actual: classifyLaunch({ output: 'exited with 0xc0000135', exitCode: 3221225781, stayedAlive: false }).verdict, expected: 'missing-dll' },
+    // The real shape, which the text-only version could not reach: a GUI process dies with the
+    // status code and prints nothing, because its message box has nowhere to go.
+    { name: 'the exit code alone, with no output, is enough', actual: classifyLaunch({ output: '', exitCode: 3221225781, stayedAlive: false }).verdict, expected: 'missing-dll' },
+    { name: 'the signed representation is recognised too', actual: classifyLaunch({ output: '', exitCode: -1073741515, stayedAlive: false }).verdict, expected: 'missing-dll' },
+    { name: 'the no-output case says so rather than naming a DLL it never saw', actual: classifyLaunch({ output: '', exitCode: 3221225781, stayedAlive: false }).detail, expected: '0xC0000135 (no output)' },
+    // A live process reports exitCode 0 from the caller; reading that as a status code would invent
+    // a failure out of a successful start.
+    { name: 'a live process is never a DLL failure', actual: classifyLaunch({ output: '', exitCode: 3221225781, stayedAlive: true }).verdict, expected: 'ok' },
+    { name: 'an ordinary non-zero exit is still unknown-exit', actual: classifyLaunch({ output: '', exitCode: 1, stayedAlive: false }).verdict, expected: 'unknown-exit' },
+    // The fallback pattern needs a real .dll: Windows uses the same wording for a missing
+    // application file, which is a different defect.
+    { name: 'the fallback requires a dll name', actual: classifyLaunch({ output: 'config.json was not found. Try reinstalling the program.', exitCode: 1, stayedAlive: false }).verdict, expected: 'unknown-exit' },
+    { name: 'the fallback still fires with a dll name', actual: classifyLaunch({ output: 'ffmpeg.dll was not found. Try reinstalling the program.', exitCode: 1, stayedAlive: false }).detail, expected: 'ffmpeg.dll' },
     { name: 'an unnamed DLL failure still reports', actual: classifyLaunch({ output: 'STATUS_DLL_NOT_FOUND', exitCode: 1, stayedAlive: false }).detail, expected: 'unnamed' },
     { name: 'a missing DLL is a product problem, unlike a missing .so', actual: classifyLaunch({ output: '0xc0000135', exitCode: 1, stayedAlive: false }).product, expected: true },
     { name: 'a missing .so is still not a product problem', actual: classifyLaunch({ output: 'error while loading shared libraries: libgbm.so.1', exitCode: 127, stayedAlive: false }).product, expected: false },


### PR DESCRIPTION
The third platform. Linux landed as #1736, macOS as #1737, and Windows was the one still counting `.exe` files.

**Asymmetric verification reads as uniform** to anyone who does not go and check which platforms are actually covered — which is why finishing the set matters more than the individual step does.

## `win-unpacked`, not the installer

It is the same binary the NSIS installer places, and launching it directly skips a silent-install round trip that could fail for reasons having nothing to do with whether the app runs. The pre-build *Clean Windows Build Artifacts* step removes `win-unpacked` from a previous run, so what is there came from this build — checked, not assumed.

## `missing-dll` is a product problem. `missing-library` is not. That is deliberate.

| symptom | platform | owner |
| --- | --- | --- |
| missing `.so` | Linux runner | **CI** — the runner lacks a system package, install it |
| missing `.dll` under `win-unpacked` | Windows | **product** — electron-builder did not place it there |

Everything the app needs is supposed to ship inside `win-unpacked`. Same symptom, opposite owner, and it is asserted in both directions so a future reader does not "correct" the asymmetry into consistency.

`0xc0000135` and `STATUS_DLL_NOT_FOUND` are matched alongside the readable message, because a GUI process on a runner often leaves only the status code — the message box it would otherwise show has nowhere to go.

## One correctness fix found while writing it

The PowerShell wrote to `$env:TEMP` while the upload step read `${{ runner.temp }}`. Those are **not guaranteed to be the same directory** on a Windows runner, and the failure mode is an artifact that silently uploads nothing.

That is precisely the shape of evidence loss this whole series is about — a step that reports success while producing nothing to read. Both sides now use `RUNNER_TEMP`.

## Verification

- **31 self-test cases**, up from 24.
- Verified locally: a named DLL failure reports `VCRUNTIME140.dll` and exits 1; the Linux `sandbox-denied`, macOS `code-signature` and clean-start `ok` verdicts are all unchanged by the new patterns.
- `actionlint` delta **0**.
- YAML re-parsed: all six smoke/upload steps register with the correct `if:` conditions.

## Scope

Issue 308 asks for interactive packaged CoreBox Everything acceptance on Windows, which needs a real machine and a real Everything install. This is the layer beneath that: whether the packaged binary starts at all. Refs #308.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows launch diagnostics by detecting missing DLL errors and identifying the affected library when possible.
  * Improved classification of Windows applications that fail to start because required system libraries are unavailable.

* **Testing**
  * Added a Windows packaging smoke test that monitors the built application for 45 seconds.
  * Windows launch logs are now uploaded for both successful and failed smoke tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->