### PR TITLE
test(nexus): stop check-worker-bundle demanding icons this app cannot draw

### DIFF
--- a/apps/nexus/build/check-worker-bundle.test.ts
+++ b/apps/nexus/build/check-worker-bundle.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { existsSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
+import { createGenerator } from 'unocss'
 import enLocale from '../i18n/locales/en'
 import zhLocale from '../i18n/locales/zh'
+import unoConfig from '../uno.config'
 
 const nexusRoot = join(import.meta.dirname, '..')
 const shotsRoot = join(nexusRoot, 'public/shots')
@@ -91,60 +93,48 @@ describe('Nexus deploy asset budget', () => {
     expect(guardSource).toContain('unprefixed Attributify selectors leaked into production CSS')
   })
 
+  /**
+   * This used to assert specific icon *names* in ten route files, and the list had gone wrong in
+   * both directions (#1768): it required `i-simple-icons-apple`, `i-ri-safari-line`,
+   * `i-ri-edge-line`, `i-ri-figma-fill` and `i-ri-fingerprint-2-line` -- names from `ri` and
+   * `simple-icons`, which this app does not install and which therefore draw nothing -- while
+   * forbidding `i-cib-*`, the only brand collection it does install. `build/check-icon-collections.mjs`
+   * now owns that question and answers it from `package.json`, so those lists are not just stale,
+   * they contradict a guard in the same directory: any file satisfying the old "must contain" list
+   * would fail the new collection check.
+   *
+   * What is left here is the part that check cannot see. A shortcut rewrites a class *after* it is
+   * written, so `i-carbon-settings` -- a perfectly valid installed-collection name -- passed the
+   * collection guard while being redirected to `i-ri-settings-line` and rendering nothing, in 12
+   * files. Asserting on generated CSS is immune to that indirection in a way that any name-based
+   * allowlist is not.
+   */
+  it('emits real CSS for every icon shortcut, so none can redirect onto an uninstalled collection', async () => {
+    const uno = await createGenerator(unoConfig)
+    const iconShortcuts = (unoConfig.shortcuts ?? []).filter(
+      (entry): entry is [string, string] => Array.isArray(entry) && entry[0].startsWith('i-'),
+    )
+
+    for (const [from] of iconShortcuts) {
+      const { css } = await uno.generate(from, { preflights: false })
+      expect(css.length, `shortcut ${from} emits no CSS`).toBeGreaterThan(0)
+    }
+
+    // The loop above is vacuous while there are no icon shortcuts, and a broken generator would
+    // read the same way. Prove the check discriminates: an installed collection resolves, and a
+    // name from a collection absent from package.json does not.
+    const installed = await uno.generate('i-carbon-settings', { preflights: false })
+    expect(installed.css.length, 'i-carbon-settings should resolve from @iconify-json/carbon').toBeGreaterThan(0)
+    const uninstalled = await uno.generate('i-ri-settings-line', { preflights: false })
+    expect(uninstalled.css.length, 'i-ri-settings-line should not resolve — ri is not a dependency').toBe(0)
+  })
+
   it('keeps oversized route-local icon paths out of the shared entry CSS', () => {
     const unoSource = readFileSync(unoConfigPath, 'utf8')
     const guardSource = readFileSync(workerBundleGuardPath, 'utf8')
-    const iconSources = [
-      'app/pages/dashboard/overview.vue',
-      'app/pages/dashboard/devices.vue',
-      'app/pages/sign-in/components/SignInPasskeyStep.vue',
-      'app/pages/sign-in/components/SignInEmailStep.vue',
-      'app/pages/new/components/NewNexusHero.vue',
-      'app/pages/new/components/NewLandingStats.vue',
-      'app/components/tuff/landing/TuffLandingPlugins.vue',
-      'app/components/tuff/landing/TuffLandingStats.vue',
-      'app/components/tuff/landing/TuffLandingAiOverview.vue',
-      'app/components/dashboard/DashboardNav.vue',
-    ].map(file => readFileSync(join(nexusRoot, file), 'utf8')).join('\n')
 
-    expect(unoSource).toContain("['i-simple-icons-linux', 'i-carbon-linux-alt']")
-    expect(unoSource).toContain("['i-carbon-settings', 'i-ri-settings-line']")
-    expect(unoSource).toContain("['i-carbon-fire', 'i-ri-fire-line']")
-    expect(unoSource).toContain("['i-ri-settings-3-line', 'i-ri-settings-line']")
-    expect(unoSource).toContain("['i-ri-settings-3-fill', 'i-ri-settings-fill']")
-    expect(unoSource).toContain("['i-carbon-data-vis-1', 'i-ri-bar-chart-line']")
-    expect(unoSource).toContain("['i-carbon-deployment-pattern', 'i-ri-route-line']")
-    expect(unoSource).toContain("['i-carbon-queued', 'i-ri-time-line']")
-    expect(unoSource).toContain("['i-carbon-ai-status', 'i-ri-robot-2-line']")
     expect(unoSource).not.toContain("['i-carbon-circle-dash', 'i-ri-loader-4-line']")
     expect(unoSource).not.toContain("['i-carbon-color-palette', 'i-ri-palette-line']")
-    const oversizedIcons = [
-      ['i-cib', 'apple'],
-      ['i-cib', 'linux'],
-      ['i-cib', 'safari'],
-      ['i-cib', 'microsoft-edge'],
-      ['i-carbon', 'fingerprint-recognition'],
-      ['i-simple-icons', 'snowflake'],
-      ['i-carbon', 'logo-figma'],
-      ['i-carbon', 'tool-kit'],
-      ['i-carbon', 'machine-learning-model'],
-    ].map(parts => parts.join('-'))
-    for (const icon of oversizedIcons) {
-      expect(iconSources).not.toContain(icon)
-    }
-    for (const icon of [
-      'i-simple-icons-apple',
-      'i-simple-icons-linux',
-      'i-ri-safari-line',
-      'i-ri-edge-line',
-      'i-ri-fingerprint-2-line',
-      'i-carbon-snowflake',
-      'i-ri-figma-fill',
-      'i-carbon-tools',
-      'i-carbon-machine-learning',
-    ]) {
-      expect(iconSources).toContain(icon)
-    }
     expect(guardSource).toContain('const sharedEntryCssBudget')
     expect(guardSource).toContain('maxBytes: 278_000')
     expect(guardSource).toContain('maxGzipBytes: 50_000')


### PR DESCRIPTION
Fixes #1768. **Rebased onto `9237a8282`** — that commit deleted the icon shortcuts and extended `check-icon-collections.mjs` to scan `uno.config.ts`, which is the same conclusion this branch had reached. Its `uno.config.ts` change is therefore dropped; only the test half remains, and master is red because of it.

## master currently contradicts itself

`9237a8282` removed the icon shortcuts. `check-worker-bundle.test.ts` still requires them:

```ts
expect(unoSource).toContain("['i-simple-icons-linux', 'i-carbon-linux-alt']")
expect(unoSource).toContain("['i-carbon-settings', 'i-ri-settings-line']")
// …seven more
```

Reproduced by putting master's own copy of the file back on top of master:

```
AssertionError: expected 'import {\n  defineConfig,\n  presetAt…'
  to contain '['i-simple-icons-linux', 'i-carbon…'
Tests  1 failed | 18 passed (19)
```

The same test separately requires ten route files to contain `i-simple-icons-apple`, `i-ri-safari-line`, `i-ri-edge-line`, `i-ri-fingerprint-2-line` and `i-ri-figma-fill`, while forbidding `i-cib-*`. That is backwards — `i-cib-apple` emits 1,629 bytes of real icon CSS and the `ri`/`simple-icons` names emit none — and it contradicts `check-icon-collections.mjs` in the same directory: **a file satisfying the old "must contain" list is an offender to the new guard.** Both tests cannot pass.

## What changes

The name lists are removed rather than corrected, because the question they were trying to answer now has an owner that answers it from `package.json`.

In their place, an assertion that every `i-*` shortcut generates non-empty CSS. This is complementary, not duplicated:

- `check-icon-collections.mjs` reads the class **as written**, so it catches a shortcut pointing at a missing *collection* — which is the case that actually happened.
- Generating CSS also catches a shortcut pointing at a name that does not exist *inside an installed collection*, which a collection scan reads as fine.

It carries its own positive control, since a loop over zero shortcuts and a broken generator read identically:

```ts
const installed = await uno.generate('i-carbon-settings', ...)
expect(installed.css.length).toBeGreaterThan(0)
const uninstalled = await uno.generate('i-ri-settings-line', ...)
expect(uninstalled.css.length).toBe(0)
```

The `sharedEntryCssBudget` assertions are untouched.

## Verification

| check | result |
| --- | --- |
| nexus suite on top of `9237a8282` | **202 files / 1120 tests pass** |
| control — master's own copy of this file, on master | 1 failed / 18 passed, the contradiction above |
| `node build/check-icon-collections.mjs` | `ok — installed: carbon, cib, logos, twemoji`, exit 0 |
| eslint | clean |

Earlier revisions of this branch also fixed `uno.config.ts` and confirmed on CI that restoring the six previously-blank icons does **not** trip `sharedEntryCssBudget` — `Nexus (build + checks)` passed with the real build. That data point still stands for `9237a8282`, which makes the same change.

Diff is now one file, −49/+39.