### PR TITLE
chore(nexus): drop the dangling references left by the removed prerender check

### DIFF
--- a/apps/nexus/build/nexus-static-routes.mjs
+++ b/apps/nexus/build/nexus-static-routes.mjs
@@ -27,12 +27,13 @@ export const docsApiPrerenderRoutes = [
 ]
 
 /**
- * The docs routes whose prerendered output is treated as release evidence.
+ * The docs routes whose prerendered output is treated as release evidence. Consumed by
+ * `createNexusPrerenderEvidence` in `nexus-prerender-routes.ts`.
  *
- * Lives here rather than in `nexus-prerender-routes.ts` so `check-prerender-bodies.mjs` can read it
- * under plain node: that file's TS siblings use extensionless imports, which node cannot resolve
- * without a loader, and duplicating the list in the checker would let the two drift -- which is the
- * failure this list exists to prevent.
+ * Lives in this `.mjs` rather than beside its consumer so plain-node tooling can read it: the TS
+ * modules in `build/` import each other without file extensions, which node cannot resolve without
+ * a loader. Any such tool must import this list rather than restate it -- a second copy that drifts
+ * from this one is the failure the list exists to prevent.
  */
 export const docsPrerenderEvidenceRoutes = [
   '/docs',
@@ -41,7 +42,4 @@ export const docsPrerenderEvidenceRoutes = [
   '/docs/dev/components',
   '/docs/guide/start',
 ]
-
-/** Mirrors `DOCS_SUPPORTED_LOCALES` in shared/utils/docs-path.ts, for the same reason. */
-export const docsPrerenderLocales = ['en', 'zh']
 


### PR DESCRIPTION
Tail cleanup after #1802. Two dangling references, both mine.

## What was left behind

`nexus-static-routes.mjs` still explained its own existence in terms of a file that no longer exists:

```
 * Lives here rather than in `nexus-prerender-routes.ts` so `check-prerender-bodies.mjs` can read it
```

and still exported `docsPrerenderLocales`, which I added for that check and which now has **no consumer anywhere** — its own definition is the only match in the tree.

## The fix

The comment now names the real consumer (`createNexusPrerenderEvidence`) and states the constraint in its own terms rather than a deleted file's: plain-node tooling cannot resolve the extensionless imports the `build/` TS modules use, so a list that such tooling needs has to live in a `.mjs`, and must be imported rather than restated. That reasoning is still true and still worth recording — it is why the list moved in the first place, and that move remains correct.

`docsPrerenderLocales` is deleted.

## Why bother

Leaving a comment that points at a file which does not exist is the same defect class this session spent the day removing from the docs — a `RESOURCE_LIMIT_EXCEEDED` that existed nowhere, twelve `flow:*` channels that existed nowhere, a `ctx` handler argument that existed nowhere. It would be poor form to ship one of my own on the way out.

## Verification

| check | result |
| --- | --- |
| `docs-prerender-routes.test.ts` (the list's real consumer) | 8/8 |
| `check:doc-parity` | 0 |
| `check:mdc-fences` | 0 |
| `check:icon-collections` | 0 |
| `check:api-routes` | 0 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal documentation prerendering configuration.
  * Clarified guidance for maintaining prerendered documentation routes.
  * Removed a redundant locale export without affecting supported documentation languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->