### PR TITLE
fix(core-app): reach the diagnostics channel with send/on, not the absent invoke

### DIFF
--- a/apps/core-app/scripts/coreapp-packaged-indexing-diagnostics-probe.test.ts
+++ b/apps/core-app/scripts/coreapp-packaged-indexing-diagnostics-probe.test.ts
@@ -166,7 +166,7 @@ describe('packaged indexing diagnostics probe helpers', () => {
         target: makeTarget('overlay', 'app://tuff/renderer/index.html#/meta-overlay', 'CoreBox'),
         snapshot: {
           hasRouter: true,
-          hasIpcInvoke: true,
+          hasChannelBridge: true,
           hasSettingsShell: false,
           text: 'CoreBox'
         }
@@ -175,7 +175,7 @@ describe('packaged indexing diagnostics probe helpers', () => {
         target: makeTarget('settings', 'app://tuff/renderer/index.html#/setting', 'Settings'),
         snapshot: {
           hasRouter: true,
-          hasIpcInvoke: true,
+          hasChannelBridge: true,
           hasSettingsShell: true,
           text: 'App Settings'
         }
@@ -183,6 +183,49 @@ describe('packaged indexing diagnostics probe helpers', () => {
     ])
 
     expect(selected?.id).toBe('settings')
+  })
+
+  /**
+   * The capability this gates on has to be one the renderer can actually report. It used to be
+   * `hasIpcInvoke`, and the preload bridges send/on/removeListener with `invoke` deliberately left
+   * off — so the real answer was always false and this selector matched nothing, on every run
+   * (#1775). The old fixtures said `hasIpcInvoke: true`, a value no window could produce, so the
+   * test passed against a probe that could not select a target at all.
+   *
+   * Hence this case: a snapshot shaped like what the bridge really exposes must still select.
+   */
+  it('selects a target whose bridge exposes only send/on, as the preload does', () => {
+    const bridge = { send: () => {}, on: () => () => {} }
+    const selected = selectSettingsTarget([
+      {
+        target: makeTarget('settings', 'app://tuff/renderer/index.html#/setting', 'Settings'),
+        snapshot: {
+          hasRouter: true,
+          // Exactly the expression the probe evaluates in the page.
+          hasChannelBridge: Boolean(bridge.send && bridge.on),
+          hasSettingsShell: true,
+          text: 'App Settings'
+        }
+      }
+    ])
+
+    expect(selected?.id).toBe('settings')
+  })
+
+  it('rejects a target with no channel bridge, since the probe cannot talk to it', () => {
+    const selected = selectSettingsTarget([
+      {
+        target: makeTarget('settings', 'app://tuff/renderer/index.html#/setting', 'Settings'),
+        snapshot: {
+          hasRouter: true,
+          hasChannelBridge: false,
+          hasSettingsShell: true,
+          text: 'App Settings'
+        }
+      }
+    ])
+
+    expect(selected).toBeUndefined()
   })
 
   it('builds stable artifact names for packaged evidence', () => {

--- a/apps/core-app/scripts/coreapp-packaged-indexing-diagnostics-probe.test.ts
+++ b/apps/core-app/scripts/coreapp-packaged-indexing-diagnostics-probe.test.ts
@@ -202,7 +202,7 @@ describe('packaged indexing diagnostics probe helpers', () => {
         snapshot: {
           hasRouter: true,
           // Exactly the expression the probe evaluates in the page.
-          hasChannelBridge: Boolean(bridge.send && bridge.on),
+          hasChannelBridge: typeof bridge.send === 'function' && typeof bridge.on === 'function',
           hasSettingsShell: true,
           text: 'App Settings'
         }
@@ -210,6 +210,29 @@ describe('packaged indexing diagnostics probe helpers', () => {
     ])
 
     expect(selected?.id).toBe('settings')
+  })
+
+  /**
+   * The truthiness trap on the same expression: a bridge whose members exist but are not callable
+   * satisfies `Boolean(send && on)` and then dies in channelRequestPrelude, which requires
+   * functions. Selection applies the same typeof gate so such a target is never chosen.
+   */
+  it('rejects a target whose bridge members are truthy but not callable', () => {
+    const bridge: { send: unknown; on: unknown } = { send: true, on: 'listener' }
+    const selected = selectSettingsTarget([
+      {
+        target: makeTarget('settings', 'app://tuff/renderer/index.html#/setting', 'Settings'),
+        snapshot: {
+          hasRouter: true,
+          // Exactly the expression the probe evaluates in the page.
+          hasChannelBridge: typeof bridge.send === 'function' && typeof bridge.on === 'function',
+          hasSettingsShell: true,
+          text: 'App Settings'
+        }
+      }
+    ])
+
+    expect(selected).toBeUndefined()
   })
 
   it('rejects a target with no channel bridge, since the probe cannot talk to it', () => {

--- a/apps/core-app/scripts/coreapp-packaged-indexing-diagnostics-probe.ts
+++ b/apps/core-app/scripts/coreapp-packaged-indexing-diagnostics-probe.ts
@@ -7,6 +7,7 @@ import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 import type { IndexedSourceDiagnosticsSnapshot } from '@talex-touch/utils/search'
 import packageJson from '../package.json'
+import { RAW_MAIN_PROCESS_CHANNEL } from '../src/shared/ipc/raw-channel'
 import {
   applySettingsIndexingDiagnosticsEnvelopeGate,
   verifySettingsIndexingDiagnosticsEvidence
@@ -674,7 +675,12 @@ function inspectTargetExpression(): string {
     href: location.href,
     readyState: document.readyState,
     hasRouter: Boolean(window.__VUE_ROUTER__?.push),
-    hasIpcInvoke: Boolean(window.electron?.ipcRenderer?.invoke),
+    // Was \`hasIpcInvoke\`, which no renderer can ever report true: the preload bridges send/on/
+    // removeListener and leaves \`invoke\` off deliberately. selectSettingsTarget required it, so it
+    // matched no target at all (#1775). This reports what the probe actually needs.
+    hasChannelBridge: Boolean(
+      window.electron?.ipcRenderer?.send && window.electron?.ipcRenderer?.on
+    ),
     hasSettingsShell: Boolean(document.querySelector('.AppSettings-Container')),
     text: document.body?.innerText?.slice(0, 1000) || ''
   }))()`
@@ -697,17 +703,69 @@ function openFileIndexSettingsExpression(): string {
   }`
 }
 
+/**
+ * The renderer half of the channel request/response protocol, rebuilt for `Runtime.evaluate`.
+ *
+ * Both expressions below used to call `window.electron.ipcRenderer.invoke`, which does not exist:
+ * the preload bridges `send` / `on` / `removeListener` over a two-channel allowlist and states that
+ * `invoke` is "deliberately absent rather than allowlisted" (`src/preload/index.ts`). So every run
+ * threw before reaching a single assertion (#1775).
+ *
+ * `send` + `on` are enough, because they are exactly what the renderer's own client uses. This
+ * mirrors `renderer/src/modules/channel/channel-core.ts` — the same envelope, the same reply match
+ * on `header.status === 'reply'` and `sync.id`. It is a reimplementation and will drift if that
+ * protocol changes; the alternative was widening the preload surface the preload deliberately
+ * narrowed, for a diagnostics script.
+ *
+ * `transport.on(AppEvents.indexedSource.*)` registers through `regChannel(BRIDGE_CHANNEL.MAIN, …)`
+ * under the plain event name (`transport/sdk/main-transport.ts:738`), so these events are reachable
+ * here without touching the MessagePort the transport prefers.
+ */
+function channelRequestPrelude(): string {
+  return `
+    const bridge = window.electron?.ipcRenderer
+    if (!bridge || typeof bridge.send !== 'function' || typeof bridge.on !== 'function') {
+      throw new Error('window.electron.ipcRenderer send/on are unavailable')
+    }
+    const channelRequest = (eventName, payload, timeoutMs, timeoutValue) =>
+      new Promise((resolve) => {
+        const id = Date.now() + '#' + eventName + '@probe' + Math.random().toString(16).slice(2)
+        let settled = false
+        let off = null
+        let timer = null
+        const finish = (value) => {
+          if (settled) return
+          settled = true
+          if (timer !== null) clearTimeout(timer)
+          if (typeof off === 'function') off()
+          resolve(value)
+        }
+        off = bridge.on(${JSON.stringify(RAW_MAIN_PROCESS_CHANNEL)}, (_event, raw) => {
+          if (!raw || typeof raw !== 'object') return
+          if (raw.header && raw.header.status !== 'reply') return
+          if (!raw.sync || raw.sync.id !== id) return
+          finish(raw.data)
+        })
+        timer = setTimeout(() => finish(timeoutValue), timeoutMs)
+        bridge.send(${JSON.stringify(RAW_MAIN_PROCESS_CHANNEL)}, {
+          code: 200,
+          data: payload,
+          sync: { timeStamp: Date.now(), timeout: timeoutMs, id },
+          name: eventName,
+          header: { status: 'request', type: 'main' }
+        })
+      })
+  `
+}
+
 function loadDiagnosticsExpression(sourceId: string): string {
   return `async () => {
-    const invoke = window.electron?.ipcRenderer?.invoke?.bind(window.electron.ipcRenderer)
-    if (!invoke) throw new Error('window.electron.ipcRenderer.invoke is unavailable')
-    const invokeWithTimeout = (payload, timeoutMs = 12000) =>
-      Promise.race([
-        invoke(${JSON.stringify(INDEXED_SOURCE_DIAGNOSTICS_EVENT)}, payload),
-        new Promise((resolve) => setTimeout(() => resolve({ sources: [], summary: { total: 0 }, timeout: true }), timeoutMs))
-      ])
-    const allDiagnostics = await invokeWithTimeout(undefined)
-    const sourceDiagnostics = await invokeWithTimeout({ sourceId: ${JSON.stringify(sourceId)} })
+    ${channelRequestPrelude()}
+    const emptySnapshot = { sources: [], summary: { total: 0 }, timeout: true }
+    const request = (payload) =>
+      channelRequest(${JSON.stringify(INDEXED_SOURCE_DIAGNOSTICS_EVENT)}, payload, 12000, emptySnapshot)
+    const allDiagnostics = await request(undefined)
+    const sourceDiagnostics = await request({ sourceId: ${JSON.stringify(sourceId)} })
     return { allDiagnostics, sourceDiagnostics }
   }`
 }
@@ -735,12 +793,13 @@ function runMaintenanceActionExpression(
           }
 
   return `async () => {
-    const invoke = window.electron?.ipcRenderer?.invoke?.bind(window.electron.ipcRenderer)
-    if (!invoke) throw new Error('window.electron.ipcRenderer.invoke is unavailable')
-    return await Promise.race([
-      invoke(${JSON.stringify(eventName)}, ${JSON.stringify(payload)}),
-      new Promise((resolve) => setTimeout(() => resolve({ timeout: true }), 45000))
-    ])
+    ${channelRequestPrelude()}
+    return await channelRequest(
+      ${JSON.stringify(eventName)},
+      ${JSON.stringify(payload)},
+      45000,
+      { timeout: true }
+    )
   }`
 }
 
@@ -850,7 +909,12 @@ function inspectSettingsDomExpression(): string {
 export function selectSettingsTarget(
   snapshots: Array<{
     target: DevToolsTarget
-    snapshot: { hasRouter: boolean; hasIpcInvoke: boolean; hasSettingsShell: boolean; text: string }
+    snapshot: {
+      hasRouter: boolean
+      hasChannelBridge: boolean
+      hasSettingsShell: boolean
+      text: string
+    }
   }>
 ): DevToolsTarget | undefined {
   return snapshots.find((entry) => {
@@ -858,7 +922,7 @@ export function selectSettingsTarget(
       entry.target.type === 'page' &&
       Boolean(entry.target.webSocketDebuggerUrl) &&
       entry.snapshot.hasRouter &&
-      entry.snapshot.hasIpcInvoke &&
+      entry.snapshot.hasChannelBridge &&
       (entry.snapshot.hasSettingsShell ||
         entry.snapshot.text.includes('应用设置') ||
         entry.snapshot.text.includes('App Settings'))
@@ -886,7 +950,7 @@ async function pickInteractiveSettingsTarget(
       target: DevToolsTarget
       snapshot: {
         hasRouter: boolean
-        hasIpcInvoke: boolean
+        hasChannelBridge: boolean
         hasSettingsShell: boolean
         text: string
       }
@@ -896,7 +960,7 @@ async function pickInteractiveSettingsTarget(
         const snapshot = await withTarget(target, (send) =>
           evaluate<{
             hasRouter: boolean
-            hasIpcInvoke: boolean
+            hasChannelBridge: boolean
             hasSettingsShell: boolean
             text: string
           }>(send, inspectTargetExpression(), 5000)

--- a/apps/core-app/scripts/coreapp-packaged-indexing-diagnostics-probe.ts
+++ b/apps/core-app/scripts/coreapp-packaged-indexing-diagnostics-probe.ts
@@ -677,10 +677,12 @@ function inspectTargetExpression(): string {
     hasRouter: Boolean(window.__VUE_ROUTER__?.push),
     // Was \`hasIpcInvoke\`, which no renderer can ever report true: the preload bridges send/on/
     // removeListener and leaves \`invoke\` off deliberately. selectSettingsTarget required it, so it
-    // matched no target at all (#1775). This reports what the probe actually needs.
-    hasChannelBridge: Boolean(
-      window.electron?.ipcRenderer?.send && window.electron?.ipcRenderer?.on
-    ),
+    // matched no target at all (#1775). This reports what the probe actually needs — and it must
+    // be callable, not merely truthy: channelRequestPrelude refuses non-function members, so
+    // selection has to apply the same gate.
+    hasChannelBridge:
+      typeof window.electron?.ipcRenderer?.send === 'function' &&
+      typeof window.electron?.ipcRenderer?.on === 'function',
     hasSettingsShell: Boolean(document.querySelector('.AppSettings-Container')),
     text: document.body?.innerText?.slice(0, 1000) || ''
   }))()`


### PR DESCRIPTION
#1775, and the scope there was too small — see below.

## What was broken

The probe called `window.electron.ipcRenderer.invoke` in three places. It does not exist. The preload bridges `send` / `on` / `removeListener` over a two-channel allowlist and says so explicitly:

> `invoke` and `sendSync` are deliberately absent rather than allowlisted — nothing calls them, and adding them back should be a decision rather than an inheritance.

Confirmed against the implementation rather than the `.d.ts`, since a declaration can be narrower than the runtime: `src/preload/index.ts:183-197` exposes exactly those three methods, and the `invoke` at line 57 is inside the preload, on the privileged side.

**Wider than the issue recorded.** I filed #1775 as "`--runMaintenanceAction` always throws". In fact `loadDiagnosticsExpression` — the main path at line 1268, behind no flag — used `invoke` too, and worse:

```ts
export function selectSettingsTarget(...) {
  return snapshots.find((entry) =>
    entry.target.type === 'page' && … && entry.snapshot.hasIpcInvoke && …
```

`hasIpcInvoke` is `Boolean(window.electron?.ipcRenderer?.invoke)`, so it is always false and this selector **matched no target at all**. The probe could not choose a window, never mind run an action. Nothing about that was flag-gated.

Its unit test passed throughout, because the fixtures asserted `hasIpcInvoke: true` — a value no window can produce. The test described a renderer that does not exist.

## The fix

`send` + `on` are enough, because they are what the renderer's own client uses. `channelRequestPrelude()` mirrors `renderer/src/modules/channel/channel-core.ts:205-230`: same envelope, same reply match on `header.status === 'reply'` and `sync.id`, listener removed via the remover `on` returns.

That is reachable because `transport.on(AppEvents.indexedSource.*)` ends at `regChannel(BRIDGE_CHANNEL.MAIN, eventName, …)` (`transport/sdk/main-transport.ts:738`) under the plain event name — so these events do not require the MessagePort the transport prefers. `RAW_MAIN_PROCESS_CHANNEL` is in `BRIDGED_IPC_CHANNELS`, which both `send` and `on` check, so the allowlist permits it.

The capability probe now reports `hasChannelBridge` — what this actually needs — instead of a capability that could never be true.

I did not re-add `invoke` to the preload, which was my first instinct on the issue. It would reopen a surface the preload closed on purpose, to serve a diagnostics script. The cost of the direction taken is real and worth naming: this is a second implementation of the channel protocol and will drift if that protocol changes. There is no shared helper to import from a `scripts/` file today.

## Tests

Two cases the old suite could not have failed on:

- a snapshot shaped like the real bridge (`send` and `on` present, nothing else) must still select a target — this is the one that was silently false before;
- a target with no bridge must be rejected, so the field is not merely decorative.

## Verification, and its limits

This worktree cannot run the suite: `vitest.config.ts` needs `@vitejs/plugin-vue` and `tsc -p tsconfig.node.json` reports `Cannot find module` for ~40 workspace imports — missing dependencies, not this change. I did not copy the files into the main checkout to run them there; that tree has concurrent edits.

So locally this is parse-checked only, with the control established rather than assumed — my first two attempts at that control were themselves broken (an extra `(` is still valid JS; a failed `sed` produced an empty file that parsed fine). The one that works removes the final `}` and is rejected with `Unexpected end of file`, while both real files pass. CI is the gate for the tests.

**Not verified: that a real run now succeeds.** That needs a packaged app plus a CDP session, and it is the claim that matters most. The three failure modes above are all provable from the source; that the rebuilt request actually returns a diagnostics snapshot is not, and I am not asserting it.

## Left alone deliberately

Three sibling probes carry the same dependency and are untouched — `coreapp-visible-app-index-workbench-probe.ts` (7 references, including the same `hasIpcInvoke` selector at lines 1027/1037/1066), `coreapp-visible-assistant-floating-ball-probe.ts`, and `coreapp-visible-assistant-image-translate-probe.ts`. Four of the nine CDP probes in that directory, so this is systemic rather than one script's slip. Bundling them would make one unreviewable diff across four tools I cannot run; they are recorded on the issue with locations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics communication with renderer targets.
  * Added reliable request tracking, response filtering, timeout handling, and listener cleanup.
  * Updated Settings target detection to recognize supported channel bridges.
  * Prevented unsupported targets without a channel bridge from being selected.
  * Improved reliability when communicating with supported targets during diagnostics and maintenance operations.

* **Tests**
  * Added coverage confirming valid bridged targets are selected and unsupported targets are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->