### PR TITLE
docs(release): add v2.4.14-beta.18 notes

### DIFF
--- a/notes/update_2.4.14-beta.18.en.md
+++ b/notes/update_2.4.14-beta.18.en.md
@@ -1,0 +1,11 @@
+# Tuff v2.4.14-beta.18 Release Notes
+
+## Summary Notes
+
+- **Fixed macOS AutoPaste permission diagnostics:** a system-level keystroke denial after a successful clipboard write is no longer reported as a lost target focus.
+- **Separated Accessibility from Automation permission failures:** System Events error 1002 now points to Accessibility, while Apple Events error -1743 keeps the Automation recovery path.
+- **Aligned Intelligence plugin recovery guidance:** touch-intelligence now shows the same actionable permission path as the host when answer replacement fails.
+
+## What's Changed
+
+- Added the typed `MACOS_ACCESSIBILITY_PERMISSION_DENIED` result and a regression using the real `osascript` error 1002 sample.

--- a/notes/update_2.4.14-beta.18.zh.md
+++ b/notes/update_2.4.14-beta.18.zh.md
@@ -1,0 +1,11 @@
+# Tuff v2.4.14-beta.18 更新说明
+
+## 摘要
+
+- **修复 macOS 自动粘贴权限诊断：** 剪贴板写入后按键注入被系统拒绝时，不再误报为目标应用失去焦点。
+- **区分辅助功能与自动化权限：** System Events 错误 1002 会指向“辅助功能”，Apple Events 错误 -1743 继续指向“自动化”。
+- **同步智能插件恢复提示：** touch-intelligence 替换回答失败时会展示与宿主一致的权限修复路径。
+
+## 变更内容
+
+- 新增类型化错误 `MACOS_ACCESSIBILITY_PERMISSION_DENIED`，并使用真实 `osascript` 1002 错误样本覆盖回归测试。


### PR DESCRIPTION
## Summary

Add the bilingual release notes for Tuff v2.4.14-beta.18. The notes describe the macOS AutoPaste Accessibility error classification and recovery guidance shipped by PR #1826.

## Verification

- `corepack pnpm release:notes:verify`
- `mise run docs:verify`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added English and Chinese release notes for Tuff v2.4.14-beta.18.
  * Documented improved macOS AutoPaste permission diagnostics.
  * Clarified separate handling for Accessibility and Automation permission errors.
  * Aligned touch-intelligence recovery guidance with the latest behavior.
  * Documented a clearer Accessibility permission-denied result and regression coverage for macOS automation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->