### PR TITLE
docs(nexus): correct four lifecycle claims I got wrong in #1795

### DIFF
--- a/apps/nexus/content/docs/dev/api/division-box.en.mdc
+++ b/apps/nexus/content/docs/dev/api/division-box.en.mdc
@@ -240,15 +240,18 @@ The initial state of a session, between the `open()` call and window creation.
 - The main process validates the config, assigns a session id, and constructs the session.
 
 **Resources**
-- A session id is allocated.
+- The global session cap is checked *before* anything is allocated.
+- A session id is generated and the session registered in the session map.
 - The config is validated and defaults applied; the plugin owner is resolved before any window is constructed.
-- Session state storage is initialized.
-- With `keepAlive`, the session is registered with the LRU cache.
+- With `keepAlive`, a state-change handler is installed. It does not put the session in the LRU cache yet — the cache entry is added when the session first reaches `inactive`, refreshed on return to `active`, and removed on `destroy`.
 
 **Failures**
-- Global session cap reached → `DivisionBoxError(LIMIT_EXCEEDED)`.
-- Missing or unauthorized plugin owner → `DivisionBoxError(PERMISSION_DENIED)`.
-- Malformed configuration → `DivisionBoxError(CONFIG_ERROR)`.
+
+All three reject the `open()` call; none of them produce a session that then transitions.
+
+- Global session cap reached → `DivisionBoxError(LIMIT_EXCEEDED)`, thrown before the session id is generated.
+- A UI view requested without an owning `pluginId`, or with a `pluginId` that resolves to no loaded plugin → `DivisionBoxError(CONFIG_ERROR)`.
+- A non-authoritative caller requesting a UI view, or a `pluginId` that does not match the calling plugin → `DivisionBoxError(PERMISSION_DENIED)`, raised at the IPC boundary before the manager is reached.
 
 ### attach
 
@@ -346,7 +349,7 @@ stateDiagram-v2
     attach --> detach: close() / reclaim
     detach --> [*]: keepAlive=false
     detach --> prepare: keepAlive=true, restored
-    prepare --> destroy: load failure / limit exceeded
+    prepare --> destroy: load failure
     attach --> destroy: load failure / crash
     active --> destroy: crash
     inactive --> destroy: LRU eviction / memory pressure

