### PR TITLE
fix(clipboard): restore original image previews

### DIFF
--- a/.trellis/spec/frontend/native-resource-protocols.md
+++ b/.trellis/spec/frontend/native-resource-protocols.md
@@ -296,6 +296,7 @@ system.resolveApplication(identifier: string): Promise<ResolvedApplication | nul
 ### 3. Contracts
 
 - A plugin manifest declares and receives `fs.tfile` before its view may request any `tfile:` URL. `isPluginViewResourceAllowed()` checks the current plugin id/sdkapi grant on every request; a grant captured only when the view is created is stale after revocation.
+- Every isolated plugin `WebContentsView` session installs the same bounded `tfile:` protocol handler before loading resources and unregisters it when the owning view is destroyed. Session registration reuses the main protocol's canonical parsing and configured managed-temp roots; it never creates a second path policy.
 - The view policy is only the control-plane gate. The `tfile` protocol still canonicalizes the path and applies `getAllowedLocalFileRoots()`; permission never widens the protocol allowlist.
 - Installed-application lookup requires `sdkapi >= 260817`, verified plugin identity, and `system.applications`. The handler accepts one trimmed exact identifier of at most 512 characters and delegates to AppProvider's exact path/bundle-id lookup.
 - AppProvider owns icon cache repair and hydration. The response contains only bounded `identifier`, `displayName`, and `icon`; it never includes executable/native paths, file records, Buffer/base64 data, launch arguments, or search-index internals.

--- a/apps/core-app/src/main/modules/file-protocol/index.ts
+++ b/apps/core-app/src/main/modules/file-protocol/index.ts
@@ -1,116 +1,24 @@
 import type { MaybePromise, ModuleKey } from '@talex-touch/utils'
-import url from 'node:url'
-import { net, session } from 'electron'
-import { normalizeAbsolutePath } from '@talex-touch/utils/common/utils/safe-path'
-import { FILE_SCHEMA } from '../../config/default'
+import { session } from 'electron'
 import { tempFileService } from '../../service/temp-file.service'
-import {
-  getAllowedLocalFileRoots,
-  isAllowedLocalFilePath,
-  normalizeDarwinUsersPath
-} from '../../utils/local-file-policy'
 import { createLogger } from '../../utils/logger'
 import { BaseModule } from '../abstract-base-module'
+import {
+  clearTfileProtocolLogState,
+  configureTfileProtocolAdditionalAllowedRoots,
+  registerTfileProtocolForSession
+} from './tfile-session'
 
-/**
- * Deduplicate error logs -- only log each failing path once, up to a bound.
- *
- * Bounded because the inputs are not: a view rendering thumbnails over a churning result set --
- * clipboard history whose temp files have been deleted, or a plugin emitting unique tfile URLs --
- * contributes one retained string per distinct missing path, for the lifetime of a launcher
- * process that is expected to run for days (#647).
- *
- * Insertion-ordered eviction rather than a true LRU: this only decides whether a warning repeats,
- * so the cheapest bound that keeps recent paths quiet is the right one.
- */
-const LOGGED_ERROR_PATH_LIMIT = 512
-const loggedErrorPaths = new Set<string>()
+export { __test__, registerTfileProtocolForSession } from './tfile-session'
 
-/** Records a path and reports whether it is newly seen, evicting the oldest entry past the cap. */
-function shouldLogPathOnce(filePath: string): boolean {
-  if (loggedErrorPaths.has(filePath)) return false
-
-  if (loggedErrorPaths.size >= LOGGED_ERROR_PATH_LIMIT) {
-    const oldest = loggedErrorPaths.values().next().value
-    if (oldest !== undefined) loggedErrorPaths.delete(oldest)
-  }
-
-  loggedErrorPaths.add(filePath)
-  return true
-}
 const fileProtocolLog = createLogger('FileProtocolModule')
