### PR TITLE
docs(nexus): write the missing English API chapters and wire the parity gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,19 @@ jobs:
       - name: Verify icon collections are installed
         run: pnpm -C apps/nexus check:icon-collections
 
+      # The third gate #1776 found defined-but-uninvoked. It stayed unwired on purpose: it would
+      # have failed the build on a gap it could not fix, since the English copies of division-box,
+      # flow-transfer and intelligence were short 15 headings between them. Those chapters are
+      # written now and the check exits 0 across all 162 pairs, so the reason to leave it out is
+      # gone. Blocking, not continue-on-error — an advisory parity check is the same defect in a
+      # quieter form.
+      #
+      # Verified it can fail before wiring, twice: demoting one `###` to bold reports
+      # "zh has 21 headings, en has 20", and changing a `##` to `###` reports
+      # "heading 10 is h2 in zh but h3 in en".
+      - name: Verify zh/en doc parity
+        run: pnpm -C apps/nexus check:doc-parity
+
       # Blocking. It was briefly continue-on-error because wiring it up is what discovered
       # the build was broken — nitro could not resolve @panva/hkdf from next-auth against a
       # root node_modules path that only existed under shamefully-hoist (#1151, #1099

--- a/apps/nexus/build/check-doc-translation-parity.mjs
+++ b/apps/nexus/build/check-doc-translation-parity.mjs
@@ -11,12 +11,15 @@
 // The check compares the *shape* — the sequence of heading depths — not the
 // text, because the headings themselves are translated.
 //
-// All 159 component doc pairs are clean. The remaining offenders are under
-// dev/api, where the English copies are missing whole chapters: division-box is
-// short an entire lifecycle chapter and flow-transfer is short five sections.
-// Those need someone who knows the subsystem, so this is NOT wired into ci.yml
-// yet — it would fail the build on a gap it cannot fix. Add the CI step once the
-// list is empty.
+// Every pair is clean and this now runs in ci.yml's nexus job. It was unwired
+// until 2026-08-27 because three dev/api pages were short 15 English headings
+// between them — division-box an entire lifecycle chapter, flow-transfer five
+// sections, intelligence one — and a gate that fails on a gap it cannot fix is
+// worse than no gate. Those chapters were written against the implementation
+// rather than translated: two claims in the Chinese copies did not survive that
+// check and were corrected rather than carried over (a `RESOURCE_LIMIT_EXCEEDED`
+// error code that exists nowhere in the codebase, and a table of `flow:*` channel
+// names missing the module segment every real event name carries).
 //
 // Headings inside fenced code blocks are skipped: a `# comment` line in a shell
 // example is not a section, and the two locales routinely differ there. MDC

--- a/apps/nexus/content/docs/dev/api/division-box.en.mdc
+++ b/apps/nexus/content/docs/dev/api/division-box.en.mdc
@@ -213,15 +213,151 @@ code: |
 | `division-box:state-changed` | Main → Renderer | State change notice |
 | `division-box:session-destroyed` | Main → Renderer | Session destroyed |
 
