### PR TITLE
feat(tuffex): give Switch a built-in label with text transition

### DIFF
--- a/apps/nexus/app/components/content/demos/SwitchCustomColorDemo.vue
+++ b/apps/nexus/app/components/content/demos/SwitchCustomColorDemo.vue
@@ -53,12 +53,8 @@ const labels = computed(() => (locale.value === 'zh'
   font-size: 14px;
 }
 
-.switch-custom-color-demo__item :deep(.tuff-switch.is-active) {
-  background-color: var(--switch-demo-color);
-}
-
-.switch-custom-color-demo__item :deep(.tuff-switch.is-active:hover:not(.is-disabled)) {
-  box-shadow: 0 0 16px 1px color-mix(in srgb, var(--switch-demo-color) 72%, transparent);
+.switch-custom-color-demo__item :deep(.tuff-switch) {
+  --tuff-switch-active-color: var(--switch-demo-color);
 }
 
 .switch-custom-color-demo__item.is-success {

--- a/apps/nexus/app/components/content/demos/SwitchDisabledDemo.vue
+++ b/apps/nexus/app/components/content/demos/SwitchDisabledDemo.vue
@@ -22,18 +22,9 @@ const labels = computed(() => (locale.value === 'zh'
 
 <template>
   <div class="switch-disabled-demo">
-    <label class="switch-disabled-demo__item">
-      <span>{{ labels.enabled }}</span>
-      <TuffSwitch v-model="enabled" />
-    </label>
-    <label class="switch-disabled-demo__item is-disabled">
-      <span>{{ labels.disabledOff }}</span>
-      <TuffSwitch v-model="disabledOff" disabled />
-    </label>
-    <label class="switch-disabled-demo__item is-disabled">
-      <span>{{ labels.disabledOn }}</span>
-      <TuffSwitch v-model="disabledOn" disabled />
-    </label>
+    <TuffSwitch v-model="enabled" :label="labels.enabled" />
+    <TuffSwitch v-model="disabledOff" :label="labels.disabledOff" disabled />
+    <TuffSwitch v-model="disabledOn" :label="labels.disabledOn" disabled />
   </div>
 </template>
 
@@ -42,18 +33,6 @@ const labels = computed(() => (locale.value === 'zh'
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 14px;
-}
-
-.switch-disabled-demo__item {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  color: var(--tx-text-color-secondary);
-  font-size: 14px;
-}
-
-.switch-disabled-demo__item.is-disabled {
-  color: var(--tx-text-color-placeholder);
+  gap: 18px;
 }
 </style>

--- a/apps/nexus/app/components/content/demos/SwitchLabelDemo.vue
+++ b/apps/nexus/app/components/content/demos/SwitchLabelDemo.vue
@@ -5,6 +5,7 @@ const { locale } = useI18n()
 
 const compact = ref(false)
 const autoSync = ref(true)
+const telemetry = ref(false)
 
 const labels = computed(() => (locale.value === 'zh'
   ? {
@@ -12,78 +13,38 @@ const labels = computed(() => (locale.value === 'zh'
       on: '开',
       compact: '紧凑模式',
       autoSync: '自动同步',
+      telemetry: '匿名统计',
     }
   : {
       off: 'Off',
       on: 'On',
       compact: 'Compact mode',
       autoSync: 'Auto sync',
+      telemetry: 'Anonymous stats',
     }))
 </script>
 
 <template>
   <div class="switch-label-demo">
-    <label class="switch-label-demo__item">
-      <span class="switch-label-demo__label">{{ labels.off }}</span>
-      <TuffSwitch v-model="compact" />
-      <span class="switch-label-demo__label is-active">{{ labels.on }}</span>
-      <strong>{{ labels.compact }}</strong>
-    </label>
-    <label class="switch-label-demo__item switch-label-demo__item--card">
-      <span>
-        <strong>{{ labels.autoSync }}</strong>
-        <small>{{ autoSync ? labels.on : labels.off }}</small>
-      </span>
-      <TuffSwitch v-model="autoSync" />
-    </label>
+    <!-- Static name, either side of the track. -->
+    <TuffSwitch v-model="compact" :label="labels.compact" />
+    <TuffSwitch v-model="telemetry" :label="labels.telemetry" label-placement="start" />
+
+    <!-- A label that flips with the value: the built-in transformer crossfades it. -->
+    <TuffSwitch v-model="autoSync" :label="autoSync ? labels.on : labels.off" />
+
+    <!-- The default slot takes arbitrary nodes; it renders as-is, no crossfade. -->
+    <TuffSwitch v-model="autoSync">
+      <strong>{{ labels.autoSync }}</strong>
+    </TuffSwitch>
   </div>
 </template>
 
 <style scoped>
 .switch-label-demo {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 12px;
-  min-width: min(100%, 360px);
-}
-
-.switch-label-demo__item {
-  display: inline-flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 10px;
-  color: var(--tx-text-color-secondary);
-  font-size: 14px;
-}
-
-.switch-label-demo__label {
-  min-width: 24px;
-  text-align: center;
-}
-
-.switch-label-demo__label.is-active,
-.switch-label-demo__item strong {
-  color: var(--tx-text-color-primary);
-}
-
-.switch-label-demo__item--card {
-  justify-content: space-between;
-  width: 100%;
-  box-sizing: border-box;
-  padding: 12px 14px;
-  border: 1px solid var(--tx-border-color-light);
-  border-radius: 14px;
-  background: color-mix(in srgb, var(--tx-fill-color-light) 72%, transparent);
-}
-
-.switch-label-demo__item--card span {
-  display: inline-flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.switch-label-demo__item--card small {
-  color: var(--tx-text-color-secondary);
-  font-size: 12px;
+  gap: 18px;
 }
 </style>

--- a/apps/nexus/app/components/content/demos/SwitchLoadingDemo.vue
+++ b/apps/nexus/app/components/content/demos/SwitchLoadingDemo.vue
@@ -40,22 +40,14 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="switch-loading-demo">
-    <label class="switch-loading-demo__item">
-      <span>{{ labels.async }}</span>
-      <TuffSwitch
-        :model-value="asyncEnabled"
-        :loading="committing"
-        @change="commit"
-      />
-    </label>
-    <label class="switch-loading-demo__item">
-      <span>{{ labels.off }}</span>
-      <TuffSwitch v-model="loadingOff" loading />
-    </label>
-    <label class="switch-loading-demo__item">
-      <span>{{ labels.on }}</span>
-      <TuffSwitch v-model="loadingOn" loading />
-    </label>
+    <TuffSwitch
+      :model-value="asyncEnabled"
+      :loading="committing"
+      :label="labels.async"
+      @change="commit"
+    />
+    <TuffSwitch v-model="loadingOff" :label="labels.off" loading />
+    <TuffSwitch v-model="loadingOn" :label="labels.on" loading />
   </div>
 </template>
 
@@ -64,14 +56,6 @@ onBeforeUnmount(() => {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 14px;
-}
-
-.switch-loading-demo__item {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  color: var(--tx-text-color-secondary);
-  font-size: 14px;
+  gap: 18px;
 }
 </style>

--- a/apps/nexus/app/components/content/demos/SwitchSettingsRowDemo.vue
+++ b/apps/nexus/app/components/content/demos/SwitchSettingsRowDemo.vue
@@ -40,7 +40,7 @@ const labels = computed(() => (locale.value === 'zh'
         <p>{{ labels.notificationsDesc }}</p>
       </div>
       <div class="switch-settings-demo__action">
-        <span>{{ settings.notifications ? labels.on : labels.off }}</span>
+        <TxTextTransformer :text="settings.notifications ? labels.on : labels.off" />
         <TuffSwitch v-model="settings.notifications" />
       </div>
     </div>
@@ -50,7 +50,7 @@ const labels = computed(() => (locale.value === 'zh'
         <p>{{ labels.focusModeDesc }}</p>
       </div>
       <div class="switch-settings-demo__action">
-        <span>{{ settings.focusMode ? labels.on : labels.off }}</span>
+        <TxTextTransformer :text="settings.focusMode ? labels.on : labels.off" />
         <TuffSwitch v-model="settings.focusMode" />
       </div>
     </div>
@@ -60,7 +60,7 @@ const labels = computed(() => (locale.value === 'zh'
         <p>{{ labels.autoUpdateDesc }}</p>
       </div>
       <div class="switch-settings-demo__action">
-        <span>{{ settings.autoUpdate ? labels.on : labels.off }}</span>
+        <TxTextTransformer :text="settings.autoUpdate ? labels.on : labels.off" />
         <TuffSwitch v-model="settings.autoUpdate" />
       </div>
     </div>

--- a/apps/nexus/app/components/content/demos/SwitchSizesDemo.vue
+++ b/apps/nexus/app/components/content/demos/SwitchSizesDemo.vue
@@ -22,18 +22,9 @@ const labels = computed(() => (locale.value === 'zh'
 
 <template>
   <div class="switch-sizes-demo">
-    <label class="switch-sizes-demo__item">
-      <span>{{ labels.small }}</span>
-      <TuffSwitch v-model="smallEnabled" size="small" />
-    </label>
-    <label class="switch-sizes-demo__item">
-      <span>{{ labels.default }}</span>
-      <TuffSwitch v-model="defaultEnabled" />
-    </label>
-    <label class="switch-sizes-demo__item">
-      <span>{{ labels.large }}</span>
-      <TuffSwitch v-model="largeEnabled" size="large" />
-    </label>
+    <TuffSwitch v-model="smallEnabled" :label="labels.small" size="small" />
+    <TuffSwitch v-model="defaultEnabled" :label="labels.default" />
+    <TuffSwitch v-model="largeEnabled" :label="labels.large" size="large" />
   </div>
 </template>
 
@@ -42,14 +33,6 @@ const labels = computed(() => (locale.value === 'zh'
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 14px;
-}
-
-.switch-sizes-demo__item {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  color: var(--tx-text-color-secondary);
-  font-size: 14px;
+  gap: 18px;
 }
 </style>

--- a/apps/nexus/content/docs/dev/components/switch.en.mdc
+++ b/apps/nexus/content/docs/dev/components/switch.en.mdc
@@ -50,7 +50,7 @@ code: |
 :::
 
 ### Sizes
-Small works well in dense lists, default fits forms, and large highlights important settings.
+Small works well in dense lists, default fits forms, and large highlights important settings. Size also drives the label font size and the track gap.
 :::TuffDemoWrapper{demo="SwitchSizesDemo" code-lang="vue"}
 ---
 code: |
@@ -64,9 +64,9 @@ code: |
 
   <template>
     <div style="display: flex; align-items: center; gap: 14px;">
-      <TuffSwitch v-model="smallEnabled" size="small" />
-      <TuffSwitch v-model="defaultEnabled" />
-      <TuffSwitch v-model="largeEnabled" size="large" />
+      <TuffSwitch v-model="smallEnabled" label="Small" size="small" />
+      <TuffSwitch v-model="defaultEnabled" label="Default" />
+      <TuffSwitch v-model="largeEnabled" label="Large" size="large" />
     </div>
   </template>
 ---
@@ -87,9 +87,9 @@ code: |
 
   <template>
     <div style="display: flex; align-items: center; gap: 14px;">
-      <TuffSwitch v-model="enabled" />
-      <TuffSwitch v-model="disabledOff" disabled />
-      <TuffSwitch v-model="disabledOn" disabled />
+      <TuffSwitch v-model="enabled" label="Enabled" />
+      <TuffSwitch v-model="disabledOff" label="Disabled / off" disabled />
+      <TuffSwitch v-model="disabledOn" label="Disabled / on" disabled />
     </div>
   </template>
 ---
@@ -119,16 +119,16 @@ code: |
 
   <template>
     <div style="display: flex; align-items: center; gap: 14px;">
-      <TuffSwitch :model-value="asyncEnabled" :loading="committing" @change="commit" />
-      <TuffSwitch v-model="loadingOff" loading />
-      <TuffSwitch v-model="loadingOn" loading />
+      <TuffSwitch :model-value="asyncEnabled" :loading="committing" label="Async commit" @change="commit" />
+      <TuffSwitch v-model="loadingOff" label="Loading / off" loading />
+      <TuffSwitch v-model="loadingOn" label="Loading / on" loading />
     </div>
   </template>
 ---
 :::
 
 ### Labels Before and After
-Place state labels before or after the switch, or combine it with setting copy.
+`label` renders beside the track and `labelPlacement` picks the side. When the text changes it crossfades through the built-in `TxTextTransformer` instead of hard-swapping; the default slot takes arbitrary nodes and renders them as-is, with no transition.
 :::TuffDemoWrapper{demo="SwitchLabelDemo" code-lang="vue"}
 ---
 code: |
@@ -136,31 +136,29 @@ code: |
   import { ref } from 'vue'
 
   const compact = ref(false)
+  const telemetry = ref(false)
   const autoSync = ref(true)
   </script>
 
   <template>
-    <div style="display: flex; flex-direction: column; align-items: flex-start; gap: 12px;">
-      <label style="display: inline-flex; align-items: center; gap: 10px;">
-        <span>Off</span>
-        <TuffSwitch v-model="compact" />
-        <span>On</span>
-        <strong>Compact mode</strong>
-      </label>
-      <label style="display: flex; justify-content: space-between; align-items: center; gap: 10px; width: 100%; max-width: 320px; padding: 12px 14px; border: 1px solid var(--tx-border-color-light); border-radius: 14px;">
-        <span style="display: inline-flex; flex-direction: column; gap: 4px;">
-          <strong>Auto sync</strong>
-          <small style="color: var(--tx-text-color-secondary); font-size: 12px;">{{ autoSync ? 'On' : 'Off' }}</small>
-        </span>
-        <TuffSwitch v-model="autoSync" />
-      </label>
+    <div style="display: flex; flex-wrap: wrap; align-items: center; gap: 18px;">
+      <TuffSwitch v-model="compact" label="Compact mode" />
+      <TuffSwitch v-model="telemetry" label="Anonymous stats" label-placement="start" />
+
+      <!-- A label that flips with the value: the built-in transformer crossfades it -->
+      <TuffSwitch v-model="autoSync" :label="autoSync ? 'On' : 'Off'" />
+
+      <!-- The slot takes arbitrary nodes and renders them as-is -->
+      <TuffSwitch v-model="autoSync">
+        <strong>Auto sync</strong>
+      </TuffSwitch>
     </div>
   </template>
 ---
 :::
 
 ### Custom Colors
-Switch does not expose a color prop yet. Override the active state with CSS variables or local classes.
+Override `--tuff-switch-active-color` (and `--tuff-switch-track-color` / `--tuff-switch-thumb-color`) to recolor a switch. The track visuals live on `.tuff-switch__track`, so overriding the root's `background-color` no longer reaches them.
 :::TuffDemoWrapper{demo="SwitchCustomColorDemo" code-lang="vue"}
 ---
 code: |
@@ -204,8 +202,8 @@ code: |
     color: var(--switch-demo-color);
   }
 
-  .switch-custom-color-demo__item :deep(.tuff-switch.is-active) {
-    background-color: var(--switch-demo-color);
+  .switch-custom-color-demo__item :deep(.tuff-switch) {
+    --tuff-switch-active-color: var(--switch-demo-color);
   }
 
   .switch-custom-color-demo__item.is-success {
@@ -230,7 +228,9 @@ code: |
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `modelValue` | `boolean` | `false` | Checked state controlled by `v-model`. |
-| `size` | `'small' \| 'default' \| 'large'` | `'default'` | Visual size variant. The default size does not add a modifier class. |
+| `label` | `string` | - | Visible text beside the track. Changes crossfade through the built-in `TxTextTransformer`; its presence adds `has-label` and suppresses `aria-label`. |
+| `labelPlacement` | `'start' \| 'end'` | `'end'` | Which side of the track the label sits on. No effect without a label. |
+| `size` | `'small' \| 'default' \| 'large'` | `'default'` | Visual size variant, which also drives the label font size and the track gap. The default size does not add a modifier class. |
 | `disabled` | `boolean` | `false` | Removes focusability and blocks click, Enter, and Space toggles. |
 | `loading` | `boolean` | `false` | Pending async commit: morphs the thumb into a spinning ring, adds `is-loading` plus `aria-busy="true"`, and blocks toggling. |
 
@@ -245,7 +245,7 @@ code: |
 
 | Slot | Props | Description |
 |------|------|-------------|
-| - | - | `TuffSwitch` has no slots. Pair it with external labels or setting-row copy. |
+| `default` | - | Custom visible text, taking precedence over `label`. It accepts arbitrary nodes, so it does **not** animate; use `label` when you want the transition. |
 
 ## Interaction Contract
 
@@ -253,12 +253,14 @@ code: |
 - `disabled=true` sets the native `disabled` attribute (which removes it from the tab order), adds `is-disabled`, and prevents click, Enter, and Space from emitting events.
 - `loading=true` sets the native `disabled` attribute and blocks events just like `disabled`, but adds `is-loading` instead of `is-disabled` — so it skips the dimmed disabled look — and renders `aria-busy="true"`. Both classes appear when both props are true.
 - Enabled toggles emit both `update:modelValue` and `change`; the component does not mutate external state without `v-model` update handling.
+- The root is a flex container; the track lives on the child `.tuff-switch__track` and the thumb on `.tuff-switch__thumb`. Every state class (`is-active` / `is-disabled` / `is-loading` / `has-label`) still sits on the root.
+- A `label` or default slot adds `has-label` and stops `aria-label` from rendering — visible text is already the accessible name, and a competing `aria-label` would override the words a speech-control user actually reads.
 - `size="small"` and `size="large"` add modifier classes; `size="default"` intentionally leaves the base class only.
 
 ## Composite Patterns
 
 ### Settings Row
-Switch paired with labels, helper copy, and live state text for settings lists.
+Switch paired with labels, helper copy, and live state text for settings lists. When the state text sits outside the component, run it through `TxTextTransformer` so it uses the same text transition.
 ::::TuffDemoWrapper{demo="SwitchSettingsRowDemo" code-lang="vue"}
 ---
 code: |
@@ -279,7 +281,10 @@ code: |
           <TxTag label="Notifications" />
           <p>Receive important system and plugin alerts.</p>
         </div>
-        <TuffSwitch v-model="settings.notifications" />
+        <div class="settings-state">
+          <TxTextTransformer :text="settings.notifications ? 'On' : 'Off'" />
+          <TuffSwitch v-model="settings.notifications" />
+        </div>
       </div>
       <div class="settings-row">
         <div>
@@ -313,9 +318,10 @@ code: |
 - Use switches for immediate boolean settings. Use checkboxes when the value is part of a submitted form or multi-select group.
 - When a toggle needs server confirmation, use `loading` to cover that not-immediate gap rather than letting the switch jump to the new value and back.
 - Do not write `modelValue` back optimistically while `loading` is set. Leave the thumb on the old value, commit on success, and simply clear `loading` on failure so the state stays where it was.
-- Place a readable text label next to the switch; the component itself intentionally renders only the control.
+- Use `label` for readable text rather than hand-rolling a `<span>` beside the control — the built-in path brings the text transition and the `aria-label` suppression with it.
+- Put the control's **name** in `label` ("Compact mode"). Keep state text ("On") outside and run it through `TxTextTransformer`: that component carries its own `aria-live="polite"`, so inside the label every toggle would be announced twice.
 - Keep labels vertically centered and leave enough hit area around dense settings rows.
-- Override active colors with local classes only; preserve disabled, focus, and size classes from the base component.
+- Recolor by overriding `--tuff-switch-active-color` and friends rather than rewriting `.tuff-switch__track` rules, so disabled, focus, and size styling survives.
 
 ## Review Notes
 
@@ -323,7 +329,8 @@ code: |
 - **Keyboard contract:** Enabled switches respond to click, Enter, and Space via native button semantics. Disabled switches leave the tab order through the native `disabled` attribute, keep `aria-disabled="true"`, and emit nothing.
 - **Loading contract:** `loading` is a purely visual and blocking state; the component owns no async logic. Thumb position still follows `modelValue`, so the loading ring sits on the old side to show that this toggle has not landed yet.
 - **Motion fallback:** The ring stops rotating under `prefers-reduced-motion: reduce`; its gapped border is a static glyph on its own, so the busy cue survives.
-- **Verified coverage:** `switch.test.ts` covers active aria state, size classes, click emission, disabled blocking, loading blocking and the `aria-busy` lifecycle, and asserts that no `tabindex` is rendered in either state.
+- **Class contract change (2026-08-31):** the track visuals moved off the root onto `.tuff-switch__track`, so `.tuff-switch.is-active { background-color }` — the override this page used to recommend — **no longer reaches them**; use `--tuff-switch-active-color`. Root classes, `closest('.tuff-switch')` hit-testing, and every event contract are unchanged.
+- **Verified coverage:** `switch.test.ts` covers active aria state, size classes, click emission, disabled blocking, loading blocking and the `aria-busy` lifecycle, plus the label structure: no `__label` without one, `label` routed through `TxTextTransformer`, slot content bypassing the transformer, `labelPlacement` ordering, and `aria-label` disappearing once visible text names the control; it also asserts that no `tabindex` is rendered in either state.
 
 ## Source
 

--- a/apps/nexus/content/docs/dev/components/switch.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/switch.zh.mdc
@@ -50,7 +50,7 @@ code: |
 :::
 
 ### 不同大小
-小尺寸适合密集列表，默认尺寸适合表单，大尺寸适合突出设置项。
+小尺寸适合密集列表，默认尺寸适合表单，大尺寸适合突出设置项。尺寸同时决定 label 字号与轨道间距。
 :::TuffDemoWrapper{demo="SwitchSizesDemo" code-lang="vue"}
 ---
 code: |
@@ -64,9 +64,9 @@ code: |
 
   <template>
     <div style="display: flex; align-items: center; gap: 14px;">
-      <TuffSwitch v-model="smallEnabled" size="small" />
-      <TuffSwitch v-model="defaultEnabled" />
-      <TuffSwitch v-model="largeEnabled" size="large" />
+      <TuffSwitch v-model="smallEnabled" label="小尺寸" size="small" />
+      <TuffSwitch v-model="defaultEnabled" label="默认尺寸" />
+      <TuffSwitch v-model="largeEnabled" label="大尺寸" size="large" />
     </div>
   </template>
 ---
@@ -87,9 +87,9 @@ code: |
 
   <template>
     <div style="display: flex; align-items: center; gap: 14px;">
-      <TuffSwitch v-model="enabled" />
-      <TuffSwitch v-model="disabledOff" disabled />
-      <TuffSwitch v-model="disabledOn" disabled />
+      <TuffSwitch v-model="enabled" label="可操作" />
+      <TuffSwitch v-model="disabledOff" label="禁用 / 关闭" disabled />
+      <TuffSwitch v-model="disabledOn" label="禁用 / 开启" disabled />
     </div>
   </template>
 ---
@@ -119,16 +119,16 @@ code: |
 
   <template>
     <div style="display: flex; align-items: center; gap: 14px;">
-      <TuffSwitch :model-value="asyncEnabled" :loading="committing" @change="commit" />
-      <TuffSwitch v-model="loadingOff" loading />
-      <TuffSwitch v-model="loadingOn" loading />
+      <TuffSwitch :model-value="asyncEnabled" :loading="committing" label="异步提交" @change="commit" />
+      <TuffSwitch v-model="loadingOff" label="加载中 / 关闭" loading />
+      <TuffSwitch v-model="loadingOn" label="加载中 / 开启" loading />
     </div>
   </template>
 ---
 :::
 
 ### 前后 Label
-在开关前后放置状态文本，或与说明文案组成设置行。
+`label` 渲染在轨道旁边，`labelPlacement` 决定在前还是在后。文案变化时由内置的 `TxTextTransformer` 做模糊交叉淡入，不会硬切；默认插槽接受任意节点，按原样渲染、不参与动效。
 :::TuffDemoWrapper{demo="SwitchLabelDemo" code-lang="vue"}
 ---
 code: |
@@ -136,31 +136,29 @@ code: |
   import { ref } from 'vue'
 
   const compact = ref(false)
+  const telemetry = ref(false)
   const autoSync = ref(true)
   </script>
 
   <template>
-    <div style="display: flex; flex-direction: column; align-items: flex-start; gap: 12px;">
-      <label style="display: inline-flex; align-items: center; gap: 10px;">
-        <span>关</span>
-        <TuffSwitch v-model="compact" />
-        <span>开</span>
-        <strong>紧凑模式</strong>
-      </label>
-      <label style="display: flex; justify-content: space-between; align-items: center; gap: 10px; width: 100%; max-width: 320px; padding: 12px 14px; border: 1px solid var(--tx-border-color-light); border-radius: 14px;">
-        <span style="display: inline-flex; flex-direction: column; gap: 4px;">
-          <strong>自动同步</strong>
-          <small style="color: var(--tx-text-color-secondary); font-size: 12px;">{{ autoSync ? '开' : '关' }}</small>
-        </span>
-        <TuffSwitch v-model="autoSync" />
-      </label>
+    <div style="display: flex; flex-wrap: wrap; align-items: center; gap: 18px;">
+      <TuffSwitch v-model="compact" label="紧凑模式" />
+      <TuffSwitch v-model="telemetry" label="匿名统计" label-placement="start" />
+
+      <!-- 文案随值翻转：内置 transformer 负责交叉淡入 -->
+      <TuffSwitch v-model="autoSync" :label="autoSync ? '开' : '关'" />
+
+      <!-- 插槽接受任意节点，原样渲染 -->
+      <TuffSwitch v-model="autoSync">
+        <strong>自动同步</strong>
+      </TuffSwitch>
     </div>
   </template>
 ---
 :::
 
 ### 自定义颜色
-Switch 暂不提供颜色 prop，可通过 CSS 变量或局部 class 覆盖激活态颜色。
+覆盖 `--tuff-switch-active-color`（以及 `--tuff-switch-track-color` / `--tuff-switch-thumb-color`）即可换色。轨道视觉在 `.tuff-switch__track` 上，覆盖根节点的 `background-color` 不再生效。
 :::TuffDemoWrapper{demo="SwitchCustomColorDemo" code-lang="vue"}
 ---
 code: |
@@ -204,8 +202,8 @@ code: |
     color: var(--switch-demo-color);
   }
 
-  .switch-custom-color-demo__item :deep(.tuff-switch.is-active) {
-    background-color: var(--switch-demo-color);
+  .switch-custom-color-demo__item :deep(.tuff-switch) {
+    --tuff-switch-active-color: var(--switch-demo-color);
   }
 
   .switch-custom-color-demo__item.is-success {
@@ -230,7 +228,9 @@ code: |
 | 属性名 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `modelValue` | `boolean` | `false` | 由 `v-model` 控制的开关状态。 |
-| `size` | `'small' \| 'default' \| 'large'` | `'default'` | 视觉尺寸。默认尺寸不添加额外 modifier class。 |
+| `label` | `string` | - | 轨道旁的可见文案。变化时经由内置 `TxTextTransformer` 交叉淡入；存在时会添加 `has-label` 并抑制 `aria-label`。 |
+| `labelPlacement` | `'start' \| 'end'` | `'end'` | label 位于轨道前还是后。无 label 时无效。 |
+| `size` | `'small' \| 'default' \| 'large'` | `'default'` | 视觉尺寸，同时决定 label 字号与轨道间距。默认尺寸不添加额外 modifier class。 |
 | `disabled` | `boolean` | `false` | 移除可聚焦能力，并阻止点击、Enter、Space 切换。 |
 | `loading` | `boolean` | `false` | 异步提交中：滑块变为旋转环，添加 `is-loading` 与 `aria-busy="true"`，并阻止切换。 |
 
@@ -245,7 +245,7 @@ code: |
 
 | 插槽名 | Props | 说明 |
 |------|-------|------|
-| - | - | `TuffSwitch` 没有插槽；标签与设置说明放在组件外部组合。 |
+| `default` | - | 自定义可见文案，优先于 `label`。接受任意节点，因此**不走**文字过渡；需要动效就用 `label`。 |
 
 ## 交互契约
 
@@ -253,12 +253,14 @@ code: |
 - `disabled=true` 时设置原生 `disabled`（因而移出 Tab 序列）、添加 `is-disabled`，并阻止点击、Enter、Space 触发事件。
 - `loading=true` 与 `disabled` 一样设置原生 `disabled` 并阻止事件，但添加的是 `is-loading` 而非 `is-disabled`：不套用禁用态的降透明度，另外渲染 `aria-busy="true"`。两者同时为 true 时两个 class 都会出现。
 - 启用切换会同时触发 `update:modelValue` 与 `change`；组件不会在宿主未处理 `v-model` 更新时自行修改外部状态。
+- 根节点是 flex 容器，轨道在子节点 `.tuff-switch__track` 上，滑块在 `.tuff-switch__thumb`。状态 class（`is-active` / `is-disabled` / `is-loading` / `has-label`）仍然全部挂在根节点。
+- `label` 或默认插槽存在时添加 `has-label`，并且不再渲染 `aria-label`——可见文案已经是可访问名称，再叠一个 `aria-label` 会盖掉语音控制用户实际读到的文字。
 - `size="small"` 与 `size="large"` 会添加尺寸 modifier；`size="default"` 只保留基础 class。
 
 ## 组合示例
 
 ### 设置项
-开关搭配标签、说明文案和状态文本，用于设置列表。
+开关搭配标签、说明文案和状态文本，用于设置列表。状态文本在组件外部时，用 `TxTextTransformer` 保持同一套文字过渡。
 ::::TuffDemoWrapper{demo="SwitchSettingsRowDemo" code-lang="vue"}
 ---
 code: |
@@ -279,7 +281,10 @@ code: |
           <TxTag label="通知" />
           <p>接收系统和插件的重要提醒。</p>
         </div>
-        <TuffSwitch v-model="settings.notifications" />
+        <div class="settings-state">
+          <TxTextTransformer :text="settings.notifications ? '已开启' : '已关闭'" />
+          <TuffSwitch v-model="settings.notifications" />
+        </div>
       </div>
       <div class="settings-row">
         <div>
@@ -313,9 +318,10 @@ code: |
 - Switch 用于即时生效的布尔设置；表单提交项或多选组优先使用 Checkbox。
 - 切换需要等待服务端确认时用 `loading` 补上这个「不即时」的空档，别让开关先跳到新值再跳回来。
 - `loading` 期间不要抢先写回 `modelValue`；让滑块停在旧值上，提交成功后再更新，失败则直接撤下 loading，状态自然回到原位。
-- 在开关旁提供可读文本标签；组件本身只负责控件，不渲染内置文案。
+- 用 `label` 提供可读文案，而不是在外面手写一个 `<span>`——内置路径自带文字过渡与 `aria-label` 抑制。
+- `label` 放控件的**名称**（「紧凑模式」）。状态文本（「已开启」）放外面并用 `TxTextTransformer`：`TxTextTransformer` 自带 `aria-live="polite"`，放进 label 会让每次切换被朗读两遍。
 - 标签与开关保持垂直居中，密集设置行也要保留足够点击区域。
-- 自定义激活色只使用局部 class 覆盖，保留基础组件的禁用、焦点与尺寸样式。
+- 自定义颜色覆盖 `--tuff-switch-active-color` 等变量，不要去改 `.tuff-switch__track` 的具体规则，以保留禁用、焦点与尺寸样式。
 
 ## 审阅说明 / Review Notes
 
@@ -323,7 +329,8 @@ code: |
 - **键盘契约:** 启用状态响应点击、Enter 与 Space（原生按钮语义）。禁用状态由原生 `disabled` 移出 Tab 序列，保持 `aria-disabled="true"`，且不派发事件。
 - **加载契约:** `loading` 是纯视觉与阻断状态，组件不持有异步逻辑。滑块位置仍由 `modelValue` 决定，因此加载中的环停在旧值一侧，表示这一次切换尚未落地。
 - **动效降级:** 环形指示器在 `prefers-reduced-motion: reduce` 下停止旋转；缺口边框本身是静态字形，提示不会消失。
-- **实测覆盖:** `switch.test.ts` 覆盖 active aria 状态、尺寸 class、点击派发、禁用阻断、加载中阻断与 `aria-busy` 生命周期，并断言两种状态下均不渲染 `tabindex`。
+- **Class 契约变更（2026-08-31）:** 轨道视觉从根节点下沉到 `.tuff-switch__track`，`.tuff-switch.is-active { background-color }` 这条曾被本页推荐的覆盖写法**不再生效**，改用 `--tuff-switch-active-color`。根节点的 class、`closest('.tuff-switch')` 命中与所有事件契约不变。
+- **实测覆盖:** `switch.test.ts` 覆盖 active aria 状态、尺寸 class、点击派发、禁用阻断、加载中阻断与 `aria-busy` 生命周期，以及 label 结构：无 label 时不渲染 `__label`、`label` 走 `TxTextTransformer`、插槽绕过 transformer、`labelPlacement` 的前后顺序、有可见文案时 `aria-label` 消失；并断言两种状态下均不渲染 `tabindex`。
 
 ## Source
 

--- a/packages/tuffex/packages/components/src/switch/__tests__/switch.test.ts
+++ b/packages/tuffex/packages/components/src/switch/__tests__/switch.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
 import TxSwitch from '../src/TxSwitch.vue'
 
 describe('txSwitch', () => {
@@ -20,6 +21,82 @@ describe('txSwitch', () => {
     expect(wrapper.classes()).toContain('is-active')
     expect(wrapper.classes()).toContain('tuff-switch--large')
     expect(wrapper.attributes('aria-busy')).toBeUndefined()
+    // The track is a child now; the root is the flex wrapper that also holds
+    // the label. State classes stay on the root.
+    expect(wrapper.find('.tuff-switch__track .tuff-switch__thumb').exists()).toBe(true)
+  })
+
+  it('renders no label markup when none is given', () => {
+    const wrapper = mount(TxSwitch)
+
+    expect(wrapper.find('.tuff-switch__label').exists()).toBe(false)
+    expect(wrapper.classes()).not.toContain('has-label')
+  })
+
+  it('renders a label prop through the text transformer', () => {
+    const wrapper = mount(TxSwitch, {
+      props: { label: 'Compact mode' },
+    })
+
+    expect(wrapper.classes()).toContain('has-label')
+    expect(wrapper.text()).toContain('Compact mode')
+    expect(wrapper.findComponent({ name: 'TxTextTransformer' }).exists()).toBe(true)
+  })
+
+  it('drops aria-label once a visible label names the control', () => {
+    const wrapper = mount(TxSwitch, {
+      props: { label: 'Compact mode', ariaLabel: 'Hidden name' },
+    })
+
+    expect(wrapper.attributes('aria-label')).toBeUndefined()
+
+    const slotted = mount(TxSwitch, {
+      props: { ariaLabel: 'Hidden name' },
+      slots: { default: 'Slotted name' },
+    })
+
+    expect(slotted.attributes('aria-label')).toBeUndefined()
+    expect(slotted.text()).toContain('Slotted name')
+  })
+
+  it('renders slot content directly rather than through the transformer', () => {
+    const wrapper = mount(TxSwitch, {
+      props: { label: 'ignored' },
+      slots: { default: '<strong>Rich label</strong>' },
+    })
+
+    // Arbitrary nodes cannot be crossfaded as text, so the slot wins outright.
+    expect(wrapper.find('.tuff-switch__label strong').exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'TxTextTransformer' }).exists()).toBe(false)
+  })
+
+  it('crossfades the old label text when the label changes', async () => {
+    const wrapper = mount(TxSwitch, {
+      props: { label: 'Off' },
+    })
+
+    await wrapper.setProps({ label: 'On' })
+    await nextTick()
+
+    // Mid-transition the transformer keeps the outgoing text in a second,
+    // aria-hidden layer. Its presence is what proves the animation ran rather
+    // than the text being swapped in place.
+    const prev = wrapper.find('.tx-text-transformer__layer--prev')
+    expect(prev.exists()).toBe(true)
+    expect(prev.text()).toBe('Off')
+    expect(prev.attributes('aria-hidden')).toBe('true')
+    expect(wrapper.find('.tx-text-transformer__layer--current').text()).toBe('On')
+  })
+
+  it('places the label before the track when labelPlacement is start', () => {
+    const wrapper = mount(TxSwitch, {
+      props: { label: 'Before', labelPlacement: 'start' },
+    })
+
+    expect(wrapper.element.firstElementChild?.classList.contains('tuff-switch__label')).toBe(true)
+
+    const end = mount(TxSwitch, { props: { label: 'After' } })
+    expect(end.element.firstElementChild?.classList.contains('tuff-switch__track')).toBe(true)
   })
 
   it('emits v-model and change events on click', async () => {

--- a/packages/tuffex/packages/components/src/switch/src/TxSwitch.vue
+++ b/packages/tuffex/packages/components/src/switch/src/TxSwitch.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import { computed } from 'vue'
+import { computed, useSlots } from 'vue'
+import { TxTextTransformer } from '../../text-transformer'
 
 defineOptions({
   name: 'TuffSwitch',
@@ -12,7 +13,11 @@ const props = withDefaults(
     /** Pending async commit: morphs the thumb into a spinning ring and blocks toggling. */
     loading?: boolean
     size?: 'small' | 'default' | 'large'
-    /** Accessible name. Prefer `ariaLabelledby` when a visible label already exists. */
+    /** Visible text beside the track. Changes crossfade through `TxTextTransformer`. */
+    label?: string
+    /** Which side the label sits on. */
+    labelPlacement?: 'start' | 'end'
+    /** Accessible name. Ignored once a visible label or the default slot is present. */
     ariaLabel?: string
     /** Id of a visible label element that names this switch. */
     ariaLabelledby?: string
@@ -22,6 +27,7 @@ const props = withDefaults(
     disabled: false,
     loading: false,
     size: 'default',
+    labelPlacement: 'end',
     ariaLabel: 'Toggle',
     ariaLabelledby: undefined,
   },
@@ -32,6 +38,8 @@ const emit = defineEmits<{
   'change': [value: boolean]
 }>()
 
+const slots = useSlots()
+
 const isActive = computed({
   get: () => props.modelValue,
   set: (val: boolean) => emit('update:modelValue', val),
@@ -40,6 +48,16 @@ const isActive = computed({
 // Loading blocks input the same way `disabled` does, but stays a separate class
 // so the ring indicator reads as "busy" instead of inheriting the dimmed look.
 const isBlocked = computed(() => props.disabled || props.loading)
+
+const hasLabel = computed(() => Boolean(props.label) || Boolean(slots.default))
+
+// A visible label already names the control, and a competing `aria-label` would
+// override the text a speech-control user actually reads (label-in-name).
+const effectiveAriaLabel = computed(() => {
+  if (props.ariaLabelledby || hasLabel.value)
+    return undefined
+  return props.ariaLabel
+})
 
 function toggle() {
   if (isBlocked.value)
@@ -57,7 +75,7 @@ function toggle() {
     :aria-checked="isActive"
     :aria-disabled="isBlocked"
     :aria-busy="loading || undefined"
-    :aria-label="ariaLabelledby ? undefined : ariaLabel"
+    :aria-label="effectiveAriaLabel"
     :aria-labelledby="ariaLabelledby"
     :disabled="isBlocked"
     class="tuff-switch" :class="[
@@ -65,11 +83,25 @@ function toggle() {
         'is-active': isActive,
         'is-disabled': disabled,
         'is-loading': loading,
+        'has-label': hasLabel,
         [`tuff-switch--${size}`]: size !== 'default',
       },
     ]"
     @click="toggle"
   >
-    <span class="tuff-switch__thumb" />
+    <span v-if="hasLabel && labelPlacement === 'start'" class="tuff-switch__label">
+      <!-- The prop path animates; slot content is arbitrary nodes we cannot diff. -->
+      <TxTextTransformer v-if="!slots.default" :text="label ?? ''" />
+      <slot v-else />
+    </span>
+
+    <span class="tuff-switch__track">
+      <span class="tuff-switch__thumb" />
+    </span>
+
+    <span v-if="hasLabel && labelPlacement === 'end'" class="tuff-switch__label">
+      <TxTextTransformer v-if="!slots.default" :text="label ?? ''" />
+      <slot v-else />
+    </span>
   </button>
 </template>

--- a/packages/tuffex/packages/components/src/switch/style/index.scss
+++ b/packages/tuffex/packages/components/src/switch/style/index.scss
@@ -1,21 +1,49 @@
 .tuff-switch {
+  // Override points. The track visuals moved off the root when the label was
+  // added, so `.tuff-switch.is-active { background-color }` no longer reaches
+  // them — these variables are the supported way to recolor a switch.
+  --tuff-switch-track-color: var(--tx-fill-color, #f0f2f5);
+  --tuff-switch-active-color: var(--tx-color-primary, #409eff);
   --tuff-switch-thumb-color: var(--tx-text-color-secondary, #909399);
   --tuff-switch-ring-width: 2px;
+  --tuff-switch-track-width: 44px;
+  --tuff-switch-track-height: 24px;
+  --tuff-switch-track-radius: 10px;
+  --tuff-switch-thumb-radius: 6px;
 
   appearance: none;
-  position: relative;
   display: inline-flex;
   align-items: center;
-  width: 44px;
-  height: 24px;
+  gap: 8px;
   padding: 0;
   border: 0;
   cursor: pointer;
   color: inherit;
   font: inherit;
-  border-radius: 10px;
-  background-color: var(--tx-fill-color, #f0f2f5);
-  transition: all 0.25s ease-in-out;
+  text-align: inherit;
+  background: transparent;
+  user-select: none;
+  outline: none;
+
+  &__track {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    flex: none;
+    width: var(--tuff-switch-track-width);
+    height: var(--tuff-switch-track-height);
+    border-radius: var(--tuff-switch-track-radius);
+    background-color: var(--tuff-switch-track-color);
+    transition: all 0.25s ease-in-out;
+  }
+
+  &__label {
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+    font-size: 14px;
+    color: var(--tx-text-color-regular, #606266);
+  }
 
   &__thumb {
     position: absolute;
@@ -23,7 +51,7 @@
     aspect-ratio: 1 / 1;
     top: 15%;
     left: 10%;
-    border-radius: 6px;
+    border-radius: var(--tuff-switch-thumb-radius);
     background-color: var(--tuff-switch-thumb-color);
     transition: all 0.25s ease-in-out;
 
@@ -42,7 +70,9 @@
   }
 
   &.is-active {
-    background-color: var(--tx-color-primary, #409eff);
+    .tuff-switch__track {
+      background-color: var(--tuff-switch-active-color);
+    }
 
     .tuff-switch__thumb {
       left: 50%;
@@ -72,44 +102,56 @@
     pointer-events: none;
   }
 
-  &:hover:not(.is-disabled):not(.is-loading) {
-    box-shadow: 0 0 12px 1px var(--tx-fill-color);
+  &:hover:not(.is-disabled):not(.is-loading) .tuff-switch__track {
+    box-shadow: 0 0 12px 1px var(--tuff-switch-track-color);
   }
 
-  &.is-active:hover:not(.is-disabled):not(.is-loading) {
-    box-shadow: 0 0 16px 1px var(--tx-color-primary-light-3, #79bbff);
+  &.is-active:hover:not(.is-disabled):not(.is-loading) .tuff-switch__track {
+    box-shadow: 0 0 16px 1px color-mix(in srgb, var(--tuff-switch-active-color) 55%, white);
   }
 
   &:active:not(.is-disabled):not(.is-loading) .tuff-switch__thumb {
     transform: scale(0.85);
   }
 
+  // The outline follows border-radius. Unlabelled, the root box is exactly the
+  // track, so it keeps the pill radius; with a label it wraps both and takes a
+  // small uniform radius instead.
   &:focus-visible {
     outline: 2px solid var(--tx-color-primary-light-5, #a0cfff);
     outline-offset: 2px;
+    border-radius: var(--tuff-switch-track-radius);
+  }
+
+  &.has-label:focus-visible {
+    border-radius: 6px;
   }
 
   &--small {
     --tuff-switch-ring-width: 1.5px;
+    --tuff-switch-track-width: 36px;
+    --tuff-switch-track-height: 20px;
+    --tuff-switch-track-radius: 8px;
+    --tuff-switch-thumb-radius: 5px;
 
-    width: 36px;
-    height: 20px;
-    border-radius: 8px;
+    gap: 6px;
 
-    .tuff-switch__thumb {
-      border-radius: 5px;
+    .tuff-switch__label {
+      font-size: 13px;
     }
   }
 
   &--large {
     --tuff-switch-ring-width: 2.5px;
+    --tuff-switch-track-width: 52px;
+    --tuff-switch-track-height: 28px;
+    --tuff-switch-track-radius: 12px;
+    --tuff-switch-thumb-radius: 6px;
 
-    width: 52px;
-    height: 28px;
-    border-radius: 12px;
+    gap: 10px;
 
-    .tuff-switch__thumb {
-      border-radius: 6px;
+    .tuff-switch__label {
+      font-size: 15px;
     }
   }
 }


### PR DESCRIPTION
## What

`TxSwitch` gains `label` / `labelPlacement` / a default slot — the API `TxCheckbox` has had since it landed. Until now the switch rendered no text and every caller hand-rolled a `<span>` beside it.

The `label` prop is routed through `TxTextTransformer`, so a label that changes crossfades (blur + fade) instead of hard-swapping. The default slot takes arbitrary nodes and renders them as-is — they cannot be diffed as text — so `label` is the path that animates.

```vue
<TuffSwitch v-model="compact" label="Compact mode" />
<TuffSwitch v-model="stats" label="Anonymous stats" label-placement="start" />
<TuffSwitch v-model="sync" :label="sync ? 'On' : 'Off'" />  <!-- crossfades -->
<TuffSwitch v-model="sync"><strong>Auto sync</strong></TuffSwitch>  <!-- as-is -->
```

Where state text stays *outside* the component — the settings-row composition — it now runs through `TxTextTransformer` too, so both placements share one text transition.

## ⚠️ Breaking, styling only

The track visuals move off the root onto `.tuff-switch__track`, because the root now has to hold the label as well. **`.tuff-switch.is-active { background-color }` — the override this component's own docs used to recommend — no longer reaches them.**

Replaced by variables, which is a better API than reaching into a class:

| variable | default |
| --- | --- |
| `--tuff-switch-active-color` | `--tx-color-primary` |
| `--tuff-switch-track-color` | `--tx-fill-color` |
| `--tuff-switch-thumb-color` | `--tx-text-color-secondary` |

Unchanged: root classes (`is-active` / `is-disabled` / `is-loading`, plus the new `has-label`), `closest('.tuff-switch')` hit-testing, sizing, and every event contract. An unlabelled switch is pixel-identical to before.

Swept the repo for the old override: the only consumer was `SwitchCustomColorDemo` (migrated here). `HeaderUserMenu.vue` uses `closest('.tuff-switch')`, which still resolves. `apps/nexus/app/components/ui/Switch.vue` forwards `$attrs`, so it picks up the new props with no change. The ~18 core-app / plugin call sites pass no label and are unaffected.

## Accessibility

A visible label suppresses `aria-label` — the text is already the accessible name, and a competing `aria-label` would override the words a speech-control user reads (label-in-name).

Documented caveat: `TxTextTransformer` carries its own `aria-live="polite"`. Put the control's *name* in `label` and keep state text outside, or every toggle gets announced twice.

## Verification

- switch 15 tests (up from 10), group-block + checkbox re-run green — 38 total.
- Negative control: replacing the transformer with a plain `<span>` turns both label-animation tests red, so they test the wiring rather than the markup.
- The crossfade test asserts the outgoing text is still present in the `aria-hidden` prev layer after a label change — a static screenshot cannot show that.
- tuffex `eslint` + `vue-tsc` clean; nexus `nuxt typecheck` **0 errors**; `check:demo-registry` / `check:mdc-fences` / `check:doc-parity` pass.
- Visual: SSR-rendered against the built CSS, light + dark, across no-label / label-end / label-start / small / large / loading / disabled.

## Docs

Rewrote the label section in both languages, migrated every switch demo to the built-in label, documented the new CSS variables, and recorded the class-contract change in the Review Notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional visible labels to switches, with configurable placement before or after the control.
  * Added support for custom label content and animated label transitions.
  * Updated switch sizes to adjust label typography and spacing.
  * Improved accessibility behavior when visible labels are present.
  * Added CSS variable support for customizing active switch colors.

* **Documentation**
  * Updated English and Chinese switch documentation with the new label, slot, sizing, accessibility, and styling guidance.

* **Tests**
  * Added coverage for label rendering, placement, transitions, slots, and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->