### PR TITLE
feat(nexus): fail the build when a prerendered docs page has no body

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,11 @@ jobs:
       - name: Verify zh/en doc parity
         run: pnpm -C apps/nexus check:doc-parity
 
+      # The self-test runs before the build so a broken judge is reported in seconds rather than
+      # after a full nexus build. A gate whose own logic is never exercised is what #1794 is about.
+      - name: Self-test the prerender body judge
+        run: pnpm -C apps/nexus check:prerender-bodies:self-test
+
       # Blocking. It was briefly continue-on-error because wiring it up is what discovered
       # the build was broken — nitro could not resolve @panva/hkdf from next-auth against a
       # root node_modules path that only existed under shamefully-hoist (#1151, #1099
@@ -422,6 +427,16 @@ jobs:
       # break its build silently, which is the state #552 found it in.
       - name: Build
         run: pnpm -C apps/nexus build
+
+      # The build proves the pages compile; it does not prove they rendered. This site has already
+      # shipped docs pages that prerendered to an empty shell, which produced a green build, a green
+      # fence check and a green route-list test (#1794). This reads the emitted HTML for the five
+      # evidence routes in both locales and fails when a page carries no prose.
+      #
+      # Verified against a real build before wiring: the ten pages render 423-10090 visible chars,
+      # and blanking one page's <main> drops it to 91 and fails the step by name.
+      - name: Verify prerendered docs pages carry their content
+        run: pnpm -C apps/nexus check:prerender-bodies
 
   job_app_tests:
     name: App suites (${{ matrix.app }})

