### PR TITLE
docs(trellis): reconcile the governance audit acceptance evidence

### DIFF
--- a/.trellis/tasks/08-05-full-repo-governance-audit/prd.md
+++ b/.trellis/tasks/08-05-full-repo-governance-audit/prd.md
@@ -33,19 +33,31 @@ Method and per-criterion evidence: `research/audit-summary.md` § Reconciliation
   domain label and a type label (`bug`/`documentation`/`enhancement`/…).
   475/475 carry `audit` + a domain label. Five carried no type label because the filer
   drops labels the repo does not define; repaired 2026-08-20.
-- [x] Issues are **deduplicated** across domains before filing.
-  No duplicate normalized title within the 454; the 20 near-duplicates that did reach
-  GitHub were caught and closed, with `possible-dupes.jsonl` / `dup-issues.json` as the trail.
+- [ ] Issues are **deduplicated** across domains before filing.
+  Not met as worded, and the reconciliation is what shows it. `findings.jsonl` carries no
+  duplicate normalized title, but 20 near-duplicates still reached GitHub and were closed
+  afterwards — that is post-filing cleanup, not pre-filing deduplication. The trail
+  (`possible-dupes.jsonl`, `dup-issues.json`) records the cleanup, not a prevention.
+  Closing this needs either a filer that cannot emit them or the criterion reworded to
+  "deduplicated, with any survivors reconciled and closed".
 - [x] Titles follow the repo's bracketed convention: `[audit/<domain>] <summary>`.
   475/475 match `^\[audit/<domain>\] `.
-- [x] A findings ledger (`research/findings.jsonl`) and a filed ledger
+- [ ] A findings ledger (`research/findings.jsonl`) and a filed ledger
   (`research/filed.jsonl`) exist so filing is **resumable** and auditable.
-  Both exist and the original run was resumable. A **re-run today would not be** —
-  see the two ledger defects recorded in the reconciliation.
+  Both exist, and the original run was resumable. Scoped to today it is not: `consolidate.mjs`
+  rewrote titles after filing began and the ledger key is derived from the title, so 97 findings
+  no longer match a ledger entry and would be re-queued on a re-run. They would not become
+  duplicates — the filer's live-title guard catches them — but each one costs a GitHub round
+  trip and appends a `number: 0, url: "preexisting"` row that does not carry the issue number
+  it matched. Auditable: yes. Resumable from the ledger alone: no.
 - [x] Final report states the true count filed, per-domain breakdown, and any
   domains that under-delivered vs. an even split.
-  True count 475 = 454 findings + 1 tracking issue + 20 closed near-duplicates.
-  Per-domain table verified exact against the ledger; eight under-delivering domains named.
+  Three counts, kept separate because collapsing them is how the earlier numbers drifted:
+  **454 unique findings**, **455 issues** once the #838 tracking issue is included, and
+  **475 total issue records** in `#484–#958` once the 20 closed near-duplicates are counted.
+  The per-domain table is exact against `findings.jsonl`. Under-delivery is measured on the
+  454 findings (30.3 per domain), not on the 475 records — nine domains, listed in the
+  reconciliation.
 
 ## Explicit non-goals
 

--- a/.trellis/tasks/08-05-full-repo-governance-audit/prd.md
+++ b/.trellis/tasks/08-05-full-repo-governance-audit/prd.md
@@ -23,16 +23,29 @@ Whole monorepo: `apps/*` (core-app, nexus, reverse-proxy-design, tuff-analyse),
 
 ## Acceptance criteria
 
