### PR TITLE
fix(nexus): redact credentials from the deployed-preview HARs before they land

### DIFF
--- a/apps/nexus/scripts/collect-deployed-preview-evidence.mjs
+++ b/apps/nexus/scripts/collect-deployed-preview-evidence.mjs
@@ -2,6 +2,7 @@
 import { Buffer } from 'node:buffer'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
+import { redactHarFile } from './redact-har.mjs'
 import { fileURLToPath } from 'node:url'
 
 const currentDir = dirname(fileURLToPath(import.meta.url))
@@ -262,6 +263,7 @@ async function collectRoute(browser, route) {
   const allRequests = [...requests, ...failed]
   const requestSummary = summarizeRouteRequests(allRequests, route)
   await context.close()
+  await redactHarFile(harPath)
   return {
     path: route.path,
     status: response?.status() ?? 0,
@@ -343,6 +345,7 @@ async function collectBfcache(browser) {
     events: window.__nexusBfcacheEvents ?? [],
   }))
   await context.close()
+  await redactHarFile(harPath)
   const pageshowPersisted = summary.events.filter(event => event.type === 'pageshow').map(event => event.persisted)
   return {
     ...summary,
@@ -363,6 +366,7 @@ async function collectAuthenticatedDashboard(browser) {
   const response = await page.goto(`${baseUrl}/dashboard/`, { waitUntil: 'networkidle', timeout: 45_000 })
   const bodyText = await page.locator('body').innerText().catch(() => '')
   await context.close()
+  await redactHarFile(harPath)
   return {
     ok: response?.ok() ?? false,
     status: response?.status() ?? 0,

--- a/apps/nexus/scripts/redact-har.mjs
+++ b/apps/nexus/scripts/redact-har.mjs
@@ -1,0 +1,117 @@
+// Strips credentials from a Playwright-recorded HAR.
+//
+// `collect-deployed-preview-evidence.mjs` records HARs with `content: 'embed'` against a live
+// OAuth session, so an unredacted file contains the session cookie and bearer token in plain text.
+// Playwright offers no header filtering and writes the HAR when the context closes, so this is a
+// post-pass.
+//
+// It lives in its own module because the collector is a script: importing it runs the whole
+// collection and calls `process.exit`, which leaves the redaction untestable in place.
+
+import { readFile, writeFile } from 'node:fs/promises'
+
+/**
+ * Header and query names whose values are credentials rather than evidence.
+ *
+ * `Cookie` and `Set-Cookie` carry the session this run authenticates with; `Authorization` carries
+ * the bearer. The query names are the OAuth callback's — a `code` or `id_token` in a recorded URL
+ * is a live credential until it is exchanged or expires.
+ */
+const HAR_SECRET_HEADERS = new Set(['authorization', 'cookie', 'set-cookie', 'proxy-authorization'])
+const HAR_SECRET_QUERY = new Set(['code', 'state', 'token', 'id_token', 'access_token', 'refresh_token'])
+const REDACTED = '[redacted]'
+
+function redactHarNameValueList(list, secretNames) {
+  if (!Array.isArray(list)) return 0
+  let count = 0
+  for (const item of list) {
+    if (item && typeof item.name === 'string' && secretNames.has(item.name.toLowerCase())) {
+      item.value = REDACTED
+      count += 1
+    }
+  }
+  return count
+}
+
+/** Every recorded cookie is a session credential: the name is evidence, the value never is. */
+function redactHarCookies(cookies) {
+  if (!Array.isArray(cookies)) return 0
+  let count = 0
+  for (const cookie of cookies) {
+    if (cookie && typeof cookie === 'object' && 'value' in cookie) {
+      cookie.value = REDACTED
+      count += 1
+    }
+  }
+  return count
+}
+
+function redactHarUrl(url) {
+  if (typeof url !== 'string' || !url.includes('?')) return url
+  try {
+    const parsed = new URL(url)
+    let changed = false
+    for (const key of [...parsed.searchParams.keys()]) {
+      if (HAR_SECRET_QUERY.has(key.toLowerCase())) {
+        parsed.searchParams.set(key, REDACTED)
+        changed = true
+      }
+    }
+    return changed ? parsed.toString() : url
+  }
+  catch {
+    return url
+  }
+}
+
+/**
+ * Strips credentials from a recorded HAR, in place.
+ *
+ * Playwright writes the HAR when the context closes and offers no header filtering, so this is a
+ * post-pass. It runs before the evidence file records the HAR's path, so a run that fails partway
+ * still leaves nothing unredacted behind.
+ *
+ * Deliberately narrow: headers, cookies, the OAuth callback query and request bodies. Response
+ * bodies are left alone -- they are the evidence this collector exists to capture, and blanking
+ * them would leave a file with nothing in it.
+ */
+export async function redactHarFile(harPath) {
+  let har
+  try {
+    har = JSON.parse(await readFile(harPath, 'utf8'))
+  }
+  catch {
+    // A context that recorded nothing writes no file. Not an error, and not something to hide.
+    return { redacted: 0, entries: 0 }
+  }
+  const entries = har?.log?.entries
+  if (!Array.isArray(entries)) return { redacted: 0, entries: 0 }
+
+  let redacted = 0
+  for (const entry of entries) {
+    const request = entry?.request
+    const response = entry?.response
+    if (request) {
+      redacted += redactHarNameValueList(request.headers, HAR_SECRET_HEADERS)
+      redacted += redactHarCookies(request.cookies)
+      redacted += redactHarNameValueList(request.queryString, HAR_SECRET_QUERY)
+      const url = redactHarUrl(request.url)
+      if (url !== request.url) {
+        request.url = url
+        redacted += 1
+      }
+      if (request.postData && typeof request.postData.text === 'string' && request.postData.text) {
+        request.postData.text = REDACTED
+        redacted += 1
+      }
+    }
+    if (response) {
+      redacted += redactHarNameValueList(response.headers, HAR_SECRET_HEADERS)
+      redacted += redactHarCookies(response.cookies)
+    }
+  }
+
+  await writeFile(harPath, `${JSON.stringify(har, null, 2)}\n`)
+  return { redacted, entries: entries.length }
+}
+

--- a/apps/nexus/scripts/redact-har.test.mjs
+++ b/apps/nexus/scripts/redact-har.test.mjs
@@ -1,0 +1,156 @@
+// Covers the HAR redaction pass used by the deployed-preview collector, which is the one part of
+// handles credentials.
+//
+// The collector records HARs with `content: 'embed'` against a live OAuth session, so an
+// unredacted file contains the session cookie and bearer token in plain text. Playwright offers no
+// header filtering and writes the HAR when the context closes, so redaction is a post-pass — and a
+// post-pass that silently did nothing would look exactly like one that worked, which is why every
+// case here asserts on the redacted output rather than on the absence of an error.
+
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { redactHarFile } from './redact-har.mjs'
+
+async function withHar(har, run) {
+  const dir = await mkdtemp(join(tmpdir(), 'har-redact-'))
+  const path = join(dir, 'evidence.har')
+  try {
+    await writeFile(path, JSON.stringify(har))
+    const result = await redactHarFile(path)
+    const after = JSON.parse(await readFile(path, 'utf8'))
+    return await run(after, result)
+  }
+  finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+function harWith(entry) {
+  return { log: { version: '1.2', entries: [entry] } }
+}
+
+describe('redactHarFile', () => {
+  it('strips credential request headers and leaves the rest legible', async () => {
+    await withHar(
+      harWith({
+        request: {
+          url: 'https://example.test/dashboard',
+          headers: [
+            { name: 'Authorization', value: 'Bearer real-token' },
+            { name: 'Cookie', value: 'session=abc123' },
+            { name: 'Accept', value: 'text/html' },
+          ],
+        },
+        response: { headers: [] },
+      }),
+      (after) => {
+        const headers = after.log.entries[0].request.headers
+        expect(headers.find(h => h.name === 'Authorization').value).toBe('[redacted]')
+        expect(headers.find(h => h.name === 'Cookie').value).toBe('[redacted]')
+        // Evidence, not a credential: a redaction that ate this would gut the file.
+        expect(headers.find(h => h.name === 'Accept').value).toBe('text/html')
+      },
+    )
+  })
+
+  it('matches header names case-insensitively, as HTTP does', async () => {
+    await withHar(
+      harWith({
+        request: { url: 'https://example.test/', headers: [{ name: 'authorization', value: 'Bearer t' }] },
+        response: { headers: [{ name: 'SET-COOKIE', value: 'session=abc; HttpOnly' }] },
+      }),
+      (after) => {
+        expect(after.log.entries[0].request.headers[0].value).toBe('[redacted]')
+        expect(after.log.entries[0].response.headers[0].value).toBe('[redacted]')
+      },
+    )
+  })
+
+  it('blanks every cookie value while keeping the names', async () => {
+    await withHar(
+      harWith({
+        request: { url: 'https://example.test/', headers: [], cookies: [{ name: 'next-auth.session-token', value: 'secret' }] },
+        response: { headers: [], cookies: [{ name: 'csrf', value: 'also-secret' }] },
+      }),
+      (after) => {
+        const [entry] = after.log.entries
+        expect(entry.request.cookies[0]).toEqual({ name: 'next-auth.session-token', value: '[redacted]' })
+        expect(entry.response.cookies[0]).toEqual({ name: 'csrf', value: '[redacted]' })
+      },
+    )
+  })
+
+  it('redacts the OAuth callback query in both the URL and the parsed list', async () => {
+    await withHar(
+      harWith({
+        request: {
+          url: 'https://example.test/callback?code=live-auth-code&provider=github',
+          headers: [],
+          queryString: [
+            { name: 'code', value: 'live-auth-code' },
+            { name: 'provider', value: 'github' },
+          ],
+        },
+        response: { headers: [] },
+      }),
+      (after) => {
+        const { request } = after.log.entries[0]
+        // The URL matters as much as the parsed list: a reader greps the file, not the schema.
+        expect(request.url).not.toContain('live-auth-code')
+        expect(request.url).toContain('provider=github')
+        expect(request.queryString.find(q => q.name === 'code').value).toBe('[redacted]')
+        expect(request.queryString.find(q => q.name === 'provider').value).toBe('github')
+      },
+    )
+  })
+
+  it('blanks request bodies, which carry credentials on a sign-in post', async () => {
+    await withHar(
+      harWith({
+        request: { url: 'https://example.test/api/auth', headers: [], postData: { mimeType: 'application/json', text: '{"password":"hunter2"}' } },
+        response: { headers: [] },
+      }),
+      (after) => {
+        expect(after.log.entries[0].request.postData.text).toBe('[redacted]')
+      },
+    )
+  })
+
+  it('leaves response bodies alone, since they are the evidence', async () => {
+    await withHar(
+      harWith({
+        request: { url: 'https://example.test/', headers: [] },
+        response: { headers: [], content: { mimeType: 'text/html', text: '<h1>Dashboard</h1>' } },
+      }),
+      (after) => {
+        expect(after.log.entries[0].response.content.text).toBe('<h1>Dashboard</h1>')
+      },
+    )
+  })
+
+  it('reports how much it redacted, so a silent no-op is visible', async () => {
+    await withHar(
+      harWith({
+        request: { url: 'https://example.test/', headers: [{ name: 'Cookie', value: 'a=b' }] },
+        response: { headers: [{ name: 'Set-Cookie', value: 'a=b' }] },
+      }),
+      (_after, result) => {
+        expect(result.entries).toBe(1)
+        expect(result.redacted).toBe(2)
+      },
+    )
+  })
+
+  it('treats a context that recorded nothing as empty rather than failing the run', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'har-redact-'))
+    try {
+      const result = await redactHarFile(join(dir, 'never-written.har'))
+      expect(result).toEqual({ redacted: 0, entries: 0 })
+    }
+    finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/apps/nexus/vitest.config.ts
+++ b/apps/nexus/vitest.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    include: ['server/**/*.test.ts', 'server/**/__tests__/**/*.test.ts', 'app/**/*.test.ts', 'build/**/*.test.ts', 'test/**/*.test.ts'],
+    // `scripts/` was never in this list -- there was nothing under it to run. The deployed-preview
+    // collector is plain `.mjs`, so its test is too, and the pattern matches that rather than
+    // forcing a `.ts` wrapper around a JavaScript module.
+    include: ['server/**/*.test.ts', 'server/**/__tests__/**/*.test.ts', 'app/**/*.test.ts', 'build/**/*.test.ts', 'test/**/*.test.ts', 'scripts/**/*.test.mjs'],
   },
 })


### PR DESCRIPTION
#324's step 1, taken as a precondition rather than reported as a finding.

## The gap

`collect-deployed-preview-evidence.mjs` records HARs with `content: 'embed'` at three sites — one of them `collectAuthenticatedDashboard`, which loads `storageState` from a real signed-in session. It had **no redaction of any kind**:

```
redact         0
sanitiz        0
scrub          0
Authorization  0
set-cookie     0
har           13   <- positive control, the scan reads the file
```

So a run against a live OAuth session writes the session cookie and bearer token to disk in plain text. The only thing between that and a mistake is `.gitignore` plus the operator remembering to delete the file.

#324 asks to "run the existing collector in dry-run and **validate its redaction/output plan**". The output plan validates; there was no redaction plan to validate. This adds one, and it is correct under either wording of that issue's criterion 2 — so it does not wait on the acceptance question being settled.

## What it does

Playwright offers no header filtering and flushes the HAR when the context closes, so this is a post-pass. It runs immediately after each `context.close()`, **before** the evidence file records the HAR's path, so a run that fails partway still leaves nothing unredacted behind.

| redacted | left alone |
| --- | --- |
| `Authorization`, `Cookie`, `Set-Cookie`, `Proxy-Authorization` (case-insensitive) | all other headers |
| every cookie value, request and response — names kept | cookie names |
| `code`, `state`, `token`, `id_token`, `access_token`, `refresh_token` — in **both** the parsed `queryString` and the request URL | other query params |
| request `postData.text` | **response bodies** |

Response bodies stay because they are the evidence this collector exists to capture; blanking them would leave a file with nothing in it. The URL is rewritten as well as the parsed list because a reader greps the file, not the schema.

## Why it moved to its own module

`scripts/redact-har.mjs`. The collector is a script — importing it runs the whole collection and calls `process.exit`, which I found by trying to test in place:

```
Error: process.exit unexpectedly called with "0"
```

Wrapping the entire script in an entry guard would have been a larger refactor of behaviour #324 relies on (the local-URL and non-HTTPS refusals are top-level `process.exit(1)` calls). Extracting the pure function was smaller and leaves the script's control flow untouched.

`scripts/**/*.test.mjs` joins the vitest include, which listed only `server/`, `app/`, `build/` and `test/` — `scripts/` was never excluded, there was simply nothing under it with a test.

## Verification

Redaction that silently stops working looks exactly like redaction that works, so each case was mutated:

| mutation | result |
| --- | --- |
| header matching made case-**sensitive** | **3 tests fail** |
| cookie values left alone | **1 test fails** |
| URL query redacted but parsed `queryString` not | **1 test fails** |
| unmodified | 8 pass |

Full nexus suite **1127 passed across 203 files** (the config change means all of it ran), four nexus gates 0, `node scripts/run-eslint-changed.mjs` OK.

## Scope

#324 stays open. Its steps 2–6 still need an isolated Cloudflare preview, an approved test OAuth account and short-lived storage state — all maintainer-only. This removes the reason not to run it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Automatically redacts credentials, cookies, OAuth tokens, sensitive URL parameters, and request body data from recorded HAR evidence files.
  - Preserves non-sensitive response content while sanitizing captured authentication data.

- **Testing**
  - Added coverage for redaction behavior, case-insensitive matching, missing files, and reporting of redaction counts.
  - Expanded test discovery to include JavaScript-based tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->