--- a/apps/nexus/build/check-prerender-bodies.mjs
+++ b/apps/nexus/build/check-prerender-bodies.mjs
@@ -1,0 +1,222 @@
+// Asserts that prerendered docs pages actually contain their body, not just that they exist.
+//
+// The build prerenders docs routes and `docs-prerender-routes.test.ts` checks the route *list* is
+// complete. Nothing checked the resulting HTML. That gap is not theoretical: this site has already
+// shipped docs pages that prerendered to an empty shell site-wide, because the body mode was baked
+// into the payload key and the server render and hydration disagreed. That failure produces a green
+// build, a green `check:mdc-fences`, a green route-list test, and a site with no prose on it.
+//
+// So this reads the emitted HTML for the five routes `docsPrerenderEvidenceRoutes` already curates
+// -- a list that existed for this purpose and had no consumer -- and fails when a page's rendered
+// text falls below a floor.
+//
+// Why a text floor rather than a selector: the shell renders regardless, so "an <article> exists"
+// is exactly the assertion the empty-shell bug satisfied. Stripping tags and counting visible
+// characters is the property that actually distinguishes a rendered page from a skeleton.
+//
+// Run `--self-test` to verify the judging without a build; it is wired into CI alongside the check
+// itself, because a gate whose logic is never exercised is the thing this file exists to prevent.
+
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import process from 'node:process'
+
+const nexusRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+
+/**
+ * Minimum visible characters for a prerendered docs page.
+ *
+ * Measured against a real build rather than picked. The five evidence routes render, per locale:
+ *
+ *   /zh/docs                                    423   <- the shortest, a landing page
+ *   /en/docs                                   1002
+ *   /zh/docs/guide/start                       1250
+ *   /zh/docs/dev                               1398
+ *   /en/docs/guide/start                       2097
+ *   /zh/docs/dev/getting-started/quickstart    2657
+ *   /en/docs/dev                               2794
+ *   /en/docs/dev/getting-started/quickstart    3088
+ *   /zh/docs/dev/components                    7960
+ *   /en/docs/dev/components                   10090
+ *
+ * 250 sits below the 423 floor with room for a landing page to lose a paragraph, and far above a
+ * chrome-only render, which carries nav labels and a footer and no prose at all. The number is not
+ * load-bearing -- it only has to sit inside a gap this wide -- but it should be re-measured if the
+ * docs landing pages are ever shortened.
+ */
+export const MIN_BODY_CHARS = 250
+
+/** Strips markup and script/style content, leaving what a reader would actually see. */
+export function visibleText(html) {
+  return html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/** Where a prerendered route lands on disk under the cloudflare-pages preset. */
+export function routeToHtmlPath(outputDir, route) {
+  const trimmed = route.replace(/^\/+|\/+$/g, '')
+  return trimmed ? join(outputDir, trimmed, 'index.html') : join(outputDir, 'index.html')
+}
+
+export function judgePrerenderedRoute(route, html) {
+  if (html === null) {
+    return { route, ok: false, chars: 0, detail: 'no HTML emitted for this route' }
+  }
+  const chars = visibleText(html).length
+  return {
+    route,
+    ok: chars >= MIN_BODY_CHARS,
+    chars,
+    detail:
+      chars >= MIN_BODY_CHARS
+        ? `${chars} visible chars`
+        : `${chars} visible chars, below the ${MIN_BODY_CHARS} floor -- the page rendered its shell without its body`,
+  }
+}
+
+export function judgePrerenderedRoutes(routes, readHtml) {
+  return routes.map(route => judgePrerenderedRoute(route, readHtml(route)))
+}
+
+function selfTest() {
+  const body = `<html><body><nav>Docs Guide API</nav><article>${'word '.repeat(200)}</article></body></html>`
+  const shell = '<html><body><nav>Docs Guide API</nav><article></article><footer>MIT</footer></body></html>'
+  const scriptOnly = `<html><body><nav>Docs</nav><script>${'x'.repeat(5000)}</script></body></html>`
+
+  const cases = [
+    {
+      name: 'a rendered page passes',
+      actual: judgePrerenderedRoute('/en/docs', body).ok,
+      expected: true,
+    },
+    // The failure this file exists for. The shell renders, the article element is present, and the
+    // page is empty -- so an element-presence check would pass here and this must not.
+    {
+      name: 'an empty shell fails even though its article element exists',
+      actual: judgePrerenderedRoute('/en/docs', shell).ok,
+      expected: false,
+    },
+    {
+      name: 'the empty-shell failure says the body is missing, not merely that it is short',
+      actual: judgePrerenderedRoute('/en/docs', shell).detail.includes('without its body'),
+      expected: true,
+    },
+    // Payload scripts are large. Counting raw bytes would let a body-less page pass on script
+    // weight alone, which is the same false green in a different costume.
+    {
+      name: 'script content does not count toward the floor',
+      actual: judgePrerenderedRoute('/en/docs', scriptOnly).ok,
+      expected: false,
+    },
+    {
+      name: 'a route that emitted no file fails rather than being skipped',
+      actual: judgePrerenderedRoute('/en/docs', null).ok,
+      expected: false,
+    },
+    {
+      name: 'a missing file is reported as missing, not as a short body',
+      actual: judgePrerenderedRoute('/en/docs', null).detail.includes('no HTML emitted'),
+      expected: true,
+    },
+    {
+      name: 'comments are stripped rather than counted',
+      actual: judgePrerenderedRoute('/en/docs', `<html><body><!--${'c'.repeat(5000)}--></body></html>`).ok,
+      expected: false,
+    },
+    { name: 'nested routes map to <route>/index.html', actual: routeToHtmlPath('/o', '/en/docs/dev'), expected: '/o/en/docs/dev/index.html' },
+    { name: 'the root route maps to index.html', actual: routeToHtmlPath('/o', '/'), expected: '/o/index.html' },
+    { name: 'every route is judged, not just the failing ones', actual: judgePrerenderedRoutes(['/a', '/b'], () => shell).length, expected: 2 },
+  ]
+
+  // An end-to-end pass over real files, so the reader is exercised and not only the judging.
+  const dir = mkdtempSync(join(tmpdir(), 'prerender-selftest-'))
+  try {
+    const full = routeToHtmlPath(dir, '/en/docs')
+    mkdirSync(dirname(full), { recursive: true })
+    writeFileSync(full, body)
+    const read = route => (existsSync(routeToHtmlPath(dir, route)) ? readFileSync(routeToHtmlPath(dir, route), 'utf8') : null)
+    const results = judgePrerenderedRoutes(['/en/docs', '/zh/docs'], read)
+    cases.push(
+      { name: 'reads a written page from disk and passes it', actual: results[0].ok, expected: true },
+      { name: 'reports an absent sibling rather than assuming it', actual: results[1].ok, expected: false },
+    )
+  }
+  finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+
+  let failed = 0
+  for (const testCase of cases) {
+    const pass = testCase.actual === testCase.expected
+    if (!pass) {
+      failed += 1
+      console.error(`  x ${testCase.name}: expected ${testCase.expected}, got ${testCase.actual}`)
+    }
+  }
+  console.log(
+    failed === 0
+      ? `check-prerender-bodies --self-test: ${cases.length} cases passed`
+      : `check-prerender-bodies --self-test: ${failed} of ${cases.length} cases failed`,
+  )
+  return failed === 0 ? 0 : 1
+}
+
+async function main() {
+  if (process.argv.includes('--self-test')) {
+    process.exit(selfTest())
+  }
+
+  // `dist` is authoritative: wrangler.toml sets `pages_build_output_dir = "apps/nexus/dist"`.
+  // `.output/public` is probed as a fallback so a preset change does not silently skip the gate.
+  const dirArgIndex = process.argv.indexOf('--output')
+  const candidates = dirArgIndex >= 0
+    ? [process.argv[dirArgIndex + 1]]
+    : ['dist', '.output/public']
+  const outputDir = candidates.map(dir => resolve(nexusRoot, dir)).find(dir => existsSync(dir))
+
+  if (!outputDir) {
+    // Refuse rather than pass. "No build output" and "every page is fine" must not look the same,
+    // which is the whole failure mode this check was written against.
+    console.error(
+      `[nexus-prerender-bodies] no build output found. Looked in: ${candidates.join(', ')}. `
+      + 'Run `pnpm -C apps/nexus build` first, or pass --output <dir>.',
+    )
+    process.exit(2)
+  }
+
+  // Read from the .mjs module rather than nexus-prerender-routes.ts: that file's TS siblings use
+  // extensionless imports, which plain node cannot resolve. Running this for real is what surfaced
+  // that -- the self-test never touches this path.
+  const { docsPrerenderEvidenceRoutes, docsPrerenderLocales } = await import('./nexus-static-routes.mjs')
+  const routes = docsPrerenderEvidenceRoutes.flatMap(route =>
+    docsPrerenderLocales.map(locale => `/${locale}${route}`),
+  )
+
+  const results = judgePrerenderedRoutes(routes, (route) => {
+    const file = routeToHtmlPath(outputDir, route)
+    return existsSync(file) ? readFileSync(file, 'utf8') : null
+  })
+
+  for (const result of results)
+    console.log(`  ${result.ok ? '[32m✓[0m' : '[31m✗[0m'} ${result.route}: ${result.detail}`)
+
+  const failures = results.filter(result => !result.ok)
+  if (failures.length) {
+    console.error(
+      `\n[nexus-prerender-bodies] ${failures.length} of ${results.length} prerendered pages have no body.`,
+    )
+    process.exit(1)
+  }
+  console.log(`\n[nexus-prerender-bodies] ${results.length} prerendered pages carry their content.`)
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href)
+  await main()

--- a/apps/nexus/build/check-prerender-bodies.mjs
+++ b/apps/nexus/build/check-prerender-bodies.mjs
@@ -218,5 +218,9 @@ async function main() {
   console.log(`\n[nexus-prerender-bodies] ${results.length} prerendered pages carry their content.`)
 }
 
-if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href)
-  await main()
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
+}