+## Resource Limits
+
+Enforced by the main process in `apps/core-app/src/main/modules/division-box/manager.ts`; treat these as the authority rather than the numbers here.
+
+| Limit | Value | Meaning |
+| --- | ---: | --- |
+| `MAX_ACTIVE_SESSIONS` | 5 | Live sessions globally, matching the window pool. Opening past it throws `DivisionBoxErrorCode.LIMIT_EXCEEDED`. |
+| `MAX_CACHED_SESSIONS` | 5 | `keepAlive` sessions held in the LRU cache. Beyond it the least recently used is evicted and destroyed. |
+| `MAX_VIEWS_PER_SESSION` | 3 | Reserved upper bound. The current runtime flow attaches at most one view per session. |
+
+## Technical Notes
+- DivisionBox is managed by the main process using `WebContentsView`.
+- The SDK wraps IPC events and normalizes lifecycle updates.
+
+## Lifecycle in Detail
+
+The state machine is `prepare → attach → active → inactive → detach → destroy`, declared as `DivisionBoxState` in `packages/utils/types/division-box.ts`.
+
+### prepare
+
+The initial state of a session, between the `open()` call and window creation.
+
+**Entered when**
+- `divisionBox.open(config)` is called.
+- The main process validates the config, assigns a session id, and constructs the session.
+
+**Resources**
+- A session id is allocated.
+- The config is validated and defaults applied; the plugin owner is resolved before any window is constructed.
+- Session state storage is initialized.
+- With `keepAlive`, the session is registered with the LRU cache.
+
+**Failures**
+- Global session cap reached → `DivisionBoxError(LIMIT_EXCEEDED)`.
+- Missing or unauthorized plugin owner → `DivisionBoxError(PERMISSION_DENIED)`.
+- Malformed configuration → `DivisionBoxError(CONFIG_ERROR)`.
+
+### attach
+
+Reached once the window exists and the view is attached to it.
+
+**Entered when**
+- A `WebContentsView` is created and attached to the window.
+- The plugin UI begins loading (`did-start-loading`).
+
+**Resources**
+- The view is created and the URL loaded.
+- IPC listeners are registered.
+- When detaching from CoreBox, ownership of the existing UI view is transferred rather than reloaded.
+
+**Failures**
+- `did-fail-load` → the session moves to `destroy`.
+- `render-process-gone` → the session moves to `destroy`.
+
+### active
+
+The user is interacting with the DivisionBox.
+
+**Entered when**
+- The window takes focus.
+- The page finishes loading (`did-finish-load`).
+- Focus returns from `inactive`.
+
+**Resources**
+- Steady state. IPC is safe to use here.
+
+### inactive
+
+The window lost focus or is occluded.
+
+**Entered when**
+- The window emits `blur`.
+- Another DivisionBox or CoreBox window covers it.
+
+**Resources**
+- With `keepAlive: false`, deferred destruction may be scheduled.
+- With `keepAlive: true`, resources are retained at lower priority.
+- The LRU cache may reclaim low-priority sessions from here.
+
+**Failures**
+- Prolonged inactivity can trigger memory-pressure reclamation.
+- Past `MAX_CACHED_SESSIONS`, the least recently used session is destroyed.
+
+### detach
+
+The window closed, or the session was explicitly detached.
+
+**Entered when**
+- `divisionBox.close(sessionId)` is called.
+- The user closes the window.
+- A resource limit forces teardown.
+
+**Resources**
+- With `keepAlive: true`, the session enters the LRU cache and can be restored.
+- With `keepAlive: false`, it proceeds straight to `destroy`.
+- The view and its associated resources are released.
+
+**Failures**
+- The close animation can be interrupted with `force: true`.
+- A full cache means immediate destruction instead of caching.
+
+### destroy
+
+Terminal state; resources are fully released.
+
+**Entered when**
+- `detach` completes with `keepAlive: false`.
+- A `keepAlive` session is evicted by the LRU cache.
+- Memory pressure or a resource limit forces teardown.
+
+**Resources**
+- All associated resources are released.
+- The session is removed from the session map and the LRU cache.
+- IPC listeners are unregistered.
+- `division-box:session-destroyed` is emitted.
+
+**Failures**
+- Nothing should throw here. A failed release is logged and does not block the transition — a stuck session would be worse than a leaked handle.
+
+### State transitions
+
+```mermaid
+stateDiagram-v2
+    [*] --> prepare: open()
+    prepare --> attach: window created
+    attach --> active: window focused
+    active --> inactive: window blurred
+    inactive --> active: window refocused
+    inactive --> detach: close() / reclaim
+    active --> detach: close() / reclaim
+    attach --> detach: close() / reclaim
+    detach --> [*]: keepAlive=false
+    detach --> prepare: keepAlive=true, restored
+    prepare --> destroy: load failure / limit exceeded
+    attach --> destroy: load failure / crash
+    active --> destroy: crash
+    inactive --> destroy: LRU eviction / memory pressure
+    destroy --> [*]
+```
+
 ## Best Practices
 - Enable `keepAlive` for frequently used panels.
 - Choose `size` based on content density.
 - Persist user state via `updateState/getState`.
 - Release resources on `inactive` and `destroy` states.
