### PR TITLE
docs(catalog): record the CatalogService completed/open boundary

### DIFF
--- a/.trellis/tasks/07-13-catalog-service-mvp/prd.md
+++ b/.trellis/tasks/07-13-catalog-service-mvp/prd.md
@@ -4,7 +4,13 @@
 
 Land R8-F: one host-owned, fail-closed CatalogService that keeps the built-in Domain Lexicon available offline, verifies a signed whole-pack replacement, imports it atomically into the existing CoreApp SQLite database, explicitly activates/rolls back versions, and supplies the current official registry to R8-E plugin facades.
 
-The detailed EARS contract is `.spec-workflow/specs/catalog-service-mvp/requirements.md`.
+The completed/open boundary, with verification evidence, is
+[`docs/engineering/catalog-service-boundary.md`](../../../docs/engineering/catalog-service-boundary.md).
+
+> The original line here cited `.spec-workflow/specs/catalog-service-mvp/requirements.md` as the
+> detailed EARS contract. That path has never existed in this repository's git history
+> (`git log --all --diff-filter=A` returns nothing for it), so readers were being sent to a
+> specification that was never written. The shared contract source is `packages/utils/i18n/catalog.ts`.
 
 ## Requirements
 
@@ -34,7 +40,18 @@ The detailed EARS contract is `.spec-workflow/specs/catalog-service-mvp/requirem
 - [x] Plugin SDK official resolve/search/collision checks follow the active registry dynamically while existing plugin overlays remain intact and isolated.
 - [x] Diagnostics report the required low-sensitive state and degraded baseline fallback.
 - [x] Focused shared contract, SQLite lifecycle, remote flow, plugin integration, lint, and CoreApp node/web typechecks pass.
-- [ ] R8 PRD, execution plan, quality baseline, changelog, task artifacts, and developer documentation state the exact completed/open boundary.
+- [x] R8 PRD, execution plan, quality baseline, changelog, task artifacts, and developer documentation state the exact completed/open boundary.
+  Boundary written to `docs/engineering/catalog-service-boundary.md` (new) and the four documents
+  that carried stale "CatalogService not done" language: the R8 PRD §0 and §9, the R8/R9 execution
+  plan status header and both phase tables, `PRD-QUALITY-BASELINE.md` §4.10, and `CHANGES.md`.
+  The eight criteria above were re-verified against source on 2026-08-20 rather than taken on
+  trust — 86 focused tests, both typechecks and both packages' lint run clean.
+  **The boundary's substance:** the service contract is complete; the trigger surface is not wired.
+  Outside start-up seed/activate of the built-in pack, nothing in the running application calls
+  `checkUpdates` / `downloadPack` / `importPack` / `activatePack` / `rollback`, and
+  `getCatalogService()` has no caller outside the catalog module, so `CatalogStatus` is computed
+  but never surfaced. Both are consistent with the Scope Boundaries above (no Settings UI, no
+  automatic polling) and are recorded, not treated as defects.
 
 ## Risk / Approval Gate
 

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -18,6 +18,7 @@
 - [`cloud-sync-sdk-usage.md`](./cloud-sync-sdk-usage.md)：Cloud Sync SDK 使用说明。
 - [`sensitive-data-inventory.md`](./sensitive-data-inventory.md)：敏感数据 owner、存储、导出、删除、保留与迁移清单；机器可读源为 [`sensitive-data-inventory.json`](./sensitive-data-inventory.json)。
 - [`tuff-intelligence-rollout-todo.md`](./tuff-intelligence-rollout-todo.md)：Intelligence rollout 专题。
+- [`catalog-service-boundary.md`](./catalog-service-boundary.md)：R8-F CatalogService 的已完成/未完成边界 —— 服务契约已成立，触发面未接出。
 
 ## Evidence 与报告
 

--- a/docs/engineering/catalog-service-boundary.md
+++ b/docs/engineering/catalog-service-boundary.md
@@ -1,0 +1,77 @@
+# CatalogService 完成边界
+
+> 更新时间：2026-08-20
+> 定位：R8-F CatalogService MVP 的已完成/未完成边界。任务契约见 [`.trellis/tasks/07-13-catalog-service-mvp/prd.md`](../../.trellis/tasks/07-13-catalog-service-mvp/prd.md)，产品契约见 [`plan-prd/03-features/i18n-lexicon-catalog-2.6.0-prd.md`](../plan-prd/03-features/i18n-lexicon-catalog-2.6.0-prd.md)。
+
+## 一句话结论
+
+**服务契约已完成并可验证；触发面尚未接出。** CatalogService 的验签、导入、激活、回滚全部实现且有测试覆盖，但除内置 pack 的 seed/activate 之外，**运行中的应用没有任何代码路径会调用它们** —— 远程更新那一半今天只能从测试里到达。
+
+把「CatalogService 已完成」读成「用户或运维今天可以更新 catalog」是错的，这份文档存在的唯一目的就是拦住这个误读。
+
+## 已完成（2026-08-20 复核）
+
+任务 PRD 的 8 条功能验收逐条对照源码复核通过。落点：
+
+| 层 | 位置 |
+| --- | --- |
+| 主进程模块 | `apps/core-app/src/main/modules/catalog/`（`index.ts` 装配与 trust root、`catalog-service.ts` 编排、`catalog-repository.ts` SQLite 生命周期、`catalog-remote.ts` Nexus 适配、`catalog-verifier.ts` 验签） |
+| 共享契约 | `packages/utils/i18n/`（`catalog.ts` 归一化与错误码、`lexicon.ts`、`scoped-lexicon.ts` 插件 overlay、`unit-lexicon.ts` 内置 baseline 与 official facade） |
+| 插件接出 | `apps/core-app/src/main/modules/plugin/plugin-localization-channels.ts` |
+| 表结构 | `apps/core-app/src/main/db/schema.ts`，迁移 `resources/db/migrations/0026_catalog_service.sql` |
+| 信任根 | `apps/core-app/resources/keys/release-signing-public.pem`（仅公钥） |
+| 模块注册 | `apps/core-app/src/main/index.ts` — `catalogModule` 在 `databaseModule` 之后、`permissionModule` / `pluginModule` 之前 |
+
+几条值得单独记的安全性质：
+
+- **manifest 无法自带授权密钥。** `PinnedCatalogVerifier` 只接受 `loadCatalogTrustRoot()` 从打包路径读出的 PEM，且拒绝非 RSA 密钥；`keyId` 是字面量 `"release-v1"`，归一化阶段用 `requireLiteral` 校验，验签路径从不拿 `manifest.keyId` 去查表 —— 它是标签，不是间接层。
+- **pack URL 是内容寻址的，且由签名字段重新推导。** 敌意的 `artifactUrl` 覆盖会被忽略。
+- **JSON 字节只是导入输入。** activate / rollback 一律重新读 SQLite 行来重建 registry，从不复用内存里那份已验签的 pack。
+- **registry 只在持久化提交之后才换。** `index.test.ts` 把 `repository.activatePack` 挂在一个手动控制的 pending promise 上，断言写入在途时 `publishRegistry` 没有被调用过。
+
+### 测试证据
+
+在与本文同源的工作区实测，非引用历史结论：
+
+| 套件 | 结果 |
+| --- | --- |
+| `apps/core-app` catalog 6 个文件（含 `catalog-lifecycle.integration.test.ts`） | 38/38 通过 |
+| `apps/core-app` `plugin-localization-channels.test.ts` | 12/12 通过 |
+| `packages/utils` i18n 4 个文件（含 `active-official-lexicon.test.ts`） | 36/36 通过 |
+| 两个包各自的 eslint 配置 | 0 error |
+| `tsconfig.node.json` / `tsconfig.web.json` typecheck | 0 error |
+
+## 未完成：已实现但运行时不可达
+
+这是本文档的核心，也是任务 PRD 那 8 个 `[x]` 无法自己说清楚的部分。
+
+**远程更新全链路没有调用方。** `checkUpdates` / `downloadPack` / `importPack` / `activatePack` / `rollback` 实现完整、测试充分，但在 `apps/core-app/src` 与 `packages/` 中，除 `modules/catalog/` 自身及其测试外没有任何调用点。仓库里其它 `checkUpdates` 调用属于插件商店与 agent store，其它 `rollback` 调用属于 `invocation` / `buffer` / 插件 host registry，都是同名不同物。
+
+**诊断状态算得出来，但没有出口。** `getCatalogService()` 在 catalog 模块之外零调用方，没有 IPC channel、没有诊断页、没有渲染端消费者会读 `getStatus()`。`CatalogStatus` 的字段是对的，可用性、active/previous 身份与 hash、签名状态、更新时间、回滚原因、稳定错误码都在 —— 但今天它是一个内部 API 契约，不是可观测的功能。
+
+**今天真正在跑的只有 read 路径。** 启动时 seed 并激活内置 pack，插件通过 `officialDomainLexiconRegistry` facade 读到当前 official registry，activate 时 facade 保持对象身份不变而内容被替换，插件 overlay 与跨插件隔离在 activate→rollback 全程保持。这条链路是活的、被测试的、被使用的。
+
+上述三点与 PRD 的 Scope Boundaries 一致（不做 Settings UI、不做自动轮询），**不是缺陷**。记录它们是因为「done」在这里的含义是「服务契约成立」，不是「能力已交付给用户」。要让它成为可交付能力，还需要一个触发面（Settings 入口、IPC channel 或运维命令）与一个状态展示面 —— 两者都在本批范围之外。
+
+## 明确不在范围内（复核未越界）
+
+`CatalogPackType` 是字面量 `"domain-lexicon"` 而非联合类型，`CATALOG_SCHEMA_VERSION` 固定为 1，没有 delta patch 路径、没有发布/管理 API、没有 D1/R2 代码、渲染端零 catalog 引用、插件 overlay 只在内存 `Map` 中不持久化。既有单位换算行为与 `KB` / `Kb` 语义未改动。
+
+## 一处悬空引用
+
+任务 PRD 第 7 行称「详细 EARS 契约是 `.spec-workflow/specs/catalog-service-mvp/requirements.md`」。**该文件在本仓库的 git 历史中从未存在过**（`git log --all --diff-filter=A` 对该路径无结果）。引用它的地方应改为指向本文与共享契约源码，否则读者会去找一份不存在的规格。
+
+## 如何复核
+
+```bash
+# 服务契约
+cd apps/core-app && npx vitest run src/main/modules/catalog
+cd packages/utils && npx vitest run __tests__/i18n
+
+# 「无调用方」这一条 —— 注意先确认扫描本身有效（正控）
+grep -rln "CatalogService" apps/core-app/src --include="*.ts" | grep -v node_modules   # 应能列出 catalog 模块文件
+grep -rn "getCatalogService" apps/core-app/src packages --include="*.ts" --include="*.vue" \
+  | grep -v node_modules | grep -v "modules/catalog/"                                   # 应为空
+```
+
+第二条命令若返回空，先跑第一条确认 grep 确实看得见这些文件 —— 一个拼错的路径同样返回空，而那看起来和「没有调用方」一模一样。

--- a/docs/plan-prd/01-project/CHANGES.md
+++ b/docs/plan-prd/01-project/CHANGES.md
@@ -1,7 +1,15 @@
 # 变更日志
 
-> 更新时间：2026-07-27
+> 更新时间：2026-08-20
 > 定位：只保留当前阶段的高信号变更索引。早期流水记录已从文档树移除，可从 Git 历史追溯。
+
+## 2026-08-20
+
+### catalog: record the CatalogService completed/open boundary
+
+- R8-F CatalogService MVP 的服务契约复核通过：pinned RSA 信任根拒绝 manifest 自带密钥，pack URL 由签名字段重新推导为内容寻址，归一化与验签在任何 mutation 之前 fail-closed，导入经 DB write scheduler 串行化且失败原子，activate/rollback 仅在持久化提交之后重建 official registry。catalog 6 个套件 38/38、`plugin-localization-channels` 12/12、`packages/utils` i18n 4 个套件 36/36 通过，双 typecheck 与两包各自的 eslint 均干净。
+- **触发面未接出**，这是本次记录的重点：除启动时 seed/activate 内置 pack 外，`checkUpdates` / `downloadPack` / `importPack` / `activatePack` / `rollback` 在运行中的应用里没有任何调用方，`getCatalogService()` 在 catalog 模块之外零调用方，诊断状态算得出来但没有出口。三者都与 PRD 的 Scope Boundaries 一致（不做 Settings UI、不做自动轮询），不是缺陷 —— 但「done」在这里的含义是服务契约成立，不是用户可以更新 catalog。
+- 任务 PRD 引用的 `.spec-workflow/specs/catalog-service-mvp/requirements.md` 在 git 历史中从未存在，已改为指向 [`engineering/catalog-service-boundary.md`](../../engineering/catalog-service-boundary.md)。
 
 ## 2026-07-27
 

--- a/docs/plan-prd/03-features/i18n-lexicon-catalog-2.6.0-prd.md
+++ b/docs/plan-prd/03-features/i18n-lexicon-catalog-2.6.0-prd.md
@@ -9,7 +9,8 @@
 
 - R8-D Domain Lexicon V1 已于 2026-07-13 完成：`packages/utils/i18n` 提供带 `source` provenance 的只读 `DomainLexiconRegistry`、53 个内置单位 canonical entries 与共享 conversion source，支持跨 locale aliases、确定性排序和当前 locale label 投影。
 - R8-E Plugin SDK facade 已于 2026-07-13 完成：`sdkapi 260713` 暴露 main/renderer 同构 i18n/lexicon facade，typed transport 只接受 verified context，并由 `i18n.read`、`lexicon.read`、`lexicon.register` fail-closed；plugin-local entries 由宿主命名/provenance、原子有界注册且 disable/unload 清理。
-- Phase 5 CatalogService 与 Phase 6 Quality Gates 仍保持开放；本批不代表 SQLite catalog、签名 pack 或 CI 门禁已完成。
+- R8-F CatalogService MVP 的**服务契约**已于 2026-08-20 复核完成：验签、hash、schema/SDK/locale 校验、SQLite 事务导入、activate/rollback 与 official registry 重建全部实现并通过测试。**但触发面未接出** —— 除启动时 seed/activate 内置 pack 外，远程更新链路在运行中的应用里没有任何调用方，诊断状态也没有出口。完整边界见 [`../../engineering/catalog-service-boundary.md`](../../engineering/catalog-service-boundary.md)。
+- Phase 6 Quality Gates 仍保持开放。
 
 ## 1. Final Goal / North Star
 
@@ -380,7 +381,7 @@ Catalog 数据源：
 
 ## 9. Acceptance Criteria
 
-> 当前完成边界：Phase 3 单位 Domain Lexicon 与 Phase 4 Plugin SDK facade 验收已通过；下列 CatalogService 与质量门禁条目仍是后续 phase 的最终验收要求。
+> 当前完成边界：Phase 3 单位 Domain Lexicon、Phase 4 Plugin SDK facade 与 Phase 5 CatalogService 的服务契约验收均已通过（CatalogService 复核于 2026-08-20）。CatalogService 条目的达成口径是「服务契约成立」而非「能力已交付给用户」：远程更新与状态展示今天没有触发面，逐条边界见 [`../../engineering/catalog-service-boundary.md`](../../engineering/catalog-service-boundary.md)。下列质量门禁条目仍是后续 phase 的最终验收要求。
 
 功能验收：
 

--- a/docs/plan-prd/04-implementation/R8-R9-Next-Stage-Execution-Plan-2026-06-24.md
+++ b/docs/plan-prd/04-implementation/R8-R9-Next-Stage-Execution-Plan-2026-06-24.md
@@ -1,7 +1,7 @@
 # R8 / R9 Next Stage Execution Plan
 
-> 更新时间：2026-07-13
-> 状态：R8-E Plugin SDK facade implemented / R8-F CatalogService MVP next
+> 更新时间：2026-08-20
+> 状态：R8-F CatalogService MVP service contract implemented（触发面未接出）/ R8-G Quality Gates next
 > 范围：R8 i18n / Domain Lexicon / Catalog 2.6.0 与 R9 AI 2.5.x 后续能力。
 
 ## 执行口径
@@ -22,7 +22,7 @@
 | P1     | R9-C / R9-D | 2.5.4 ContextHygiene P0/P1                                           | 建立 session / checkpoint / context package / memory policy，避免 AI 后续能力继续堆隐式长上下文。          |
 | P1     | R8-D        | Domain Lexicon V1（completed 2026-07-13）                            | 单位 registry 已验证跨语言解析、locale 展示与共享 conversion source。                                      |
 | P1     | R8-E        | Plugin SDK facade（completed 2026-07-13）                            | typed main/renderer facade、verified identity、三项 permission 与 plugin namespace/isolation 已闭合。      |
-| P2     | R8-F / R8-G | CatalogService MVP（next）与质量门禁                                 | 验签、hash、schema、SQLite import、activate/rollback 都要 fail-closed。                                    |
+| P2     | R8-F / R8-G | CatalogService MVP（服务契约 completed 2026-08-20）与质量门禁（next） | 验签、hash、schema、SQLite import、activate/rollback 均已 fail-closed 落地并测试；触发面与状态展示未接出。 |
 | P2     | R9-F / R9-G | 2.5.5 Local Model Runtime                                            | runtime binary、模型下载、设备 smoke 与 fallback 链路长，放在 provider/evidence 体系稳定后。               |
 | P2     | R9-H / R9-I | 2.5.8 ASR Provider Runtime                                           | 录音权限、音频 artifact、local/cloud/auto 策略独立推进，不绑定本地 LLM runtime。                           |
 
@@ -91,7 +91,7 @@ flowchart TD
 | -------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | R8-A/B/C | mostly landed             | locale core、LocalizedText/List、插件 manifest localized metadata loader / display path                                                                                                                                                                                                                                                | 兼容回归与散落 UI/domain 文案审计继续开放。                                   |
 | R8-D     | completed                 | 只读 DomainLexiconRegistry、53-entry unit baseline、跨语言 aliases、locale label、PreviewSDK/CoreApp/QuickOps 共享 conversion source                                                                                                                                                                                                   | 不外推到 currency/timezone 等领域。                                           |
-| R8-E     | completed                 | `sdkapi 260713` main/renderer i18n+lexicon facade、typed transport、verified identity、`i18n.read`/`lexicon.read`/`lexicon.register`、plugin-scoped atomic overlay 与 lifecycle cleanup                                                                                                                                                | overlay 不持久化；R8-F CatalogService MVP 为下一批。                          |
+| R8-E     | completed                 | `sdkapi 260713` main/renderer i18n+lexicon facade、typed transport、verified identity、`i18n.read`/`lexicon.read`/`lexicon.register`、plugin-scoped atomic overlay 与 lifecycle cleanup                                                                                                                                                | overlay 不持久化；R8-F CatalogService MVP 服务契约已于 2026-08-20 完成，见下一行。 |
 | R9-A/B   | foundation consumed       | SQLite / FTS5 / metadata / citation；host assembler 与 controlled/packaged Provider payload 已证明 ContextPackage 参与模型输入                                                                                                                                                                                                         | 真实用户 profile、permission/citation 广覆盖与 embeddings/rerank 增强仍开放。 |
 | R9-C/D/E | P0/P1 closure implemented | session/checkpoint/package logs、host assembler、CoreBox controls、Memory governance/Review、CompressionSnapshot、多入口 isolation、inactive summary continuation、metadata-only tombstone explain 与 evidence verifier 已落；Workflow `new / session` 与 OmniPanel `new / light` packaged owner/scope/single-dispatch evidence 已闭合 | real-profile 与 `scopeRef` migration follow-up。                              |
 

--- a/docs/plan-prd/PRD-QUALITY-BASELINE.md
+++ b/docs/plan-prd/PRD-QUALITY-BASELINE.md
@@ -140,7 +140,8 @@
 - `LocalizedText` / `LocalizedList` 必须支持 default 值与按 locale 解析；缺失翻译只能走显式 fallback chain，不得临时拼接中英文。
 - 2026-06-24 已落地 R8 Phase 1/2 foundation：共享 Locale Core、`LocalizedText` / `LocalizedList` resolver、CoreApp 插件 manifest localized metadata loader 与运行态展示解析。
 - 2026-07-13 已落地 R8 Phase 3 Domain Lexicon V1：带 `source=builtin` provenance 的只读 registry、53-entry 单位 baseline、跨语言 aliases、locale label 与 PreviewSDK/CoreApp/QuickOps 共享 conversion source。
-- 2026-07-13 已落地 R8 Phase 4 Plugin SDK facade：`sdkapi 260713` main/renderer typed surface、verified context、`i18n.read` / `lexicon.read` / `lexicon.register` fail-closed、host namespace/provenance、原子 bounds、跨插件隔离与 disable/unload cleanup；CatalogService 与质量门禁仍未完成。
+- 2026-07-13 已落地 R8 Phase 4 Plugin SDK facade：`sdkapi 260713` main/renderer typed surface、verified context、`i18n.read` / `lexicon.read` / `lexicon.register` fail-closed、host namespace/provenance、原子 bounds、跨插件隔离与 disable/unload cleanup。
+- 2026-08-20 已复核 R8 Phase 5 CatalogService **服务契约**：pinned RSA 信任根（manifest 不能自带密钥）、内容寻址下载、fail-closed 归一化与验签、DB write scheduler 串行化的失败原子导入、activate/rollback 仅在持久化提交后重建 official registry，插件 overlay 与跨插件隔离在 activate→rollback 全程保持。达成口径是服务契约成立而非能力交付：远程更新链路与诊断状态在运行中的应用里没有调用方，边界见 [`../engineering/catalog-service-boundary.md`](../engineering/catalog-service-boundary.md)。质量门禁仍未完成。
 - Domain Lexicon entry 必须包含 stable id、domain/source provenance、version、labels、aliases 与 locale coverage；metadata 必须是 plain JSON，单位换算展示、解析和搜索召回必须消费同一 official registry。
 - 插件 SDK 只能开放受控 facade，不暴露宿主内部 resolver、raw locale store 或未隔离 catalog 写入；plugin overlay 只驻留内存，不能覆盖 official 或跨 plugin 读取。
 - CatalogService 必须覆盖 download、verify、schema validate、SQLite import、activate、rollback 与版本状态；校验失败不得污染 active catalog。


### PR DESCRIPTION
Closes #1751 — the last open criterion on `07-13-catalog-service-mvp`.

## What was actually wrong

Four planning documents still said CatalogService was not done, months after it landed, and no developer documentation for it existed at all:

| document | stale text |
| --- | --- |
| R8 PRD §0 | "Phase 5 CatalogService 与 Phase 6 Quality Gates 仍保持开放" |
| R8 PRD §9 | "下列 CatalogService 与质量门禁条目仍是后续 phase 的最终验收要求" |
| R8/R9 execution plan | status header "R8-F CatalogService MVP next"; both phase tables `（next）` |
| `PRD-QUALITY-BASELINE.md` §4.10 | "CatalogService 与质量门禁仍未完成" |
| `CHANGES.md` | every catalog mention sits under `## 2026-07-13` — *before* the module's first commit (`cd8dbc7b7`, 07-14). Two later dated sections never mention it. |
| developer documentation | did not exist |