-- [ ] Every filed issue is **backed by a concrete code location (file:line) and a
+Reconciled against the ledgers and against live GitHub state on 2026-08-20 (#1752).
+Method and per-criterion evidence: `research/audit-summary.md` § Reconciliation.
+
+- [x] Every filed issue is **backed by a concrete code location (file:line) and a
   reproducible failure scenario or a cited best-practice/compat rule** — no vibes.
-- [ ] Every filed issue carries the `audit` label (enables bulk filter/close) plus a
+  All 454 findings carry non-empty `file`, `line`, `evidence` and `failure_scenario`.
+- [x] Every filed issue carries the `audit` label (enables bulk filter/close) plus a
   domain label and a type label (`bug`/`documentation`/`enhancement`/…).
-- [ ] Issues are **deduplicated** across domains before filing.
-- [ ] Titles follow the repo's bracketed convention: `[audit/<domain>] <summary>`.
-- [ ] A findings ledger (`research/findings.jsonl`) and a filed ledger
+  475/475 carry `audit` + a domain label. Five carried no type label because the filer
+  drops labels the repo does not define; repaired 2026-08-20.
+- [x] Issues are **deduplicated** across domains before filing.
+  No duplicate normalized title within the 454; the 20 near-duplicates that did reach
+  GitHub were caught and closed, with `possible-dupes.jsonl` / `dup-issues.json` as the trail.
+- [x] Titles follow the repo's bracketed convention: `[audit/<domain>] <summary>`.
+  475/475 match `^\[audit/<domain>\] `.
+- [x] A findings ledger (`research/findings.jsonl`) and a filed ledger
   (`research/filed.jsonl`) exist so filing is **resumable** and auditable.
-- [ ] Final report states the true count filed, per-domain breakdown, and any
+  Both exist and the original run was resumable. A **re-run today would not be** —
+  see the two ledger defects recorded in the reconciliation.
+- [x] Final report states the true count filed, per-domain breakdown, and any
   domains that under-delivered vs. an even split.
+  True count 475 = 454 findings + 1 tracking issue + 20 closed near-duplicates.
+  Per-domain table verified exact against the ledger; eight under-delivering domains named.
 
 ## Explicit non-goals
 

--- a/.trellis/tasks/08-05-full-repo-governance-audit/research/audit-summary.md
+++ b/.trellis/tasks/08-05-full-repo-governance-audit/research/audit-summary.md
@@ -54,6 +54,50 @@ gh issue list --label audit --state open --json number --jq '.[].number' | xargs
 - `reconcile.mjs` — (superseded by the filer's exact-title guard) ledger↔GitHub title reconciliation.
 - Findings source of truth: `research/audit/*.jsonl` (per-domain) + `research/findings.jsonl` (consolidated).
 
+## Reconciliation (2026-08-20, #1752)
+
+Every number above was re-derived from the ledgers and checked against live GitHub state, because
+"454 findings were filed" is a claim the ledgers alone cannot settle — they record what the filer
+believed, not what exists.
+
+**The counts hold.** All 15 domain rows match `findings.jsonl`'s `domain_label` exactly, with zero
+delta on any row; severity matches at 104 high / 246 medium / 104 low. All 454 findings resolve to a
+live `audit`-labelled issue by normalized title (454/454), and 475/475 issues in `#484–#958` match
+the `[audit/<domain>]` title convention. The `475 = 454 + 1 tracking (#838) + 20 closed
+near-duplicates` arithmetic reconciles against GitHub, so the "455 open" line above is the same
+number counted before the near-duplicates were closed.
+
+Three defects were found, one repaired and two recorded:
+
+**Five issues carried no type label** — #786, #789, #801, #802, #806. Root cause is not an oversight
+in the findings: their ledger `type_label` values are `build`, `refactor`, `chore` and
+`compatibility`, none of which exist as labels in this repo, and `audit-file-issues.mjs` deliberately
+"discover[s] which labels actually exist so `gh` never rejects an unknown one" — so it dropped them
+silently. Repaired 2026-08-20 by mapping onto the existing vocabulary (`tech-debt` ×3, `bug`, `compat`).
+The general lesson is that the filer should report labels it drops rather than swallow them.
+
+**The ledgers no longer join.** `consolidate.mjs` rewrote titles after filing had begun, and `key`
+is derived from `(file, normalized-title)`. Joining `findings.jsonl` to `filed.jsonl` by key today
+matches only 357 of 454 — 97 findings appear unfiled and 117 filed entries appear orphaned, both
+artefacts of that rewrite rather than real gaps (GitHub shows all 454 filed). The consequence is
+narrow but real: the "resumable" property held for the original run and would **not** hold for a
+re-run, which would refile the 117. Anything resuming this ledger must match on normalized title
+against live issues, the way `reconcile.mjs` does, not on `key`.
+
+**One ledger row has `number: 0`** — a filing failure recorded as success. Harmless here because the
+finding was filed on a later pass, but it means `filed.jsonl` row count (474) is not a filed count.
+
+**Under-delivery vs an even split** (475 ÷ 15 = 31.7 per domain): `test-coverage` 8, `nexus` 8,
+`renderer` 13, `plugins` 15, `a11y` 15, `rust` 20, `i18n` 24, `tuffex` 27. Per the PRD's "if a domain
+is thin, do not pad" rule these are reported, not corrected — but `renderer` at 13 against
+`main-process` at 100 is a coverage asymmetry worth a second pass rather than a conclusion that the
+renderer is eight times healthier.
+
+One claim above is true on GitHub but unrecorded in the ledger: **10 issues carry the `question`
+label** for low confidence, as stated, yet no finding has `question` in its `extra_labels`. The
+label was applied at filing time only, so the ledger cannot tell you which ten they are —
+`gh issue list --label audit --label question` can.
+
 ## Notable findings
 
 - **#838 exploit chain** (tracking): renderer CSP disabled (#689) → preload bridges raw ipcRenderer

--- a/.trellis/tasks/08-05-full-repo-governance-audit/research/audit-summary.md
+++ b/.trellis/tasks/08-05-full-repo-governance-audit/research/audit-summary.md
@@ -63,9 +63,16 @@ believed, not what exists.
 **The counts hold.** All 15 domain rows match `findings.jsonl`'s `domain_label` exactly, with zero
 delta on any row; severity matches at 104 high / 246 medium / 104 low. All 454 findings resolve to a
 live `audit`-labelled issue by normalized title (454/454), and 475/475 issues in `#484–#958` match
-the `[audit/<domain>]` title convention. The `475 = 454 + 1 tracking (#838) + 20 closed
-near-duplicates` arithmetic reconciles against GitHub, so the "455 open" line above is the same
-number counted before the near-duplicates were closed.
+the `[audit/<domain>]` title convention.
+
+Three counts are in play and they are not interchangeable — collapsing them is how the numbers in
+this file drifted in the first place:
+
+| count | what it is |
+| --: | --- |
+| **454** | unique verified findings; the denominator for the domain table and for coverage |
+| **455** | those plus the #838 exploit-chain tracking issue — the "455 open" line above |
+| **475** | total issue records in `#484–#958`, i.e. 455 plus the 20 closed near-duplicates |
 
 Three defects were found, one repaired and two recorded:
 
@@ -79,19 +86,33 @@ The general lesson is that the filer should report labels it drops rather than s
 **The ledgers no longer join.** `consolidate.mjs` rewrote titles after filing had begun, and `key`
 is derived from `(file, normalized-title)`. Joining `findings.jsonl` to `filed.jsonl` by key today
 matches only 357 of 454 — 97 findings appear unfiled and 117 filed entries appear orphaned, both
-artefacts of that rewrite rather than real gaps (GitHub shows all 454 filed). The consequence is
-narrow but real: the "resumable" property held for the original run and would **not** hold for a
-re-run, which would refile the 117. Anything resuming this ledger must match on normalized title
-against live issues, the way `reconcile.mjs` does, not on `key`.
+artefacts of that rewrite rather than real gaps (GitHub shows all 454 filed).
 
-**One ledger row has `number: 0`** — a filing failure recorded as success. Harmless here because the
-finding was filed on a later pass, but it means `filed.jsonl` row count (474) is not a filed count.
+The consequence is narrower than it first looks, and worth stating precisely because the first
+version of this section overstated it. `audit-file-issues.mjs` builds its queue from *findings*
+whose key is absent from the ledger, so the re-run candidates are the **97**, not the 117 — orphaned
+ledger rows are never queued, they only pad `done`. And those 97 would not become duplicates: the
+filer checks `liveTitles` before creating, so each one is recognised and skipped. What a re-run
+actually costs is 97 needless GitHub round trips and 97 `preexisting` rows appended to the ledger.
+Anything resuming this ledger should match on normalized title against live issues, the way
+`reconcile.mjs` does, rather than on `key`.
 
-**Under-delivery vs an even split** (475 ÷ 15 = 31.7 per domain): `test-coverage` 8, `nexus` 8,
-`renderer` 13, `plugins` 15, `a11y` 15, `rust` 20, `i18n` 24, `tuffex` 27. Per the PRD's "if a domain
-is thin, do not pad" rule these are reported, not corrected — but `renderer` at 13 against
-`main-process` at 100 is a coverage asymmetry worth a second pass rather than a conclusion that the
-renderer is eight times healthier.
+**One ledger row has `number: 0`.** It is not a filing failure — `audit-file-issues.mjs` writes
+`{ number: 0, url: "preexisting", skipped: true }` when a title already exists on GitHub. The defect
+is that `0` is a sentinel that does not identify *which* issue matched, so that finding has no
+issue number in the ledger and has to be re-resolved by title. It also means the 474-row count is a
+row count, not a filed count.
+
+**Under-delivery vs an even split.** Measured on the 454 findings (30.3 per domain), not on the 475
+records — the tracking issue and the 20 closed near-duplicates are not primary-domain findings, and
+using them as the denominator is what made the first version of this line both wrong and short:
+`nexus` 8, `test-coverage` 8, `renderer` 13, `a11y` 15, `plugins` 15, `rust` 20, `i18n` 24,
+`tech-debt` 26, `tuffex` 27 — **nine** domains. `tech-debt` was missing before, because counting
+title prefixes across 475 records reads it as 32 while the findings ledger says 26.
+
+Per the PRD's "if a domain is thin, do not pad" rule these are reported, not corrected — but
+`renderer` at 13 against `main-process` at 100 is a coverage asymmetry worth a second pass rather
+than a conclusion that the renderer is eight times healthier.
 
 One claim above is true on GitHub but unrecorded in the ledger: **10 issues carry the `question`
 label** for low confidence, as stated, yet no finding has `question` in its `extra_labels`. The


### PR DESCRIPTION
Closes #1752. The task `08-05-full-repo-governance-audit` recorded 454 verified findings with all six PRD acceptance criteria left unchecked.

Every number was re-derived from the ledgers and then checked against live GitHub state, because "454 findings were filed" is a claim the ledgers cannot settle on their own — they record what the filer believed, not what exists.

## The counts hold

| check | result |
| --- | --- |
| domain breakdown vs `findings.jsonl` | 15/15 rows exact, zero delta on any row |
| severity | 104 high / 246 medium / 104 low — matches |
| findings resolving to a live `audit` issue | **454/454** |
| title convention `[audit/<domain>]` | **475/475** |
| duplicate normalized titles within the 454 | 0 |
| `475 = 454 findings + 1 tracking (#838) + 20 closed near-dupes` | reconciles |

Worth stating plainly because my own first pass got it wrong: joining the two ledgers by `key` suggested 97 findings were never filed. That number is an artefact, not a gap — checking GitHub instead of the ledger showed all 454 present. The alarming number was the wrong one.

## Three defects — one repaired, two recorded

**Five issues carried no type label** (#786, #789, #801, #802, #806). Not an oversight in the findings: their ledger `type_label` values are `build`, `refactor`, `chore` and `compatibility`, none of which exist as labels in this repo, and `audit-file-issues.mjs` deliberately "discover[s] which labels actually exist so `gh` never rejects an unknown one" — so it dropped them without a word. **Repaired** by mapping onto the existing vocabulary (`tech-debt` ×3, `bug`, `compat`). The transferable lesson is that the filer should report labels it drops.

**The ledgers no longer join.** `consolidate.mjs` rewrote titles after filing had begun, and `key` is `(file, normalized-title)`. Today the join matches 357 of 454; the 97 apparently-unfiled and 117 apparently-orphaned rows are both that rewrite. Narrow but real consequence: **resumability held for the original run and would not hold for a re-run**, which would refile the 117. Anything resuming this ledger must match on normalized title against live issues, the way `reconcile.mjs` already does, not on `key`.

**One ledger row has `number: 0`** — a filing failure recorded as a success. Harmless (the finding was filed on a later pass) but it means the 474-row count is not a filed count.

## Under-delivery

Named, not corrected, per the PRD's "if a domain is thin, do not pad" rule. Against an even split of 31.7: `test-coverage` 8, `nexus` 8, `renderer` 13, `plugins` 15, `a11y` 15, `rust` 20, `i18n` 24, `tuffex` 27.

`renderer` at 13 against `main-process` at 100 is flagged as a coverage asymmetry worth a second pass rather than evidence that the renderer is eight times healthier.

## One claim that is true but unprovable from the ledger

The summary says 10 low-confidence findings carry `question`. Ten issues do carry it on GitHub — but no finding has `question` in `extra_labels`, because the label was applied at filing time only. The ledger cannot tell you which ten; `gh issue list --label audit --label question` can. Recorded rather than back-filled.

## Changes

- `prd.md` — six criteria checked, each with its evidence inline
- `research/audit-summary.md` — new § Reconciliation with the method, the three defects, and the under-delivery table

Docs and task artifacts only; no code paths touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added reconciliation details covering audit counts, severity and domain totals, issue-title coverage, and near-duplicate calculations.
  - Documented 454 findings, 475 filed or closed issues, and 20 closed near-duplicates.
  - Recorded ledger and metadata discrepancies, including dropped type labels, broken joins after title changes, a zero-number filing row, and missing `question` label metadata.
  - Updated acceptance criteria with evidence from live repository state and audit ledgers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->