--- a/apps/nexus/build/nexus-prerender-routes.ts
+++ b/apps/nexus/build/nexus-prerender-routes.ts
@@ -1,16 +1,8 @@
 import { createDocsPageApiPrerenderRoutes, createDocsPrerenderRoutes } from './docs-prerender-routes'
-import { docsApiPrerenderRoutes, publicPrerenderRoutes } from './nexus-static-routes.mjs'
+import { docsApiPrerenderRoutes, docsPrerenderEvidenceRoutes, publicPrerenderRoutes } from './nexus-static-routes.mjs'
 import { toLocalizedDocsPaths } from '../shared/utils/docs-path'
 
-export { docsApiPrerenderRoutes, publicPrerenderRoutes }
-
-export const docsPrerenderEvidenceRoutes = [
-  '/docs',
-  '/docs/dev',
-  '/docs/dev/getting-started/quickstart',
-  '/docs/dev/components',
-  '/docs/guide/start',
-] as const
+export { docsApiPrerenderRoutes, docsPrerenderEvidenceRoutes, publicPrerenderRoutes }
 
 export function createNexusPrerenderRoutes(nexusRoot: string) {
   return [

--- a/apps/nexus/build/nexus-static-routes.mjs
+++ b/apps/nexus/build/nexus-static-routes.mjs
@@ -25,3 +25,23 @@ export const docsApiPrerenderRoutes = [
   '/api/docs/sidebar-components/en',
   '/api/docs/sidebar-components/zh',
 ]
+
+/**
+ * The docs routes whose prerendered output is treated as release evidence.
+ *
+ * Lives here rather than in `nexus-prerender-routes.ts` so `check-prerender-bodies.mjs` can read it
+ * under plain node: that file's TS siblings use extensionless imports, which node cannot resolve
+ * without a loader, and duplicating the list in the checker would let the two drift -- which is the
+ * failure this list exists to prevent.
+ */
+export const docsPrerenderEvidenceRoutes = [
+  '/docs',
+  '/docs/dev',
+  '/docs/dev/getting-started/quickstart',
+  '/docs/dev/components',
+  '/docs/guide/start',
+]
+
+/** Mirrors `DOCS_SUPPORTED_LOCALES` in shared/utils/docs-path.ts, for the same reason. */
+export const docsPrerenderLocales = ['en', 'zh']
+

--- a/apps/nexus/package.json
+++ b/apps/nexus/package.json
@@ -13,6 +13,8 @@
     "check:mdc-fences": "node build/check-mdc-fences.mjs",
     "check:doc-parity": "node build/check-doc-translation-parity.mjs",
     "check:icon-collections": "node build/check-icon-collections.mjs",
+    "check:prerender-bodies": "node build/check-prerender-bodies.mjs",
+    "check:prerender-bodies:self-test": "node build/check-prerender-bodies.mjs --self-test",
     "check:preview-secrets": "node scripts/preview-secret-preflight.mjs",
     "check:runtime-evidence": "node build/check-runtime-evidence.mjs",
     "check:runtime-evidence:deployed": "node build/check-runtime-evidence.mjs --require-deployed-preview",


### PR DESCRIPTION
Closes the gap found while triaging #1754 and recorded on #1794.

## The gap

The nexus build prerenders docs routes, and `docs-prerender-routes.test.ts` verifies the route **list** is complete. Nothing read the emitted HTML. Searching `apps/nexus/build/` for `innerText`, `textContent`, `<article>` or any body-length assertion returned nothing, and `check:runtime-evidence` is unwired on purpose (`ci.yml:361` — it "exits 1, wants an output/playwright directory from a prior run").

So a page that prerenders to an empty shell produces a green build, a green `check:mdc-fences`, a green route-list test, and a site with no prose on it. **This site has already shipped exactly that, sitewide**, when the body mode was baked into the payload key and the server render and hydration disagreed.

## The check

`check:prerender-bodies` reads the emitted HTML for the five routes `docsPrerenderEvidenceRoutes` already curated — a list that existed for this purpose and had no consumer — across both locales, and fails when visible text falls below a floor.

**A text floor rather than an element check, deliberately.** The shell renders regardless, so "an `<article>` exists" is precisely the assertion the empty-shell bug satisfied. Script and comment content is stripped first, because payload scripts are large enough to carry a body-less page over any raw-byte threshold — the same false green in a different costume.

**`MIN_BODY_CHARS = 250`, measured not picked.** Against a real build:

```
/zh/docs                                    423   <- shortest, a landing page
/en/docs                                   1002
/zh/docs/guide/start                       1250
/zh/docs/dev                               1398
/en/docs/guide/start                       2097
/zh/docs/dev/getting-started/quickstart    2657
/en/docs/dev                               2794
/en/docs/dev/getting-started/quickstart    3088
/zh/docs/dev/components                    7960
/en/docs/dev/components                   10090
```

A page whose `<main>` is emptied renders **91**. The floor sits in that gap with room for a landing page to lose a paragraph. The full table is in the source comment so the next person can re-measure rather than guess.

## One structural change

`docsPrerenderEvidenceRoutes` moves from `nexus-prerender-routes.ts` to `nexus-static-routes.mjs`, where `publicPrerenderRoutes` and `docsApiPrerenderRoutes` already live, and is re-exported so nothing else changes.

**Running the check for real is what forced that.** The self-test passed happily while the actual run died on `ERR_MODULE_NOT_FOUND` — the TS module's siblings use extensionless imports that plain node cannot resolve without a loader. Duplicating the route list in the checker would have worked and would have let the two drift, which is the failure this list exists to prevent.

## Verification

| check | result |
| --- | --- |
| self-test | 12 cases pass |
| mutation: drop the `<script>` strip | fails the script-weight case |
| mutation: treat a missing file as a pass | fails two cases |
| against a real build | 10/10, counts above |
| **end-to-end negative control**: empty `<main>` on one real page | drops to 91 chars, **fails the run and names the route** |
| `docs-prerender-routes.test.ts` after the constant moved | 8/8 |
| `actionlint -shellcheck` on the edited `ci.yml` | 0 |
| the four existing nexus gates | all 0 |

The self-test is wired **before** the build so a broken judge is reported in seconds rather than after a full nexus build. A gate whose own logic is never exercised is the thing #1794 is about.

## What this does not cover

The five evidence routes, not all ~160 docs pages — that is what the curated list scopes, and widening it is a separate decision about build-time cost. It also says nothing about *correctness* of the rendered prose, only that prose exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure prerendered documentation pages contain visible content instead of empty page shells.
  * Checks documentation routes across supported locales after each build and blocks releases when content is missing.

* **Tests**
  * Added a self-test for the prerendered page content validation.
  * Expanded build verification across multiple documentation pages and locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->