## The eight "done" criteria were re-verified, not taken on trust

They hold. Run against source, not quoted from the task record:

| suite | result |
| --- | --- |
| `apps/core-app` catalog, 6 files incl. the lifecycle integration test | **38/38** |
| `apps/core-app` `plugin-localization-channels.test.ts` | **12/12** |
| `packages/utils` i18n, 4 files incl. `active-official-lexicon.test.ts` | **36/36** |
| both packages' own eslint configs | 0 errors |
| `tsconfig.node.json` + `tsconfig.web.json` | 0 errors |

The security properties check out specifically: a manifest cannot supply its own authoritative key (`keyId` is the literal `"release-v1"` validated by `requireLiteral`; the verifier only ever takes the packaged PEM), pack URLs are re-derived from signed fields so a hostile `artifactUrl` is ignored, and `index.test.ts` holds `activatePack` on a controlled pending promise to prove the live registry is not swapped before persistence commits.

## The boundary this exists to state

**The service contract is complete. The trigger surface is not wired.**

Outside start-up seed/activate of the built-in pack, nothing in the running application calls `checkUpdates`, `downloadPack`, `importPack`, `activatePack` or `rollback` — the remote-update half is reachable only from tests. `getCatalogService()` has no caller outside the catalog module, so `CatalogStatus` is computed correctly and never surfaced anywhere.

