### PR TITLE
docs(tuff-intelligence): record that dist is not a consumption surface

### DIFF
--- a/packages/tuff-intelligence/README.md
+++ b/packages/tuff-intelligence/README.md
@@ -132,3 +132,15 @@ registry.registerTool(kit.get("text.uppercase")!);
 ## 运行时边界
 
 `buildGraphArtifacts()` 与 `invokeGraph()` 已提供真实的 LangGraph 顺序执行器，但只运行调用方注入的步骤；未传入步骤时使用 identity `noop`，不会隐式调用任何 AI provider。CoreApp 负责把 provider runtime、能力调用、配额/审计和 Agent 图组合起来；其他宿主也应在自己的 runtime 中注入对应步骤和存储实现。
+
+## `dist/` 不是消费面
+
+这个包**发布源码，不发布构建产物**。三条独立证据：
+
+- `package.json` 的 `files` 只有 `["src"]`，`dist/` 根本不会进发布包；
+- 四个 `exports` 条目全部指向 `./src/*.ts`，`main` / `module` / `types` 同理；
+- 仓内没有任何地方 import `tuff-intelligence/dist`，也没有任何 CI 作业调用 `build`（根 `build` 只跑 core-app）。
+
+所以本地 `dist/` 的时间戳落后 `src/` **不代表任何东西**——它是一个没人调的 tsup 脚本留下的残留物，既不发布也不被解析。#970 曾把它记为待办，那是基于「dist 是消费面」的假设，而这个假设不成立。
+
+如果将来要改成发布构建产物，`scripts/validate-publish-manifests.mjs` 已经覆盖本包（今天验证通过），入口指向未构建的输出会直接让校验失败——所以那次改动会被迫同时接上构建，不需要在这里再加一道守卫。


### PR DESCRIPTION
Item 3 of #970 asked for a decision: rebuild the stale `dist`, or mark it as not a consumption surface. It is the second — and the evidence makes it a fact rather than a preference.

## Three independent checks, each sufficient alone

| check | result |
| --- | --- |
| `files` | `["src"]` — `dist/` is never packed into the published tarball |
| `exports` / `main` / `module` / `types` | all four entries point at `./src/*.ts`; no `publishConfig` swap |
| consumers | nothing in the repo imports `tuff-intelligence/dist`; no CI job runs the package `build` (the root `build` is core-app only) |

So a `dist/` older than `src/` **means nothing**. It is residue from a `tsup` script nobody invokes — neither published nor resolved by anything.

#970 recorded it as a follow-up on the assumption that dist was a consumption surface. That assumption does not hold, and the follow-up was tracking a number that could never matter.

Worth noting the issue's own figure had drifted too: it says dist is stuck at 7-29, and locally it is dated Aug 11. That the number moved and nobody noticed is itself evidence that nothing depends on it.

## No new guard, because the one that matters already exists

`scripts/validate-publish-manifests.mjs` already lists `@talex-touch/tuff-intelligence` and passes today. An entry pointing at an unbuilt output fails it. So if someone later switches this package to publishing `dist`, that change is forced to wire up the build in the same PR — which is exactly the failure this item was worried about, already covered.

Adding a second guard for the same property would be the duplication these checks exist to prevent.

## Scope

Items 1 (the "5 times" retry anomaly, waiting on a log from a real run) and 2 (re-verifying the pi contract after an upgrade) are untouched — both need something outside this checkout. Refs #970.