-
-## Technical Notes
-- DivisionBox is managed by the main process using `WebContentsView`.
-- The SDK wraps IPC events and normalizes lifecycle updates.
 
 ## Related Docs
 - [Flow Transfer API](./flow-transfer.en.mdc)

--- a/apps/nexus/content/docs/dev/api/division-box.zh.mdc
+++ b/apps/nexus/content/docs/dev/api/division-box.zh.mdc
@@ -416,9 +416,9 @@ code: |
 - 如果配置了 `keepAlive`，注册到 LRU 缓存管理器
 
 **异常处理**：
-- URL 协议不支持 → 返回 `DivisionBoxError`（`INVALID_URL`）
-- 权限不足 → 返回 `DivisionBoxError`（`PERMISSION_DENIED`）
-- 资源超限（超过 `MAX_ACTIVE_SESSIONS`）→ 返回 `DivisionBoxError`（`RESOURCE_LIMIT_EXCEEDED`）
+- 超过全局会话上限 `MAX_ACTIVE_SESSIONS` → 抛出 `DivisionBoxError`（`LIMIT_EXCEEDED`）
+- 插件归属缺失或无权限 → 抛出 `DivisionBoxError`（`PERMISSION_DENIED`）
+- 配置不合法 → 抛出 `DivisionBoxError`（`CONFIG_ERROR`）
 
 ### attach 阶段
 

--- a/apps/nexus/content/docs/dev/api/flow-transfer.en.mdc
+++ b/apps/nexus/content/docs/dev/api/flow-transfer.en.mdc
@@ -138,7 +138,49 @@ code: |
 ---
 :::
 
-**Native share**
+## Flow Session State
+
+A session moves through these states; `flow:session:update` broadcasts every transition.
+
+:::TuffCodeBlock{lang="typescript"}
+---
+code: |
+  type FlowSessionState =
+    | 'INIT'             // created, no target chosen yet
+    | 'TARGET_SELECTING' // the chooser is open
+    | 'TARGET_SELECTED'  // a target has been picked
+    | 'DELIVERING'       // payload is being handed to the target
+    | 'DELIVERED'        // the target received it
+    | 'PROCESSING'       // the target is working on it
+    | 'ACKED'            // the target acknowledged completion
+    | 'FAILED'           // terminal failure
+    | 'CANCELLED'        // cancelled by the sender or the user
+---
+:::
+
+## Error Handling
+
+`ctx.reportError()` and failed dispatches carry a `FlowErrorCode`. Treat any unrecognised value as `INTERNAL_ERROR` rather than assuming the list is closed.
+
+:::TuffCodeBlock{lang="typescript"}
+---
+code: |
+  enum FlowErrorCode {
+    SENDER_NOT_ALLOWED = 'SENDER_NOT_ALLOWED',
+    TARGET_NOT_FOUND = 'TARGET_NOT_FOUND',
+    TARGET_OFFLINE = 'TARGET_OFFLINE',
+    PAYLOAD_INVALID = 'PAYLOAD_INVALID',
+    PAYLOAD_TOO_LARGE = 'PAYLOAD_TOO_LARGE',
+    TYPE_NOT_SUPPORTED = 'TYPE_NOT_SUPPORTED',
+    PERMISSION_DENIED = 'PERMISSION_DENIED',
+    TIMEOUT = 'TIMEOUT',
+    CANCELLED = 'CANCELLED',
+    INTERNAL_ERROR = 'INTERNAL_ERROR'
+  }
+---
+:::
+
+## Native System Sharing
 
 Flow Transfer can call native share targets. If your plugin is sharing the current CoreBox item from a MetaK / Quick Actions action, prefer [QuickActions SDK](./quick-actions.en.mdc) `shareItem()` so target resolution and platform fallback stay centralized.
 