-
-/**
- * Extract an absolute file path from a `tfile` URL.
- *
- * Electron may hand custom standard-scheme requests back as host-style URLs
- * such as `tfile://users/name/file.png` even when renderer code originally
- * assigned `tfile:///Users/name/file.png`. We normalize both shapes here and
- * keep the actual file access guarded by the local file allowlist below.
- */
-function extractAbsolutePath(rawUrl: string): string | null {
-  const normalizeDecodedPath = (value: string): string => {
-    const normalized = value.replace(/\\/g, '/')
-    if (/^\/[a-z]:\//i.test(normalized)) {
-      return normalized.slice(1)
-    }
-    if (/^[a-z]:\//i.test(normalized)) {
-      return normalized
-    }
-    return normalized.startsWith('/') ? normalized : `/${normalized}`
-  }
-
-  const decodeStable = (value: string): string => {
-    let decoded = value
-    for (let i = 0; i < 3; i++) {
-      try {
-        const next = decodeURIComponent(decoded)
-        if (next === decoded) break
-        decoded = next
-      } catch {
-        break
-      }
-    }
-    return decoded
-  }
-
-  const prefix = `${FILE_SCHEMA}://`
-  if (rawUrl.startsWith(prefix)) {
-    const rawWithTail = rawUrl.slice(prefix.length)
-    const tailIndex = rawWithTail.search(/[?#]/)
-    const body = tailIndex >= 0 ? rawWithTail.slice(0, tailIndex) : rawWithTail
-    if (!body) {
-      return null
-    }
-    return normalizeDecodedPath(decodeStable(body))
-  }
-
-  try {
-    const parsed = new URL(rawUrl)
-    if (parsed.protocol !== `${FILE_SCHEMA}:`) {
-      return null
-    }
-    const merged = parsed.hostname
-      ? /^[a-z]$/i.test(parsed.hostname) && parsed.pathname.startsWith('/')
-        ? `${parsed.hostname}:${parsed.pathname}`
-        : `/${parsed.hostname}${parsed.pathname}`
-      : parsed.pathname
-    return normalizeDecodedPath(decodeStable(merged))
-  } catch {
-    return null
-  }
-}
-
-export const __test__ = {
-  shouldLogPathOnce,
-  loggedErrorPaths,
-  LOGGED_ERROR_PATH_LIMIT,
-  extractAbsolutePath
-}
 
 class FileProtocolModule extends BaseModule {
   static key: symbol = Symbol.for('FileProtocolModule')
   name: ModuleKey = FileProtocolModule.key
+
+  private releaseConfiguredRoots: (() => void) | null = null
+  private releaseProtocol: (() => void) | null = null
 
   constructor() {
     super(FileProtocolModule.key, {
@@ -119,53 +27,19 @@ class FileProtocolModule extends BaseModule {
   }
 
   onInit(): MaybePromise<void> {
-    const ses = session.defaultSession
-    const allowedRoots = [...getAllowedLocalFileRoots(), tempFileService.getBaseDir()]
-
-    ses.protocol.handle(FILE_SCHEMA, async (request) => {
-      const extractedPath = extractAbsolutePath(request.url)
-      if (!extractedPath) {
-        fileProtocolLog.warn('Rejected non-canonical tfile URL', {
-          meta: {
-            requestUrl: request.url
-          }
-        })
-        return new Response('Bad Request', { status: 400 })
-      }
-      const filePath = normalizeDarwinUsersPath(extractedPath)
-      const normalizedPath = normalizeAbsolutePath(filePath)
-      if (!normalizedPath || !isAllowedLocalFilePath(normalizedPath, allowedRoots)) {
-        if (shouldLogPathOnce(filePath)) {
-          fileProtocolLog.warn(`Blocked path: ${filePath}`)
-        }
-        return new Response('Forbidden', { status: 403 })
-      }
-
-      const fileUrl = url.pathToFileURL(normalizedPath).toString()
-
-      try {
-        return await net.fetch(fileUrl, { bypassCustomProtocolHandlers: true })
-      } catch (error) {
-        if (shouldLogPathOnce(normalizedPath)) {
-          fileProtocolLog.error('tfile request error', {
-            meta: {
-              filePath: normalizedPath,
-              fileUrl,
-              url: request.url
-            },
-            error: error instanceof Error ? error.message : String(error)
-          })
-        }
-        return new Response('File not found', { status: 404 })
-      }
-    })
-
+    this.releaseConfiguredRoots = configureTfileProtocolAdditionalAllowedRoots([
+      tempFileService.getBaseDir()
+    ])
+    this.releaseProtocol = registerTfileProtocolForSession(session.defaultSession)
     fileProtocolLog.info('tfile protocol registered')
   }
 
   onDestroy(): MaybePromise<void> {
-    session.defaultSession.protocol.unhandle(FILE_SCHEMA)
-    loggedErrorPaths.clear()
+    this.releaseProtocol?.()
+    this.releaseProtocol = null
+    this.releaseConfiguredRoots?.()
+    this.releaseConfiguredRoots = null
+    clearTfileProtocolLogState()
   }
 }
 

--- a/apps/core-app/src/main/modules/file-protocol/tfile-session.ts
+++ b/apps/core-app/src/main/modules/file-protocol/tfile-session.ts
@@ -1,0 +1,178 @@
+import url from 'node:url'
+import { normalizeAbsolutePath } from '@talex-touch/utils/common/utils/safe-path'
+import { net } from 'electron'
+import { FILE_SCHEMA } from '../../config/default'
+import {
+  getAllowedLocalFileRoots,
+  isAllowedLocalFilePath,
+  normalizeDarwinUsersPath
+} from '../../utils/local-file-policy'
+import { createLogger } from '../../utils/logger'
+
+/**
+ * Deduplicate error logs -- only log each failing path once, up to a bound.
+ *
+ * Bounded because the inputs are not: a view rendering thumbnails over a churning result set --
+ * clipboard history whose temp files have been deleted, or a plugin emitting unique tfile URLs --
+ * contributes one retained string per distinct missing path, for the lifetime of a launcher
+ * process that is expected to run for days (#647).
+ *
+ * Insertion-ordered eviction rather than a true LRU: this only decides whether a warning repeats,
+ * so the cheapest bound that keeps recent paths quiet is the right one.
+ */
+const LOGGED_ERROR_PATH_LIMIT = 512
+const loggedErrorPaths = new Set<string>()
+
+/** Records a path and reports whether it is newly seen, evicting the oldest entry past the cap. */
+function shouldLogPathOnce(filePath: string): boolean {
+  if (loggedErrorPaths.has(filePath)) return false
+
+  if (loggedErrorPaths.size >= LOGGED_ERROR_PATH_LIMIT) {
+    const oldest = loggedErrorPaths.values().next().value
+    if (oldest !== undefined) loggedErrorPaths.delete(oldest)
+  }
+
+  loggedErrorPaths.add(filePath)
+  return true
+}
+const fileProtocolLog = createLogger('FileProtocolModule')
+
+/**
+ * Extract an absolute file path from a `tfile` URL.
+ *
+ * Electron may hand custom standard-scheme requests back as host-style URLs
+ * such as `tfile://users/name/file.png` even when renderer code originally
+ * assigned `tfile:///Users/name/file.png`. We normalize both shapes here and
+ * keep the actual file access guarded by the local file allowlist below.
+ */
+function extractAbsolutePath(rawUrl: string): string | null {
+  const normalizeDecodedPath = (value: string): string => {
+    const normalized = value.replace(/\\/g, '/')
+    if (/^\/[a-z]:\//i.test(normalized)) {
+      return normalized.slice(1)
+    }
+    if (/^[a-z]:\//i.test(normalized)) {
+      return normalized
+    }
+    return normalized.startsWith('/') ? normalized : `/${normalized}`
+  }
+
+  const decodeStable = (value: string): string => {
+    let decoded = value
+    for (let i = 0; i < 3; i++) {
+      try {
+        const next = decodeURIComponent(decoded)
+        if (next === decoded) break
+        decoded = next
+      } catch {
+        break
+      }
+    }
+    return decoded
+  }
+
+  const prefix = `${FILE_SCHEMA}://`
+  if (rawUrl.startsWith(prefix)) {
+    const rawWithTail = rawUrl.slice(prefix.length)
+    const tailIndex = rawWithTail.search(/[?#]/)
+    const body = tailIndex >= 0 ? rawWithTail.slice(0, tailIndex) : rawWithTail
+    if (!body) {
+      return null
+    }
+    return normalizeDecodedPath(decodeStable(body))
+  }
+
+  try {
+    const parsed = new URL(rawUrl)
+    if (parsed.protocol !== `${FILE_SCHEMA}:`) {
+      return null
+    }
+    const merged = parsed.hostname
+      ? /^[a-z]$/i.test(parsed.hostname) && parsed.pathname.startsWith('/')
+        ? `${parsed.hostname}:${parsed.pathname}`
+        : `/${parsed.hostname}${parsed.pathname}`
+      : parsed.pathname
+    return normalizeDecodedPath(decodeStable(merged))
+  } catch {
+    return null
+  }
+}
+
+export const __test__ = {
+  shouldLogPathOnce,
+  loggedErrorPaths,
+  LOGGED_ERROR_PATH_LIMIT,
+  extractAbsolutePath
+}
+
+export function clearTfileProtocolLogState(): void {
+  loggedErrorPaths.clear()
+}
+
+let configuredAdditionalAllowedRoots: string[] = []
+
+export function configureTfileProtocolAdditionalAllowedRoots(roots: string[]): () => void {
+  const configuredRoots = roots.filter((root) => typeof root === 'string' && root.length > 0)
+  configuredAdditionalAllowedRoots = configuredRoots
+
+  return () => {
+    if (configuredAdditionalAllowedRoots === configuredRoots) {
+      configuredAdditionalAllowedRoots = []
+    }
+  }
+}
+
+export function registerTfileProtocolForSession(
+  targetSession: Electron.Session,
+  additionalAllowedRoots: string[] = []
+): () => void {
+  const allowedRoots = [
+    ...getAllowedLocalFileRoots(),
+    ...configuredAdditionalAllowedRoots,
+    ...additionalAllowedRoots
+  ]
+  targetSession.protocol.handle(FILE_SCHEMA, async (request) => {
+    const extractedPath = extractAbsolutePath(request.url)
+    if (!extractedPath) {
+      fileProtocolLog.warn('Rejected non-canonical tfile URL', {
+        meta: {
+          requestUrl: request.url
+        }
+      })
+      return new Response('Bad Request', { status: 400 })
+    }
+    const filePath = normalizeDarwinUsersPath(extractedPath)
+    const normalizedPath = normalizeAbsolutePath(filePath)
+    if (!normalizedPath || !isAllowedLocalFilePath(normalizedPath, allowedRoots)) {
+      if (shouldLogPathOnce(filePath)) {
+        fileProtocolLog.warn(`Blocked path: ${filePath}`)
+      }
+      return new Response('Forbidden', { status: 403 })
+    }
+
+    const fileUrl = url.pathToFileURL(normalizedPath).toString()
+
+    try {
+      return await net.fetch(fileUrl, { bypassCustomProtocolHandlers: true })
+    } catch (error) {
+      if (shouldLogPathOnce(normalizedPath)) {
+        fileProtocolLog.error('tfile request error', {
+          meta: {
+            filePath: normalizedPath,
+            fileUrl,
+            url: request.url
+          },
+          error: error instanceof Error ? error.message : String(error)
+        })
+      }
+      return new Response('File not found', { status: 404 })
+    }
+  })
+
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    targetSession.protocol.unhandle(FILE_SCHEMA)
+  }
+}

--- a/apps/core-app/src/main/modules/plugin/runtime/plugin-window-policy.ts
+++ b/apps/core-app/src/main/modules/plugin/runtime/plugin-window-policy.ts
@@ -7,6 +7,7 @@ import type {
   PluginWindowNewRequest,
   PluginWindowOptions
 } from '@talex-touch/utils/transport/events/types'
+import { registerTfileProtocolForSession } from '../../file-protocol/tfile-session'
 import { PluginViewCompatibilityError } from './plugin-view-security-profile'
 import { getPermissionModule } from '../../permission/permission-module-ref'
 import fs from 'node:fs/promises'
@@ -574,6 +575,10 @@ export function installPluginViewNavigationPolicy(
   })
 
   const pluginSession = webContents.session
+  const releaseTfileProtocol =
+    typeof pluginSession.protocol?.handle === 'function'
+      ? registerTfileProtocolForSession(pluginSession)
+      : null
   pluginSession.setPermissionCheckHandler(() => false)
   pluginSession.setPermissionRequestHandler((_requestingWebContents, _permission, callback) => {
     callback(false)
@@ -588,6 +593,7 @@ export function installPluginViewNavigationPolicy(
   }
   pluginSession.on('will-download', denyDownload)
   webContents.once('destroyed', () => {
+    releaseTfileProtocol?.()
     pluginSession.removeListener('will-download', denyDownload)
   })
 }

--- a/plugins/clipboard-history/src/components/ClipboardDetail.vue
+++ b/plugins/clipboard-history/src/components/ClipboardDetail.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type { PluginClipboardItem } from '@talex-touch/utils/plugin/sdk/types'
 import type { ResolvedApplication } from '@talex-touch/utils/transport/events/types'
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import ClipboardGlyph from './ClipboardGlyph.vue'
 import {
   getClipboardColorTokens,
@@ -30,6 +30,10 @@ const textInsight = computed(() => getClipboardTextInsight(props.item))
 const colorTokens = computed(() => getClipboardColorTokens(props.item))
 const ocrInsight = computed(() => getClipboardOcrInsight(props.item))
 const failedImageSources = ref<ReadonlySet<string>>(new Set())
+const retriedImageSources = ref<ReadonlySet<string>>(new Set())
+const imageRetryNonce = ref(0)
+let imageRetryTimer: ReturnType<typeof setTimeout> | null = null
+
 const imagePreview = computed(() => {
   const primary = resolveDetailImagePreview(props.item, props.resolvedImageUrl)
   if (!primary.src || !failedImageSources.value.has(primary.src)) {
@@ -43,17 +47,42 @@ const imagePreview = computed(() => {
   }
 })
 
-watch(
-  () => props.item?.id,
-  () => {
-    failedImageSources.value = new Set()
-  },
-)
+function resetImageFailureState(): void {
+  if (imageRetryTimer) {
+    clearTimeout(imageRetryTimer)
+    imageRetryTimer = null
+  }
+  failedImageSources.value = new Set()
+  retriedImageSources.value = new Set()
+  imageRetryNonce.value += 1
+}
+
+watch([() => props.item?.id, () => props.resolvedImageUrl], resetImageFailureState)
+
+onBeforeUnmount(() => {
+  if (imageRetryTimer) {
+    clearTimeout(imageRetryTimer)
+  }
+})
 
 function handleImageError(): void {
-  const failedSource = imagePreview.value.src
+  const failedPreview = imagePreview.value
+  const failedSource = failedPreview.src
   if (!failedSource) return
+
   failedImageSources.value = new Set([...failedImageSources.value, failedSource])
+  if (failedPreview.isThumbnailOnly || retriedImageSources.value.has(failedSource)) {
+    return
+  }
+
+  retriedImageSources.value = new Set([...retriedImageSources.value, failedSource])
+  imageRetryTimer = setTimeout(() => {
+    failedImageSources.value = new Set(
+      [...failedImageSources.value].filter(source => source !== failedSource),
+    )
+    imageRetryNonce.value += 1
+    imageRetryTimer = null
+  }, 160)
 }
 
 function handleSourceIconError(event: Event): void {
@@ -78,6 +107,7 @@ function handleSourceIconError(event: Event): void {
       <template v-else-if="item.type === 'image' && imagePreview.src">
         <div class="image-container">
           <img
+            :key="imageRetryNonce"
             :src="imagePreview.src || undefined"
             :alt="getClipboardTitle(item)"
             class="preview-img"

--- a/plugins/clipboard-history/src/views/ClipboardManagerView.test.ts
+++ b/plugins/clipboard-history/src/views/ClipboardManagerView.test.ts
@@ -24,7 +24,7 @@ const sdkMocks = vi.hoisted(() => ({
   },
   box: {
     expand: vi.fn(),
-    getInput: vi.fn(),
+    setInput: vi.fn(),
   },
 }))
 
@@ -60,7 +60,7 @@ describe('clipboardManagerView', () => {
     sdkMocks.clipboard.history.setFavorite.mockResolvedValue(undefined)
     sdkMocks.clipboard.history.deleteItem.mockResolvedValue(undefined)
     sdkMocks.box.expand.mockResolvedValue(undefined)
-    sdkMocks.box.getInput.mockResolvedValue('')
+    sdkMocks.box.setInput.mockResolvedValue(undefined)
     sdkMocks.feature.onInputChange.mockReturnValue(vi.fn())
     sdkMocks.system.resolveApplication.mockResolvedValue(null)
   })

--- a/plugins/clipboard-history/src/views/ClipboardManagerView.vue
+++ b/plugins/clipboard-history/src/views/ClipboardManagerView.vue
@@ -45,6 +45,7 @@ const resolvingSourceApplicationIds = reactive(new Set<string>())
 let unsubscribeClipboard: (() => void) | null = null
 let unsubscribeInput: (() => void) | null = null
 let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null
+let aliasClearRetryTimer: ReturnType<typeof setTimeout> | null = null
 let requestGeneration = 0
 
 const SEARCH_DEBOUNCE_MS = 180
@@ -246,7 +247,14 @@ function handleKeydown(event: KeyboardEvent): void {
   }
 }
 
+function clearAliasInput(): void {
+  void box.setInput('').catch(() => {})
+}
+
 function queueSearch(input: string): void {
+  if (input === searchQuery.value) {
+    return
+  }
   searchQuery.value = input
   requestGeneration += 1
   if (searchDebounceTimer) {
@@ -421,19 +429,14 @@ async function handleDelete(): Promise<void> {
 
 onMounted(async () => {
   document.addEventListener('keydown', handleKeydown, true)
-  void box.expand({ forceMax: true }).catch(() => {})
+  await box.expand({ forceMax: true }).catch(() => {})
+  searchQuery.value = ''
+  debouncedQuery.value = ''
   unsubscribeInput = feature.onInputChange(queueSearch)
 
-  try {
-    const initialQuery = await box.getInput()
-    searchQuery.value = initialQuery
-    debouncedQuery.value = initialQuery.trim()
-  } catch {
-    searchQuery.value = ''
-    debouncedQuery.value = ''
-  }
-
   await loadHistory({ reset: true })
+  clearAliasInput()
+  aliasClearRetryTimer = setTimeout(clearAliasInput, 250)
   unsubscribeClipboard = clipboard.history.onDidChange(async () => {
     await loadHistory({ reset: true })
   })
@@ -441,6 +444,9 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', handleKeydown, true)
+  if (aliasClearRetryTimer) {
+    clearTimeout(aliasClearRetryTimer)
+  }
   if (searchDebounceTimer) {
     clearTimeout(searchDebounceTimer)
   }


### PR DESCRIPTION
## Summary
- clear CoreBox alias input after Clipboard History opens
- register the shared `tfile:` handler in isolated plugin view sessions without weakening live permission or path gates
- retry transient original-image failures while preserving thumbnail fallback
- preserve and verify the existing macOS Vision OCR metadata/display flow

## Verification
- `pnpm --filter @talex-touch/clipboard-history-plugin test`
- `pnpm --filter @talex-touch/clipboard-history-plugin typecheck`
- `pnpm --filter @talex-touch/core-app exec vitest run src/main/modules/file-protocol/index.test.ts src/main/modules/plugin/runtime/plugin-window-policy.test.ts`
- `pnpm --filter @talex-touch/core-app typecheck:node`
- real Electron CDP smoke: alias input empty, original `tfile:` response 200, preview 1830x1596, no thumbnail badge
- OCR record 1911 completed in one attempt; result confidence 91.25% and visible OCR detail


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image previews with automatic retry when loading fails.
  * Clipboard search now starts with a clean input and reliably clears stale input values.
  * Improved loading of permitted temporary files in isolated plugin views.

* **Documentation**
  * Documented consistent permission handling for file resources across plugin views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->