### PR TITLE
fix(corebox): resolve bundled preload path

### DIFF
--- a/apps/core-app/src/main/config/default.ts
+++ b/apps/core-app/src/main/config/default.ts
@@ -1,6 +1,12 @@
 import path from 'node:path'
+import { app } from 'electron'
 import { buildWindowArgs } from '@talex-touch/utils/renderer/window-role'
 import { buildWindowWebPreferences } from '../core/window-security-profile'
+
+// Resolve from the application root: this module may be emitted into out/main/chunks, where
+// __dirname-relative paths incorrectly point at out/main/preload instead of out/preload.
+const CORE_APP_ROOT = app?.getAppPath?.() ?? process.cwd()
+const CORE_APP_PRELOAD_PATH = path.join(CORE_APP_ROOT, 'out', 'preload', 'index.js')
 
 export const AppName = 'Tuff'
 
@@ -28,7 +34,7 @@ export const MainWindowOption: Electron.BrowserWindowConstructorOptions = {
   // dark/contrast themes and the layout has no way to know how much room it takes — with the
   // top bar gone it would sit straight on top of each page's own top-right controls.
   webPreferences: buildWindowWebPreferences('app', {
-    preload: path.join(__dirname, '..', 'preload', 'index.js'),
+    preload: CORE_APP_PRELOAD_PATH,
     scrollBounce: true,
     additionalArguments: buildWindowArgs({ touchType: 'main' })
   })
@@ -49,7 +55,7 @@ export const BoxWindowOption: Electron.BrowserWindowConstructorOptions = {
   show: false,
   transparent: true,
   webPreferences: buildWindowWebPreferences('app', {
-    preload: path.join(__dirname, '..', 'preload', 'index.js'),
+    preload: CORE_APP_PRELOAD_PATH,
     scrollBounce: true,
     additionalArguments: buildWindowArgs({ touchType: 'core-box' })
   })
@@ -76,7 +82,7 @@ export const DivisionBoxWindowOption: Electron.BrowserWindowConstructorOptions =
     symbolColor: '#1f2937'
   },
   webPreferences: buildWindowWebPreferences('app', {
-    preload: path.join(__dirname, '..', 'preload', 'index.js'),
+    preload: CORE_APP_PRELOAD_PATH,
     scrollBounce: true,
     additionalArguments: buildWindowArgs({ touchType: 'core-box', coreType: 'division-box' })
   })
@@ -99,7 +105,7 @@ export const AssistantFloatingBallWindowOption: Electron.BrowserWindowConstructo
   transparent: true,
   hasShadow: true,
   webPreferences: buildWindowWebPreferences('app', {
-    preload: path.join(__dirname, '..', 'preload', 'index.js'),
+    preload: CORE_APP_PRELOAD_PATH,
     scrollBounce: true,
     additionalArguments: buildWindowArgs({
       touchType: 'assistant',
@@ -123,7 +129,7 @@ export const AssistantVoicePanelWindowOption: Electron.BrowserWindowConstructorO
   transparent: true,
   hasShadow: true,
   webPreferences: buildWindowWebPreferences('app', {
-    preload: path.join(__dirname, '..', 'preload', 'index.js'),
+    preload: CORE_APP_PRELOAD_PATH,
     scrollBounce: true,
     additionalArguments: buildWindowArgs({
       touchType: 'assistant',
@@ -149,7 +155,7 @@ export const ScreenshotOverlayWindowOption: Electron.BrowserWindowConstructorOpt
   backgroundColor: '#00000000',
   enableLargerThanScreen: true,
   webPreferences: buildWindowWebPreferences('app', {
-    preload: path.join(__dirname, '..', 'preload', 'index.js'),
+    preload: CORE_APP_PRELOAD_PATH,
     scrollBounce: false,
     additionalArguments: buildWindowArgs({
       touchType: 'screenshot',
@@ -173,7 +179,7 @@ export const ScreenshotEditorWindowOption: Electron.BrowserWindowConstructorOpti
   transparent: false,
   backgroundColor: '#111315',
   webPreferences: buildWindowWebPreferences('app', {
-    preload: path.join(__dirname, '..', 'preload', 'index.js'),
+    preload: CORE_APP_PRELOAD_PATH,
     scrollBounce: false,
     additionalArguments: buildWindowArgs({
       touchType: 'screenshot',
@@ -197,7 +203,7 @@ export const OmniPanelWindowOption: Electron.BrowserWindowConstructorOptions = {
   show: false,
   transparent: true,
   webPreferences: buildWindowWebPreferences('app', {
-    preload: path.join(__dirname, '..', 'preload', 'index.js'),
+    preload: CORE_APP_PRELOAD_PATH,
     scrollBounce: true,
     additionalArguments: buildWindowArgs({ touchType: 'core-box', coreType: 'omni-panel' })
   })

--- a/apps/core-app/src/main/modules/file-protocol/index.test.ts
+++ b/apps/core-app/src/main/modules/file-protocol/index.test.ts
@@ -7,6 +7,7 @@ const { fetchMock, handleMock, unhandleMock } = vi.hoisted(() => ({
 }))
 
 vi.mock('electron', () => ({
+  app: { getAppPath: () => '/app' },
   net: {
     fetch: fetchMock
   },


### PR DESCRIPTION
## Problem

CoreBox and the main renderer can stay blank because electron-vite emits `default.ts` into `out/main/chunks`. Resolving preload from `__dirname` then points to the nonexistent `out/main/preload/index.js`, so the preload bridge never initializes.

## Fix

Resolve the shared preload entry from Electron `app.getAppPath()` and reuse it across all BrowserWindow configurations. A `process.cwd()` fallback keeps config imports testable under the existing Electron stubs.

## Verification

- `pnpm run typecheck:node`
- `pnpm exec vitest run src/main/core/window-security-profile.test.ts src/main/core/window-effects.test.ts src/main/modules/box-tool/core-box/window.test.ts` (34 passed)
- `pnpm exec eslint src/main/config/default.ts`
- Live `pnpm core:dev`: renderer mounted; CoreBox input, placeholder and controls rendered; recommendation engine returned 8 items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preload loading for application windows in packaged and development environments.
  * Improved reliability for the main window, panels, overlays, and assistant views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->