@@ -165,6 +207,58 @@ code: |
 
 Flow target lists expose the system chooser as `system-share`; `flow.nativeShare()` also accepts `system` as a compatibility alias. Windows and Linux currently expose only the explicit `mail` fallback, not a fake system share panel.
 
+## Target Ordering Rules
+
+The target list is ordered by:
+
+1. **Native share targets** — the system chooser and its siblings come first.
+2. **Adapted plugins** — those that registered an `onFlowTransfer` handler.
+3. **Unadapted plugins** — shown with an adaptation hint rather than hidden, so a user can tell the difference between "cannot receive this" and "not installed".
+
+:::TuffCodeBlock{lang="typescript"}
+---
+code: |
+  // The adaptation fields on FlowTargetInfo
+  interface FlowTargetInfo {
+    // ...other fields
+    hasFlowHandler: boolean    // an onFlowTransfer handler is registered
+    isNativeShare?: boolean    // this is a native share target
+    adaptationHint?: string    // shown when the plugin has not adapted yet
+  }
+---
+:::
+
+## IPC Channels
+
+Event names are composed as `namespace:module:action`, so every Flow channel carries a module segment. These are the names the main process actually registers — see `apps/core-app/src/main/modules/flow-bus/`.
+
+| Channel | Direction | Purpose |
+| --- | --- | --- |
+| `flow:bus:dispatch` | plugin → main | Start a flow |
+| `flow:bus:get-targets` | plugin → main | List available targets |
+| `flow:bus:cancel` | plugin → main | Cancel a session |
+| `flow:bus:acknowledge` | target → main | Acknowledge completion |
+| `flow:bus:report-error` | target → main | Report a `FlowErrorCode` |
+| `flow:bus:select-target` | UI → main | User picked a target in the chooser |
+| `flow:session:update` | main → all | Broadcast a session state transition |
+| `flow:session:deliver` | main → target | Hand the payload to the target |
+| `flow:native:share` | plugin → main | Invoke a native share target |
+| `flow:consent:check` | plugin → main | Check transfer consent |
+| `flow:consent:grant` | UI → main | Grant transfer consent |
+| `flow:ui:trigger-transfer` | main → UI | Open the transfer surface |
+| `flow:ui:trigger-detach` | main → UI | Detach the transfer surface |
+
+Plugin registration, from the plugin process:
+
+| Channel | Purpose |
+| --- | --- |
+| `flow:plugin:register-targets` | Register this plugin's targets |
+| `flow:plugin:unregister-targets` | Remove them |
+| `flow:plugin:set-plugin-enabled` | Update the plugin's enabled state |
+| `flow:plugin:set-plugin-handler` | Declare whether `onFlowTransfer` is registered |
+
+Prefer the `FlowEvents` constants over these literals — the SDK builds the name from the same builder, so a rename stays in one place.
+
 ## Best Practices
 - Register `onFlowTransfer` to avoid being marked “not supported”.
 - Provide clear `supportedTypes` and `description` for better target ranking.
