### PR TITLE
test(core-app): time the CLI evidence tests against their spawn chain, not the 5s default

### DIFF
--- a/apps/core-app/scripts/search-index-migration-evidence-verify.test.ts
+++ b/apps/core-app/scripts/search-index-migration-evidence-verify.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   verifySearchIndexMigrationEvidence,
   type SearchIndexMigrationSettingsVisibleArtifactEvidence
@@ -218,6 +218,21 @@ function runCli(args: string[]): string {
     stdio: ['ignore', 'pipe', 'pipe']
   })
 }
+
+/**
+ * Three tests below go through `runCli`, which pays corepack resolution, `pnpm exec` and a tsx
+ * transpile before the verifier starts. Vitest's 5,000 ms default covers that setup as well as the
+ * work, so an oversubscribed runner expires on cost that is not the verifier's — one failure in
+ * 6,257 tests, on a PR that changed only a workflow step (#1778).
+ *
+ * File-scoped rather than per-test, which is the weaker scope and deliberate. The `it(name, fn, ms)`
+ * and `it(name, { timeout }, fn)` forms both push the call past core-app's `printWidth: 100`, and
+ * prettier then breaks the arguments and re-indents all three bodies — about 170 lines of
+ * whitespace to express one number, which buries the change in review and in blame. The fourteen
+ * in-process tests inherit this; the cost is a slower failure if one ever hangs, which is the
+ * cheaper of the two.
+ */
+vi.setConfig({ testTimeout: 60_000 })
 
 const strictRequirements = {
   requireRealProfilePreflight: true,


### PR DESCRIPTION
#1778. A false red on PR #1777, whose only change is a step in `job_nexus` — it cannot reach core-app's vitest run.

```
FAIL  scripts/search-index-migration-evidence-verify.test.ts
      > passes strict CLI verification with PNG screenshots and DOM artifacts
Error: Test timed out in 5000ms.

Tests  1 failed | 6252 passed | 4 skipped (6257)
```

## The cause

`runCli` at line 214 shells out through four links before the verifier does anything:

```ts
execFileSync('corepack', ['pnpm', 'exec', 'tsx', scriptPath, ...args], { … })
```

corepack resolving, `pnpm exec`, tsx transpiling the script, and only then the work under test. Vitest's 5,000 ms default covers all of it, and no test in the file set a timeout. The failing run took 194s wall with 227s in collect, so the runner was oversubscribed — which is exactly when a fixed-cost spawn crosses the line. It passes on master, so this is load-dependent, not broken.

## Why file-scoped, having argued the opposite first

My first version put the timeout on the three tests that call `runCli` and left the other fourteen on the default, which is the scope this deserves. CI rejected it — 166 lint warnings, 0 errors:

```
672:1  warning  Replace `··},·CLI_TEST_TIMEOUT_MS` with `····},⏎····CLI_TEST_TIMEOUT_MS⏎··`
✖ 166 problems (0 errors, 166 warnings)
```

Both per-test forms push the call past core-app's `printWidth: 100` — its own `.prettierrc.yaml`, not the root's 120 — so prettier breaks the arguments and re-indents all three bodies. Those three tests are ~170 lines, which is the whole warning count. Measured, not assumed: I ran prettier on a probe under each config and watched it hug at 120 and break at 100.

So the choice was ~170 lines of whitespace churn to express one number, or one line at file scope. The churn buries the change in review and in blame, and the price of the wider scope is bounded and dull: if one of the fourteen in-process tests ever hangs, it fails in 60s instead of 5s. I took the one-liner and wrote the trade into the comment so the next person does not have to rediscover why the obvious scoping was not used.

Still out of scope, and noted on the issue instead: the three tests each pay the spawn chain independently, and resolving the binary once would remove most of the cost rather than budgeting for it. That is a change to how the tests set up, not a flake fix.

## Verification

Prettier clean under core-app's config, with a negative control so the check is known to discriminate — a copy with the spacing mangled is reported, the real file passes:

```
[warn] apps/core-app/scripts/__negfmt.test.ts        <- negative control, reported
Checking formatting...
All matched files use Prettier code style!           <- real file
```

**What I could not do locally:** this worktree has no `@vitejs/plugin-vue`, so `vitest.config.ts` fails to load and the suite will not run here. I did not copy the file into the main checkout to run it — that tree has concurrent edits and overwriting one is a mistake I have already made. CI on this PR is the real gate for the timeout actually taking effect.

Worth recording, since this PR is about a check that measured the wrong thing: my first attempt at the local parse check passed an invalid flag, and *both* the real and the deliberately-broken file failed identically. Without the negative control that would have read as a clean result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved migration evidence verification test reliability by enabling test mocking utilities.
  * Increased the test timeout allowance to support longer-running verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->