### PR TITLE
release: v2.4.14-beta.18

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/core-app",
-  "version": "2.4.14-beta.17",
+  "version": "2.4.14-beta.18",
   "private": true,
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@talex-touch/tuff",
   "homepage": "https://tuff.tagzxia.com",
   "type": "module",
-  "version": "2.4.14-beta.17",
+  "version": "2.4.14-beta.18",
   "packageManager": "pnpm@10.34.4",
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",


### PR DESCRIPTION
## Summary

Synchronize the root and CoreApp versions for Tuff v2.4.14-beta.18 after the AutoPaste Accessibility fix and bilingual release notes have merged.

## Verification

- version generated by `pnpm run version 2.4.14-beta.18`
- root and CoreApp versions synchronized
- lockfile remains unchanged
- annotated tag will be recreated on the final merged `origin/master` SHA after protected checks pass