### PR TITLE
ci(nexus): run the icon-collection gate that was written but never invoked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,13 +394,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Both verified passing on a clean tree before being wired: the route-tree check exits 0
-      # with "server/api route tree verified", the fence check exits 0 silently.
+      # All three verified passing on a clean tree before being wired: the route-tree check exits 0
+      # with "server/api route tree verified", the fence check exits 0 silently, and the icon check
+      # exits 0 with "ok — installed: carbon, cib, logos, twemoji".
       - name: Verify server API route tree
         run: pnpm -C apps/nexus check:api-routes
 
       - name: Verify MDC fences
         run: pnpm -C apps/nexus check:mdc-fences
+
+      # #1768 shipped blank icons for two days: eight of nine shortcuts aliased onto
+      # `@iconify-json/ri`, which this app does not install, and UnoCSS emits nothing for a
+      # collection it cannot resolve. The aliases were fixed and this script was written to block a
+      # relapse — but it was never invoked by anything, so it blocked nothing (#1776).
+      #
+      # Also verified it can fail, since a gate that only ever passes is what let #1768 land: a
+      # planted `class="i-ri-refresh-line"` under app/components/ exits 1 and names the file.
+      - name: Verify icon collections are installed
+        run: pnpm -C apps/nexus check:icon-collections
 
       # Blocking. It was briefly continue-on-error because wiring it up is what discovered
       # the build was broken — nitro could not resolve @panva/hkdf from next-auth against a


### PR DESCRIPTION
First of the three items in #1776, which stays open for the other two.

## What was wrong

`check:icon-collections` was written alongside the #1768 fix specifically to stop a relapse, and `check-worker-bundle.test.ts:122` states that it does:

> …and `pnpm check:icon-collections` now blocks a relapse by comparing every class against the installed @iconify-json deps.

That comment was the only reference to the script anywhere in the repository outside its own `package.json` entry. No workflow, no aggregate script, no git hook — `.husky/pre-commit` touches only `apps/core-app/package.json`, `commit-msg` is commitlint, and `lint-staged` does not mention it. So the sentence describes something that was not happening, and a relapse would have landed exactly the way #1768 did.

The condition it guards is still live on master:

```
@iconify-json/carbon         RESOLVES     <- positive control
@iconify-json/cib            RESOLVES     <- positive control
@iconify-json/ri             unresolvable
@iconify-json/simple-icons   unresolvable
@iconify/json  (monolith)    unresolvable
```

## Verification

The two steps this sits next to set a convention in their comment — verified passing on a clean tree before being wired — so I did that, and one thing more.

**It passes on a clean tree**, which is what makes it safe to make blocking today:

```
[check-icon-collections] ok — installed: carbon, cib, logos, twemoji
exit 0
```

**And it can fail**, which matters more here than usual: a gate that only ever passes is the exact shape that let #1768 ship for two days. Planting `class="i-ri-refresh-line"` in a file under `app/components/`:

```
[check-icon-collections] icon classes from collections this app does not install:
  installed: carbon, cib, logos, twemoji

  i-ri-refresh-line
    components/__negctl_icon_probe.vue

These render as nothing. Remap them onto an installed collection, or add the dependency.
exit 1
```

Worth recording how nearly I got that wrong: my first run of the negative control read the exit code through a pipe, so `$?` was `tail`'s status and reported 0 — a passing-looking result for a check that had just printed a complaint. The exit codes above are node's own.

**This PR exercises its own change.** The `nexus` path filter includes `.github/workflows/ci.yml`, so `job_nexus` runs here and the new step executes rather than being skipped.

## Not in scope

The other two items in #1776 are left alone. `build:analyze-worker` cannot simply be wired the same way — `check-worker-bundle.mjs:48` still budgets `i-ri-settings-3-line` and `i-ri-settings-3-fill`, that guard reports a token emitting no CSS as missing rather than passing it, and `ri` cannot resolve, so it would go red on entries #1768 already found had no call sites. Removing them also means moving the two assertions at `check-worker-bundle.test.ts:151-152`. `check:doc-parity` I have not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced automated quality checks to verify that required icon collections are installed.
  - Releases now receive an additional validation step alongside existing API and content-format checks, helping identify configuration issues before changes are delivered.
  - Updated verification guidance to clarify the icon collection checks and improve consistency across the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->