### PR TITLE
test(core-app): stop the window-manager redaction scan grepping random tokens

### DIFF
--- a/apps/core-app/src/main/modules/plugin/host/plugin-window-manager-capabilities.test.ts
+++ b/apps/core-app/src/main/modules/plugin/host/plugin-window-manager-capabilities.test.ts
@@ -151,6 +151,11 @@ function createHarness(
   }
 }
 
+/** Serializes a result with token values blanked, so a redaction scan cannot match random token text. */
+function withoutTokens(result: unknown): string {
+  return JSON.stringify(result).replace(/"token":"[^"]*"/g, '"token":""')
+}
+
 function firstToken(result: unknown, kind: 'window' | 'app' = 'window'): string {
   const items = (result as { items: Array<{ kind: string; token: string }> }).items
   const item = items.find((entry) => entry.kind === kind)
@@ -181,7 +186,12 @@ describe('isolated window manager capability', () => {
       topmost: false,
       actions: PLUGIN_WINDOW_MANAGER_ACTION_IDS.filter((action) => action !== 'launch')
     })
-    expect(JSON.stringify(result)).not.toMatch(/6389|Program Files|nativeId|pid|handle|appPath/i)
+    // Tokens are 32 random base64url characters, so scanning the serialized result as-is greps
+    // random data for short words: a real CI run produced `wm_5T_MjLgIStPiDP2nOQbiC5sdxqWQHhgE`,
+    // whose `PiD` matched /pid/i and failed this line while nothing had leaked. At three tokens per
+    // result that is roughly 1 run in 370. Blank the tokens first -- their shape is asserted
+    // separately below -- so this checks redaction rather than token entropy.
+    expect(withoutTokens(result)).not.toMatch(/6389|Program Files|nativeId|pid|handle|appPath/i)
     expect(firstToken(result)).toMatch(/^wm_[A-Za-z0-9_-]{32}$/)
     expect(harness.spawn).toHaveBeenCalledExactlyOnceWith(
       'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',


### PR DESCRIPTION
A flaky test, caught in the act with the failing value in hand.

## The flake

`plugin-window-manager-capabilities.test.ts:184` asserts the serialized result does not contain leaked fields:

```ts
expect(JSON.stringify(result)).not.toMatch(/6389|Program Files|nativeId|pid|handle|appPath/i)
```

That result carries **three opaque tokens of 32 random base64url characters**. So the assertion is also grepping random data for three-letter words. It failed on CI with nothing leaked:

```
wm_5T_MjLgIStPiDP2nOQbiC5sdxqWQHhgE
          ^^^   matches /pid/i
```

Every fixture secret was correctly redacted. The token simply happened to contain `PiD`.

**Rate:** `pid` has 8 case-insensitive variants; over 30 positions in a 64-character alphabet that is ≈9.2e-4 per token, ≈2.7e-3 per run with three tokens — **about 1 run in 370**, on a suite that runs on every PR. (`6389` and `handle` are longer and contribute negligibly.)

## The fix

Blank token values before the scan. Their shape is asserted on the very next line —

```ts
expect(firstToken(result)).toMatch(/^wm_[A-Za-z0-9_-]{32}$/)
```

— so nothing is lost. The assertion now checks redaction rather than token entropy.

## Verification

A redaction test that stops failing is indistinguishable from one that stopped checking, so both directions are controlled:

| control | result |
| --- | --- |
| force every token to the exact CI value that broke it (`wm_5T_MjLgIStPiDP2nOQbiC5sdxqWQHhgE`) | **21/21 pass** — the flake is gone |
| emit a literal `appPath: 'C:\Program Files\Terminal\terminal.exe'` from the redacted display DTO | **this line fails, alone** — a real leak is still caught |
| unmodified | 21/21 |

## Scope

`plugin-window-preset-capabilities.test.ts:143` has the same shape (`/handle|title|pid|powershell/i` over a serialized result) but its result carries no tokens, so it scans deterministic data and is not affected. Checked and left alone rather than changed on suspicion.

Found because it failed #1802 — a nexus-only change that cannot touch core-app.