### PR TITLE
release: publish the six packages on their Node 26 floor

### DIFF
--- a/packages/tuff-cli/package.json
+++ b/packages/tuff-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@talex-touch/tuff-cli",
   "type": "module",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Tuff CLI entrypoint",
   "license": "MIT",
   "keywords": [

--- a/packages/tuff-core/package.json
+++ b/packages/tuff-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@talex-touch/tuff-core",
   "type": "module",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Low-level build and publish primitives for Tuff",
   "license": "MIT",
   "keywords": [

--- a/packages/tuff-intelligence/package.json
+++ b/packages/tuff-intelligence/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@talex-touch/tuff-intelligence",
   "type": "module",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "LangGraph-powered intelligence orchestration for Tuff (providers, prompts, quotas, audit)",
   "license": "MIT",
   "keywords": [

--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/tuffex",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "engines": {
     "node": ">=26.0.0"
   },

--- a/packages/unplugin-export-plugin/package.json
+++ b/packages/unplugin-export-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@talex-touch/unplugin-export-plugin",
   "type": "module",
-  "version": "1.2.16",
+  "version": "2.0.0",
   "description": "Export unplugin for talex-touch",
   "license": "MIT",
   "homepage": "https://github.com/talex-touch/unplugin-export-plugin#readme",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/utils",
-  "version": "1.0.50",
+  "version": "2.0.0",
   "private": false,
   "description": "Tuff series utils",
   "author": "TalexDreamSoul",


### PR DESCRIPTION
| package | from | to |
| --- | --- | --- |
| `@talex-touch/utils` | 1.0.50 | **2.0.0** |
| `@talex-touch/unplugin-export-plugin` | 1.2.16 | **2.0.0** |
| `@talex-touch/tuffex` | 0.3.9 | **0.4.0** |
| `@talex-touch/tuff-core` | 0.0.1 | **0.1.0** |
| `@talex-touch/tuff-cli` | 0.0.7 | **0.1.0** |
| `@talex-touch/tuff-intelligence` | 0.0.2 | **0.1.0** |

Merging lands the version change on master, which is what triggers each `package-*-publish.yml`.

## Why none of these is a patch

#1839 raised `engines.node` from `>=24.15.0` to `>=26.0.0` on every published package. That is a consumer contract: anyone installing these on Node 24 is refused by the new floor. The two 1.x packages take a major; the 0.x ones take a minor, which is the only signal a pre-1.0 version has for a break.

## ⚠️ `ci / CI - tuffex` is red here, and is expected to be

Its `audit:types` step packs tuffex and installs the tarball into a scratch project against the **real registry**. `pnpm pack` rewrites `workspace:^` using the workspace's current utils version, so the packed manifest asks for `@talex-touch/utils@^2.0.0` before that exists on npm.

I tried splitting this into two waves (leaf packages first) and it does not help: the rewrite follows the *workspace* version of utils, not tuffex's own, so tuffex's audit fails the moment utils is bumped regardless of whether tuffex is. `waitForPackages` in the publish config already sequences utils ahead of tuffex at publish time, and the audit goes green once utils is on npm.

It is not one of the required checks. All seven required checks pass.

## Also worth knowing

`node-pty` fails its native rebuild intermittently on Node 26 — `gyp_main.py: Permission denied`, make Error 126 — because the new ABI forces a source build and pnpm's bundled node-gyp has a non-executable gyp script in the store. It hit `ci / CI - utils` and `ci / CI - tuffex` on an earlier push here and cleared on re-run. npm only has `node-pty@1.2.0-beta.*` above the pinned 1.1.0, so this wants either a CI-side node-gyp fix or a considered move to a prerelease native module — worth its own issue rather than a rushed dependency bump.

## Checks

- `scripts/validate-publish-manifests.mjs` passes for all six
- Inter-package dependencies are `workspace:` ranges and needed no edit
- `scripts/publish-package.mjs` skips any package whose version already exists on npm, so nothing here can double-publish