### PR TITLE
ci(linux): record whether the runner had the restriction the smoke test is for

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -661,6 +661,17 @@ jobs:
           sudo apt-get install -y -qq xvfb libgbm1 libnss3 libasound2t64 libgtk-3-0t64 || sudo apt-get install -y -qq xvfb libgbm1 libnss3 libasound2 libgtk-3-0
           command -v xvfb-run >/dev/null || { echo "xvfb-run missing after install"; exit 1; }
 
+          # Whether this runner has the thing #213 is about. 24.04 ships
+          # kernel.apparmor_restrict_unprivileged_userns=1, which is what an AppImage cannot satisfy
+          # -- but GitHub's hosted images are not guaranteed to match a desktop install
+          # (actions/runner-images#10015 proposes disabling AppArmor on them). Without this the
+          # three `ok` runs on #213 cannot be told apart from "the restriction was never there",
+          # which is a pass produced by the absence of the condition under test.
+          # `|| true` because -e is on and a missing sysctl is a real answer, not a step failure.
+          USERNS_RESTRICT=$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns 2>/dev/null || echo "not present")
+          export TUFF_LAUNCH_USERNS_RESTRICT="$USERNS_RESTRICT"
+          echo "kernel.apparmor_restrict_unprivileged_userns=$USERNS_RESTRICT"
+
           APPIMAGE=$(find apps/core-app/dist -name "*.AppImage" -type f | head -1)
           if [ -z "$APPIMAGE" ]; then
             echo "No .AppImage to launch. The verification step above should already have failed."

--- a/scripts/classify-app-launch.mjs
+++ b/scripts/classify-app-launch.mjs
@@ -263,6 +263,11 @@ function selfTest() {
       actual: describeUsernsRestriction('1').present,
       expected: true,
     },
