### PR TITLE
fix(nexus): split the preview bar and mark the version green

### DIFF
--- a/apps/nexus/app/components/docs/DocsComponentsGallery.vue
+++ b/apps/nexus/app/components/docs/DocsComponentsGallery.vue
@@ -937,7 +937,8 @@ function scrollToSuite(key: string) {
 .docs-gallery__bar {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  /* Install command anchors the left edge, version the right. */
+  justify-content: space-between;
   gap: 10px;
   padding: 12px 18px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -945,11 +946,21 @@ function scrollToSuite(key: string) {
   color: var(--docs-muted);
 }
 
+/* Green marks the published version as the healthy/current one, and separates
+   it from the neutral install command sharing the bar.
+
+   `--tx-color-success` is the same #67c23a in both themes, which is only
+   ~2.2:1 as 12px text on a light page. Mixing toward the body text color
+   darkens it under light and lightens it under dark from one declaration —
+   this style block is scoped, and `:global(.dark)` is dropped at compile time
+   here, so a theme selector is not an option. Measured at this ratio:
+   4.66:1 on white, 10.97:1 on the dark page. */
 .docs-gallery__version {
   padding: 2px 7px;
   border-radius: 6px;
-  border: 1px solid var(--docs-inline-code-border);
-  background: var(--docs-inline-code-bg);
+  border: 1px solid color-mix(in srgb, var(--tx-color-success) 40%, transparent);
+  background: color-mix(in srgb, var(--tx-color-success) 12%, transparent);
+  color: color-mix(in srgb, var(--tx-color-success) 55%, var(--tx-text-color-primary));
   line-height: 1.4;
 }
 


### PR DESCRIPTION
## What

The component gallery's header packed the install command and the version badge together against the right edge, leaving the whole left half of the bar empty.

- Install command anchors the **left**, version the **right** (`justify-content: space-between`).
- The version badge reads **green** — it marks the published/current version and separates it from the neutral install command sharing the bar.

Before / after, same bar:

```
before:                        [ $ pnpm add @talex-touch/tuffex ⧉ ] [v0.3.9]
after:   [ $ pnpm add @talex-touch/tuffex ⧉ ]                       [v0.3.9]  ← green
```

## Contrast

`--tx-color-success` is the same `#67c23a` under both themes — only ~2.2:1 as 12px text on a light page, well under the 4.5:1 normal-text bar.

The badge text mixes it toward `--tx-text-color-primary` instead, which darkens under light and lightens under dark from a single declaration. Measured in a browser (letting it compute the `color-mix`, then sampling): **4.66:1 on white**, **10.97:1 on the dark page**.

A theme selector was not an option here: the style block is scoped, and `:global(.dark)` is dropped at compile time in this repo.

## Scope

`DocsComponentsGallery` renders on the components hub plus the base and pro suite overviews, so all six pages (zh + en) pick this up from the one change.

## Verification

- Rendered the bar headless on `base-suite` and confirmed the split layout and the green badge.
- eslint clean; `nuxt typecheck` **0 errors**.

## Note

This file is being edited concurrently by another session (adding `loading` specimens to the gallery). This commit contains **only** the two style hunks — the other session's five hunks were left unstaged and untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the documentation gallery header layout for clearer separation between the install command and version badge.
  * Updated the version badge with a success-themed color treatment and improved contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->