### PR TITLE
chore(trellis): restore the ai-toolchain blocker dropped by a merge

### DIFF
--- a/.trellis/tasks/08-05-ai-toolchain-suite/task.json
+++ b/.trellis/tasks/08-05-ai-toolchain-suite/task.json
@@ -30,5 +30,8 @@
   "parent": null,
   "relatedFiles": [],
   "notes": "",
-  "meta": {}
+  "meta": {
+    "blocker": "Deferred by docs/plan-prd/TODO.md:9 -- remaining independently-owned active tasks continue only after the preceding blocker lane resolves. As of 2026-08-13 lane 1 (release/runtime blockers: #326 OTA, #482 release notes) and lane 2 (search and cross-platform remediation: #334, #351) are both open. TODO.md:37 additionally names AI/Assistant/OmniPanel polish as paused until its execution lane is reached.",
+    "nextAction": "Release condition: reopen when lanes 1 and 2 close. No bounded child is named yet because the ordering, not the scope, is what is blocking (#309)."
+  }
 }


### PR DESCRIPTION
Single bookkeeping fix: re-adds the ai-toolchain-suite blocker record in task.json that an earlier merge dropped (+4/-1). Committed in the tt-wt-1727 worktree; surfaced during the workspace-wide merge sweep.