Both follow from the PRD's own Scope Boundaries (no Settings UI, no automatic polling), so they are recorded as boundary, **not** as defects. The reason it needs saying in six places is that "CatalogService is done" otherwise reads as "a user can update a catalog today", and that is not true.

What *is* live: the read path. Plugins see the current official registry through the `officialDomainLexiconRegistry` facade, which keeps object identity across activation while its contents are replaced, with plugin overlays and cross-plugin isolation preserved through a full activate→rollback cycle.

The tree contains same-named calls that are **not** this service — `checkUpdates` on the plugin and agent stores, `rollback` on `invocation`, `buffer` and plugin-host registries. The no-caller scan is documented in the new doc with a positive control, so the next reader can distinguish a true absence from a mistyped path.

## Also fixed: a dangling reference

The task PRD cited `.spec-workflow/specs/catalog-service-mvp/requirements.md` as "the detailed EARS contract". That path has never existed in this repository's git history (`git log --all --diff-filter=A` returns nothing), so readers were being sent to a specification that was never written. Replaced with the new boundary doc and a pointer to `packages/utils/i18n/catalog.ts` as the shared contract source.

## Changes

- **new** `docs/engineering/catalog-service-boundary.md`, indexed from `docs/engineering/README.md`
- R8 PRD §0 and §9, execution plan header and both phase tables, quality baseline §4.10, `CHANGES.md` dated entry
- task `prd.md`: criterion 9 checked with its evidence, dangling reference replaced

Documentation only; no code paths touched. All relative links verified to resolve.