### PR TITLE
feat(home): generate a short conversation title after the first turn

### DIFF
--- a/apps/core-app/src/renderer/src/modules/conversation/conversation-title.test.ts
+++ b/apps/core-app/src/renderer/src/modules/conversation/conversation-title.test.ts
@@ -9,6 +9,12 @@ import {
   shouldGenerateTitle
 } from './conversation-title'
 
+const STRINGS = {
+  prompt: '用不超过 8 个字概括这段对话的主题。只输出标题本身。',
+  userLabel: '用户',
+  assistantLabel: '助手'
+}
+
 function chatResult(result: string): IntelligenceInvokeResult<string> {
   return {
     result,
@@ -107,7 +113,12 @@ describe('deriveRestoredTitle', () => {
 describe('generateConversationTitle', () => {
   it('sends one low-stakes chat call and normalizes the answer', async () => {
     const chat = vi.fn<TitleChatSdk['text']['chat']>(async () => chatResult('「整理下载目录」'))
-    const title = await generateConversationTitle({ text: { chat } }, '帮我整理下载目录', '好的…')
+    const title = await generateConversationTitle(
+      { text: { chat } },
+      '帮我整理下载目录',
+      '好的…',
+      STRINGS
+    )
     expect(title).toBe('整理下载目录')
     expect(chat).toHaveBeenCalledTimes(1)
     const [payload, options] = chat.mock.calls[0]!
@@ -119,7 +130,12 @@ describe('generateConversationTitle', () => {
 
   it('clips long transcripts before they reach the prompt', async () => {
     const chat = vi.fn<TitleChatSdk['text']['chat']>(async () => chatResult('长文摘要'))
-    await generateConversationTitle({ text: { chat } }, '长'.repeat(2000), '答'.repeat(2000))
+    await generateConversationTitle(
+      { text: { chat } },
+      '长'.repeat(2000),
+      '答'.repeat(2000),
+      STRINGS
+    )
     const [payload] = chat.mock.calls[0]!
     const sent = String(payload.messages[1]?.content ?? '')
     expect([...sent].length).toBeLessThan(800)
@@ -130,13 +146,17 @@ describe('generateConversationTitle', () => {
     const chat = vi.fn(async () => {
       throw new Error('provider down')
     })
-    await expect(generateConversationTitle({ text: { chat } }, 'u', 'a')).resolves.toBeNull()
+    await expect(
+      generateConversationTitle({ text: { chat } }, 'u', 'a', STRINGS)
+    ).resolves.toBeNull()
   })
 
   it('resolves null when the answer is unusable', async () => {
     const chat = vi.fn(async () =>
       chatResult('这不是一个标题,而是一段没有守住字数约束的完整解释性文字。')
     )
-    await expect(generateConversationTitle({ text: { chat } }, 'u', 'a')).resolves.toBeNull()
+    await expect(
+      generateConversationTitle({ text: { chat } }, 'u', 'a', STRINGS)
+    ).resolves.toBeNull()
   })
 })

--- a/apps/core-app/src/renderer/src/modules/conversation/conversation-title.test.ts
+++ b/apps/core-app/src/renderer/src/modules/conversation/conversation-title.test.ts
@@ -1,0 +1,142 @@
+import type { IntelligenceInvokeResult } from '@talex-touch/utils/types/intelligence'
+import { describe, expect, it, vi } from 'vitest'
+import type { TitleChatSdk } from './conversation-title'
+import {
+  CONVERSATION_TITLE_MAX_CODEPOINTS,
+  deriveRestoredTitle,
+  generateConversationTitle,
+  normalizeGeneratedTitle,
+  shouldGenerateTitle
+} from './conversation-title'
+
+function chatResult(result: string): IntelligenceInvokeResult<string> {
+  return {
+    result,
+    usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    model: 'm',
+    latency: 1,
+    traceId: 't',
+    provider: 'p'
+  }
+}
+
+describe('normalizeGeneratedTitle', () => {
+  it('passes a plain short title through', () => {
+    expect(normalizeGeneratedTitle('整理下载目录')).toBe('整理下载目录')
+  })
+
+  it('strips wrapping quotes, CJK marks and a trailing full stop', () => {
+    expect(normalizeGeneratedTitle('「整理下载目录」')).toBe('整理下载目录')
+    expect(normalizeGeneratedTitle('"Download cleanup"')).toBe('Download cleanup')
+    expect(normalizeGeneratedTitle('《整理下载目录》。')).toBe('整理下载目录')
+  })
+
+  it('unwraps nested decoration but keeps interior quotes', () => {
+    expect(normalizeGeneratedTitle('「"整理下载目录"」')).toBe('整理下载目录')
+    expect(normalizeGeneratedTitle('讨论"quoted"用法')).toBe('讨论"quoted"用法')
+  })
+
+  /**
+   * Rejection, not truncation: a model that answered in prose must not have its first clause
+   * persisted as the label — the user's own words read better than a cut-off sentence.
+   */
+  it('rejects prose-length answers instead of truncating them', () => {
+    const prose = '这段对话主要讨论了如何整理下载目录并批量重命名其中的文件,涉及脚本编写'
+    expect([...prose].length).toBeGreaterThan(CONVERSATION_TITLE_MAX_CODEPOINTS)
+    expect(normalizeGeneratedTitle(prose)).toBeNull()
+  })
+
+  it('rejects multi-line answers, empty strings and non-strings', () => {
+    expect(normalizeGeneratedTitle('标题\n还有解释')).toBeNull()
+    expect(normalizeGeneratedTitle('   ')).toBeNull()
+    expect(normalizeGeneratedTitle('「」')).toBeNull()
+    expect(normalizeGeneratedTitle(null)).toBeNull()
+    expect(normalizeGeneratedTitle(undefined)).toBeNull()
+  })
+
+  it('counts code points, not UTF-16 units, at the ceiling', () => {
+    const emoji = '🧭'.repeat(CONVERSATION_TITLE_MAX_CODEPOINTS)
+    expect(normalizeGeneratedTitle(emoji)).toBe(emoji)
+    expect(normalizeGeneratedTitle(`${emoji}🧭`)).toBeNull()
+  })
+})
+
+describe('shouldGenerateTitle', () => {
+  const ready = {
+    generatedTitle: null,
+    inFlight: false,
+    firstUserContent: '帮我整理下载目录',
+    firstAssistantContent: '好的,可以按扩展名分组…'
+  }
+
+  it('fires exactly on the ready shape', () => {
+    expect(shouldGenerateTitle(ready)).toBe(true)
+  })
+
+  it('never fires twice: an existing title, restored or generated, blocks it', () => {
+    expect(shouldGenerateTitle({ ...ready, generatedTitle: '整理下载' })).toBe(false)
+  })
+
+  it('does not stack calls while one is in flight', () => {
+    expect(shouldGenerateTitle({ ...ready, inFlight: true })).toBe(false)
+  })
+
+  it('waits for a completed exchange', () => {
+    expect(shouldGenerateTitle({ ...ready, firstAssistantContent: undefined })).toBe(false)
+    expect(shouldGenerateTitle({ ...ready, firstAssistantContent: '  ' })).toBe(false)
+    expect(shouldGenerateTitle({ ...ready, firstUserContent: undefined })).toBe(false)
+  })
+})
+
+describe('deriveRestoredTitle', () => {
+  it('treats a stored title equal to the opening message as the working title, not a custom one', () => {
+    // Blocking generation forever on the pre-generation persist is the bug this guards.
+    expect(deriveRestoredTitle('帮我整理下载目录', '帮我整理下载目录')).toBeNull()
+  })
+
+  it('keeps a stored title that differs from the opening message', () => {
+    expect(deriveRestoredTitle('整理下载', '帮我整理下载目录')).toBe('整理下载')
+  })
+
+  it('ignores empty storage', () => {
+    expect(deriveRestoredTitle('', '帮我整理下载目录')).toBeNull()
+    expect(deriveRestoredTitle(undefined, '帮我整理下载目录')).toBeNull()
+  })
+})
+
+describe('generateConversationTitle', () => {
+  it('sends one low-stakes chat call and normalizes the answer', async () => {
+    const chat = vi.fn<TitleChatSdk['text']['chat']>(async () => chatResult('「整理下载目录」'))
+    const title = await generateConversationTitle({ text: { chat } }, '帮我整理下载目录', '好的…')
+    expect(title).toBe('整理下载目录')
+    expect(chat).toHaveBeenCalledTimes(1)
+    const [payload, options] = chat.mock.calls[0]!
+    expect(payload.messages).toHaveLength(2)
+    expect(payload.temperature).toBeLessThanOrEqual(0.5)
+    expect(payload.maxTokens).toBeLessThanOrEqual(64)
+    expect(options?.timeout).toBeLessThanOrEqual(15_000)
+  })
+
+  it('clips long transcripts before they reach the prompt', async () => {
+    const chat = vi.fn<TitleChatSdk['text']['chat']>(async () => chatResult('长文摘要'))
+    await generateConversationTitle({ text: { chat } }, '长'.repeat(2000), '答'.repeat(2000))
+    const [payload] = chat.mock.calls[0]!
+    const sent = String(payload.messages[1]?.content ?? '')
+    expect([...sent].length).toBeLessThan(800)
+  })
+
+  /** A label is never worth an error surface: every failure path is silently null. */
+  it('resolves null when the call rejects', async () => {
+    const chat = vi.fn(async () => {
+      throw new Error('provider down')
+    })
+    await expect(generateConversationTitle({ text: { chat } }, 'u', 'a')).resolves.toBeNull()
+  })
+
+  it('resolves null when the answer is unusable', async () => {
+    const chat = vi.fn(async () =>
+      chatResult('这不是一个标题,而是一段没有守住字数约束的完整解释性文字。')
+    )
+    await expect(generateConversationTitle({ text: { chat } }, 'u', 'a')).resolves.toBeNull()
+  })
+})

--- a/apps/core-app/src/renderer/src/modules/conversation/conversation-title.ts
+++ b/apps/core-app/src/renderer/src/modules/conversation/conversation-title.ts
@@ -35,8 +35,19 @@ export const CONVERSATION_TITLE_MAX_CODEPOINTS = 24
 /** How much of each side of the exchange the summariser sees. Enough for topic, not the essay. */
 const EXCERPT_CODEPOINTS = 320
 
-const TITLE_PROMPT =
-  '用不超过 8 个字概括这段对话的主题。只输出标题本身——不要引号、书名号、句号,不要任何解释。'
+/**
+ * The instruction and transcript labels, supplied by the caller from the renderer catalog.
+ *
+ * Model-facing text is still locale text: a hardcoded Chinese prompt asks an English-locale user's
+ * model for a Chinese label, and "≤8 个字" is not even the right unit outside CJK — the English
+ * catalog asks for words. Keeping the module free of vue-i18n keeps it pure and testable; the
+ * lookup happens once at the call site.
+ */
+export interface TitlePromptStrings {
+  prompt: string
+  userLabel: string
+  assistantLabel: string
+}
 
 function clip(value: string, max: number): string {
   const points = [...value]
@@ -134,16 +145,17 @@ export function deriveRestoredTitle(
 export async function generateConversationTitle(
   sdk: TitleChatSdk,
   firstUserContent: string,
-  firstAssistantContent: string
+  firstAssistantContent: string,
+  strings: TitlePromptStrings
 ): Promise<string | null> {
   try {
     const result = await sdk.text.chat(
       {
         messages: [
-          { role: 'system', content: TITLE_PROMPT },
+          { role: 'system', content: strings.prompt },
           {
             role: 'user',
-            content: `用户：${clip(firstUserContent, EXCERPT_CODEPOINTS)}\n助手：${clip(firstAssistantContent, EXCERPT_CODEPOINTS)}`
+            content: `${strings.userLabel}：${clip(firstUserContent, EXCERPT_CODEPOINTS)}\n${strings.assistantLabel}：${clip(firstAssistantContent, EXCERPT_CODEPOINTS)}`
           }
         ],
         temperature: 0.2,

--- a/apps/core-app/src/renderer/src/modules/conversation/conversation-title.ts
+++ b/apps/core-app/src/renderer/src/modules/conversation/conversation-title.ts
@@ -1,0 +1,158 @@
+import type {
+  IntelligenceChatPayload,
+  IntelligenceInvokeOptions,
+  IntelligenceInvokeResult
+} from '@talex-touch/utils/types/intelligence'
+
+/**
+ * Generates the short conversation title HomePage's working title stands in for (#969).
+ *
+ * The working title is the user's opening message verbatim, which a long prompt turns into a
+ * top-bar and sidebar full of one paragraph. After the first turn settles, one low-stakes model
+ * call summarises the exchange into a handful of characters; every failure path falls back to the
+ * working title by returning null, silently — a conversation must never fail, stall or toast over
+ * its own label.
+ */
+export interface TitleChatSdk {
+  text: {
+    chat: (
+      payload: IntelligenceChatPayload,
+      options?: IntelligenceInvokeOptions
+    ) => Promise<IntelligenceInvokeResult<string>>
+  }
+}
+
+/**
+ * Hard ceiling on a stored title, in code points.
+ *
+ * The prompt asks for ≤8 characters; the clamp sits well above it so a slightly chatty but usable
+ * answer ("整理下载目录的脚本") survives while a model that ignored the instruction and answered in
+ * prose does not get persisted as the label. Overflow rejects rather than truncates: a cut-off
+ * sentence reads worse than the user's own words.
+ */
+export const CONVERSATION_TITLE_MAX_CODEPOINTS = 24
+
+/** How much of each side of the exchange the summariser sees. Enough for topic, not the essay. */
+const EXCERPT_CODEPOINTS = 320
+
+const TITLE_PROMPT =
+  '用不超过 8 个字概括这段对话的主题。只输出标题本身——不要引号、书名号、句号,不要任何解释。'
+
+function clip(value: string, max: number): string {
+  const points = [...value]
+  return points.length <= max ? value : `${points.slice(0, max).join('')}…`
+}
+
+/**
+ * Trims decoration a model wraps titles in despite the prompt: whitespace, wrapping quote pairs
+ * (straight, curly, CJK corner and title marks), and a trailing full stop. Anything still empty or
+ * over the ceiling afterwards is rejected as null.
+ */
+export function normalizeGeneratedTitle(raw: string | null | undefined): string | null {
+  if (typeof raw !== 'string') return null
+  let title = raw.trim()
+  // One leading/trailing pair per pass; loop so 「"标题"」 unwraps fully but inner quotes survive.
+  const PAIRS: Array<[string, string]> = [
+    ['"', '"'],
+    ["'", "'"],
+    ['“', '”'],
+    ['‘', '’'],
+    ['「', '」'],
+    ['『', '』'],
+    ['《', '》'],
+    ['(', ')'],
+    ['（', '）']
+  ]
+  // Unwrapping and period-stripping interleave until stable: `《标题》。` only exposes its pair
+  // after the stop goes, and `「」` unwraps to empty — `>=` admits the bare pair so it lands in the
+  // empty-string rejection below instead of surviving as decoration.
+  let before = ''
+  while (before !== title) {
+    before = title
+    title = title.replace(/[。.．]+$/u, '').trim()
+    for (const [open, close] of PAIRS) {
+      if (
+        title.length >= open.length + close.length &&
+        title.startsWith(open) &&
+        title.endsWith(close)
+      ) {
+        title = title.slice(open.length, title.length - close.length).trim()
+      }
+    }
+  }
+  // A model that answered in prose put line breaks in; a title has none.
+  if (/[\r\n]/.test(title)) return null
+  if (title.length === 0) return null
+  if ([...title].length > CONVERSATION_TITLE_MAX_CODEPOINTS) return null
+  return title
+}
+
+/**
+ * Whether this settled turn is the one that should trigger generation.
+ *
+ * Only once per conversation (a non-null generated title, restored or fresh, blocks it), and only
+ * when there is a completed exchange to summarise — a failed or empty first turn keeps the working
+ * title, and the next settled turn gets another chance.
+ */
+export function shouldGenerateTitle(args: {
+  generatedTitle: string | null
+  inFlight: boolean
+  firstUserContent: string | undefined
+  firstAssistantContent: string | undefined
+}): boolean {
+  if (args.generatedTitle !== null || args.inFlight) return false
+  if (!args.firstUserContent?.trim()) return false
+  if (!args.firstAssistantContent?.trim()) return false
+  return true
+}
+
+/**
+ * The stored title, when it is a real one.
+ *
+ * `history.load` hands back whatever `persist` wrote. Before a title was ever generated that is the
+ * working title — the opening message verbatim — and treating it as custom would freeze the label
+ * and block generation forever. Only a stored title that *differs* from the opening message is
+ * information.
+ */
+export function deriveRestoredTitle(
+  storedTitle: string | null | undefined,
+  firstUserContent: string | null | undefined
+): string | null {
+  const stored = storedTitle?.trim()
+  if (!stored) return null
+  if (stored === firstUserContent?.trim()) return null
+  return stored
+}
+
+/**
+ * One summarisation call, resolving to null on every failure.
+ *
+ * Low temperature and a tight token budget because the task is extraction, not writing; a short
+ * timeout because a label is not worth queueing behind — the working title is already on screen
+ * and perfectly serviceable.
+ */
+export async function generateConversationTitle(
+  sdk: TitleChatSdk,
+  firstUserContent: string,
+  firstAssistantContent: string
+): Promise<string | null> {
+  try {
+    const result = await sdk.text.chat(
+      {
+        messages: [
+          { role: 'system', content: TITLE_PROMPT },
+          {
+            role: 'user',
+            content: `用户：${clip(firstUserContent, EXCERPT_CODEPOINTS)}\n助手：${clip(firstAssistantContent, EXCERPT_CODEPOINTS)}`
+          }
+        ],
+        temperature: 0.2,
+        maxTokens: 32
+      },
+      { timeout: 10_000 }
+    )
+    return normalizeGeneratedTitle(result?.result ?? null)
+  } catch {
+    return null
+  }
+}

--- a/apps/core-app/src/renderer/src/modules/conversation/useConversationHistory.test.ts
+++ b/apps/core-app/src/renderer/src/modules/conversation/useConversationHistory.test.ts
@@ -111,8 +111,10 @@ describe('load', () => {
 
     const restored = await useConversationHistory().load('c1')
 
-    expect(restored?.map((entry) => entry.content)).toEqual(['hi', 'yo'])
-    expect(restored?.[1]?.meta).toEqual({ model: 'm' })
+    expect(restored?.messages.map((entry) => entry.content)).toEqual(['hi', 'yo'])
+    expect(restored?.messages[1]?.meta).toEqual({ model: 'm' })
+    // The stored title survives the trip out (#969): restore has to know whether it is custom.
+    expect(restored?.title).toBe('Title')
   })
 
   it('repairs duplicate ids stored by the old per-conversation counters', async () => {
@@ -140,10 +142,10 @@ describe('load', () => {
 
     const restored = await useConversationHistory().load('c1')
 
-    const ids = restored?.map((entry) => entry.id) ?? []
+    const ids = restored?.messages.map((entry) => entry.id) ?? []
     expect(new Set(ids).size).toBe(ids.length)
     // Order and content untouched; only the collision got a suffix.
-    expect(restored?.map((entry) => entry.content)).toEqual(['one', 'two', 'three'])
+    expect(restored?.messages.map((entry) => entry.content)).toEqual(['one', 'two', 'three'])
     expect(ids[0]).toBe('user-5')
     expect(ids[2]).not.toBe('user-5')
   })
@@ -221,9 +223,9 @@ describe('parts persistence', () => {
     })
 
     const restored = await history.load('c1')
-    expect(restored?.[0]?.parts).toHaveLength(3)
-    expect(restored?.[0]?.parts?.[1]).toMatchObject({ type: 'tool-call', output: 'data' })
-    expect(restored?.[0]?.meta).toEqual({ provider: 'pi', model: 'gpt' })
+    expect(restored?.messages[0]?.parts).toHaveLength(3)
+    expect(restored?.messages[0]?.parts?.[1]).toMatchObject({ type: 'tool-call', output: 'data' })
+    expect(restored?.messages[0]?.meta).toEqual({ provider: 'pi', model: 'gpt' })
   })
 
   it('truncates verbose tool output before storing', async () => {
@@ -308,9 +310,9 @@ describe('load survives a store failure', () => {
       messages: [{ id: 'm1', role: 'user', content: 'hi', status: 'complete', meta: {} }]
     })
 
-    await expect(useConversationHistory().load('c1')).resolves.toMatchObject([
-      { id: 'm1', role: 'user', content: 'hi' }
-    ])
+    await expect(useConversationHistory().load('c1')).resolves.toMatchObject({
+      messages: [{ id: 'm1', role: 'user', content: 'hi' }]
+    })
   })
 
   it('不存在的会话仍然返回 null', async () => {

--- a/apps/core-app/src/renderer/src/modules/conversation/useConversationHistory.ts
+++ b/apps/core-app/src/renderer/src/modules/conversation/useConversationHistory.ts
@@ -12,7 +12,12 @@ export interface UseConversationHistoryReturn {
   conversations: Ref<ConversationRecord[]>
   loading: Ref<boolean>
   refresh: () => Promise<void>
-  load: (id: string) => Promise<ConversationMessage[] | null>
+  /**
+   * Title rides along because a stored custom title (#969) has to survive restore: HomePage
+   * recomputes the working title from the opening message, and without the stored one the top bar
+   * and the sidebar would disagree after a reload.
+   */
+  load: (id: string) => Promise<{ title: string; messages: ConversationMessage[] } | null>
   persist: (id: string, title: string, messages: ConversationMessage[]) => Promise<void>
   remove: (id: string) => Promise<void>
 }
@@ -110,7 +115,9 @@ export function useConversationHistory(): UseConversationHistoryReturn {
     }
   }
 
-  async function load(id: string): Promise<ConversationMessage[] | null> {
+  async function load(
+    id: string
+  ): Promise<{ title: string; messages: ConversationMessage[] } | null> {
     let detail: Awaited<ReturnType<typeof sdk.get>>
     try {
       detail = await sdk.get(id)
@@ -128,7 +135,7 @@ export function useConversationHistory(): UseConversationHistoryReturn {
     // duplicate corrupts the keyed diff — suffix survivors once on the way
     // in; the next persist then stores the repaired ids.
     const seen = new Set<string>()
-    return detail.messages.map((message) => {
+    const messages = detail.messages.map((message) => {
       let messageId = message.id
       while (seen.has(messageId)) messageId = `${messageId}-r`
       seen.add(messageId)
@@ -144,6 +151,7 @@ export function useConversationHistory(): UseConversationHistoryReturn {
         ...(Array.isArray(parts) && parts.length > 0 ? { parts } : {})
       }
     }) as ConversationMessage[]
+    return { title: detail.title ?? '', messages }
   }
 
   async function persist(

--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -1113,6 +1113,11 @@
       "failed": "This widget could not start."
     },
     "modelName": "Tuff Auto",
+    "titleGen": {
+      "prompt": "Summarize the topic of this conversation in at most 4 words. Output only the title itself — no quotes, no trailing period, no explanation.",
+      "userLabel": "User",
+      "assistantLabel": "Assistant"
+    },
     "effortHigh": "High",
     "attach": "Add attachment",
     "attachRemove": "Remove attachment",
@@ -1134,7 +1139,11 @@
     "chartRemove": "Remove row",
     "chartLabel": "Label",
     "chartAddPlaceholder": "New point label",
-    "chartView": {"line": "Line", "bar": "Bar", "area": "Area"},
+    "chartView": {
+      "line": "Line",
+      "bar": "Bar",
+      "area": "Area"
+    },
     "toolPayload": "Payload",
     "toolInterrupted": "This call never returned; the turn ended.",
     "formSubmit": "Submit",
@@ -3800,10 +3809,6 @@
       "capabilityPromptSectionDesc": "System prompt appended when the capability is invoked.",
       "testCapability": "Run test",
       "selectProvider": "Select channel",
-      "userMessageLabel": "User message",
-      "userMessagePlaceholder": "Hello, can you summarize this...",
-      "promptVariablesLabel": "Prompt variables (JSON)",
-      "promptVariablesPlaceholder": "{'{\"name\":\"Talex\"}'}",
       "manageModels": "Manage models",
       "editPrompt": "Edit prompt",
       "latestTestResult": "Latest test result",
@@ -4122,7 +4127,10 @@
           "notRetryable": "This error requires manual diagnosis before retrying."
         },
         "phases": {
-          "idle": { "label": "Idle", "description": "No update attempt is active." },
+          "idle": {
+            "label": "Idle",
+            "description": "No update attempt is active."
+          },
           "checking": {
             "label": "Checking for updates",
             "description": "The update service is checking the selected channel."
@@ -4454,36 +4462,36 @@
       "unofficial": "Current version has not passed official build verification, may be unsafe"
     }
   },
-    "widgetFrame": {
-      "compileFailed": "Widget compile failed",
-      "loading": "Loading widget",
-      "rendererMissing": "Widget renderer missing",
-      "rendererUnregistered": "Widget renderer not registered",
-      "missingRendererId": "Missing rendererId",
-      "renderFailed": "Widget failed to render"
-    },
-    "fileIndex": {
-      "failTitle": "File index initialization failed",
-      "failMessage": "The file index failed to initialize, so search may not work correctly.",
-      "viewErrorDetails": "View error details",
-      "rebuilding": "Rebuilding…",
-      "rebuildIndex": "Rebuild index",
-      "later": "Later",
-      "dontRemindAgain": "Don't remind me again"
-    },
-    "previewHistory": {
-      "copyResult": "Copy result",
-      "resultLabel": "Result",
-      "recentTitle": "Recent",
-      "countSummary": "{count} total",
-      "noRecords": "No records yet"
-    },
-    "boxTag": {
-      "image": "Image",
-      "imageCount": "{count} images",
-      "charCount": "{count} chars total",
-      "preparingFiles": "Preparing files…"
-    },
+  "widgetFrame": {
+    "compileFailed": "Widget compile failed",
+    "loading": "Loading widget",
+    "rendererMissing": "Widget renderer missing",
+    "rendererUnregistered": "Widget renderer not registered",
+    "missingRendererId": "Missing rendererId",
+    "renderFailed": "Widget failed to render"
+  },
+  "fileIndex": {
+    "failTitle": "File index initialization failed",
+    "failMessage": "The file index failed to initialize, so search may not work correctly.",
+    "viewErrorDetails": "View error details",
+    "rebuilding": "Rebuilding…",
+    "rebuildIndex": "Rebuild index",
+    "later": "Later",
+    "dontRemindAgain": "Don't remind me again"
+  },
+  "previewHistory": {
+    "copyResult": "Copy result",
+    "resultLabel": "Result",
+    "recentTitle": "Recent",
+    "countSummary": "{count} total",
+    "noRecords": "No records yet"
+  },
+  "boxTag": {
+    "image": "Image",
+    "imageCount": "{count} images",
+    "charCount": "{count} chars total",
+    "preparingFiles": "Preparing files…"
+  },
   "common": {
     "imagePreviewAlt": "Image preview",
     "wallpaperPreviewAlt": "Custom background preview",
@@ -5043,7 +5051,15 @@
       "failure": "Failure",
       "promptTokens": "Prompt Tokens",
       "completionTokens": "Completion Tokens",
-      "weekdays": ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+      "weekdays": [
+        "Sun",
+        "Mon",
+        "Tue",
+        "Wed",
+        "Thu",
+        "Fri",
+        "Sat"
+      ]
     },
     "memoryReview": {
       "title": "Memory Review",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -1113,6 +1113,11 @@
       "failed": "这个组件没能运行起来。"
     },
     "modelName": "Tuff 智能",
+    "titleGen": {
+      "prompt": "用不超过 8 个字概括这段对话的主题。只输出标题本身——不要引号、书名号、句号,不要任何解释。",
+      "userLabel": "用户",
+      "assistantLabel": "助手"
+    },
     "effortHigh": "高",
     "attach": "添加附件",
     "attachRemove": "移除附件",
@@ -1134,7 +1139,11 @@
     "chartRemove": "删除此行",
     "chartLabel": "标签",
     "chartAddPlaceholder": "新数据点标签",
-    "chartView": {"line": "线", "bar": "柱", "area": "面"},
+    "chartView": {
+      "line": "线",
+      "bar": "柱",
+      "area": "面"
+    },
     "toolPayload": "参数",
     "toolInterrupted": "该调用未返回，回合已结束",
     "formSubmit": "提交",
@@ -2205,26 +2214,50 @@
         "withIssue": "{preview} · 捕获提示：{issue}"
       },
       "actions": {
-        "quickReview": { "title": "QuickReview", "description": "检查缺陷、安全风险和最佳实践" },
-        "translate": { "title": "翻译", "description": "使用现有 Translation 插件翻译选中文本" },
-        "summarize": { "title": "总结", "description": "提取选中文本的主要结论" },
-        "polish": { "title": "润色", "description": "优化表达、语法和专业度" },
-        "rewrite": { "title": "改写", "description": "以更简洁自然的方式重写" },
+        "quickReview": {
+          "title": "QuickReview",
+          "description": "检查缺陷、安全风险和最佳实践"
+        },
+        "translate": {
+          "title": "翻译",
+          "description": "使用现有 Translation 插件翻译选中文本"
+        },
+        "summarize": {
+          "title": "总结",
+          "description": "提取选中文本的主要结论"
+        },
+        "polish": {
+          "title": "润色",
+          "description": "优化表达、语法和专业度"
+        },
+        "rewrite": {
+          "title": "改写",
+          "description": "以更简洁自然的方式重写"
+        },
         "saveSnippet": {
           "title": "保存为 Snippet",
           "description": "交给 Snippets 插件保存当前文本"
         },
-        "webSearch": { "title": "网页搜索", "description": "在系统默认浏览器中搜索选中文本" },
+        "webSearch": {
+          "title": "网页搜索",
+          "description": "在系统默认浏览器中搜索选中文本"
+        },
         "devTools": {
           "title": "开发工具",
           "description": "使用现有 JSON、Base64、URL/JWT 等本地工具"
         },
-        "ocr": { "title": "OCR 识别", "description": "使用系统 OCR 提取图片文字" },
+        "ocr": {
+          "title": "OCR 识别",
+          "description": "使用系统 OCR 提取图片文字"
+        },
         "translateImageText": {
           "title": "翻译图片文字",
           "description": "先 OCR，再翻译识别出的文字"
         },
-        "explainImage": { "title": "AI 解释图片", "description": "使用视觉能力解释图片主要内容" }
+        "explainImage": {
+          "title": "AI 解释图片",
+          "description": "使用视觉能力解释图片主要内容"
+        }
       },
       "results": {
         "quickReview": "QuickReview 已完成",
@@ -4094,14 +4127,26 @@
           "notRetryable": "重试前需要先进行人工诊断。"
         },
         "phases": {
-          "idle": { "label": "空闲", "description": "当前没有进行中的更新尝试。" },
-          "checking": { "label": "正在检查更新", "description": "更新服务正在检查所选渠道。" },
-          "available": { "label": "发现可用更新", "description": "已发现可下载的新版本。" },
+          "idle": {
+            "label": "空闲",
+            "description": "当前没有进行中的更新尝试。"
+          },
+          "checking": {
+            "label": "正在检查更新",
+            "description": "更新服务正在检查所选渠道。"
+          },
+          "available": {
+            "label": "发现可用更新",
+            "description": "已发现可下载的新版本。"
+          },
           "downloading": {
             "label": "正在下载更新",
             "description": "正在下载当前平台对应的安装包。"
           },
-          "verifying": { "label": "正在验证更新", "description": "正在验证完整性和发布元数据。" },
+          "verifying": {
+            "label": "正在验证更新",
+            "description": "正在验证完整性和发布元数据。"
+          },
           "ready": {
             "label": "可以安装",
             "description": "安装包已通过验证，可以由用户明确触发安装。"
@@ -4118,7 +4163,10 @@
             "label": "等待健康确认",
             "description": "更新后的应用已启动，仍需报告健康状态。"
           },
-          "healthy": { "label": "更新运行正常", "description": "已安装版本通过生命周期健康确认。" },
+          "healthy": {
+            "label": "更新运行正常",
+            "description": "已安装版本通过生命周期健康确认。"
+          },
           "recovery-required": {
             "label": "需要恢复",
             "description": "更新未能进入健康状态，请先检查恢复元数据。"
@@ -4414,36 +4462,36 @@
       "unofficial": "当前版本未通过官方构建验证，可能不安全"
     }
   },
-    "widgetFrame": {
-      "compileFailed": "Widget 编译失败",
-      "loading": "Widget 加载中",
-      "rendererMissing": "Widget renderer 缺失",
-      "rendererUnregistered": "Widget renderer 未注册",
-      "missingRendererId": "缺少 rendererId",
-      "renderFailed": "Widget 渲染失败"
-    },
-    "fileIndex": {
-      "failTitle": "文件索引初始化失败",
-      "failMessage": "文件索引初始化失败，可能导致搜索功能无法正常使用。",
-      "viewErrorDetails": "查看错误详情",
-      "rebuilding": "重建中...",
-      "rebuildIndex": "重新建立索引",
-      "later": "稍后处理",
-      "dontRemindAgain": "不再提醒"
-    },
-    "previewHistory": {
-      "copyResult": "复制结果",
-      "resultLabel": "结果",
-      "recentTitle": "最近处理",
-      "countSummary": "共 {count} 条",
-      "noRecords": "暂无记录"
-    },
-    "boxTag": {
-      "image": "图像",
-      "imageCount": "{count} 张图像",
-      "charCount": "共 {count} 字",
-      "preparingFiles": "文件准备中..."
-    },
+  "widgetFrame": {
+    "compileFailed": "Widget 编译失败",
+    "loading": "Widget 加载中",
+    "rendererMissing": "Widget renderer 缺失",
+    "rendererUnregistered": "Widget renderer 未注册",
+    "missingRendererId": "缺少 rendererId",
+    "renderFailed": "Widget 渲染失败"
+  },
+  "fileIndex": {
+    "failTitle": "文件索引初始化失败",
+    "failMessage": "文件索引初始化失败，可能导致搜索功能无法正常使用。",
+    "viewErrorDetails": "查看错误详情",
+    "rebuilding": "重建中...",
+    "rebuildIndex": "重新建立索引",
+    "later": "稍后处理",
+    "dontRemindAgain": "不再提醒"
+  },
+  "previewHistory": {
+    "copyResult": "复制结果",
+    "resultLabel": "结果",
+    "recentTitle": "最近处理",
+    "countSummary": "共 {count} 条",
+    "noRecords": "暂无记录"
+  },
+  "boxTag": {
+    "image": "图像",
+    "imageCount": "{count} 张图像",
+    "charCount": "共 {count} 字",
+    "preparingFiles": "文件准备中..."
+  },
   "common": {
     "imagePreviewAlt": "图片预览",
     "wallpaperPreviewAlt": "自定义背景预览",
@@ -5003,7 +5051,15 @@
       "failure": "失败",
       "promptTokens": "输入 Token",
       "completionTokens": "输出 Token",
-      "weekdays": ["日", "一", "二", "三", "四", "五", "六"]
+      "weekdays": [
+        "日",
+        "一",
+        "二",
+        "三",
+        "四",
+        "五",
+        "六"
+      ]
     },
     "memoryReview": {
       "title": "记忆审核",

--- a/apps/core-app/src/renderer/src/views/base/home/HomePage.vue
+++ b/apps/core-app/src/renderer/src/views/base/home/HomePage.vue
@@ -37,6 +37,11 @@ import ToolFormCard from '~/components/intelligence/ToolFormCard.vue'
 import { toMessageSegments } from '~/modules/conversation/chain-steps'
 import { createLatestOnly } from '~/modules/conversation/latest-only'
 import {
+  deriveRestoredTitle,
+  generateConversationTitle,
+  shouldGenerateTitle
+} from '~/modules/conversation/conversation-title'
+import {
   CONVERSATION_ERROR_EMPTY_RESPONSE,
   CONVERSATION_ERROR_PROVIDER_UNAVAILABLE
 } from '~/modules/conversation/conversation-error-display'
@@ -106,13 +111,20 @@ const modelLabel = computed(() => selectedModel.value ?? t('home.modelName'))
 const canSend = computed(() => draft.value.trim().length > 0 && !isStreaming.value)
 
 /**
- * Working title until R2 generates one: the opening message is what the user themselves called the
- * conversation. Deliberately not truncated here — the top bar ellipsises on overflow, and a title
- * cut in the data layer would stay cut once R2 persists it.
+ * The opening message is the working title until the model summarises one (#969).
+ *
+ * Generation is once per conversation, after the first settled turn, and every failure keeps the
+ * working title silently — the label is never worth an error surface. `generatedTitle` also carries
+ * a stored custom title across restore, so the top bar agrees with the sidebar after a reload.
  */
-const conversationTitle = computed(
+const generatedTitle = ref<string | null>(null)
+let titleInFlight = false
+const titleSequence = createLatestOnly()
+
+const firstUserContent = computed(
   () => messages.value.find((message) => message.role === 'user')?.content
 )
+const conversationTitle = computed(() => generatedTitle.value ?? firstUserContent.value)
 
 /**
  * Auto Context has no composer control any more: it and the old tools pill read as the same
@@ -1105,6 +1117,7 @@ watch(
       const composerEl = composerRef.value
       const first = composerEl?.getBoundingClientRect()
       conversation.reset()
+      generatedTitle.value = null
       await nextTick()
       if (composerEl && first && !prefersReducedMotion()) {
         const dy = first.top - composerEl.getBoundingClientRect().top
@@ -1124,7 +1137,14 @@ watch(
     // of teleporting. Thread-to-thread hops measure ~0 and stay still.
     const composerEl = composerRef.value
     const first = composerEl?.getBoundingClientRect()
-    conversation.restore(restored)
+    conversation.restore(restored.messages)
+    // A stored title that differs from the opening message is a real one; the working-title
+    // persist writes the opening message back, and treating that as custom would block
+    // generation forever.
+    generatedTitle.value = deriveRestoredTitle(
+      restored.title,
+      restored.messages.find((message) => message.role === 'user')?.content
+    )
     // Wholesale replacement doesn't trip the stream's prepend anchoring, and keep-alive
     // reuses this instance — landing at the latest message needs an explicit call.
     await nextTick()
@@ -1136,6 +1156,49 @@ watch(
   },
   { immediate: true }
 )
+
+/**
+ * Fire-and-forget: the settled-turn persist above already wrote the working title, so the thread is
+ * durable before the summary call even starts, and a second persist upgrades the label when the
+ * call lands. Claimed against `titleSequence` so switching threads mid-call drops the result
+ * instead of stamping it onto the wrong conversation.
+ */
+function maybeGenerateTitle(): void {
+  const firstAssistant = messages.value.find(
+    (message) => message.role === 'assistant' && message.status === 'complete'
+  )?.content
+  if (
+    !shouldGenerateTitle({
+      generatedTitle: generatedTitle.value,
+      inFlight: titleInFlight,
+      firstUserContent: firstUserContent.value,
+      firstAssistantContent: firstAssistant
+    })
+  ) {
+    return
+  }
+  const idAtStart = conversationId.value
+  if (!idAtStart) return
+  const isCurrent = titleSequence.claim()
+  titleInFlight = true
+  void (async () => {
+    try {
+      const title = await generateConversationTitle(
+        intelligenceSdk,
+        firstUserContent.value ?? '',
+        firstAssistant ?? ''
+      )
+      if (!title || !isCurrent() || conversationId.value !== idAtStart) return
+      generatedTitle.value = title
+      await history.persist(idAtStart, title, messages.value)
+    } catch (error) {
+      // The working title is already on screen and persisted; a label upgrade may fail silently.
+      homeLog.warn('Conversation title generation failed', String(error))
+    } finally {
+      titleInFlight = false
+    }
+  })()
+}
 
 /**
  * Writes after every settled turn.
@@ -1153,6 +1216,7 @@ watch(
       if (route.params.id !== conversationId.value) {
         await router.replace(`/home/c/${conversationId.value}`)
       }
+      maybeGenerateTitle()
     } catch (error) {
       // A watcher rejection is an unhandled promise nobody sees, and losing a thread silently is
       // worse than losing it loudly — the conversation stays on screen either way.

--- a/apps/core-app/src/renderer/src/views/base/home/HomePage.vue
+++ b/apps/core-app/src/renderer/src/views/base/home/HomePage.vue
@@ -118,8 +118,28 @@ const canSend = computed(() => draft.value.trim().length > 0 && !isStreaming.val
  * a stored custom title across restore, so the top bar agrees with the sidebar after a reload.
  */
 const generatedTitle = ref<string | null>(null)
-let titleInFlight = false
+/**
+ * Which conversation has a title call in flight — an id, not a boolean. This component instance is
+ * reused across thread switches, so a flat flag set by conversation A would make conversation B's
+ * settled turn skip its own generation window.
+ */
+let titleInFlightFor: string | null = null
 const titleSequence = createLatestOnly()
+
+/**
+ * Every conversation-store write goes through here, in order.
+ *
+ * The settled-turn watcher and the title upgrade both persist, and the SDK does not promise write
+ * ordering — a title upgrade holding an older message snapshot could land after a newer settled
+ * turn and shrink the stored thread. Chaining makes the order the call order, and each writer
+ * re-reads live state inside its queued turn so nothing stale is captured.
+ */
+let persistChain: Promise<void> = Promise.resolve()
+function enqueuePersist(write: () => Promise<void>): Promise<void> {
+  const next = persistChain.then(write, write)
+  persistChain = next.catch(() => {})
+  return next
+}
 
 const firstUserContent = computed(
   () => messages.value.find((message) => message.role === 'user')?.content
@@ -1167,35 +1187,45 @@ function maybeGenerateTitle(): void {
   const firstAssistant = messages.value.find(
     (message) => message.role === 'assistant' && message.status === 'complete'
   )?.content
+  const idAtStart = conversationId.value
+  if (!idAtStart) return
   if (
     !shouldGenerateTitle({
       generatedTitle: generatedTitle.value,
-      inFlight: titleInFlight,
+      inFlight: titleInFlightFor === idAtStart,
       firstUserContent: firstUserContent.value,
       firstAssistantContent: firstAssistant
     })
   ) {
     return
   }
-  const idAtStart = conversationId.value
-  if (!idAtStart) return
   const isCurrent = titleSequence.claim()
-  titleInFlight = true
+  titleInFlightFor = idAtStart
   void (async () => {
     try {
       const title = await generateConversationTitle(
         intelligenceSdk,
         firstUserContent.value ?? '',
-        firstAssistant ?? ''
+        firstAssistant ?? '',
+        {
+          prompt: t('home.titleGen.prompt'),
+          userLabel: t('home.titleGen.userLabel'),
+          assistantLabel: t('home.titleGen.assistantLabel')
+        }
       )
       if (!title || !isCurrent() || conversationId.value !== idAtStart) return
       generatedTitle.value = title
-      await history.persist(idAtStart, title, messages.value)
+      // Queued behind any settled-turn write, and the messages are read inside the queued turn:
+      // however late this lands, it stores the thread as it is then, never a shrunken snapshot.
+      await enqueuePersist(async () => {
+        if (conversationId.value !== idAtStart) return
+        await history.persist(idAtStart, title, messages.value)
+      })
     } catch (error) {
       // The working title is already on screen and persisted; a label upgrade may fail silently.
       homeLog.warn('Conversation title generation failed', String(error))
     } finally {
-      titleInFlight = false
+      if (titleInFlightFor === idAtStart) titleInFlightFor = null
     }
   })()
 }
@@ -1211,7 +1241,10 @@ watch(
   async (streaming, wasStreaming) => {
     if (streaming || !wasStreaming || !conversationId.value) return
     try {
-      await history.persist(conversationId.value, conversationTitle.value ?? '', messages.value)
+      await enqueuePersist(async () => {
+        if (!conversationId.value) return
+        await history.persist(conversationId.value, conversationTitle.value ?? '', messages.value)
+      })
       // Landing on the conversation's own URL is what lets the sidebar and a reload return to it.
       if (route.params.id !== conversationId.value) {
         await router.replace(`/home/c/${conversationId.value}`)


### PR DESCRIPTION
Item 1 of #969: the working title — the user's opening message verbatim — becomes a model-generated short label after the first settled turn. Item 2 (sidebar time buckets) landed with the app-shell-v2 convergence; this was the half still open.

## Design constraints, all from the issue

- **Same provider, low stakes**: one `text.chat` call, temperature 0.2, 32 tokens, 10s timeout, fired only after the first exchange completes.
- **Silent fallback, everywhere**: the settled-turn persist writes the working title *before* generation starts, so the thread is durable regardless; a rejection, timeout, empty or unusable answer all resolve to null and keep what is on screen. A label is never worth an error surface.
- **Once per conversation**: a non-null title — generated now or restored from storage — blocks regeneration; an in-flight flag stops a second settled turn from stacking a call; `createLatestOnly` drops a result that lands after a thread switch, so a slow answer cannot stamp the wrong conversation.

## Rejection, not truncation

A model that answers in prose does not get its first clause persisted as the label — over-ceiling and multi-line answers normalise to null, and the user's own words stay. Wrapping quotes (straight, curly, CJK corner and title marks) and trailing stops are stripped; the unwrap and the period-strip interleave until stable because `《标题》。` only exposes its pair after the stop goes, and a bare `「」` unwraps to empty and is rejected.

## `history.load` now returns `{ title, messages }`

It always fetched the title and dropped it — fine while the title was derivable from the messages, wrong the moment one is not. Without it, the top bar (recomputed working title) would disagree with the sidebar (stored title) after every reload. `deriveRestoredTitle` treats a stored title equal to the opening message as *not custom*: the pre-generation persist writes exactly that back, and reading it as custom would block generation forever.

## Verification

- 17 new module tests: normalization both directions (pass-through, unwrap, reject), the fire-once predicate, restore derivation, and the SDK call shape (message count, temperature/token/timeout ceilings, transcript clipping, silent-null on rejection and on unusable answers).
- The history suite reshaped for the new return type, with a new assertion that the stored title survives the trip out.
- 148 conversation-module tests green; `vue-tsc -p tsconfig.web.json` at 0.
- Wiring in `HomePage.vue` is deliberately thin (one call from the existing settled-turn watcher + one derive on restore); the SFC has no mounting harness, so the logic lives in the tested module and the wiring stays small enough to read.

Refs #969


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic conversation titles based on the initial exchange.
  * Preserved custom titles when restoring conversations.
  * Generated titles are cleaned, shortened, and saved automatically.
  * Conversation restoration now includes both saved titles and messages.

* **Bug Fixes**
  * Prevented duplicate or outdated title generation during navigation.
  * Added graceful handling for unavailable or invalid title-generation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->