--- a/apps/nexus/content/docs/dev/api/division-box.en.mdc
+++ b/apps/nexus/content/docs/dev/api/division-box.en.mdc
@@ -236,8 +236,8 @@ The state machine is `prepare → attach → active → inactive → detach → 
 The initial state of a session, between the `open()` call and window creation.
 
 **Entered when**
-- `divisionBox.open(config)` is called.
-- The main process validates the config, assigns a session id, and constructs the session.
+- `divisionBox.open(config)` is called **and** passes the preflight checks below. A rejected open never reaches this state.
+- The main process then assigns a session id and constructs the session.
 
 **Resources**
 - The global session cap is checked *before* anything is allocated.
@@ -309,7 +309,7 @@ The window closed, or the session was explicitly detached.
 - A resource limit forces teardown.
 
 **Resources**
-- With `keepAlive: true`, the session enters the LRU cache and can be restored.
+- With `keepAlive: true`, the session is already in the LRU cache from its first `inactive`, and can be restored from there.
 - With `keepAlive: false`, it proceeds straight to `destroy`.
 - The view and its associated resources are released.
 

--- a/apps/nexus/content/docs/dev/api/division-box.zh.mdc
+++ b/apps/nexus/content/docs/dev/api/division-box.zh.mdc
@@ -410,15 +410,18 @@ code: |
 - 主进程验证配置、分配 sessionId、创建 DivisionBoxSession 实例
 
 **资源管理**：
-- 分配 sessionId（自增计数器）
-- 验证 URL 协议和权限
-- 初始化会话状态存储
-- 如果配置了 `keepAlive`，注册到 LRU 缓存管理器
+- 先检查全局会话上限，通过后才分配任何资源
+- 生成 sessionId 并登记到 session map
+- 验证配置并应用默认值；构造窗口前先解析插件归属
+- 配置了 `keepAlive` 时只是安装状态变更回调，此时**尚未**进入 LRU 缓存——缓存条目在会话首次进入 `inactive` 时加入，回到 `active` 时刷新访问时间，`destroy` 时移除
 
 **异常处理**：
-- 超过全局会话上限 `MAX_ACTIVE_SESSIONS` → 抛出 `DivisionBoxError`（`LIMIT_EXCEEDED`）
-- 插件归属缺失或无权限 → 抛出 `DivisionBoxError`（`PERMISSION_DENIED`）
-- 配置不合法 → 抛出 `DivisionBoxError`（`CONFIG_ERROR`）
+
+以下三种都会让 `open()` 直接失败，不会产生一个随后再发生状态转换的会话。
+
+- 超过全局会话上限 `MAX_ACTIVE_SESSIONS` → 抛出 `DivisionBoxError`（`LIMIT_EXCEEDED`），在生成 sessionId 之前
+- 请求 UI view 但缺少 `pluginId`，或 `pluginId` 找不到已加载插件 → 抛出 `DivisionBoxError`（`CONFIG_ERROR`）
+- 非 authoritative 调用方请求 UI view，或 `pluginId` 与调用插件不符 → 抛出 `DivisionBoxError`（`PERMISSION_DENIED`），在 IPC 边界拦截，不会进入 manager
 
 ### attach 阶段
 
@@ -521,7 +524,7 @@ stateDiagram-v2
     attach --> detach: close() / 资源回收
     detach --> [*]: keepAlive=false
     detach --> prepare: keepAlive=true, 恢复
-    prepare --> destroy: 加载失败 / 资源超限
+    prepare --> destroy: 加载失败
     attach --> destroy: 加载失败 / 崩溃
     active --> destroy: 崩溃
     inactive --> destroy: LRU 回收 / 内存压力

--- a/apps/nexus/content/docs/dev/api/division-box.zh.mdc
+++ b/apps/nexus/content/docs/dev/api/division-box.zh.mdc
@@ -406,8 +406,8 @@ code: |
 `prepare` 是 DivisionBox 会话的初始状态，发生在 `open()` 调用后、窗口创建前。
 
 **触发时机**：
-- 调用 `divisionBox.open(config)` 时立即进入
-- 主进程验证配置、分配 sessionId、创建 DivisionBoxSession 实例
+- 调用 `divisionBox.open(config)` 且通过下述前置检查后进入；被拒绝的 open 不会到达该状态
+- 随后主进程分配 sessionId、创建 DivisionBoxSession 实例
 
 **资源管理**：
 - 先检查全局会话上限，通过后才分配任何资源
@@ -481,7 +481,7 @@ code: |
 - 资源超限触发的强制销毁
 
 **资源管理**：
-- 如果 `keepAlive=true`，会话进入 LRU 缓存等待恢复
+- 如果 `keepAlive=true`，会话在首次 `inactive` 时就已进入 LRU 缓存，此处从缓存中等待恢复
 - 如果 `keepAlive=false`，直接进入 `destroy` 阶段
 - 释放 WebContentsView 和关联资源
 

--- a/apps/nexus/content/docs/dev/api/flow-transfer.en.mdc
+++ b/apps/nexus/content/docs/dev/api/flow-transfer.en.mdc
@@ -127,12 +127,14 @@ code: |
 
   const flow = createFlowSDK(channel, 'my-plugin-id')
 
-  flow.onFlowTransfer(async (payload, ctx) => {
+  const unsubscribe = flow.onFlowTransfer(async (payload, sessionId, sender) => {
+    console.log(`Received ${payload.type} from ${sender.senderName}`)
+
     try {
-      await handlePayload(payload)
-      ctx.acknowledge({ success: true })
+      const result = await handlePayload(payload)
+      await flow.acknowledge(sessionId, { success: true, result })
     } catch (error) {
-      ctx.reportError({ message: 'Failed to handle payload' })
+      await flow.reportError(sessionId, 'Failed to handle payload')
     }
   })
 ---
@@ -160,7 +162,7 @@ code: |
 
 ## Error Handling
 
-`ctx.reportError()` and failed dispatches carry a `FlowErrorCode`. Treat any unrecognised value as `INTERNAL_ERROR` rather than assuming the list is closed.
+`flow.reportError(sessionId, message)` and failed dispatches carry a `FlowErrorCode`. Treat any unrecognised value as `INTERNAL_ERROR` rather than assuming the list is closed.
 
 :::TuffCodeBlock{lang="typescript"}
 ---

--- a/apps/nexus/content/docs/dev/api/flow-transfer.zh.mdc
+++ b/apps/nexus/content/docs/dev/api/flow-transfer.zh.mdc
@@ -310,6 +310,8 @@ code: |
 
 ## 错误处理
 
+`ctx.reportError()` 与失败的 dispatch 都会带上 `FlowErrorCode`。把无法识别的值一律当作 `INTERNAL_ERROR` 处理，不要假设这个列表是封闭的。
+
 :::TuffCodeBlock{lang="typescript"}
 ---
 code: |

--- a/apps/nexus/content/docs/dev/api/flow-transfer.zh.mdc
+++ b/apps/nexus/content/docs/dev/api/flow-transfer.zh.mdc
@@ -310,7 +310,7 @@ code: |
 
 ## 错误处理
 
-`ctx.reportError()` 与失败的 dispatch 都会带上 `FlowErrorCode`。把无法识别的值一律当作 `INTERNAL_ERROR` 处理，不要假设这个列表是封闭的。
+`flow.reportError(sessionId, message)` 与失败的 dispatch 都会带上 `FlowErrorCode`。把无法识别的值一律当作 `INTERNAL_ERROR` 处理，不要假设这个列表是封闭的。
 
 :::TuffCodeBlock{lang="typescript"}
 ---

--- a/apps/nexus/content/docs/dev/api/intelligence.en.mdc
+++ b/apps/nexus/content/docs/dev/api/intelligence.en.mdc
@@ -416,6 +416,10 @@ code: |
   import { intelligence } from '@talex-touch/utils/plugin/sdk'
 
   async function recognizeText(imageDataUrl: string) {
+  // Same discovery gate as above: an unconfigured provider makes this unavailable.
+  const status = await intelligence.getCapabilityStatus({ capabilityId: 'vision.ocr' })
+  if (!status.available) return null
+
   const result = await intelligence.vision.ocr({
   source: { type: 'data-url', dataUrl: imageDataUrl },
   includeKeywords: true

--- a/apps/nexus/content/docs/dev/api/intelligence.zh.mdc
+++ b/apps/nexus/content/docs/dev/api/intelligence.zh.mdc
@@ -410,6 +410,10 @@ code: |
   import { intelligence } from '@talex-touch/utils/plugin/sdk'
 
   async function recognizeText(imageDataUrl: string) {
+  // 与上例相同的能力发现门：未配置 provider 时该能力不可用。
+  const status = await intelligence.getCapabilityStatus({ capabilityId: 'vision.ocr' })
+  if (!status.available) return null
+
   const result = await intelligence.vision.ocr({
   source: { type: 'data-url', dataUrl: imageDataUrl },
   includeKeywords: true


### PR DESCRIPTION
Post-merge review on #1795 caught four statements in the new DivisionBox lifecycle chapter that do not match the implementation. Three were mine. All four are fixed in both languages.

## What was wrong

Read from `apps/core-app/src/main/modules/division-box/manager.ts:204-262`:

| Claim as written | What `createSession` actually does |
| --- | --- |
| `prepare --> destroy: load failure / limit exceeded` | The `MAX_ACTIVE_SESSIONS` check runs **first** — before `generateSessionId()` and before `new DivisionBoxSession(...)`. A rejected open never produces a `prepare` session, so that edge cannot occur. Removed the limit-exceeded half. |
| "With `keepAlive`, the session is registered with the LRU cache" (in **prepare**) | `keepAlive` installs a *state-change handler*. `lruCache.add(session)` fires when the session first reaches `INACTIVE`; `updateAccess` on return to `ACTIVE`; `remove` on `DESTROY`. Nothing enters the cache during prepare. |
| "Missing or unauthorized plugin owner → `PERMISSION_DENIED`" | Both missing-owner branches throw **`CONFIG_ERROR`** — no `pluginId`, and a `pluginId` resolving to no loaded plugin. `PERMISSION_DENIED` lives at a different boundary entirely (`ipc.ts:229,241`): a non-authoritative caller requesting a UI view, or a `pluginId` that does not match the caller. |

The third is the one worth naming. I inferred the error code from the phrase "missing or unauthorized plugin owner" instead of reading the `throw` statements — the exact shortcut the rest of #1795 was written to avoid, and the same class of defect that PR corrected in the Chinese copies (a `RESOURCE_LIMIT_EXCEEDED` that existed nowhere, and a table of `flow:*` channels missing their module segment).

Both prepare sections now also state explicitly that all three failures reject the `open()` call rather than producing a session that later transitions, since that distinction is what made the state diagram wrong.

## Two consistency gaps, also fixed

- **`flow-transfer.zh`** did not carry the "treat an unrecognised `FlowErrorCode` as `INTERNAL_ERROR`" rule that the English copy states. A reader of the Chinese page would not know the enum is open. Added.
- **Both OCR examples** called `intelligence.vision.ocr` directly, while the same page (line 84) requires discovery before invocation and the translation example beside them does exactly that. Both now gate on `getCapabilityStatus({ capabilityId: 'vision.ocr' })`.

## Verification

| gate | exit |
| --- | ---: |
| `check:doc-parity` | 0 |
| `check:mdc-fences` | 0 |
| `check:api-routes` | 0 |
| `check:icon-collections` | 0 |

Parity is preserved because every change here is body text — no headings added, removed, or re-nested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified DivisionBox session limits, configuration validation, permission checks, lifecycle behavior, and failure outcomes.
  * Documented standardized flow error handling, including fallback treatment for unknown error codes.
  * Updated the OCR plugin example to check capability availability before making recognition requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->