### PR TITLE
build(deps): bump napi to 3.10.0, the last version that links

### DIFF
--- a/packages/tuff-native/Cargo.lock
+++ b/packages/tuff-native/Cargo.lock
@@ -501,6 +501,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
 
 [[package]]
+name = "ctor"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,12 +1374,12 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.8.6"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e55037284865448ecf329baa86a4d05401f647ebde99f5747b640d32c2c5226"
+checksum = "abd366ba6a12e4bdbc360e1ad4e1f01da40c4395eef1f9e872d88f8b135e8048"
 dependencies = [
  "bitflags 2.13.1",
- "ctor",
+ "ctor 1.0.13",
  "futures",
  "napi-build",
  "napi-sys",
@@ -1395,7 +1401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ba740fe4c9524d86fd90798fd8ccdb23402b3eef7e7c30897a8a369b529fcf"
 dependencies = [
  "convert_case",
- "ctor",
+ "ctor 0.11.1",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
@@ -1417,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
+checksum = "85fbf1fa9f1babfe396d74bbbf52b3643770243e8f5b0b46715d4caf7f0dfc9a"
 dependencies = [
  "libloading 0.9.0",
 ]

--- a/packages/tuff-native/Cargo.toml
+++ b/packages/tuff-native/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 license = "MPL-2.0"
 
 [workspace.dependencies]
-napi = { version = "=3.8.6", default-features = false, features = ["napi4"] }
+napi = { version = "=3.10.0", default-features = false, features = ["napi4"] }
 napi-derive = "=3.5.5"
 napi-build = "=2.4.1"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Supersedes #1756. That PR proposes `napi` 3.12.2, which fails `cargo test` on every runner:

```
rust-lld: error: undefined symbol: napi_call_threadsafe_function
  >>> napi-….rlib(<napi::error::ErrorRef as core::ops::drop::Drop>::drop::{closure#0})
```

I reproduced it locally on macOS with the same symbol and bisected to the exact release.

## Bisect

Each data point resets `Cargo.toml` **and** `Cargo.lock` from master first, and counts only if the run printed `test result: ok` or `Undefined symbols`:

| napi | result |
| --- | --- |
| 3.8.6 (current) | ok — 37 passed |
| **3.10.0** | **ok — last good** |
| 3.10.1 | undefined symbols |
| 3.10.2 | undefined symbols |
| 3.10.3 | undefined symbols |
| 3.10.4 | undefined symbols |
| 3.12.2 (#1756) | undefined symbols |

So 3.10.0 takes most of the available update without the regression. The break is upstream's — nothing in this workspace changed between those releases.

**A note on how I nearly got this wrong.** My first pass used `cargo test --no-run` and treated "no undefined-symbol error" as success. It reported 3.10.3 as good, which is false: a warm cache skips relinking entirely, so the absence of a link error meant nothing. The table above is from the redone bisect, where an inconclusive run is recorded as inconclusive rather than as a pass.

## #1758 cannot be taken yet, at any linkable napi

`napi-derive` 3.6.3 requires `NativeBorrowBarrier` and `NativeBorrowScope` from `napi::bindgen_prelude`. Those are absent in 3.10.0, and every napi version that has them is on the broken side of the bisect. Verified directly: napi 3.10.0 + napi-derive 3.6.3 fails to compile with exactly those two names unresolved.

So `napi-derive` stays at 3.5.5 here, and #1758 stays blocked until upstream fixes the link regression. It is drafted for that reason.

## Verification, with CI's own commands

| command | result |
| --- | --- |
| `cargo test --manifest-path packages/tuff-native/Cargo.toml --workspace` | **144 passed**, 0 failed |
| `cargo clippy … --workspace --all-targets -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |

`Cargo.lock` is updated in the same commit — the transitive deltas are `ctor` 1.0.13 added and `napi-sys` 3.2.1 → 3.3.0.

## Disposition of the two dependabot PRs

- **#1756** — superseded by this; close it once this merges.
- **#1758** — stays draft. Blocked upstream, not by us, and this PR records why.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal native component dependency to a newer version, with no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->