### PR TITLE
release: v2.4.14-beta.16

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/core-app",
-  "version": "2.4.14-beta.15",
+  "version": "2.4.14-beta.16",
   "private": true,
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/notes/update_2.4.14-beta.16.en.md
+++ b/notes/update_2.4.14-beta.16.en.md
@@ -1,0 +1,20 @@
+# Tuff v2.4.14-beta.16 Release Notes
+
+## Summary Notes
+
+- **Fixed blank CoreBox and main windows:** preload now resolves from the Electron application root, preventing electron-vite's `out/main/chunks` output from redirecting it to the nonexistent `out/main/preload` path.
+- **Unified desktop-window startup contracts:** Main, CoreBox, Division, Assistant, Screenshot, and OmniPanel now share one verified preload entry so the IPC bridge initializes consistently in every window.
+- **Closed the release regression gap:** Electron mocks now implement the `app.getAppPath()` contract; the full CoreApp suite, workspace type checking, release gates, and a live CoreBox startup smoke all pass.
+
+## What's Changed
+
+- **CoreApp window startup**
+
+- Centralized the preload entry at `app.getAppPath()/out/preload/index.js` instead of deriving it from the emitted chunk's `__dirname`. Tests retain a `process.cwd()` fallback so lightweight Electron mocks can import the configuration safely.
+- Reused the entry across all eight `BrowserWindow` configurations, fixing the preload `ENOENT` that removed `window.electron.ipcRenderer`, prevented Vue from mounting, and left CoreBox as an empty panel.
+
+- **Verification**
+
+- GitHub PR CI passed workspace type checking, CoreApp/Nexus/integration suites, documentation quality, PR Quality, and CodeQL.
+- A live macOS development startup mounted the main renderer; CoreBox displayed its input, placeholder, and controls, and the recommendation engine returned eight items.
+- This remains a Beta prerelease. After upgrading, verify the main window and the CoreBox shortcut path before broad rollout.

--- a/notes/update_2.4.14-beta.16.zh.md
+++ b/notes/update_2.4.14-beta.16.zh.md
@@ -1,0 +1,20 @@
+# Tuff v2.4.14-beta.16 更新说明
+
+## 摘要
+
+- **修复 CoreBox 与主窗口白屏：** 窗口 preload 入口改为从 Electron 应用根目录解析，避免 electron-vite 将配置打包进 `out/main/chunks` 后把路径错误指向不存在的 `out/main/preload`。
+- **统一桌面窗口启动契约：** Main、CoreBox、Division、Assistant、Screenshot 与 OmniPanel 共用同一条经过验证的 preload 路径，确保 IPC bridge 在所有窗口一致初始化。
+- **补齐发布回归：** Electron 测试桩同步 `app.getAppPath()` 契约；CoreApp 完整测试、工作区类型检查、发布门禁与真实 CoreBox 启动验证均已通过。
+
+## 变更内容
+
+- **CoreApp 窗口启动**
+
+- 将 preload 入口集中为 `app.getAppPath()/out/preload/index.js`，不再依赖最终 chunk 所在目录的 `__dirname`；测试环境保留 `process.cwd()` 降级，避免 Electron 桩导入失败。
+- 八类 `BrowserWindow` 配置统一复用该入口，修复 preload `ENOENT` 导致的 `window.electron.ipcRenderer` 缺失、Vue 根节点无法挂载和 CoreBox 空白面板。
+
+- **验证**
+
+- GitHub PR CI 的工作区类型检查、CoreApp/Nexus/集成测试、文档质量、PR Quality 与 CodeQL 均通过。
+- macOS 开发态实际启动后，Main renderer 正常挂载；CoreBox 输入框、占位文字和控件可见，推荐引擎成功返回 8 项结果。
+- 本版本仍为 Beta 预发布通道；建议升级后优先确认主窗口和 CoreBox 快捷键唤起路径。

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@talex-touch/tuff",
   "homepage": "https://tuff.tagzxia.com",
   "type": "module",
-  "version": "2.4.14-beta.15",
+  "version": "2.4.14-beta.16",
   "packageManager": "pnpm@10.34.4",
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",


### PR DESCRIPTION
Bumps the merged CoreBox preload-path fix to v2.4.14-beta.16 and adds strict bilingual release notes.

## Included

- Resolve every desktop window preload entry from the Electron app root.
- Restore the preload IPC bridge and Vue mount for Main/CoreBox and related panels.
- Keep Electron mocks aligned with the `app.getAppPath()` contract.

## Verification

- Fix PR #1815: all required CI and CodeQL checks passed.
- `pnpm release:notes:verify` passed for v2.4.14-beta.16.
- Version metadata is synchronized in root and CoreApp manifests.
- Live macOS smoke rendered CoreBox and returned 8 recommendations.