@@ -173,7 +267,7 @@ Flow target lists expose the system chooser as `system-share`; `flow.nativeShare
 
 ## Technical Notes
 - Target list is maintained by the main process and merged with native share targets.
-- Plugins are registered via `flow:register-targets`; missing registration means targets won’t appear.
+- Plugins are registered via `flow:plugin:register-targets`; missing registration means targets won’t appear.
 
 ## Related Docs
 - [QuickActions SDK](./quick-actions.en.mdc)

--- a/apps/nexus/content/docs/dev/api/flow-transfer.zh.mdc
+++ b/apps/nexus/content/docs/dev/api/flow-transfer.zh.mdc
@@ -53,7 +53,7 @@ code: |
 
 > 当前实现说明：FlowTarget 的最终可用列表由主进程维护。
 > - Native share targets：由主进程在启动时注册。
-> - Plugin targets：当前通过主进程通道 `flow:register-targets` 注册（由运行时/加载器负责触发）。
+> - Plugin targets：当前通过主进程通道 `flow:plugin:register-targets` 注册（由运行时/加载器负责触发）。
 >   如果你发现 manifest 声明的 targets 没有出现在列表中，说明对应注册流程尚未覆盖到你的运行路径。
 
 **Flow Target（流转目标）**
@@ -397,23 +397,28 @@ code: |
 
 ## IPC 通道（实现对齐）
 
-以下通道是当前实现中使用到的关键事件名（详见主进程 `apps/core-app/src/main/modules/flow-bus/`）：
+事件名由 `namespace:module:action` 组成，因此每个 Flow 通道都带有 module 段。以下是主进程实际注册的名称（详见 `apps/core-app/src/main/modules/flow-bus/`）：
 
-- **`flow:dispatch`**：发起 flow
-- **`flow:get-targets`**：获取可用 targets
-- **`flow:cancel`**：取消 session
-- **`flow:acknowledge`**：ack
-- **`flow:report-error`**：上报错误
-- **`flow:session-update`**：广播 session 状态更新
-- **`flow:select-target`**：用户在选择面板选中 target（UI → 主进程）
-- **`flow:native-share`**：系统分享
+- **`flow:bus:dispatch`**：发起 flow
+- **`flow:bus:get-targets`**：获取可用 targets
+- **`flow:bus:cancel`**：取消 session
+- **`flow:bus:acknowledge`**：ack
+- **`flow:bus:report-error`**：上报错误
+- **`flow:bus:select-target`**：用户在选择面板选中 target（UI → 主进程）
+- **`flow:session:update`**：广播 session 状态更新
+- **`flow:session:deliver`**：将 payload 投递给 target
+- **`flow:native:share`**：系统分享
+- **`flow:consent:check`** / **`flow:consent:grant`**：传输授权检查与授予
+- **`flow:ui:trigger-transfer`** / **`flow:ui:trigger-detach`**：主进程驱动 UI 打开/分离传输面板
 
-插件集成（主进程侧注册）：
+插件集成（插件进程侧发起）：
 
-- **`flow:register-targets`**：注册 targets（plugin → 主进程）
-- **`flow:unregister-targets`**：卸载 targets
-- **`flow:set-plugin-enabled`**：更新 plugin enabled 状态
-- **`flow:set-plugin-handler`**：声明当前插件是否已注册 `onFlowTransfer` handler
+- **`flow:plugin:register-targets`**：注册 targets
+- **`flow:plugin:unregister-targets`**：卸载 targets
+- **`flow:plugin:set-plugin-enabled`**：更新 plugin enabled 状态
+- **`flow:plugin:set-plugin-handler`**：声明当前插件是否已注册 `onFlowTransfer` handler
+
+优先使用 `FlowEvents` 常量而非这些字面量——SDK 用同一个 builder 生成名称，改名时只需改一处。
 
 ---
 

--- a/apps/nexus/content/docs/dev/api/intelligence.en.mdc
+++ b/apps/nexus/content/docs/dev/api/intelligence.en.mdc
@@ -48,7 +48,7 @@ Plugin UI and lifecycle code should use the plugin SDK export or `context.utils.
 code: |
   import { intelligence } from '@talex-touch/utils/plugin/sdk'
 
-  ## void intelligence
+  void intelligence
 ---
 :::
 
@@ -376,6 +376,64 @@ Stream consumers must treat event boundaries as transport details:
 
 ---
 