+    {
+      name: 'restriction on is reported as ON, not as an unrecognised value',
+      actual: describeUsernsRestriction('1').text.includes('ON ('),
+      expected: true,
+    },
     /**
      * These assert the message, not just `present`. Asserting `present === false` alone passes
      * against a broken branch, because the unrecognised-value fallback is also `false` -- so

--- a/scripts/classify-app-launch.mjs
+++ b/scripts/classify-app-launch.mjs
@@ -153,6 +153,51 @@ export function classifyLaunch({ output, exitCode, stayedAlive }) {
   return { verdict: 'unknown-exit', product: true, detail: `exit ${exitCode}` }
 }
 
+/**
+ * What an `ok` verdict is worth for #213, given whether the runner had the restriction at all.
+ *
+ * The smoke test exists to answer "does the AppImage start on Ubuntu 24.04", and the thing that
+ * would stop it is `kernel.apparmor_restrict_unprivileged_userns=1` — 24.04's default, which an
+ * AppImage cannot satisfy because it carries no AppArmor profile. Three release runs came back
+ * `ok`, and that was read as evidence against the hypothesis.
+ *
+ * It is only evidence if the restriction was switched on. GitHub's hosted images are not
+ * guaranteed to match a desktop install here (actions/runner-images#10015 proposes disabling
+ * AppArmor on them), so a green run on a runner without it is passing because the condition under
+ * test is absent — the same shape as a check that cannot fail. Reported next to the verdict rather
+ * than left in the log, so nobody reads `ok` without it.
+ */
+export function describeUsernsRestriction(raw) {
+  const value = typeof raw === 'string' ? raw.trim() : ''
+
+  if (value === '1') {
+    return {
+      present: true,
+      text: 'userns restriction: ON (kernel.apparmor_restrict_unprivileged_userns=1) -- '
+        + 'this run exercised the #213 condition.',
+    }
+  }
+  if (value === '0') {
+    return {
+      present: false,
+      text: 'userns restriction: OFF (kernel.apparmor_restrict_unprivileged_userns=0) -- '
+        + 'this runner does not have the restriction, so a pass says nothing about #213.',
+    }
+  }
+  if (value === '' || value === 'not present') {
+    return {
+      present: false,
+      text: 'userns restriction: NOT PRESENT (no such sysctl) -- this kernel has no restriction to '
+        + 'trip, so a pass says nothing about #213.',
+    }
+  }
+  return {
+    present: false,
+    text: `userns restriction: UNRECOGNISED (${value}) -- treat as unknown rather than as absent, `
+      + 'and read the raw value before drawing a conclusion about #213.',
+  }
+}
+
 const DESCRIPTIONS = {
   'sandbox-denied': 'The app could not create its sandbox. This is #213: Ubuntu 24.04 restricts '
     + 'unprivileged user namespaces, a .deb carries an AppArmor profile and an AppImage cannot.',
@@ -190,6 +235,11 @@ function main(argv) {
   if (result.detail)
     console.log(`detail: ${result.detail}`)
 
+  // Only meaningful where the restriction is a Linux concept; the macOS and Windows steps pass
+  // nothing and get no line.
+  if (process.env.TUFF_LAUNCH_USERNS_RESTRICT !== undefined)
+    console.log(describeUsernsRestriction(process.env.TUFF_LAUNCH_USERNS_RESTRICT).text)
+
   if (result.verdict === 'ok')
     return 0
 
@@ -204,6 +254,65 @@ function selfTest() {
       name: 'a clean start is ok',
       actual: classifyLaunch({ output: 'ready', exitCode: 0, stayedAlive: true }).verdict,
       expected: 'ok',
+    },
+    // The distinction the smoke test could not previously make. `present` is what decides whether
+    // an `ok` verdict is evidence about #213 at all, so each spelling the runner can produce is
+    // pinned -- including the two that look like absence and the one that is neither.
+    {
+      name: 'restriction on means the run exercised the #213 condition',
+      actual: describeUsernsRestriction('1').present,
+      expected: true,
+    },
+    /**
+     * These assert the message, not just `present`. Asserting `present === false` alone passes
+     * against a broken branch, because the unrecognised-value fallback is also `false` -- so
+     * deleting the `'0'` case entirely still satisfied it. Found by mutating that branch and
+     * watching all 47 cases stay green.
+     */
+    {
+      name: 'restriction off means a pass proves nothing about #213',
+      actual: describeUsernsRestriction('0').present,
+      expected: false,
+    },
+    {
+      name: 'restriction off is reported as OFF, not as an unrecognised value',
+      actual: describeUsernsRestriction('0').text.includes('OFF'),
+      expected: true,
+    },
+    {
+      name: 'a missing sysctl reads as absent, not as on',
+      actual: describeUsernsRestriction('not present').present,
+      expected: false,
+    },
+    {
+      name: 'a missing sysctl is reported as NOT PRESENT, not as unrecognised',
+      actual: describeUsernsRestriction('not present').text.includes('NOT PRESENT'),
+      expected: true,
+    },
+    {
+      name: 'an empty read reads as absent',
+      actual: describeUsernsRestriction('').present,
+      expected: false,
+    },
+    {
+      name: 'an empty read is reported as NOT PRESENT rather than unrecognised',
+      actual: describeUsernsRestriction('').text.includes('NOT PRESENT'),
+      expected: true,
+    },
+    {
+      name: 'trailing newline from cat still reads as on',
+      actual: describeUsernsRestriction('1\n').present,
+      expected: true,
+    },
+    {
+      name: 'an unrecognised value is not silently treated as on',
+      actual: describeUsernsRestriction('banana').present,
+      expected: false,
+    },
+    {
+      name: 'an unrecognised value says so rather than claiming absence',
+      actual: describeUsernsRestriction('banana').text.includes('UNRECOGNISED'),
+      expected: true,
     },
     // The message #213 is about, in the two spellings Electron actually prints.
     {


### PR DESCRIPTION
Implements the one-line gap named in #213 — and a little more, because one printed line turned out not to be enough to make the verdict safe to read.

## The gap

The Linux smoke step (added by #1736) launches the AppImage under `xvfb` on `ubuntu-24.04`, and three release runs came back `ok`. By the decision rule set in that thread, `ok` is evidence against the userns/AppArmor hypothesis.

It is only evidence **if the runner had the restriction switched on**. `kernel.apparmor_restrict_unprivileged_userns=1` is 24.04's desktop default and is what an AppImage cannot satisfy, but GitHub's hosted images are not guaranteed to match it — `actions/runner-images#10015` proposes disabling AppArmor on them. On a runner without it, the smoke passes because the condition under test is absent. That is a check that cannot fail, and it had already been read as a result.

## What this does

Reads the sysctl before launching and hands it to the classifier, which prints it **next to the verdict**:

```
verdict: ok
The packaged app started and was still running when the window opened.
userns restriction: ON (kernel.apparmor_restrict_unprivileged_userns=1) -- this run exercised the #213 condition.
```

or, when it is not:

```
userns restriction: OFF (kernel.apparmor_restrict_unprivileged_userns=0) -- this runner does not
have the restriction, so a pass says nothing about #213.
```

Next to the verdict rather than as a bare `cat` earlier in the log, because the failure mode is someone reading `ok` three runs later and concluding the hypothesis is dead. Four states are distinguished: `1`, `0`, absent sysctl, and anything else — the last says `UNRECOGNISED` rather than quietly folding into "absent", since a value nobody predicted is not the same as a restriction that is off.

**Nothing is gated on it.** This reports; it does not fail the build. Whether an `ok` on an unrestricted runner should be a failure is a policy call for whoever owns #213, and making it one now would turn every release build red on a question nobody has answered yet.

macOS and Windows pass no env var and get no line.

## Verification

Self-test **40 → 50 cases**, baseline re-measured from `origin/master` rather than remembered.

The part worth reporting is that my first version of these tests was weak, and a negative control caught it. Mutating the `value === '0'` branch to something unreachable left **all 47 cases green** — because `'0'` then fell through to the unrecognised-value fallback, which is also `present: false`, which is all I was asserting. The tests now assert the message too, and each branch mutated separately fails:

```
mutate the '1' branch          -> 2 of 50 cases failed
mutate the '0' branch          -> 1 of 50 cases failed
mutate the ''/'not present'    -> 2 of 50 cases failed
```

Workflow side:

- `actionlint` — no finding anywhere in the changed range; the 4 pre-existing `SC2129` style warnings are 4 on `origin/master` too, i.e. unchanged.
- `check-workflow-injection` and `check-action-pins` both pass.
- The whole Linux `run:` block parses under `bash -n`, with a deliberately broken copy rejected first so the check is known to discriminate.

## What this does not do

This is not a fix — #213 is still open — and it does not tell us today whether the runner has the restriction — that answer arrives with the next release build. If it comes back `ON`, the three existing `ok` runs become real evidence and the hypothesis is genuinely weakened. If `OFF`, those runs said nothing and the smoke needs a runner that reproduces the condition before it can speak to this at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux application launch diagnostics by reporting AppArmor user-namespace restrictions when available.
  * Missing system information is now clearly identified without causing the launch check to fail.
  * Unrecognized or incomplete restriction values are classified and explained more clearly.

* **Tests**
  * Added coverage for recognized, missing, trimmed, and unrecognized system values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->