### PR TITLE
feat(nexus): list every component on each suite overview

### DIFF
--- a/apps/nexus/app/components/DocsSidebar.vue
+++ b/apps/nexus/app/components/DocsSidebar.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import DocSection from './docs/DocSection.vue'
 import { hasWindow } from '@talex-touch/utils/env'
+import type { DocsSuiteKey } from '~/utils/docs-suites'
 import { coerceJsonArray } from '~/utils/docs-api'
+import { categoryI18nKey, CATEGORY_SUITE_MAP, SUITE_CATEGORY_KEYS } from '~/utils/docs-suites'
 import { requestDocsPage } from '~/utils/docs-page-client-cache'
 import { useTypedFetch } from '~/utils/request'
 import { normalizeDocsPagePath, resolveDocsLocaleFromRoute, toLocalizedDocsPath } from '#shared/utils/docs-path'
@@ -431,7 +433,7 @@ const SECTION_ORDER: Record<string, string[]> = {
 // tuffex entry barrels stay base/pro/ai: 'data' is a docs-level split
 // (Visualization components still import from the pro barrel; the chart family
 // is the standalone @talex-touch/tuffex-charts package).
-type SuiteKey = 'concepts' | 'base' | 'pro' | 'ai' | 'data'
+type SuiteKey = DocsSuiteKey
 
 interface SuiteDef {
   key: SuiteKey
@@ -441,11 +443,20 @@ interface SuiteDef {
   standalonePages: string[]
 }
 
+// Category groups come from the shared taxonomy so the sidebar and the suite
+// overview catalogs cannot list different components.
+function suiteCategories(suite: SuiteKey) {
+  return SUITE_CATEGORY_KEYS[suite].map(key => ({
+    key,
+    label: t(`docsSidebar.categories.${categoryI18nKey(key)}`),
+  }))
+}
+
 const SUITES = computed<SuiteDef[]>(() => [
   {
     key: 'concepts',
     label: t('docsSidebar.suites.concepts'),
-    categories: [],
+    categories: suiteCategories('concepts'),
     standalonePages: [
       '/docs/dev/components/concepts-suite',
       '/docs/dev/components/foundations',
@@ -455,45 +466,25 @@ const SUITES = computed<SuiteDef[]>(() => [
   {
     key: 'base',
     label: t('docsSidebar.suites.base'),
-    categories: [
-      { key: 'Basic', label: t('docsSidebar.categories.basic') },
-      { key: 'Form', label: t('docsSidebar.categories.form') },
-      { key: 'Layout', label: t('docsSidebar.categories.layout') },
-      { key: 'Navigation', label: t('docsSidebar.categories.navigation') },
-      { key: 'Data', label: t('docsSidebar.categories.data') },
-      { key: 'Feedback', label: t('docsSidebar.categories.feedback') },
-      { key: 'Status', label: t('docsSidebar.categories.status') },
-    ],
+    categories: suiteCategories('base'),
     standalonePages: ['/docs/dev/components/base-suite'],
   },
   {
     key: 'pro',
     label: t('docsSidebar.suites.pro'),
-    categories: [
-      { key: 'Advanced', label: t('docsSidebar.categories.advanced') },
-      { key: 'Effects', label: t('docsSidebar.categories.effects') },
-      { key: 'Primitives', label: t('docsSidebar.categories.primitives') },
-    ],
+    categories: suiteCategories('pro'),
     standalonePages: ['/docs/dev/components/pro-suite'],
   },
   {
     key: 'ai',
     label: t('docsSidebar.suites.ai'),
-    categories: [
-      { key: 'AiChat', label: t('docsSidebar.categories.aiChat') },
-      { key: 'AiAgent', label: t('docsSidebar.categories.aiAgent') },
-      { key: 'AiReasoning', label: t('docsSidebar.categories.aiReasoning') },
-      { key: 'AiContext', label: t('docsSidebar.categories.aiContext') },
-    ],
+    categories: suiteCategories('ai'),
     standalonePages: ['/docs/dev/components/ai-suite'],
   },
   {
     key: 'data',
     label: t('docsSidebar.suites.data'),
-    categories: [
-      { key: 'Charts', label: t('docsSidebar.categories.charts') },
-      { key: 'Visualization', label: t('docsSidebar.categories.visualization') },
-    ],
+    categories: suiteCategories('data'),
     // The charts package overview doubles as this suite's overview page; the
     // standalone slot consumes it before the Charts group renders, so it never
     // shows twice.
@@ -501,28 +492,6 @@ const SUITES = computed<SuiteDef[]>(() => [
   },
 ])
 
-const CATEGORY_SUITE_MAP: Record<string, SuiteKey> = {
-  Foundations: 'concepts',
-  BaseSuite: 'base',
-  Basic: 'base',
-  Form: 'base',
-  Layout: 'base',
-  Navigation: 'base',
-  Data: 'base',
-  Feedback: 'base',
-  Status: 'base',
-  ProSuite: 'pro',
-  Advanced: 'pro',
-  Visualization: 'data',
-  Charts: 'data',
-  Effects: 'pro',
-  Primitives: 'pro',
-  AiSuite: 'ai',
-  AiChat: 'ai',
-  AiAgent: 'ai',
-  AiReasoning: 'ai',
-  AiContext: 'ai',
-}
 
 // Same-component doc families fold into one expandable entry inside their
 // category instead of rendering as flat sibling links. Key = head doc path (its

--- a/apps/nexus/app/components/docs/DocsSuiteCatalog.vue
+++ b/apps/nexus/app/components/docs/DocsSuiteCatalog.vue
@@ -1,0 +1,196 @@
+<script setup lang="ts">
+import type { DocsSuiteKey } from '~/utils/docs-suites'
+import { computed } from 'vue'
+import { coerceJsonArray } from '~/utils/docs-api'
+import { categoryI18nKey, SUITE_CATEGORY_KEYS } from '~/utils/docs-suites'
+import { useTypedFetch } from '~/utils/request'
+import { resolveDocsLocaleFromRoute, toLocalizedDocsPath } from '#shared/utils/docs-path'
+
+/**
+ * The complete component list for one suite, grouped by category.
+ *
+ * Reads the same `/api/docs/sidebar-components` feed the sidebar uses, so it
+ * always shows every doc that carries a category in this suite — there is no
+ * hand-maintained list to fall behind.
+ */
+const props = defineProps<{ suite: DocsSuiteKey }>()
+
+interface CatalogDoc {
+  title: string
+  normalizedPath: string
+  category: string | null
+}
+
+const route = useRoute()
+const { t } = useI18n()
+const docsLocale = computed(() => resolveDocsLocaleFromRoute(route.path))
+
+// Mirrors the sidebar's client-only lazy fetch: the docs pages prerender, and
+// the content table is not reliably queryable at that point.
+const { data: payload, pending } = await useTypedFetch<unknown>(
+  computed(() => `/api/docs/sidebar-components/${docsLocale.value}`),
+  {
+    key: computed(() => `docs-suite-catalog:${docsLocale.value}`),
+    server: false,
+    lazy: true,
+    responseType: 'json',
+    default: () => [],
+  },
+)
+
+const categoryKeys = computed(() => SUITE_CATEGORY_KEYS[props.suite] ?? [])
+
+const groups = computed(() => {
+  const docs = coerceJsonArray<CatalogDoc>(payload.value)
+  return categoryKeys.value
+    .map(key => ({
+      key,
+      label: t(`docsSidebar.categories.${categoryI18nKey(key)}`),
+      // Alphabetical rather than the sidebar's curated order: this list exists
+      // to be exhaustive and scannable, and it stays correct as docs are added.
+      items: docs
+        .filter(doc => doc.category === key)
+        .sort((a, b) => a.title.localeCompare(b.title, docsLocale.value)),
+    }))
+    .filter(group => group.items.length > 0)
+})
+
+const total = computed(() => groups.value.reduce((sum, group) => sum + group.items.length, 0))
+</script>
+
+<template>
+  <section class="docs-suite-catalog" :aria-busy="pending || undefined">
+    <p v-if="!pending && total > 0" class="docs-suite-catalog__total">
+      {{ t('docsSuiteCatalog.total', { count: total, groups: groups.length }) }}
+    </p>
+
+    <!-- Skeleton mirrors the loaded layout so nothing shifts when data lands. -->
+    <div v-if="pending" class="docs-suite-catalog__groups" aria-hidden="true">
+      <div v-for="key in categoryKeys" :key="key" class="docs-suite-catalog__group">
+        <div class="docs-suite-catalog__skeleton-heading" />
+        <div class="docs-suite-catalog__grid">
+          <div v-for="n in 6" :key="n" class="docs-suite-catalog__skeleton-chip" />
+        </div>
+      </div>
+    </div>
+
+    <div v-else class="docs-suite-catalog__groups">
+      <div v-for="group in groups" :key="group.key" class="docs-suite-catalog__group">
+        <h3 class="docs-suite-catalog__heading">
+          {{ group.label }}
+          <span class="docs-suite-catalog__count">{{ group.items.length }}</span>
+        </h3>
+        <ul class="docs-suite-catalog__grid">
+          <li v-for="item in group.items" :key="item.normalizedPath">
+            <NuxtLink
+              class="docs-suite-catalog__chip"
+              :to="toLocalizedDocsPath(item.normalizedPath, docsLocale)"
+            >
+              {{ item.title }}
+            </NuxtLink>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.docs-suite-catalog {
+  margin: 20px 0 8px;
+}
+
+.docs-suite-catalog__total {
+  margin: 0 0 16px;
+  color: var(--tx-text-color-secondary);
+  font-size: 13px;
+}
+
+.docs-suite-catalog__groups {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.docs-suite-catalog__heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 10px;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--tx-text-color-primary);
+}
+
+.docs-suite-catalog__count {
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--tx-fill-color);
+  color: var(--tx-text-color-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
+.docs-suite-catalog__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.docs-suite-catalog__chip {
+  display: block;
+  padding: 8px 12px;
+  border: 1px solid var(--tx-border-color-lighter);
+  border-radius: 10px;
+  color: var(--tx-text-color-regular);
+  font-size: 13px;
+  line-height: 1.35;
+  text-decoration: none;
+  transition: border-color 0.18s ease, color 0.18s ease, background-color 0.18s ease;
+}
+
+.docs-suite-catalog__chip:hover {
+  border-color: var(--tx-color-primary);
+  color: var(--tx-color-primary);
+  background: var(--tx-color-primary-light-9);
+}
+
+.docs-suite-catalog__skeleton-heading,
+.docs-suite-catalog__skeleton-chip {
+  border-radius: 10px;
+  background: var(--tx-fill-color);
+  animation: docs-suite-catalog-pulse 1.4s ease-in-out infinite;
+}
+
+.docs-suite-catalog__skeleton-heading {
+  width: 120px;
+  height: 18px;
+  margin: 0 0 10px;
+  border-radius: 6px;
+}
+
+.docs-suite-catalog__skeleton-chip {
+  height: 35px;
+}
+
+@keyframes docs-suite-catalog-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .docs-suite-catalog__skeleton-heading,
+  .docs-suite-catalog__skeleton-chip {
+    animation: none;
+  }
+}
+</style>

--- a/apps/nexus/app/utils/docs-suites.ts
+++ b/apps/nexus/app/utils/docs-suites.ts
@@ -1,0 +1,80 @@
+/**
+ * Component-docs suite taxonomy.
+ *
+ * The `category` frontmatter value on every doc under `content/docs/dev/components/`
+ * is the source of truth for which group a component belongs to; this module maps
+ * those values onto the five suites and fixes the order groups render in.
+ *
+ * Shared so the sidebar and the suite overview catalogs cannot drift apart. Adding
+ * a category means touching all three maps here, and nothing else.
+ */
+
+export type DocsSuiteKey = 'concepts' | 'base' | 'pro' | 'ai' | 'data'
+
+export const DOCS_SUITE_KEYS: DocsSuiteKey[] = ['concepts', 'base', 'pro', 'ai', 'data']
+
+/**
+ * Ordered `category` frontmatter values per suite.
+ *
+ * `concepts` is intentionally empty: its pages (concepts-suite, foundations,
+ * utils) render as standalone links rather than category groups.
+ */
+export const SUITE_CATEGORY_KEYS: Record<DocsSuiteKey, string[]> = {
+  concepts: [],
+  base: ['Basic', 'Form', 'Layout', 'Navigation', 'Data', 'Feedback', 'Status'],
+  pro: ['Advanced', 'Effects', 'Primitives'],
+  ai: ['AiChat', 'AiAgent', 'AiReasoning', 'AiContext'],
+  data: ['Charts', 'Visualization'],
+}
+
+/**
+ * Every `category` value, including the `*Suite` values the overview pages
+ * themselves carry, mapped onto its owning suite.
+ */
+export const CATEGORY_SUITE_MAP: Record<string, DocsSuiteKey> = {
+  Foundations: 'concepts',
+  BaseSuite: 'base',
+  Basic: 'base',
+  Form: 'base',
+  Layout: 'base',
+  Navigation: 'base',
+  Data: 'base',
+  Feedback: 'base',
+  Status: 'base',
+  ProSuite: 'pro',
+  Advanced: 'pro',
+  Effects: 'pro',
+  Primitives: 'pro',
+  Visualization: 'data',
+  Charts: 'data',
+  AiSuite: 'ai',
+  AiChat: 'ai',
+  AiAgent: 'ai',
+  AiReasoning: 'ai',
+  AiContext: 'ai',
+}
+
+/** Category value -> the `docsSidebar.categories.*` i18n key that labels it. */
+export const CATEGORY_I18N_KEY: Record<string, string> = {
+  Basic: 'basic',
+  Form: 'form',
+  Layout: 'layout',
+  Navigation: 'navigation',
+  Data: 'data',
+  Feedback: 'feedback',
+  Status: 'status',
+  Advanced: 'advanced',
+  Effects: 'effects',
+  Primitives: 'primitives',
+  Charts: 'charts',
+  Visualization: 'visualization',
+  AiChat: 'aiChat',
+  AiAgent: 'aiAgent',
+  AiReasoning: 'aiReasoning',
+  AiContext: 'aiContext',
+}
+
+/** The `docsSidebar.categories.*` key for a category, falling back to `misc`. */
+export function categoryI18nKey(category: string): string {
+  return CATEGORY_I18N_KEY[category] ?? 'misc'
+}

--- a/apps/nexus/content/docs/dev/components/ai-suite.en.mdc
+++ b/apps/nexus/content/docs/dev/components/ai-suite.en.mdc
@@ -13,6 +13,13 @@ verified: true
 
 In the components sidebar the AI suite is split into four groups: **Chat** (Chat, ChatComposer, PromptBar, AttachmentTray, MessageActions, SuggestionChips, TypingIndicator, ConversationStream), **Agents** (Agents, AgentTrace, TaskRows, ToolCallCard, ToolChips, ToolConfirmation, ApprovalCard, WorkingIndicator), **Reasoning** (AiElements, ChainOfThought, ReasoningDisclosure, ThinkingOrb, StreamMarkdown, CodeStream, InlineCitation, Sources) and **Context & Insight** (ContextCards, ContextIndicator, InsightCards, RecommendationCard, FineTuneCard). Every component in the suite can be imported through the `@talex-touch/tuffex/ai` category entry.
 
+## Groups at a Glance
+
+Every component in the suite, grouped by category. The list is read from each doc's `category` frontmatter, so new components appear on their own.
+
+::DocsSuiteCatalog{suite="ai"}
+::
+
 ## Source & License
 
 This suite is adapted from [Beautiful UI](https://www.beautifului.dev) (Turbo design studio / Shane Levine, © 2026, MIT license) — 19 component showcases for AI-native interfaces: chat, reasoning traces, human-in-the-loop approvals, agent task status and more. The port follows three principles: pixel-match the source visual language (a dedicated `--tx-bui-*` token layer, hairline ring shadows, the 13px density system); ship components as pure controlled primitives (demo timelines stay in the demo layer); and fuse with existing tuffex components instead of duplicating them — overlaps land as variants or compositions, and accessibility gaps are filled to tuffex standards. Every component source file carries the MIT attribution in its header.

--- a/apps/nexus/content/docs/dev/components/ai-suite.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/ai-suite.zh.mdc
@@ -13,6 +13,13 @@ verified: true
 
 AI 套件在组件侧边栏分为四组：**对话**（Chat、ChatComposer、PromptBar、AttachmentTray、MessageActions、SuggestionChips、TypingIndicator、ConversationStream）、**智能体**（Agents、AgentTrace、TaskRows、ToolCallCard、ToolChips、ToolConfirmation、ApprovalCard、WorkingIndicator）、**推理与生成**（AiElements、ChainOfThought、ReasoningDisclosure、ThinkingOrb、StreamMarkdown、CodeStream、InlineCitation、Sources）、**上下文与洞察**（ContextCards、ContextIndicator、InsightCards、RecommendationCard、FineTuneCard）。全部组件可经 `@talex-touch/tuffex/ai` 分类入口按套件引入。
 
+## 分组一览
+
+下面按分组列出该套件的**全部**组件，数据来自每个文档的 `category` frontmatter，新增组件会自动出现。
+
+::DocsSuiteCatalog{suite="ai"}
+::
+
 ## 来源与授权
 
 本套件移植自 [Beautiful UI](https://www.beautifului.dev)（Turbo 设计工作室 / Shane Levine，© 2026，MIT 协议），共 19 个面向 AI 原生界面的组件案例：聊天、推理轨迹、human-in-the-loop 审批、agent 任务状态等。移植遵循三条原则：像素级还原其视觉语言（独立 `--tx-bui-*` token 层、发丝环阴影、13px 密度体系）；组件做成纯受控原语（演示时间轴留在 demo 层）；与 tuffex 现有组件融合而非重复造轮子——重叠处以变体或组合落地，无障碍缺口按 tuffex 标准补齐。每个组件源码文件头保留 MIT 署名。

--- a/apps/nexus/content/docs/dev/components/base-suite.en.mdc
+++ b/apps/nexus/content/docs/dev/components/base-suite.en.mdc
@@ -22,14 +22,8 @@ Every cell is a live, interactive component; click the name in the top-left corn
 
 ## Groups at a Glance
 
-| Group | Covers |
-|-------|--------|
-| [General](/docs/dev/components/button) | Button, Icon, Avatar, Tag, Badge, Kbd, Divider |
-| [Form](/docs/dev/components/form) | Input, Select, DatePicker, Radio, Checkbox, Switch, Slider, Rating, Uploader |
-| [Layout](/docs/dev/components/container) | Container, Flex, Grid, Stack, Splitter, Collapse, Card |
-| [Navigation](/docs/dev/components/tabs) | Tabs, NavBar, SidebarNav, Breadcrumb, Steps, Pagination, DropdownMenu |
-| [Data Display](/docs/dev/components/data-table) | DataTable, Tree, SortableList, Timeline, Transfer, StatCard |
-| [Feedback](/docs/dev/components/dialog) | Dialog, Modal, Drawer, Popover, Toast, Progress, LoadingOverlay |
-| [Status & Empty](/docs/dev/components/empty) | Empty, ErrorState, OfflineState, PermissionState, Skeleton |
+Every component in the suite, grouped by category. The list is read from each doc's `category` frontmatter, so new components appear on their own.
 
-The full inventory with every link lives in the [component hub](/docs/dev/components/index) under "Basics".
+::DocsSuiteCatalog{suite="base"}
+::
+

--- a/apps/nexus/content/docs/dev/components/base-suite.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/base-suite.zh.mdc
@@ -22,14 +22,8 @@ verified: false
 
 ## 分组一览
 
-| 分组 | 覆盖 |
-|------|------|
-| [通用](/docs/dev/components/button) | Button、Icon、Avatar、Tag、Badge、Kbd、Divider |
-| [表单](/docs/dev/components/form) | Input、Select、DatePicker、Radio、Checkbox、Switch、Slider、Rating、Uploader |
-| [布局](/docs/dev/components/container) | Container、Flex、Grid、Stack、Splitter、Collapse、Card |
-| [导航](/docs/dev/components/tabs) | Tabs、NavBar、SidebarNav、Breadcrumb、Steps、Pagination、DropdownMenu |
-| [数据展示](/docs/dev/components/data-table) | DataTable、Tree、SortableList、Timeline、Transfer、StatCard |
-| [反馈](/docs/dev/components/dialog) | Dialog、Modal、Drawer、Popover、Toast、Progress、LoadingOverlay |
-| [状态占位](/docs/dev/components/empty) | Empty、ErrorState、OfflineState、PermissionState、Skeleton |
+下面按分组列出该套件的**全部**组件，数据来自每个文档的 `category` frontmatter，新增组件会自动出现。
 
-完整清单与全部链接见《[组件中心](/docs/dev/components/index)》的「基础组件」分节。
+::DocsSuiteCatalog{suite="base"}
+::
+

--- a/apps/nexus/content/docs/dev/components/charts.en.mdc
+++ b/apps/nexus/content/docs/dev/components/charts.en.mdc
@@ -33,6 +33,13 @@ import '@talex-touch/tuffex-charts/style.css'
 | `TxChart` + series primitives | [Custom Chart](/docs/dev/components/custom-chart) | The composable escape hatch: line/area/bar/scatter/donut, freely combined. |
 | `ChartPalette` / CSS variables | [Colors](/docs/dev/components/chart-colors) | Categorical, semantic, sequential and map palettes, auto light/dark. |
 
+## Groups at a Glance
+
+Every component in the suite, grouped by category. The list is read from each doc's `category` frontmatter, so new components appear on their own.
+
+::DocsSuiteCatalog{suite="data"}
+::
+
 ## Legend
 
 `TxChartLegendItem` ships two legend layouts: `small` inline rows (multi-series legends) and `large` stacked metrics (dashboard cards). `loading` renders skeleton placeholders; with a `click` listener attached it renders as a native `button`, so Enter/Space work out of the box.

--- a/apps/nexus/content/docs/dev/components/charts.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/charts.zh.mdc
@@ -33,6 +33,13 @@ import '@talex-touch/tuffex-charts/style.css'
 | `TxChart` + 系列原语 | [Custom Chart](/docs/dev/components/custom-chart) | 组合式逃生舱：折线/面积/柱/散点/环形自由拼装。 |
 | `ChartPalette` / CSS 变量 | [Colors](/docs/dev/components/chart-colors) | 分类、语义、顺序、地图色板，明暗自动。 |
 
+## 分组一览
+
+下面按分组列出该套件的**全部**组件，数据来自每个文档的 `category` frontmatter，新增组件会自动出现。
+
+::DocsSuiteCatalog{suite="data"}
+::
+
 ## 图例
 
 `TxChartLegendItem` 提供两种图例项版式：`small` 单行（多序列图例），`large` 堆叠大数值（仪表卡单指标）。`loading` 渲染骨架占位；挂了 `click` 监听时它会渲染成原生 `button`，回车/空格开箱可用。

--- a/apps/nexus/content/docs/dev/components/pro-suite.en.mdc
+++ b/apps/nexus/content/docs/dev/components/pro-suite.en.mdc
@@ -22,10 +22,8 @@ Every cell is a live, interactive component; click the name in the top-left corn
 
 ## Groups at a Glance
 
-| Group | Covers |
-|-------|--------|
-| [Interaction](/docs/dev/components/command-palette) | CommandPalette, SearchPanel, MarkdownEditor, CodeEditor, VirtualList, VersionCapsule |
-| [Effects](/docs/dev/components/glass-surface) | GlassSurface, GradientBorder, BorderBeam, GradualBlur, GlowText, Transition, Liquid |
-| [Primitives](/docs/dev/components/base-surface) | BaseSurface, BaseAnchor, Floating, AutoSizer, ResizeBox |
+Every component in the suite, grouped by category. The list is read from each doc's `category` frontmatter, so new components appear on their own.
 
-The full inventory with every link lives in the [component hub](/docs/dev/components/index) under "Pro".
+::DocsSuiteCatalog{suite="pro"}
+::
+

--- a/apps/nexus/content/docs/dev/components/pro-suite.zh.mdc
+++ b/apps/nexus/content/docs/dev/components/pro-suite.zh.mdc
@@ -22,10 +22,8 @@ verified: false
 
 ## 分组一览
 
-| 分组 | 覆盖 |
-|------|------|
-| [高级交互](/docs/dev/components/command-palette) | CommandPalette、SearchPanel、MarkdownEditor、CodeEditor、VirtualList、VersionCapsule |
-| [视觉效果](/docs/dev/components/glass-surface) | GlassSurface、GradientBorder、BorderBeam、GradualBlur、GlowText、Transition、Liquid |
-| [底层原语](/docs/dev/components/base-surface) | BaseSurface、BaseAnchor、Floating、AutoSizer、ResizeBox |
+下面按分组列出该套件的**全部**组件，数据来自每个文档的 `category` frontmatter，新增组件会自动出现。
 
-完整清单与全部链接见《[组件中心](/docs/dev/components/index)》的「进阶套件」分节。
+::DocsSuiteCatalog{suite="pro"}
+::
+

--- a/apps/nexus/i18n/locales/en.ts
+++ b/apps/nexus/i18n/locales/en.ts
@@ -598,5 +598,8 @@ export default {
       avatarBasic: 'Basic Avatar',
     },
   },
+  docsSuiteCatalog: {
+    total: '{count} components across {groups} groups',
+  },
   ...legal,
 }

--- a/apps/nexus/i18n/locales/zh.ts
+++ b/apps/nexus/i18n/locales/zh.ts
@@ -597,5 +597,8 @@ export default {
       avatarBasic: '基础头像',
     },
   },
+  docsSuiteCatalog: {
+    total: '共 {count} 个组件，分为 {groups} 个分组',
+  },
   ...legal,
 }


### PR DESCRIPTION
## What

Each suite overview page now lists **every** component in its categories, instead of a hand-written sample.

The "groups at a glance" table named ~55 of the base suite's 91 components and pointed at the hub for the rest. Nothing kept it current, so it drifted every time a component doc landed.

`::DocsSuiteCatalog{suite="..."}` reads the same `/api/docs/sidebar-components` feed the sidebar uses and groups by the `category` frontmatter every doc already declares — so the list is exhaustive by construction and new docs appear on their own.

| suite | before (sample) | after (complete) |
| --- | --- | --- |
| base | ~55 names, 7 groups | **91**, 7 groups |
| pro | ~18 names, 3 groups | **27**, 3 groups |
| ai | prose paragraph | **29**, 4 groups |
| data | — | **10**, 2 groups |

Counts match the frontmatter inventory exactly (`grep -h '^category:' content/docs/dev/components/*.zh.mdc | sort | uniq -c`).

## One source of truth

The suite → category taxonomy moves out of `DocsSidebar.vue` into `app/utils/docs-suites.ts`. The sidebar now builds its groups from that shared order too, so the sidebar and the catalogs cannot list different components. Adding a category means touching the three maps in that one file.

## Placement

- **base / pro** — the sample table is replaced in place.
- **ai** — added alongside the existing BUI provenance table, which maps the 19 upstream cases to components and is a different kind of index, not a category listing.
- **charts** — doubles as the data suite overview (same as in the sidebar's `standalonePages`).
- **concepts** — has no category groups; its pages are standalone links, so it keeps its current shape.

## Notes

- The fetch is client-only and lazy, mirroring the sidebar: docs pages prerender and the content table is not reliably queryable at that point. Loading renders a skeleton that mirrors the loaded layout, per the frontend spec's default for anything that waits on data.
- Sorted alphabetically within a group rather than following the sidebar's curated `SECTION_ORDER` — this list exists to be exhaustive and scannable, and alphabetical stays correct as docs are added without a second ordered list to maintain.

## Verification

- Loaded all four pages headless and counted the hydrated DOM: 91 / 27 / 29 / 10 components across 7 / 3 / 4 / 2 groups, with the group labels and totals rendering in both locales.
- Confirmed the sidebar still renders all seven base groups and all five suite tabs after the taxonomy refactor.
- `nuxt typecheck` **0 errors**; eslint clean; `check:doc-parity` / `check:mdc-fences` / `check:demo-registry` pass. All eight `::DocsSuiteCatalog` placements land at identical line numbers in the zh and en files.