+## Complete Examples
+
+**Translation plugin**
+
+Check availability before invoking: `getCapabilityStatus` returns `{ capabilityId, available, providerIds, reason? }`, and `available` is `false` when no configured provider serves that capability.
+
+:::TuffCodeBlock{lang="typescript"}
+---
+code: |
+  import { intelligence, useClipboard } from '@talex-touch/utils/plugin/sdk'
+
+  const clipboard = useClipboard()
+
+  async function translateAndPaste(content: string, targetLang: string) {
+  const status = await intelligence.getCapabilityStatus({ capabilityId: 'text.translate' })
+  if (!status.available) return
+
+      const result = await intelligence.text.translate({
+        text: content,
+        targetLang
+      })
+
+      await clipboard.copyAndPaste({ text: result.result })
+
+  }
+
+  void translateAndPaste
+---
+:::
+
+**OCR plugin**
+
+`vision.ocr` resolves to an `IntelligenceInvokeResult<IntelligenceVisionOcrResult>`, so the extracted text is at `result.result.text`. `keywords` is populated only when `includeKeywords` is set, and stays optional even then.
+
+:::TuffCodeBlock{lang="typescript"}
+---
+code: |
+  import { intelligence } from '@talex-touch/utils/plugin/sdk'
+
+  async function recognizeText(imageDataUrl: string) {
+  const result = await intelligence.vision.ocr({
+  source: { type: 'data-url', dataUrl: imageDataUrl },
+  includeKeywords: true
+  })
+
+      return {
+        text: result.result.text,
+        keywords: result.result.keywords
+      }
+
+  }
+
+  void recognizeText
+---
+:::
+
+---
+
 ## State Management
 
 :::TuffCodeBlock{lang="typescript"}
@@ -410,7 +468,7 @@ code: |
   CUSTOM = 'custom'
   }
 
-  ## void IntelligenceProviderType.OPENAI
+  void IntelligenceProviderType.OPENAI
 ---
 :::
 

--- a/apps/nexus/content/docs/dev/api/intelligence.zh.mdc
+++ b/apps/nexus/content/docs/dev/api/intelligence.zh.mdc
@@ -48,7 +48,7 @@ code: |
 code: |
   import { intelligence } from '@talex-touch/utils/plugin/sdk'
 
-  ## void intelligence
+  void intelligence
 ---
 :::
 
@@ -398,7 +398,7 @@ code: |
 
   }
 
-  ## void translateAndPaste
+  void translateAndPaste
 ---
 :::
 
@@ -422,7 +422,7 @@ code: |
 
   }
 
-  ## void recognizeText
+  void recognizeText
 ---
 :::
 
@@ -459,7 +459,7 @@ code: |
   CUSTOM = 'custom'
   }
 
-  ## void IntelligenceProviderType.OPENAI
+  void IntelligenceProviderType.OPENAI
 ---
 :::
 


### PR DESCRIPTION
Closes the second of the three items in #1776 — the `check:doc-parity` gate that was defined but invoked by nothing.

## Why it was unwired

Not an oversight. The script's own header said so:

> Those need someone who knows the subsystem, so this is NOT wired into ci.yml yet — it would fail the build on a gap it cannot fix. **Add the CI step once the list is empty.**

Measured at the start of this change:

```
EXIT=1
content/docs/dev/api/division-box:  zh 21 headings, en 12   (9 missing)
content/docs/dev/api/flow-transfer: zh 14 headings, en  9   (5 missing)
content/docs/dev/api/intelligence:  zh 20 headings, en 19   (1 missing)
```

The list is empty now, so the step is added.

## These were written against source, not translated — and two Chinese claims did not survive that

This is the part worth reviewing carefully. Checking each statement against the implementation before writing the English turned up two fabrications in the existing Chinese copies:

