### PR TITLE
refactor(search): declare onDestroy on ISearchProvider and drop the structural cast

### DIFF
--- a/apps/core-app/src/main/modules/box-tool/search-engine/search-provider-registry.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/search-provider-registry.ts
@@ -54,19 +54,6 @@ export interface SearchProviderRegistrySnapshot {
   issues: SearchProviderRegistryIssue[]
 }
 
-/**
- * `onDestroy` is not on `ISearchProvider` (#334), so the registry reaches for it structurally.
- *
- * It returns `void | Promise<void>` because implementations already return both: `AppProvider`'s is
- * `async onDestroy(): Promise<void>` and awaits `prepareForSearchIndexShutdown()`, while
- * `EverythingProvider`'s and `FileSystemWatcher`'s are synchronous. Declaring it `() => void` made
- * the async one look settled at the call site, so `destroy()` resolved before the search index had
- * finished shutting down, and TypeScript could not see the floating promise.
- */
-type DestroyableSearchProvider = ISearchProvider<ProviderContext> & {
-  onDestroy?: () => void | Promise<void>
-}
-
 const SEARCH_PROVIDER_ISSUE_CODES: Record<SearchProviderRegistryIssue['code'], true> = {
   SEARCH_PROVIDER_DERIVED_FROM_PUSH_FEATURE: true,
   SEARCH_PROVIDER_PARTIAL_PUSH_FEATURE_COVERAGE: true,
@@ -418,8 +405,9 @@ export class SearchProviderRegistry {
     // that rejects must not abort the rest -- which is why the catch is inside the loop.
     for (const provider of this.providers.values()) {
       try {
-        const destroyableProvider = provider as DestroyableSearchProvider
-        if (destroyableProvider.onDestroy) await destroyableProvider.onDestroy()
+        // `onDestroy` is declared on `ISearchProvider` as `() => void | Promise<void>`, so the
+        // await settles the async implementations rather than leaving a floating promise (#334).
+        if (provider.onDestroy) await provider.onDestroy()
         else provider.onDeactivate?.()
       } catch (error) {
         log.warn(`Provider '${provider.id}' cleanup failed`, { error })

--- a/packages/utils/core-box/tuff/tuff-dsl.ts
+++ b/packages/utils/core-box/tuff/tuff-dsl.ts
@@ -1645,6 +1645,17 @@ export interface ISearchProvider<C> {
    * @param context The context of the provider.
    */
   onLoad?: (context: C) => Promise<void>
+
+  /**
+   * Optional teardown, called once when the provider is removed from the registry.
+   *
+   * Returns `void | Promise<void>` because implementations do both: `AppProvider`'s is `async` and
+   * awaits `prepareForSearchIndexShutdown()`, while `EverythingProvider`'s and
+   * `FileSystemWatcher`'s are synchronous. Declaring it `() => void` would make the async one look
+   * settled at the call site, so teardown could resolve before the search index had finished
+   * shutting down, with the floating promise invisible to TypeScript (#334, #1725).
+   */
+  onDestroy?: () => void | Promise<void>
 }
 
 // ==================== 插件接口预览 ====================


### PR DESCRIPTION
#334's first acceptance item, and the one the rest of that issue follows from.

## The problem

`ISearchProvider` declared **no disposal member at all**, so `search-provider-registry.ts` had to define its own structural type and cast to it — and document why:

```ts
/**
 * `onDestroy` is not on `ISearchProvider` (#334), so the registry reaches for it structurally.
 * ...
 */
type DestroyableSearchProvider = ISearchProvider<ProviderContext> & {
  onDestroy?: () => void | Promise<void>
}
```

A workaround that names the issue tracking it is a good comment, but it is still a workaround: nothing stops a provider author from writing `onDestroy` with a different shape, because the interface never mentioned it.

## The change

`onDestroy?: () => void | Promise<void>` now lives on the interface, and the cast is deleted.

The union is not hedging. Implementations genuinely return both:

| Provider | Signature |
| --- | --- |
| `AppProvider` | `async onDestroy(): Promise<void>` — awaits `prepareForSearchIndexShutdown()` |
| `EverythingProvider` | `onDestroy(): void` |
| `FileSystemWatcher` | `onDestroy(): void` |

Declaring it `() => void` is exactly what let `destroy()` resolve before the search index had finished shutting down, with the floating promise invisible to the compiler — the defect #1725 fixed. That reasoning moves from the cast's comment onto the declaration, where an implementer will actually see it.

## Verification

The interesting part here is that the obvious oracle is the wrong one.

| check | result |
| --- | --- |
| `tsc --noEmit -p tsconfig.node.json` | **897** errors — identical to an unmodified `origin/master` worktree. Delta zero, none naming either changed file. |
| **positive control**: remove only the new interface member | **899** — the two extra are `search-provider-registry.ts(410): Property 'onDestroy' does not exist on type 'ISearchProvider<ProviderContext>'` |
| `search-provider-registry.test.ts` | 9/9 |
| ESLint delta, both files under their own configs | 0 before, 0 after |

The positive control is the load-bearing one: it proves the typecheck is actually reading this branch's interface, so the pass is caused by the declaration rather than by the checker ignoring the file.

Two caveats stated rather than buried:

- The **897 baseline is an artefact**, not a clean tree. A worktree resolves `@talex-touch/*` through the main checkout's `node_modules`, which points at a dirty working copy. That is why it is quoted as a delta against an identically-resolved master worktree instead of as a pass. CI typechecks a clean tree.
- The **vitest run does not evidence the type change** — it resolves through `node_modules` to the main checkout, so it exercises the runtime path only. TypeScript resolves through the tsconfig `paths` mapping, which is worktree-local; that difference is why the typecheck is the valid oracle here and the test is not.

## Scope

#334 stays open. This removes the cast and gives the interface a disposal contract. Still outstanding: `onActivate`/`onDeactivate` return `void` so async activation cannot be expressed, and the registry exposes only `destroy()` — no `load`/`start`/`stop`, and none of the `registered|loading|ready|degraded|stopped|destroyed` states the issue asks for (`degraded` currently appears once, in a comment).