### PR TITLE
docs(core-app): the scan-memory benchmark cannot run the way it documents

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -15,6 +15,7 @@
     "test:core-main": "vitest run \"src/main/core\" \"src/main/channel\" \"src/main/modules/tray\"",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "corepack pnpm -F @talex-touch/tuffex run build && vue-tsc --noEmit -p tsconfig.web.json --composite false",
+    "scan:memory:benchmark": "pnpm exec tsx scripts/file-scan-memory-benchmark.mjs",
     "typecheck": "corepack pnpm run typecheck:node && corepack pnpm run typecheck:web",
     "test:omnipanel": "vitest run src/main/modules/omni-panel/index.test.ts src/renderer/src/views/omni-panel/filter-features.test.ts src/renderer/src/views/omni-panel/interaction.test.ts",
     "test:shortcut-lifecycle": "vitest run src/main/modules/global-shortcon.test.ts src/main/modules/division-box/shortcut-trigger.test.ts src/main/modules/omni-panel/index.test.ts",

--- a/apps/core-app/scripts/file-scan-memory-benchmark.mjs
+++ b/apps/core-app/scripts/file-scan-memory-benchmark.mjs
@@ -12,12 +12,19 @@
  * next batch, so it holds at most one unacknowledged batch — the bound this measures is the
  * floor, and the worker cannot exceed it.
  *
- * Usage:
- *   node apps/core-app/scripts/file-scan-memory-benchmark.mjs
- *   node apps/core-app/scripts/file-scan-memory-benchmark.mjs --counts 20000,50000,100000 --batch 500
- *   node apps/core-app/scripts/file-scan-memory-benchmark.mjs --cancel-at 5000
+ * Usage — must run under tsx, not plain node:
  *
- * Run with --expose-gc for stable heap numbers.
+ *   pnpm -C apps/core-app scan:memory:benchmark
+ *   pnpm -C apps/core-app scan:memory:benchmark -- --counts 20000,50000,100000 --batch 500
+ *   pnpm -C apps/core-app scan:memory:benchmark -- --cancel-at 5000
+ *
+ * `node <this file>` fails with ERR_UNSUPPORTED_DIR_IMPORT: it reaches
+ * `packages/utils/common/file-scan-utils.ts`, which imports `../env` — a directory index that
+ * plain node ESM does not resolve. The header said `node` until 2026-08-27 and had been wrong
+ * since `f03cc7c3f` added that import on 2026-07-16; the measurement recorded three weeks later
+ * in `07-13-search-crossplatform-audit/prd.md` must already have used a loader.
+ *
+ * Add `--expose-gc` for stable heap numbers: `NODE_OPTIONS=--expose-gc pnpm -C apps/core-app …`.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'


### PR DESCRIPTION
Found while running #318's benchmark to give that issue's open decision fresh numbers.

## The header is wrong

`file-scan-memory-benchmark.mjs` documented itself as:

```
node apps/core-app/scripts/file-scan-memory-benchmark.mjs
```

which fails, in a clean checkout and in a dirty tree alike:

```
Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '…/packages/utils/env' is not
supported resolving ES modules imported from …/packages/utils/common/file-scan-utils.ts
```

`file-scan-utils.ts:12` imports `hasWindow` from `../env`, and `packages/utils/env/index.ts` is a directory index — which plain node ESM does not resolve. It needs a TS-aware loader.

## Not a regression, which is worth saying

The `../env` import landed in `f03cc7c3f` on **2026-07-16**, three weeks *before* the 2026-08-07 measurement recorded in `07-13-search-crossplatform-audit/prd.md`. So that run already used a loader and only the usage comment was left behind. Nobody broke this; it was documented wrong from the moment the import landed.

It matters beyond tidiness because **#318's acceptance criterion rests on this benchmark**, and "the benchmark exists" and "the benchmark runs as documented" are different claims. Anyone who followed the header would have concluded the second was false — which is roughly what happened to me before I tried a loader.

## The change

- Header corrected, with the reason and the history inline so the next reader does not re-derive it.
- `scan:memory:benchmark` added to `apps/core-app/package.json`, so the documented invocation is a script rather than a path to assemble.
- The `--expose-gc` form recorded, since the heap numbers are noisy without it.

## Verification, both directions

| command | result |
| --- | --- |
| `pnpm -C apps/core-app scan:memory:benchmark -- --counts 5000 --batch 500` | runs, reports `peakHeap= 11.6MiB retained= -1.2MiB` |
| `node apps/core-app/scripts/file-scan-memory-benchmark.mjs` | **still** `ERR_UNSUPPORTED_DIR_IMPORT` |

The second is the one that matters: it confirms the corrected header is describing a real failure rather than a hypothetical.

`node scripts/run-eslint-changed.mjs` OK.

## Numbers, for #318's benefit

With the benchmark runnable, current `origin/master`, `--expose-gc`, batch 500:

```
files=  20000  peakHeap= 14.4MiB  retained= 3.2MiB
files=  50000  peakHeap= 21.0MiB  retained= 7.3MiB
files= 100000  peakHeap= 24.3MiB  retained= 1.0MiB
```

Five times the files, 1.7× the heap, `retained` flat. Posted in full on #318, which stays open — this does not touch the single-directory fan-out residual that issue was rescoped to decide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a convenient command for running the memory benchmark.

* **Documentation**
  * Updated benchmark instructions with the recommended execution method.
  * Added clearer examples for passing options, cancelling runs, and enabling garbage collection during benchmarking.
  * Documented a known limitation when attempting to run the benchmark directly with Node.js.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->