**1. `division-box.zh` invented an error code.** The prepare-phase section listed `DivisionBoxError(INVALID_URL)` and `DivisionBoxError(RESOURCE_LIMIT_EXCEEDED)`.

- `INVALID_URL` is `DownloadErrorType.INVALID_URL` — a different module.
- `RESOURCE_LIMIT_EXCEEDED` appears **nowhere in the codebase** except that sentence.

`DivisionBoxErrorCode` has exactly eight members, and the session-cap path throws `LIMIT_EXCEEDED` (`division-box/manager.ts:208`). Corrected in both copies.

**2. `flow-transfer.zh`'s IPC table — the one headed "实现对齐" (implementation-aligned) — listed twelve channel names, none of which exist.** Event names are composed as `namespace:module:action` (`transport/event/builder.ts`), so every real Flow channel carries a module segment.

Positive control, so this is a real absence and not a broken search:

```
'flow:dispatch'      0 matches under apps/core-app/src
flow:bus:dispatch    apps/core-app/src/main/modules/flow-bus/ipc.ts:159
```

Corrected in both copies, plus the five channels the table omitted entirely (`flow:session:deliver`, `flow:consent:check`, `flow:consent:grant`, `flow:ui:trigger-transfer`, `flow:ui:trigger-detach`).

## What the English chapters contain

| Page | Added |
| --- | --- |
| `division-box.en` | **Resource Limits** — the three real `RESOURCE_LIMITS` constants with the error each breach raises. **Lifecycle in Detail** — seven sections covering `prepare → attach → active → inactive → detach → destroy` plus the transition diagram |
| `flow-transfer.en` | **Flow Session State**, **Error Handling** (both enums verbatim from `types/flow.ts`), **Native System Sharing** (promoted from a bold label inside SDK Usage), **Target Ordering Rules**, **IPC Channels** |
| `intelligence.en` | **Complete Examples** — the translation and OCR plugin samples, with payload and result shapes checked against `IntelligenceTranslatePayload`, `IntelligenceVisionOcrResult`, `IntelligenceInvokeResult` and `IntelligenceCapabilityStatus` |

`## Technical Notes` moved in `division-box.en` to match the Chinese ordering — the check compares the sequence of heading depths, so position matters, not just count.

## Also: six corrupted lines

`## void intelligence`, `## void translateAndPaste` and four siblings sat inside `code: |` blocks in both intelligence copies. The idiom everywhere else in those files is a bare `void X`; the `## ` prefix rendered as literal text in the code sample. They were never counted as headings — block-scalar content is indented, so the line-anchored pattern never matched — so this is a rendering fix, not a parity one.

## Verification

Controls, not just a green run:

| check | result |
| --- | --- |
| `check:doc-parity` | **exit 0** across all pairs |
| negative control: demote one `###` to bold | fails — "zh has 21 headings, en has 20" |
| negative control: change a `##` to `###` | fails — "heading 10 is h2 in zh but h3 in en" |
| `check:mdc-fences` | 0 |
| `check:api-routes` | 0 |
| `check:icon-collections` | 0 |
| `actionlint -shellcheck` on the edited `ci.yml` | 0 |

Wired as **blocking**. An advisory parity check is the same defect in a quieter form — which is exactly what #1776 was filed about.

## Not covered here

#1776's third item, `build:analyze-worker`, is untouched. It needs the gzip budget question settled and the `check-worker-bundle.mjs` / `.test.ts` contradiction over `i-carbon-fingerprint-recognition` resolved before it can be wired at all. So this PR closes item 2, and #1776 stays open on item 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded API documentation for Division Box lifecycle states and resource limits.
  * Added Flow Transfer session states, error handling, target ordering, and IPC channel references.
  * Added complete Intelligence SDK plugin examples and corrected code formatting.
  * Updated Chinese documentation to match current error codes, channel names, and examples.
* **Chores**
  * Added an automated CI check to verify Chinese and English documentation heading parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->