### PR TITLE
docs(trellis): correct R3 — the sidebar history is not rendered at all

### DIFF
--- a/.trellis/tasks/08-04-home-conversation/prd.md
+++ b/.trellis/tasks/08-04-home-conversation/prd.md
@@ -23,7 +23,13 @@
 | R1 | 首页就地对话：发送 → 内置 AI 通道流式回复 → 增量渲染 → 可停止 → 错误可读。**不落库、不加路由** | 通路已完成，缺可用 provider |
 | R1.5 | 本地 `pi` CLI provider + 未配置引导：让首页在零凭据下真能出字 | 进行中 |
 | R2 | 数据层与持久化：两张表 + 迁移 + 对话 transport + `/home/c/:id` | 已交付 |
-| R3 | 侧栏历史分桶 + TopBar ModePill 接真实模型列表 | 部分：分桶未做 |
+| R3 | 侧栏历史分桶 + TopBar ModePill 接真实模型列表 | 部分：**侧栏历史整体未接入**（不只是分桶） |
+
+> R3 状态更正（2026-08-13，#969）。「分桶未做」读起来像「列表已在、只差分组」，实际不是：
+> `useConversationHistory` 的 `refresh()` 在整个渲染进程里**从未被调用**，`conversations` 也从未被读取——
+> `HomePage.vue` 只用了 `history.load` 和 `history.persist`。`ShellSidebar.vue:132` 的
+> `<slot name="conversations" />` 有注释说由本任务填充，但没有任何组件填过它。
+> 所以剩余工作是「渲染列表，再分组」，不是「给已有列表加分组」，工作量与验收面都不同。
 
 R1 的产物必须是可弃的最小面：消息只在内存里，刷新即丢。R2 接手时把内存 store 换成 transport，不重写 UI。
 

--- a/.trellis/tasks/08-04-home-conversation/task.json
+++ b/.trellis/tasks/08-04-home-conversation/task.json
@@ -23,8 +23,8 @@
   "relatedFiles": [],
   "notes": "",
   "meta": {
-    "nextAction": "做 R3 剩下的侧栏历史时间分桶（今天 / 昨天 / 近 7 天 / 更早），跟踪在 #969。R2 不需要再动。",
+    "nextAction": "R3 剩余：先把侧栏历史列表接进 ShellSidebar 的 conversations 插槽（refresh() 目前全渲染进程无人调用，conversations 也无人读取），再做时间分桶（今天/昨天/近 7 天/更早）。跟踪在 #969。R2 不需要再动。",
     "blocker": "无。此前的 blocker 是状态表把已交付的 R2 记成未开始，读起来像整条数据层还没起步。",
-    "evidence": "R2 四项逐一核过：conversations 与 conversation_messages 两张表在 db/schema.ts:1694 和 :1708；迁移在 apps/core-app/resources/db/migrations/*.sql；对话 transport 在 modules/conversation；路由 /home/c/:id 在 renderer/src/base/router.ts:126。R3 的侧栏分桶只有一条 zh-CN 文案、没有实现，所以标部分而不是已交付。"
+    "evidence": "2026-08-13 核实：HomePage.vue 只用 history.load / history.persist;useConversationHistory.ts:93 的 conversations.value 只在 refresh() 内被赋值,而 refresh() 无调用方;ShellSidebar.vue:132 的插槽有「由本任务填充」的注释但无人填充。"
   }
 }


### PR DESCRIPTION
#969's second item asks for time bucketing on the sidebar history, described as "R3 的最后一块". The PRD said `部分：分桶未做`. Both read the same way: **the list is there, only the grouping is missing.**

It is not there.

## Verified, with a positive control

"No matches" is exactly what a broken scan reports, so each of these was checked against something that does return hits:

| claim | evidence |
| --- | --- |
| `HomePage.vue` never reads the list | two `history.` references total — `history.load` and `history.persist` |
| nothing populates it | `useConversationHistory.ts:93` is the only assignment to `conversations.value`, inside `refresh()` — and `refresh()` has **no caller** in the renderer |
| the slot is empty | `ShellSidebar.vue:132` has `<slot name="conversations" />` with a comment saying *this task* fills it. Nothing does. |

So the remaining work is **"render the list, then group it"**, not "add grouping to a list". Different size, different acceptance surface — and the difference was invisible from the wording.

## Where the wrong wording came from

`meta.nextAction` on `08-04-home-conversation` said `做 R3 剩下的侧栏历史时间分桶`. I wrote that line **earlier today**, off the same PRD sentence rather than off the code.

A record repeated from another record is not a second source. Two places agreeing meant nothing here, because one was copied from the other — and I was the one who copied it.

## What this changes

The PRD row and the task metadata now say what is actually missing, with the three file references so the next person does not have to re-derive it.

**No implementation.** Rendering a conversation list means item state, an active indicator, a delete affordance, an empty state and a skeleton — none of which I can verify visually from this checkout, and half a sidebar is worse than none.

Item 1 of the issue (auto-generated titles) is untouched: it needs a provider call at first-turn completion, which is a different piece of work. Refs #969.
