### PR TITLE
chore(trellis): restore the ai-toolchain blocker dropped by a merge

### DIFF
--- a/.trellis/tasks/08-05-ai-toolchain-suite/task.json
+++ b/.trellis/tasks/08-05-ai-toolchain-suite/task.json
@@ -30,5 +30,8 @@
   "parent": null,
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "blocker": "Deferred by docs/plan-prd/TODO.md:9 -- remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (release/runtime blockers: #326 OTA, #482 release notes) and lane 2 (search and cross-platform remediation: #334, #351) are both open. TODO.md:37 additionally names AI/Assistant/OmniPanel polish as paused until its execution lane is reached.",
+    "nextAction": "Release condition: reopen when lanes 1 and 2 close. No bounded child is named yet because the ordering, not the scope, is what is blocking (#309)."
+  }
 }


### PR DESCRIPTION
A one-field restore, filed because of how it went missing rather than because of its size.

## What happened

PR #1735 added `meta.blocker` to 13 `task.json` files. Twelve are on master. `08-05-ai-toolchain-suite/task.json` is back to `"meta": {}`.

It was not reverted and not edited. Merge `71dc5fbe3` kept the branch's older copy of the file byte-for-byte:

```
78120ef0a  #1735 lands                             blocker present
71dc5fbe3  Merge PR #1743 (converge … into master) blocker absent
```

Two branches both changed a JSON file; there was no textual conflict, so nothing surfaced it. That is the shape worth noting — a semantic loss with no signal at merge time, which is what #309 and #304 are both circling.

## What this restores

The `meta` object, verbatim from `78120ef0a`. Checked rather than retyped:

- `meta` is **byte-identical** to what #1735 wrote (`JSON.stringify` comparison against the commit, not a visual diff).
- Every other field in the file is **unchanged** (same comparison, with `meta` deleted from both sides).
- The file keeps its original no-trailing-newline ending, so the diff is the field alone — `+4/-1`. The repo has no convention here either way: of six sampled `task.json` files on master, three end with a newline and three do not, so matching this file's own prior state is the least invasive choice.

## Still accurate

The restored text defers the task on lanes 1 and 2 and names `#326`, `#482`, `#334`, `#351`. All four are open today, so this is not a stale record being reinstated — it is the current state of that task, which has simply been unrecorded since 2026-08-13.

## Scope

One file, one field. The other point raised in #304 — that eleven planning tasks now have empty `meta` through ordinary churn rather than through a merge — is untouched here. That is a different problem with a different fix, and lumping the two would hide this one.