### PR TITLE
fix(tuff-native): take the as_chunks form clippy now requires on stable

### DIFF
--- a/packages/tuff-native/native-screenshot/src/backend/macos/system.rs
+++ b/packages/tuff-native/native-screenshot/src/backend/macos/system.rs
@@ -596,9 +596,14 @@ pub(crate) fn bgra_rows_to_rgba(
     for row in 0..height {
         let source_row = &source[row * bytes_per_row..row * bytes_per_row + packed_row_bytes];
         let destination_row = &mut rgba[row * packed_row_bytes..(row + 1) * packed_row_bytes];
+        // `as_chunks` rather than `chunks_exact`: the width is fixed at 4, so this yields
+        // `[u8; 4]` and the indexing below is bounds-checked at compile time. Both rows are exact
+        // multiples of 4 (`packed_row_bytes = width * 4`), so the returned remainders are empty.
         for (bgra, output) in source_row
-            .chunks_exact(4)
-            .zip(destination_row.chunks_exact_mut(4))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .zip(destination_row.as_chunks_mut::<4>().0)
         {
             let alpha = bgra[3];
             output[0] = unpremultiply(bgra[2], alpha);


### PR DESCRIPTION
## What this fixes

`Protocol (macos-latest)` has been failing on **master itself** since 2026-08-18, and no commit caused it.

```
08-27T12:54  failure  @da95d7d99   <- master
08-18T10:09  success  @c5e6660d9   <- master, last green
```

`native-protocol.yml:65` installs the toolchain from `dtolnay/rust-toolchain`'s **stable branch with no pin**, and `:92` lints with `-D warnings`. Rust 1.98 added `clippy::chunks_exact_to_as_chunks`, which fires twice in `bgra_rows_to_rgba`, so the gate went red on the toolchain's schedule rather than on a change of ours.

It went unnoticed for nine days because `Protocol` is not among master's seven required status checks — a red run there blocks nothing and notifies nobody.

## The change

```rust
-        for (bgra, output) in source_row
-            .chunks_exact(4)
-            .zip(destination_row.chunks_exact_mut(4))
+        for (bgra, output) in source_row
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .zip(destination_row.as_chunks_mut::<4>().0)
```

Both rows are exact multiples of 4 (`packed_row_bytes = width * 4`), so the remainder slices these two calls return are empty and no pixel is skipped. The element type becomes `[u8; 4]`, so the four indexes in the loop body are bounds-checked at compile time rather than on each access.

These are the only two `chunks_exact` uses in the whole Rust workspace.

## Verification

Run on this branch, with controls rather than a bare green:

| check | result |
| --- | --- |
| `cargo clippy -p tuff-native-screenshot --all-targets -- -D warnings` | clean |
| positive control: inject a lint violation into the same file | errors — so clippy is reading this file |
| `cargo test -p tuff-native-screenshot` | 82 passed |
| mutation control: swap the R/B channel reads in the converted loop | `bgra_copy_removes_stride_padding_and_unpremultiplies` **fails** |

The mutation control is the one that matters: it proves the 82-pass result is not vacuous for the lines I touched. That test also covers stride padding (`bytes_per_row: 8` against `width: 1`), which is the property most at risk in a chunking rewrite.

**Caveat, stated plainly:** local clippy here is 1.95 and does not carry the 1.98 lint, so what I verified locally is that the new form compiles and behaves identically. CI is the oracle for the lint itself.

## The structural half is not fixed here

This unblocks the gate; it does not stop the next stable release from doing the same thing. Two things worth deciding separately:

1. **Pin the toolchain** (a `rust-toolchain.toml`, or a version on the action) so a clippy release cannot turn master red without a commit. The trade-off is having to bump deliberately to pick up new lints.
2. **Decide whether `Protocol` should be a required check.** Right now it can be red on master indefinitely with nothing surfacing it — which is how this reached nine days.

Recorded on #1792, which is about the same shape of problem in a different gate.

## Separately: this is *not* what the four Cargo dependabot PRs are failing on

While tracing this I checked them. #1756 (`napi` 3.8.6 → 3.12.2) fails differently — `Protocol (ubuntu-latest)`, at the test step, with `rust-lld: error: undefined symbol: napi_call_threadsafe_function`. Master's ubuntu job passes, so that one is a genuine regression from the bump and should not be merged on the strength of this fix. Noted on those PRs.