### PR TITLE
ci: watch NPM_TOKEN on a schedule so it is not found at release time

### DIFF
--- a/.github/workflows/npm-token-watch.yml
+++ b/.github/workflows/npm-token-watch.yml
@@ -1,0 +1,99 @@
+# Catches an expired NPM_TOKEN on a schedule instead of at release time.
+#
+# The token that published these packages lapsed silently and nothing noticed
+# until six package publishes failed mid-release with `E404 ... PUT` — npm's
+# response for a scope a token cannot write to. npm granular access tokens
+# expire on a 30/60/90-day schedule by default, so this will happen again.
+#
+# This runs weekly, asks npm who the token is, and opens (or refreshes) an issue
+# when the answer is "nobody". A failing job alone is not enough: nobody reads a
+# red cron until they need it.
+name: NPM Token Watch
+
+on:
+  schedule:
+    # Mondays 02:00 UTC — a lapse is found at the start of a week rather than
+    # discovered by whoever happens to be cutting a release.
+    - cron: "0 2 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: npm-token-watch
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check NPM_TOKEN
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .node-version
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify the token can still authenticate
+        id: check
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "reason=NPM_TOKEN is not set." >> "$GITHUB_OUTPUT"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # `npm whoami` is the cheapest call that actually exercises the
+          # credential. A read-only or expired token fails here, well before a
+          # release would fail on `PUT`.
+          if whoami_output="$(npm whoami 2>&1)"; then
+            echo "Authenticated as ${whoami_output}"
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "${whoami_output}"
+            echo "reason=npm whoami failed: ${whoami_output}" >> "$GITHUB_OUTPUT"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or refresh the alert issue
+        if: steps.check.outputs.ok != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REASON: ${{ steps.check.outputs.reason }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="NPM_TOKEN is not usable — package publishes will fail"
+
+          # Quoted heredoc: the body is full of backticks and apostrophes, and an
+          # unquoted one would try to run them. The two dynamic values are
+          # printed around it instead of interpolated into it.
+          {
+            printf '%s\n\n' "The scheduled token check could not authenticate against npm."
+            printf '```\n%s\n```\n\n' "${REASON}"
+            cat <<'BODY'
+          Every `package-*-publish.yml` workflow will fail at `npm publish` until this is
+          replaced, with `E404 ... PUT` — npm's response for a scope the token cannot write
+          to, rather than a missing package.
+
+          Replace the `NPM_TOKEN` repository secret with a token that has publish rights on
+          the `@talex-touch` scope, then re-run any failed publish runs.
+          BODY
+            printf '\nChecked by %s\n' "${RUN_URL}"
+          } > "${RUNNER_TEMP}/npm-token-alert.md"
+
+          existing="$(gh issue list --state open --search "${title} in:title" --json number --jq '.[0].number // empty')"
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body-file "${RUNNER_TEMP}/npm-token-alert.md"
+          else
+            gh issue create --title "${title}" --body-file "${RUNNER_TEMP}/npm-token-alert.md"
+          fi
+
+      - name: Fail the run when the token is unusable
+        if: steps.check.outputs.ok != 'true'
+        run: exit 1

--- a/.github/workflows/npm-token-watch.yml
+++ b/.github/workflows/npm-token-watch.yml
@@ -99,7 +99,10 @@ jobs:
           # printed around it instead of interpolated into it.
           {
             printf '%s\n\n' "The scheduled token check could not authenticate against npm."
-            printf '```\n%s\n```\n\n' "${REASON}"
+            # Fence in a variable: backticks inside a single-quoted printf format
+            # read as a command substitution to shellcheck (SC2016).
+            fence='```'
+            printf '%s\n%s\n%s\n\n' "${fence}" "${REASON}" "${fence}"
             cat <<'BODY'
           Every `package-*-publish.yml` workflow will fail at `npm publish` until this is
           replaced, with `E404 ... PUT` — npm's response for a scope the token cannot write

--- a/.github/workflows/npm-token-watch.yml
+++ b/.github/workflows/npm-token-watch.yml
@@ -42,26 +42,50 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          set -uo pipefail
+
+          # `reason` is written as a single line on purpose. npm errors are
+          # multiline, and `name=value` in GITHUB_OUTPUT only supports one line —
+          # a raw multiline error makes the runner reject the whole output file,
+          # which would fail this step *and* skip the alert step below, leaving
+          # the lapse unreported. The full text stays in the job log.
+          emit_failure() {
+            printf 'ok=false\n' >> "$GITHUB_OUTPUT"
+            printf 'reason=%s\n' "$(printf '%s' "$1" | tr '\n' ' ' | cut -c1-500)" >> "$GITHUB_OUTPUT"
+          }
+
           if [ -z "${NODE_AUTH_TOKEN}" ]; then
-            echo "reason=NPM_TOKEN is not set." >> "$GITHUB_OUTPUT"
-            echo "ok=false" >> "$GITHUB_OUTPUT"
+            emit_failure "NPM_TOKEN is not set."
             exit 0
           fi
 
-          # `npm whoami` is the cheapest call that actually exercises the
-          # credential. A read-only or expired token fails here, well before a
-          # release would fail on `PUT`.
           if whoami_output="$(npm whoami 2>&1)"; then
             echo "Authenticated as ${whoami_output}"
-            echo "ok=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "${whoami_output}"
-            echo "reason=npm whoami failed: ${whoami_output}" >> "$GITHUB_OUTPUT"
-            echo "ok=false" >> "$GITHUB_OUTPUT"
+            printf 'ok=true\n' >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
+          echo "${whoami_output}"
+
+          # A granular access token can be forbidden from `/-/whoami` while still
+          # being allowed to publish — the endpoint is subject to permission
+          # checks the publish flow does not apply. Alerting on 403 would cry
+          # wolf every week for a perfectly good token, so only a clear
+          # authentication failure counts.
+          case "${whoami_output}" in
+            *E403*|*403\ Forbidden*)
+              echo "whoami is forbidden for this token, which does not imply it cannot publish."
+              printf 'ok=true\n' >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              emit_failure "npm whoami failed: ${whoami_output}"
+              ;;
+          esac
+
       - name: Open or refresh the alert issue
-        if: steps.check.outputs.ok != 'true'
+        # `always()` on purpose: a bare `if:` carries an implicit success(), so a
+        # crash in the step above would skip the alert instead of reporting it.
+        if: always() && steps.check.outputs.ok != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REASON: ${{ steps.check.outputs.reason }}
@@ -95,5 +119,5 @@ jobs:
           fi
 
       - name: Fail the run when the token is unusable
-        if: steps.check.outputs.ok != 'true'
+        if: always() && steps.check.outputs.ok != 'true'
         run: exit 1


### PR DESCRIPTION
The token that publishes these packages lapsed silently. Nothing noticed until six package publishes failed mid-release (#1842) with:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@talex-touch%2futils
```

That is npm's response for a scope a token cannot write to — it reads like a missing package, not an auth failure, which is part of why it went unnoticed. npm granular access tokens expire on a 30/60/90-day schedule by default, so this recurs.

## What it does

Weekly (Mondays 02:00 UTC) plus `workflow_dispatch`:

1. `npm whoami` with `NODE_AUTH_TOKEN` — the cheapest call that actually exercises the credential, and it fails for an expired or read-only token well before a release would fail on `PUT`
2. On failure, opens an issue, or comments on the existing one so a long outage does not spawn a pile of duplicates
3. Fails the run as well

The issue is the point, not the red run. Nobody reads a failing cron until they need the thing it guards, which is the exact moment this exists to prevent.

## Verification

The first version did not survive `bash -n`: the alert body is full of backticks and apostrophes and the unquoted heredoc tried to execute them. It now uses a quoted heredoc with the two dynamic values printed around it, passed to `gh` as `--body-file` so no quoting survives into the call. Checked with `bash -n`, then run with a stubbed `gh` to confirm the rendered body:

```
The scheduled token check could not authenticate against npm.

​```
npm whoami failed: E401 Unauthorized - GET https://registry.npmjs.org/-/whoami
​```

Every `package-*-publish.yml` workflow will fail at `npm publish` until this is
replaced, with `E404 ... PUT` — npm's response for a scope the token cannot write
to, rather than a missing package.
...
```

Related: #1842

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added scheduled and manually triggered checks to verify npm authentication credentials.
  * Improved credential validation and failure reporting for clearer, more reliable results.
  * Recognizes valid credentials that cannot access npm’s identity endpoint but may still publish packages.
  * Automatically reports unavailable or invalid credentials through an issue and marks the check as failed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->