### PR TITLE
ci: re-check the PR body when it is edited, not only when it is pushed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,23 +182,11 @@ jobs:
       - name: Check maintenance-audit report claims
         run: pnpm check:audit-report-claims && pnpm check:audit-report-claims:self-test
 
-      # GitHub's closing-keyword parser is a regex over `keyword #N` and ignores the words before
-      # it, so "It does not fix #213" marks #213 for closing exactly as "Fixes #213" does. That is
-      # not hypothetical: on 2026-08-13 it closed two user-facing issues within an hour -- #213 via
-      # "does not fix", #308 via "does not close" -- and both sentences existed specifically to stop
-      # a reader mistaking instrumentation for a fix. The second happened after the first was
-      # already understood, which is why this is a check and not a note. The body is passed through
-      # the environment rather than interpolated into the shell.
-      - name: Check for negated closing keywords in the PR body
-        if: github.event_name == 'pull_request'
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          printf '%s' "$PR_BODY" > /tmp/pr-body.md
-          node scripts/check-closing-keywords.mjs /tmp/pr-body.md
-
-      - name: Check closing-keyword guard self-test
-        run: pnpm check:closing-keywords:self-test
+      # The negated-closing-keyword guard moved to .github/workflows/pr-body-guard.yml (#1773). It
+      # has to re-run when a description is edited, and this job's trigger has no `edited` type, so
+      # here it only ever saw the body as of the last push -- while GitHub reads closing keywords
+      # from the body at merge time. Adding `edited` to this workflow would re-run every step above
+      # on each description edit; the guard is a checkout and one node script, so it went alone.
 
       # 34 distinct blocked reasons live across plugins/ and 20 of them belong to exactly one
       # plugin, so the vocabulary is open and a closed union would be the wrong contract. Only the

--- a/.github/workflows/pr-body-guard.yml
+++ b/.github/workflows/pr-body-guard.yml
@@ -1,0 +1,49 @@
+# Split out of ci.yml's PR Quality job, for `types: edited` (#1773).
+#
+# The check itself is unchanged and still lives in scripts/check-closing-keywords.mjs. What was
+# wrong was when it ran: `pull_request` with no `types` defaults to opened/synchronize/reopened, so
+# the guard only ever saw the body as of the last push. GitHub reads closing keywords from the body
+# **at merge time**, so a description edited after the last push was never the document that got
+# checked -- and a body that passed could gain "this does not fix #N" during review and merge green,
+# closing an unfixed issue. That is the outcome #213 and #308 recorded, which is what the guard
+# exists to prevent.
+#
+# Its own workflow rather than adding `edited` to ci.yml: this needs to re-run on every description
+# edit, and re-running the whole PR Quality job for that would cost minutes each time on a repo
+# where descriptions get edited often. This is a checkout and one node script.
+name: PR Body Guard
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-body-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  closing_keywords:
+    name: Closing keywords
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      # The body goes through the environment rather than being interpolated into the shell, so a
+      # description cannot inject commands. `printf '%s'` rather than `echo` so a body starting with
+      # `-n` or containing backslashes reaches the file verbatim.
+      - name: Check for negated closing keywords in the PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.md"
+          node scripts/check-closing-keywords.mjs "$RUNNER_TEMP/pr-body.md"
+
+      # A guard that matches nothing looks exactly like a repository with no negated keywords, so
+      # the detector proves it fires before its verdict on the body above is worth anything.
+      - name: Check closing-keyword guard self-test
+        run: node scripts/check-closing-keywords.mjs --self-test


### PR DESCRIPTION
#1773, option 2.

## The gap

The guard reads the body out of the `pull_request` event payload, and `ci.yml`'s trigger declares no `types`, so it gets the default `opened, synchronize, reopened` — no `edited`. It therefore saw the description as of the last push. GitHub reads closing keywords from the body **at merge time**. Those are different documents the moment anyone edits a description.

The annoying half is that a body-only fix could not turn the check green — measured on #1772, where the two runs on that branch were both pushes and my edit in between produced no run at all.

The half that matters is the other direction: a body that **passed** can gain "note: this does not fix #N" during review, and nothing re-checks it. The PR merges green and closes an unfixed issue — which is exactly what happened to #213 and #308, an hour apart, and why this guard exists. The check is green, about a body that no longer exists.

## Why a separate workflow

Adding `edited` to `ci.yml` closes the gap too, but PR Quality is an install plus a dozen checks and would re-run in full on every description edit. This is a checkout and one node script. The check itself is untouched — same `scripts/check-closing-keywords.mjs`, same message.

`ci.yml` keeps a comment at the old location pointing at where it went, so the next person looking for it in PR Quality finds it rather than concluding it was dropped.

## Verification

The script's own controls, run directly rather than through the pnpm alias — `package.json:52-53` shows they are the same command, which is worth confirming rather than assuming:

```
self-test                       26 cases passed, exit 0
body "This does not close #1."  exit 1, names #1 and suggests the rephrasings
body "Part of #1."              exit 0
```

Repository checks, both of which count 23 workflows rather than 22, so they are seeing the new file rather than skipping it:

```
[workflow-injection] 23 workflows: no caller-controlled context reaches a run: body
[action-pins] 23 workflows: every third-party action is SHA-pinned (actions/* exempt)
actionlint .github/workflows/pr-body-guard.yml .github/workflows/ci.yml   exit 0
```

`actions/checkout` is in the pin-exempt namespace, per the policy stated at the top of `check-action-pins.mjs`.

The body still goes through the environment rather than shell interpolation, and writes to `$RUNNER_TEMP` rather than `/tmp`.

## What this PR does not yet show

#1773's first two acceptance lines are about behaviour I cannot demonstrate from the source: that editing a description turns the check red, and editing it back turns it green, both without a push. I will exercise that on this PR once the workflow exists on the branch, using an already-closed issue number so that the worst case if someone merges mid-demonstration is closing something already closed. Results will be posted here.
