### PR TITLE
ci: group the GITHUB_OUTPUT writes so actionlint passes on build-and-release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -182,9 +182,11 @@ jobs:
             echo "version=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
           else
             # 手动触发：只设置构建类型，不处理版本和标签
-            echo "type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
-            echo "tag=" >> "$GITHUB_OUTPUT"
-            echo "version=" >> "$GITHUB_OUTPUT"
+            {
+              echo "type=$RELEASE_TYPE"
+              echo "tag="
+              echo "version="
+            } >> "$GITHUB_OUTPUT"
           fi
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -1196,9 +1198,11 @@ jobs:
             else
               echo "type=release" >> "$GITHUB_OUTPUT"
             fi
-            echo "tag=$SYNC_TAG" >> "$GITHUB_OUTPUT"
-            echo "name=Release $SYNC_TAG" >> "$GITHUB_OUTPUT"
-            echo "target_ref=$SYNC_TAG" >> "$GITHUB_OUTPUT"
+            {
+              echo "tag=$SYNC_TAG"
+              echo "name=Release $SYNC_TAG"
+              echo "target_ref=$SYNC_TAG"
+            } >> "$GITHUB_OUTPUT"
             if [[ "$REF_NAME_LOWER" == *"beta"* || "$REF_NAME_LOWER" == *"snapshot"* ]]; then
               echo "prerelease=true" >> "$GITHUB_OUTPUT"
             else
@@ -1207,10 +1211,12 @@ jobs:
           elif [ "$EVENT_NAME" = "push" ]; then
             # 标签触发：使用标签信息创建 release
             REF_NAME_LOWER=$(echo "$REF_NAME" | tr '[:upper:]' '[:lower:]')
-            echo "type=release" >> "$GITHUB_OUTPUT"
-            echo "tag=$REF_NAME" >> "$GITHUB_OUTPUT"
-            echo "name=Release $REF_NAME" >> "$GITHUB_OUTPUT"
-            echo "target_ref=$TARGET_SHA" >> "$GITHUB_OUTPUT"
+            {
+              echo "type=release"
+              echo "tag=$REF_NAME"
+              echo "name=Release $REF_NAME"
+              echo "target_ref=$TARGET_SHA"
+            } >> "$GITHUB_OUTPUT"
             if [[ "$REF_NAME_LOWER" == *"beta"* || "$REF_NAME_LOWER" == *"snapshot"* ]]; then
               echo "prerelease=true" >> "$GITHUB_OUTPUT"
             else
@@ -1237,10 +1243,12 @@ jobs:
               beta) CHANNEL_LABEL=beta ;;
               *) CHANNEL_LABEL=master ;;
             esac
-            echo "type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
-            echo "tag=v${BASE_VERSION}-${CHANNEL_LABEL}.${TIMESTAMP}" >> "$GITHUB_OUTPUT"
-            echo "name=Manual Build ($RELEASE_TYPE) - $TIMESTAMP" >> "$GITHUB_OUTPUT"
-            echo "target_ref=$TARGET_SHA" >> "$GITHUB_OUTPUT"
+            {
+              echo "type=$RELEASE_TYPE"
+              echo "tag=v${BASE_VERSION}-${CHANNEL_LABEL}.${TIMESTAMP}"
+              echo "name=Manual Build ($RELEASE_TYPE) - $TIMESTAMP"
+              echo "target_ref=$TARGET_SHA"
+            } >> "$GITHUB_OUTPUT"
             if [ "$RELEASE_TYPE" = "snapshot" ] || [ "$RELEASE_TYPE" = "beta" ]; then
               echo "prerelease=true" >> "$GITHUB_OUTPUT"
             else


### PR DESCRIPTION
Part of #482, whose first acceptance line is *"actionlint completes successfully for `build-and-release.yml`"*.

## It does not, today

```
$ actionlint .github/workflows/build-and-release.yml
exit 1, 4 findings -- all SC2129
```

All four are runs of consecutive `echo "k=v" >> "$GITHUB_OUTPUT"`, at `Determine Release Type and Tag` in two jobs. Each flagged run is now a single grouped redirect.

Worth flagging how I nearly missed this. I checked the same file earlier today and read `exit=0` — but that was `actionlint … | head -8`, so `$?` was **head's** status, not actionlint's. The same pipeline trap cost me a false pass on a negative control earlier in the day. Unpiped, it is 1.

## Behaviour is unchanged, and I checked rather than assumed

`{ …; } >> file` differs from N individual `>> file` only in opening the file once. Ran both forms with the same inputs and diffed the result:

```
tag=v1.2.3
name=Release v1.2.3
target_ref=v1.2.3        identical
```

These are `echo`s, so there is no exit-status interaction with `set -e` to worry about either.

## Verification

- `actionlint` — **exit 0, 0 findings** (unpiped).
- Both changed `run:` blocks parse under `bash -n`, with an unbalanced-brace copy rejected first so the check is known to discriminate.
- The workflow still parses as YAML, 3 jobs.
- `check-workflow-injection` and `check-action-pins` pass.

## Scope

Only the lint finding. #482's other two acceptance lines are about the visual acceptance and the task evidence, which are separate and not touched here — that issue stays open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability and consistency of automated release metadata handling.
  * No user-facing functionality or release behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->