### PR TITLE
ci(nexus): unwire the prerender body check while its finding is triaged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,15 +428,19 @@ jobs:
       - name: Build
         run: pnpm -C apps/nexus build
 
-      # The build proves the pages compile; it does not prove they rendered. This site has already
-      # shipped docs pages that prerendered to an empty shell, which produced a green build, a green
-      # fence check and a green route-list test (#1794). This reads the emitted HTML for the five
-      # evidence routes in both locales and fails when a page carries no prose.
+      # `check:prerender-bodies` belongs here and is deliberately NOT wired yet.
       #
-      # Verified against a real build before wiring: the ten pages render 423-10090 visible chars,
-      # and blanking one page's <main> drops it to 91 and fails the step by name.
-      - name: Verify prerendered docs pages carry their content
-        run: pnpm -C apps/nexus check:prerender-bodies
+      # It was wired in #1799 and failed on its first run against master -- correctly. 8 of the 10
+      # evidence routes ship with no server-rendered body, and the production site returns the same
+      # byte counts, so it is a live defect rather than a CI artefact (#1800). Leaving the step in
+      # would hold master red for everyone while that is triaged, and marking it continue-on-error
+      # would turn a gate that just found a real defect into decoration.
+      #
+      # The self-test above stays wired, so the judge cannot rot while the step is out. Re-add this
+      # once #1800 is fixed -- it is one line, and #1800's acceptance criteria require it:
+      #
+      #   - name: Verify prerendered docs pages carry their content
+      #     run: pnpm -C apps/nexus check:prerender-bodies
 
   job_app_tests:
     name: App suites (${{ matrix.app }})


### PR DESCRIPTION
**Master is red and this makes it green.** Not by fixing the defect — by taking out the step that found it, while the defect gets triaged in #1800.

## What happened

`check:prerender-bodies` (#1799) failed on its first run against master. It was right to:

```
✓ /en/docs                                  1002 visible chars
✓ /zh/docs                                   423
✗ /en/docs/dev                               170  <- below the 250 floor
✗ /zh/docs/dev                                89
✗ /en/docs/dev/getting-started/quickstart    161
✗ /zh/docs/dev/getting-started/quickstart     86
✗ /en/docs/dev/components                    236
✗ /zh/docs/dev/components                    123
✗ /en/docs/guide/start                       156
✗ /zh/docs/guide/start                        80
```

**The production site returns the same numbers.** `/en/docs/dev` is 170 visible chars in the CI build and 170 on `tuff.tagzxia.com`; `guide/start` is 156 and 156; `components` is 236 and 236. So this is a live defect, not a CI-environment artefact, and it is filed as **#1800** with the full evidence.

Master being red blocks everyone, and the fix is a Nuxt/content render question that should not be rushed. So the step comes out.

## Why not `continue-on-error`

Because I argued against exactly that on #1776 four hours ago, and the argument still holds: a gate that just found a real defect must not be demoted into a yellow line nobody reads. That is the failure mode #1794 is about.

An open issue is louder than a passing-with-warnings CI step, and **#1800's acceptance criteria require this step restored** — so the revert has a defined end rather than becoming permanent by inertia.

## What stays

The **self-test stays wired**. It needs no build, runs in seconds, and keeps the judge from rotting while the step is out. A check that is both unwired and unexercised is precisely how `check:doc-parity` and `check:icon-collections` decayed into the state #1776 found them in.

The re-add is one line and is left in the workflow as a comment at the exact spot it belongs.

## On my own sequencing

Worth stating plainly: I wired a blocking gate whose real-world behaviour I had only verified against a **local** `dist` from the previous evening, which renders those pages at 1250–10090 chars. That build did not reproduce what CI produces, so my verification was not representative and I should have run it against a CI-equivalent build before making it blocking. The gate is correct; the rollout order was mine to get right and I did not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration checks to remove a failing prerendered-content validation step.
  * Retained the related self-test check to continue monitoring validation behavior.
  * Documented when the full validation step can be restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->