### PR TITLE
release: v2.4.14-beta.15

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/core-app",
-  "version": "2.4.14-beta.14",
+  "version": "2.4.14-beta.15",
   "private": true,
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/notes/update_2.4.14-beta.15.en.md
+++ b/notes/update_2.4.14-beta.15.en.md
@@ -8,32 +8,32 @@
 
 ## What's Changed
 
-### AI, automation, and SDK
+- **AI, automation, and SDK**
 
 - Extended the AI Agent, CLI orchestrator, and Tool Gateway with typed tool calls, streaming responses, quota handling, and error projection. Failed or cancelled calls no longer leave listeners, request state, or stream resources behind.
 - Carried tool confirmation, caller identity, and authorization constraints through the preload channel, main process, renderer, and plugin-facing APIs. System-action and file capabilities use the same authorization boundary.
 - Added regression coverage for provider-config snapshots, Nexus/local/OpenAI/Anthropic providers, and the Pi CLI runtime, preventing configuration changes or non-callable bridges from being treated as usable.
 
-### Data, privacy, and security
+- **Data, privacy, and security**
 
 - Added migration `0041_ai_orchestrator_run_retention` and included orchestration-run data in retention, cleanup, and privacy-acceptance flows.
 - Hardened privacy lifecycle management, audit-log backoff, sensitive-text processing, plugin installation, and network services. Transport SDK coverage now includes stream protocol, renderer storage, and plugin-event boundaries.
 - Fixed a Nexus admin-risk endpoint path that could reveal internal configuration clues when emergency credentials were misconfigured. Deployed-preview HARs are redacted before persistence.
 - Added service constraints and regression coverage for idempotent Credits consumption and telemetry batching, reducing duplicate debit and duplicate-count risk.
 
-### CoreApp, plugins, and interaction
+- **CoreApp, plugins, and interaction**
 
 - Improved CoreBox recommendation rebuilding, file-index settings, clipboard AutoPaste, and plugin-install queuing; added coverage for system actions, window identity, and single-instance protections.
 - Updated JSON Formatter, Clipboard History, Translation, and Intelligence plugin manifests, themes, input handling, and runtime interfaces while retaining the plugin-facing transport surface.
 - Continued TuffEx accessibility and motion work for inputs, context menus, collapsed content, and reduced-motion behavior. Reduced-motion environments no longer retain infinite animation or unreachable collapsed controls.
 
-### Nexus, docs, and release engineering
+- **Nexus, docs, and release engineering**
 
 - Consolidated Nexus documentation routes, bilingual API content, and demo/icon gates. Release downloads now handle HEAD/download responses and validate version artifacts server-side.
 - Expanded macOS/Linux updater-script regression tests and package-level CI/publish workflow validation to reduce platform-specific release drift.
 - Retained verified `napi` and `symphonia` native-audio versions. The `napi-derive` and Anthropic major upgrades are intentionally excluded because they are incompatible with the current `napi` API and `@langchain/core` peer range, respectively.
 
-### Verification
+- **Verification**
 
 - Ran `pnpm quality:pr`: release-note validation, changed-file lint, targeted tests (122 tests), and CoreApp Node/Web type checking all passed.
 - This remains a prerelease. Validate AI tool calls, plugin installation, updater handoff, and Nexus telemetry in a non-production profile before broad rollout.

--- a/notes/update_2.4.14-beta.15.zh.md
+++ b/notes/update_2.4.14-beta.15.zh.md
@@ -8,32 +8,32 @@
 
 ## 变更内容
 
-### AI、自动化与 SDK
+- **AI、自动化与 SDK**
 
 - 扩展 AI Agent、CLI 编排器和 Tool Gateway 的类型化工具调用、流式响应、配额与错误投影，避免失败或取消后遗留监听器、请求状态或未清理的流式资源。
 - 将工具确认、调用方身份和权限约束贯穿预加载通道、主进程、渲染端与插件侧 API；系统动作和文件能力遵循同一授权边界。
 - 补齐 Provider 配置快照、Nexus/本地/OpenAI/Anthropic Provider 与 Pi CLI 运行时的回归覆盖，防止配置切换或不可调用 bridge 被误判为可用。
 
-### 数据、隐私与安全
+- **数据、隐私与安全**
 
 - 新增 `0041_ai_orchestrator_run_retention` 迁移，并将编排运行数据纳入保留、清理和隐私验收链路。
 - 加固隐私生命周期、审计日志退避、敏感文本处理、插件安装与网络服务；传输 SDK 现在覆盖 stream 协议、renderer 存储和插件事件边界。
 - 修复 Nexus 管理风险接口在异常凭据配置下可能暴露内部配置线索的问题；部署预览 HAR 在落盘前执行凭据脱敏。
 - Credits 消费和遥测批量上报增加幂等性测试与服务端约束，降低重复提交导致重复扣费或重复计数的风险。
 
-### CoreApp、插件与体验
+- **CoreApp、插件与体验**
 
 - 改进 CoreBox 推荐重建、文件索引设置、剪贴板自动粘贴和插件安装队列，并补齐系统动作、窗口身份和单实例保护覆盖。
 - 更新 JSON Formatter、Clipboard History、Translation 与 Intelligence 插件的 manifest、主题、输入和运行时接口；SDK 维持面向插件的兼容 transport 表面。
 - TuffEx 继续完善输入、上下文菜单、折叠内容可访问性及动效降级；偏好减少动态效果的环境不再保留无限动画或不可达交互元素。
 
-### Nexus、文档与发布工程
+- **Nexus、文档与发布工程**
 
 - Nexus 文档页面、双语 API 内容和 demo/图标门禁同步收口；发布下载新增 HEAD/下载响应处理并强化版本工件的服务端校验。
 - 更新更新器脚本和交接助手的 macOS/Linux 回归测试；发布工作流拆分并校验各包的 CI/发布配置，减少平台特定脚本漂移。
 - 保留已验证的 `napi` 与 `symphonia` 原生音频依赖版本；未纳入分别与当前 `napi` API 和 `@langchain/core` peer 范围不兼容的 `napi-derive` 与 Anthropic major 升级。
 
-### 验证
+- **验证**
 
 - 已执行 `pnpm quality:pr`：发布说明门禁、变更 lint、目标测试（122 项）以及 CoreApp Node/Web 类型检查均通过。
 - Beta 仍是预发布通道；请优先在非生产 profile 验证 AI 工具调用、插件安装、更新交接和 Nexus 遥测路径后再扩大使用范围。

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@talex-touch/tuff",
   "homepage": "https://tuff.tagzxia.com",
   "type": "module",
-  "version": "2.4.14-beta.14",
+  "version": "2.4.14-beta.15",
   "packageManager": "pnpm@10.34.4",
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",


### PR DESCRIPTION
Bumps the merged master release candidate to v2.4.14-beta.15. Detailed bilingual notes are already committed under notes/update_2.4.14-beta.15.{zh,en}.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application version to 2.4.14-beta.15.

* **Documentation**
  * Reformatted release-note section headings in English and Chinese for improved readability.
  * Release-note content remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->