### PR TITLE
fix(core-app): clean the file index on the right database, and stop it deleting apps

### DIFF
--- a/apps/core-app/src/main/service/storage-maintenance.test.ts
+++ b/apps/core-app/src/main/service/storage-maintenance.test.ts
@@ -5,22 +5,29 @@ const {
   deleteMock,
   fileRebuildMock,
   getDbMock,
+  getSearchDbMock,
   runMock,
   selectFromMock,
-  selectMock
+  selectMock,
+  deleteWhereMock,
+  selectWhereMock
 } = vi.hoisted(() => ({
   appRebuildMock: vi.fn(),
   deleteMock: vi.fn(),
   fileRebuildMock: vi.fn(),
   getDbMock: vi.fn(),
+  getSearchDbMock: vi.fn(),
   runMock: vi.fn(),
   selectFromMock: vi.fn(),
-  selectMock: vi.fn()
+  selectMock: vi.fn(),
+  deleteWhereMock: vi.fn(),
+  selectWhereMock: vi.fn()
 }))
 
 vi.mock('../modules/database', () => ({
   databaseModule: {
     getDb: getDbMock,
+    getSearchDb: getSearchDbMock,
     getAuxDb: vi.fn()
   }
 }))
@@ -60,15 +67,28 @@ import { cleanupFileIndex } from './storage-maintenance'
 
 describe('cleanupFileIndex', () => {
   beforeEach(() => {
-    selectFromMock.mockReset().mockResolvedValue([{ count: 1 }])
+    // `.from()` is awaited directly for unscoped counts and chained with `.where()` for scoped
+    // ones, so it has to be thenable *and* carry a `where`.
+    selectWhereMock.mockReset().mockResolvedValue([{ count: 1 }])
+    selectFromMock.mockReset().mockImplementation(() => {
+      const rows = [{ count: 1 }]
+      return Object.assign(Promise.resolve(rows), { where: selectWhereMock })
+    })
     selectMock.mockReset().mockReturnValue({ from: selectFromMock })
-    deleteMock.mockReset().mockResolvedValue(undefined)
+    deleteWhereMock.mockReset().mockResolvedValue(undefined)
+    deleteMock
+      .mockReset()
+      .mockImplementation(() =>
+        Object.assign(Promise.resolve(undefined), { where: deleteWhereMock })
+      )
     runMock.mockReset().mockResolvedValue(undefined)
-    getDbMock.mockReset().mockResolvedValue({
+    const connection = {
       select: selectMock,
       delete: deleteMock,
       run: runMock
-    })
+    }
+    getDbMock.mockReset().mockResolvedValue(connection)
+    getSearchDbMock.mockReset().mockReturnValue(connection)
     appRebuildMock.mockReset().mockResolvedValue({ success: true })
     fileRebuildMock.mockReset().mockResolvedValue({ success: true })
   })
@@ -83,6 +103,34 @@ describe('cleanupFileIndex', () => {
     expect(appRebuildMock.mock.invocationCallOrder[0]).toBeLessThan(
       fileRebuildMock.mock.invocationCallOrder[0]
     )
+  })
+
+  /**
+   * #1770. File rows live in `search-index.db` under the default-on split; `getDb()` is the primary
+   * connection, which holds only the app catalog. Cleaning up through it counted and deleted from
+   * the wrong file.
+   */
+  it('cleans the search connection, not the primary', async () => {
+    await cleanupFileIndex({})
+
+    expect(getSearchDbMock).toHaveBeenCalled()
+    expect(getDbMock).not.toHaveBeenCalled()
+  })
+
+  /**
+   * The other half of #1770, which predates the split: `files` also holds the app catalog,
+   * including user-authored entries added via `addAppByPath` that exist nowhere else and that
+   * `rebuildIndex()` cannot rediscover outside the watch paths. An unscoped delete removed them.
+   */
+  it('scopes the files and file_extensions deletes so the app catalog survives', async () => {
+    await cleanupFileIndex({})
+
+    // Four tables are cleared: fileIndexProgress and scanProgress are file-only and stay
+    // unscoped, while files and file_extensions must each go through `.where(...)`. Asserting the
+    // delete counts rather than the select counts keeps this independent of how the
+    // file_extensions subquery happens to be built.
+    expect(deleteMock).toHaveBeenCalledTimes(4)
+    expect(deleteWhereMock).toHaveBeenCalledTimes(2)
   })
 
   it('returns rebuild error while still attempting file index rebuild', async () => {

--- a/apps/core-app/src/main/service/storage-maintenance.test.ts
+++ b/apps/core-app/src/main/service/storage-maintenance.test.ts
@@ -144,13 +144,14 @@ describe('cleanupFileIndex', () => {
     const [filesPredicate] = deleteWhereMock.mock.calls[1] as [SQL]
 
     expect(render(filesPredicate)).toEqual(render(ne(files.type, 'app')))
-    // The extensions delete must be scoped by the same non-app file set. Rendering the expected
-    // subquery shape verbatim would over-pin how it is built, so assert the load-bearing parts:
-    // it filters file_extensions.file_id against files rows excluding type = 'app'.
-    const extensionsRender = render(extensionsPredicate)
-    expect(extensionsRender.sql).toContain('"file_id" in ')
-    expect(extensionsRender.sql).toContain('"type" <> ?')
-    expect(extensionsRender.params).toEqual(['app'])
+
+    // The extensions delete is scoped by a subquery. Its inner SQL is not readable from here --
+    // the connection is a mock, so drizzle sees an opaque value and renders the whole subquery as
+    // a single `?` rather than nested SQL. What is readable is the predicate the subquery itself
+    // was built with, which is where the scoping actually lives.
+    expect(render(extensionsPredicate).sql).toBe('"file_extensions"."file_id" in ?')
+    const [subqueryPredicate] = selectWhereMock.mock.calls[0] as [SQL]
+    expect(render(subqueryPredicate)).toEqual(render(ne(files.type, 'app')))
   })
 
   it('returns rebuild error while still attempting file index rebuild', async () => {

--- a/apps/core-app/src/main/service/storage-maintenance.test.ts
+++ b/apps/core-app/src/main/service/storage-maintenance.test.ts
@@ -1,3 +1,6 @@
+import type { SQL } from 'drizzle-orm'
+import { ne } from 'drizzle-orm'
+import { SQLiteSyncDialect } from 'drizzle-orm/sqlite-core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -63,6 +66,7 @@ vi.mock('electron', () => ({
   }
 }))
 
+import { files } from '../db/schema'
 import { cleanupFileIndex } from './storage-maintenance'
 
 describe('cleanupFileIndex', () => {
@@ -126,11 +130,27 @@ describe('cleanupFileIndex', () => {
     await cleanupFileIndex({})
 
     // Four tables are cleared: fileIndexProgress and scanProgress are file-only and stay
-    // unscoped, while files and file_extensions must each go through `.where(...)`. Asserting the
-    // delete counts rather than the select counts keeps this independent of how the
-    // file_extensions subquery happens to be built.
+    // unscoped, while files and file_extensions must each go through `.where(...)`.
     expect(deleteMock).toHaveBeenCalledTimes(4)
     expect(deleteWhereMock).toHaveBeenCalledTimes(2)
+
+    // Counting `.where()` calls alone would pass with an inverted predicate, so pin the rendered
+    // SQL: the same clause built here must render identically to what the deletes received. If the
+    // source predicate drifts from `ne(files.type, 'app')`, the render diverges and this fails.
+    const dialect = new SQLiteSyncDialect()
+    const render = (predicate: SQL) => dialect.sqlToQuery(predicate)
+
+    const [extensionsPredicate] = deleteWhereMock.mock.calls[0] as [SQL]
+    const [filesPredicate] = deleteWhereMock.mock.calls[1] as [SQL]
+
+    expect(render(filesPredicate)).toEqual(render(ne(files.type, 'app')))
+    // The extensions delete must be scoped by the same non-app file set. Rendering the expected
+    // subquery shape verbatim would over-pin how it is built, so assert the load-bearing parts:
+    // it filters file_extensions.file_id against files rows excluding type = 'app'.
+    const extensionsRender = render(extensionsPredicate)
+    expect(extensionsRender.sql).toContain('"file_id" in ')
+    expect(extensionsRender.sql).toContain('"type" <> ?')
+    expect(extensionsRender.params).toEqual(['app'])
   })
 
   it('returns rebuild error while still attempting file index rebuild', async () => {

--- a/apps/core-app/src/main/service/storage-maintenance.ts
+++ b/apps/core-app/src/main/service/storage-maintenance.ts
@@ -1,8 +1,9 @@
+import type { SQL } from 'drizzle-orm'
 import type { LibSQLDatabase } from 'drizzle-orm/libsql'
 import type { StorageCleanupResult } from './types/storage-maintenance'
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import { eq, lt, sql } from 'drizzle-orm'
+import { eq, inArray, lt, ne, sql } from 'drizzle-orm'
 import { app } from 'electron'
 import {
   analyticsReportQueue,
@@ -85,6 +86,21 @@ async function getAuxDb(): Promise<LibSQLDatabase<typeof import('../db/schema')>
   return databaseModule.getAuxDb()
 }
 
+/**
+ * The connection the file index actually lives on.
+ *
+ * With `TUFF_DB_SEARCH_SPLIT_ENABLED` on -- the default -- file rows are written to
+ * `search-index.db` by the worker, and `database.db` keeps only the app catalog. Cleaning up
+ * through `getDb()` therefore counted and deleted from the wrong file: the live index survived and
+ * the number reported back to the UI came from a near-empty table.
+ *
+ * `getSearchDb()` returns the primary connection when the split is off or the search file is not
+ * open, so this needs no flag branch of its own.
+ */
+async function getFileIndexDb(): Promise<LibSQLDatabase<typeof import('../db/schema')> | null> {
+  return databaseModule.getSearchDb() ?? null
+}
+
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
@@ -106,7 +122,7 @@ export async function cleanupClipboard(
 export async function cleanupFileIndex(
   options?: CleanupFileIndexOptions
 ): Promise<StorageCleanupResult> {
-  const db = await getDb()
+  const db = await getFileIndexDb()
   if (!db) return { success: false }
 
   const removedCount: number[] = []
@@ -117,15 +133,40 @@ export async function cleanupFileIndex(
     await db.delete(table)
   }
 
+  /**
+   * `files` is shared: `type: 'app'` rows are the app catalog, which `app-provider` keeps on the
+   * primary connection on purpose because it includes user-authored managed entries added through
+   * `addAppByPath`. Those entries exist nowhere else -- there is no separate store -- and
+   * `rebuildIndex()` only rescans the watch paths, so an app added from outside them cannot come
+   * back. An unscoped `delete(files)` here deleted them, and had done so since this function was
+   * written, independently of the split.
+   */
+  const fileRows = ne(files.type, 'app')
+  const removeScoped = async (table: DeleteTable, where: SQL): Promise<void> => {
+    const rows = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(table)
+      .where(where)
+    removedCount.push(rows[0]?.count ?? 0)
+    await db.delete(table).where(where)
+  }
+
   await removeAll(fileIndexProgress)
-  await removeAll(fileExtensions)
-  await removeAll(files)
+  await removeScoped(
+    fileExtensions,
+    inArray(fileExtensions.fileId, db.select({ id: files.id }).from(files).where(fileRows))
+  )
+  await removeScoped(files, fileRows)
   await removeAll(scanProgress)
 
   if (options?.includeEmbeddings) {
     await db.delete(embeddings).where(eq(embeddings.sourceType, 'file'))
   }
 
+  // Adjacent gap, deliberately not widened here (#1770): `search_index` and `keyword_mappings`
+  // below carry the app catalog's searchable projection as well as the file index, so
+  // `clearSearchIndex` clears both. That is defensible while `rebuild` re-projects the catalog,
+  // and it is opt-in, but it is the same shape of over-broad delete as the one fixed above.
   if (options?.clearSearchIndex) {
     try {
       await db.run(sql`DELETE FROM search_index`)


### PR DESCRIPTION
Fixes #1770. Found while working the static half of #1748, whose stated failure mode is *"a provider writes `database.db` while readers consume `search-index.db`"*.

`cleanupFileIndex()` had **no reference to the search split at all** — grepping the file for `getSearchDb`, `isSearchSplitEnabled`, `searchIndexWriter`, `execWrite` or `searchDb` returns zero. It read and wrote through `getDb()` and deleted with no `where` clause. Two things went wrong at once, pointing opposite ways.

## It cleaned the wrong file

With the split on — default since `cd39bdbf6` — file rows live in `search-index.db`. Deleting from `database.db` left the live index intact and reported a `removedCount` counted from a near-empty table.

`getSearchDb()` already returns the primary connection when the split is off or the search file is not open (`modules/database/index.ts:145`, and its own comment says callers "never need to branch on the flag"), so this is one accessor change, not a flag branch.

## It deleted the app catalog

`files` is shared. `type: 'app'` rows are the app catalog, which `app-provider.ts:840-852` keeps on the primary **deliberately**, in its own words:

> The app CATALOG (files/file_extensions rows of type 'app', **including user-authored managed entries**) lives on the PRIMARY db … manual entries are **user data that must not move into the rebuildable search-index.db**.

Those entries have nowhere else to live — `managedEntry` is not even a column — and they are not rediscoverable: `rebuildIndex()` rescans `appScanner.getWatchPaths()`, while `addAppByPath` resolves with `skipWatchCheck: true`, so an app added from outside the watch paths cannot come back.

**This half predates the split.** The app catalog moved into `files` in `1549ab65b` (2025-08-10); this function was written in `f86d4596c` (2026-01-19). It has been true for about seven months and is independent of the flag.

`files` and `file_extensions` are now scoped to non-app rows. `file_index_progress` and `scan_progress` are file-only and stay unscoped.

## Not widened

`clearSearchIndex` also clears `search_index` and `keyword_mappings`, which carry the app catalog's searchable projection as well as the file index. Same shape of over-broad delete — but it is opt-in and `rebuild` re-projects the catalog, so it is a separate decision. Recorded as a comment at the site rather than changed here.

## Why nothing caught it

`storage-maintenance.test.ts` mocks the database module with `getDb` and `getAuxDb` only, so the suite could only ever exercise the primary path and passed identically with or without the defect.

`scripts/check-search-index-writers.mjs` cannot see this file either. Its matcher requires a literal `schema.` prefix:

```
MATCHED db.delete(schema.files)   ← the guard can see this
missed  db.delete(files)          ← how this file imports them
```

and the real code is `db.delete(table)` with `table` a **function parameter**, which no call-site regex can resolve. `OWNED_TABLES` is also only `['files', 'fileExtensions', 'keywordMappings']`, while this function deletes `fileIndexProgress`, `scanProgress` and `embeddings` too. Its "3 worker-owned tables have no writer outside 3 approved owners" should be read as "no writer *matching this regex*". Improving the guard is left to #1770; this PR does not touch it.

## Verification

| check | result |
| --- | --- |
| `storage-maintenance.test.ts` | **4/4 pass** |
| negative control — new tests against the unfixed source | both fail (`expected spy to be called at least once`, `expected 2 times, got 0`); the two pre-existing cases still pass |
| `tsc --noEmit -p tsconfig.node.json` | exit 0 |
| eslint (core-app's own config) | clean |

The runtime half of #1748 — disposable-profile first-launch reindex, count parity, WAL behaviour, `=0` rollback — is untouched and still open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file index cleanup by using the appropriate search database connection.
  * Preserved application files during cleanup.
  * Ensured related file-extension records are removed only when associated with eligible files.
  * Maintained existing cleanup behavior for other file-related data.
  * Improved cleanup consistency by applying appropriate scope to eligible file records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->