### PR TITLE
feat(clipboard): classify copied credentials

### DIFF
--- a/.trellis/archive/tasks/clipboard-credential-labels-2026-09-03/check.jsonl
+++ b/.trellis/archive/tasks/clipboard-credential-labels-2026-09-03/check.jsonl
@@ -1,0 +1,1 @@
+{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. List candidates with `find .trellis/spec -name '*.md'` — note that `get_context.py --mode packages` reports layers only and omits spec/guides, which real manifests do cite. Delete this line once real entries are added."}

--- a/.trellis/archive/tasks/clipboard-credential-labels-2026-09-03/design.md
+++ b/.trellis/archive/tasks/clipboard-credential-labels-2026-09-03/design.md
@@ -1,0 +1,38 @@
+# Design — Clipboard credential and software labels
+
+## Data flow
+
+```text
+text capture ───────────────────────────────────────────┐
+                                                          ├─ detectClipboardTags → tags + tag_search_terms → Clipboard History UI/query
+clipboard image → host-owned system OCR → recognized text ┘
+```
+
+`apps/core-app/src/main/modules/clipboard-tagging.ts` remains the single classifier. It receives bounded text and returns ordered, non-secret labels plus search aliases. The capture pipeline persists both values as ordinary clipboard metadata. The host-owned OCR service invokes the same classifier after OCR succeeds and transactionally merges both arrays with existing metadata.
+
+Clipboard image jobs no longer pin a language hint to English. The native worker forwards no hint, allowing macOS Vision to use its installed/default recognition language behavior and Windows OCR to use the current user profile language behavior. Existing persisted jobs with an explicit historical language retain it.
+
+The Clipboard History plugin reads the existing `PluginClipboardItem.meta.tags` projection and formats labels locally; it receives no new transport payload and does not inspect raw credential formats.
+
+## Contracts
+
+- `ClipboardTag` remains the canonical union and order. Labels classify an observed format or explicit software mention; they do not establish validity, ownership, or application provenance.
+- Credential platform patterns require full, provider-specific prefixes and bounded character forms. Generic `sk_` is intentionally not classified without an unambiguous provider prefix.
+- WeChat classification requires `@wx`, `@wechat`, or `微信`; it emits the `wechat` tag and aliases `wx`, `wechat`, and `微信` for metadata keyword search.
+- OCR update merges `tags` and `tag_search_terms` set-wise with persisted metadata. OCR writes must not erase capture tags, source metadata, or OCR fields.
+- Only labels and aliases are added to `clipboard_history.metadata` and `clipboard_history_meta`; no derived credential value, prefix fragment, hash, logging field, or outbound request is introduced.
+
+## UI
+
+- List rows show a compact, bounded tag strip only when tags exist.
+- Detail view shows the same labels as read-only metadata.
+- Unknown future tags degrade to the tag string; historical no-tag records show no extra UI.
+
+## Verification
+
+- Detector cases: GitHub, npm, OpenAI, Stripe, Google, AWS, Slack, WeChat aliases, plus generic and ambiguous near-matches.
+- OCR persistence case: OCR tag/alias merge preserves capture tags and aliases.
+- Query case: clipboard metadata keyword matching reaches stored aliases.
+- New image/file jobs omit the English language pin; the worker preserves an absent hint.
+- Plugin helper/component case: known labels, unknown label, absent labels.
+- Focused Vitest, CoreApp node typecheck, plugin build, and `git diff --check`.

--- a/.trellis/archive/tasks/clipboard-credential-labels-2026-09-03/implement.jsonl
+++ b/.trellis/archive/tasks/clipboard-credential-labels-2026-09-03/implement.jsonl
@@ -1,0 +1,1 @@
+{"_example": "Fill with {\"file\": \"<path>\", \"reason\": \"<why>\"}. Put spec/research files only — no code paths. List candidates with `find .trellis/spec -name '*.md'` — note that `get_context.py --mode packages` reports layers only and omits spec/guides, which real manifests do cite. Delete this line once real entries are added."}

--- a/.trellis/archive/tasks/clipboard-credential-labels-2026-09-03/implement.md
+++ b/.trellis/archive/tasks/clipboard-credential-labels-2026-09-03/implement.md
@@ -1,0 +1,7 @@
+# Implementation — Clipboard credential and software labels
+
+1. Extend the shared detector with precise credential formats, explicit WeChat references, and a canonical metadata search-term projection.
+2. Persist tag aliases in clipboard capture, and merge both tags and aliases from OCR completion without overwriting retained metadata.
+3. Remove the forced English OCR hint for new clipboard image/file jobs so native OCR resolves system/profile languages; preserve explicit historical job hints.
+4. Add Clipboard History labels for WeChat and all credential classifications.
+5. Run focused tests, CoreApp node typecheck, plugin typecheck/build/validation, and whitespace validation.

--- a/.trellis/archive/tasks/clipboard-credential-labels-2026-09-03/prd.md
+++ b/.trellis/archive/tasks/clipboard-credential-labels-2026-09-03/prd.md
@@ -1,0 +1,26 @@
+# Clipboard credential and software labels
+
+## Goal
+
+Classify clipboard text and copy-source applications using the existing application semantic catalog; make classifications searchable and visible in Clipboard History; route image OCR by the Talex Touch app language before the operating-system language.
+
+## Requirements
+
+- Keep one local credential/software classifier. No network lookup or credential validation.
+- Preserve precise credential detection and software aliases in copied text.
+- Reuse the existing application semantic catalog for every detected source application rather than maintaining a second Clipboard-only list. Persist source aliases in metadata so the existing string query reaches all catalogued applications and their aliases.
+- OCR priority is Talex Touch's active locale (`zh-CN` → `zh-Hans`, `en-US` → `en-US`); no valid app locale means no hint, allowing platform OCR to select its user/system behavior.
+- Keep explicit language hints from historical persisted OCR jobs unchanged.
+- Persist only category names, aliases, and locale identifiers; never copy credentials into metadata or logs.
+
+## Acceptance Criteria
+
+- [ ] Clipboard source metadata stores the existing catalog's aliases for a matched source application, and Clipboard History keyword search reaches them through metadata.
+- [ ] Text `@wx`, `@wechat`, and `微信` classify consistently with source-app aliases.
+- [ ] New OCR jobs translate the Talex Touch app locale to native Vision/WinRT locale hints; no app locale leaves selection to the OS.
+- [ ] OCR tag and alias enrichment remains merge-safe.
+- [ ] Focused tests, CoreApp node typecheck, plugin build/validation pass.
+
+## Notes
+
+- Clipboard already records the active source app and queries metadata by keyword. The new source alias projection connects that durable source-app identity to the catalog already used by application search.

--- a/.trellis/archive/tasks/clipboard-credential-labels-2026-09-03/task.json
+++ b/.trellis/archive/tasks/clipboard-credential-labels-2026-09-03/task.json
@@ -1,0 +1,35 @@
+{
+  "id": "clipboard-credential-labels",
+  "name": "clipboard-credential-labels",
+  "title": "Clipboard credential platform labels",
+  "description": "Classify copied credentials and software references locally, enrich Clipboard History search metadata, and prioritize the application locale for new clipboard OCR jobs.",
+  "status": "completed",
+  "dev_type": "feature",
+  "scope": "apps/core-app, plugins/clipboard-history",
+  "package": "@talex-touch/core-app",
+  "priority": "P2",
+  "creator": "TalexDreamSoul",
+  "assignee": "TalexDreamSoul",
+  "createdAt": "2026-09-03",
+  "completedAt": "2026-09-03",
+  "branch": "release/clipboard-credential-labels-20260903",
+  "base_branch": "master",
+  "worktree_path": null,
+  "commit": "5d1a931da",
+  "pr_url": "https://github.com/talex-touch/tuff/pull/1858",
+  "subtasks": [],
+  "children": [],
+  "parent": null,
+  "relatedFiles": [
+    "apps/core-app/src/main/modules/clipboard-tagging.ts",
+    "apps/core-app/src/main/modules/clipboard/clipboard-stage-b-enrichment.ts",
+    "apps/core-app/src/main/modules/ocr/ocr-service.ts",
+    "plugins/clipboard-history/src/utils/clipboard-items.ts"
+  ],
+  "notes": "Local classification only; no credential validation or network lookup.",
+  "meta": {
+    "nextAction": "Merge pull request #1858 after all required checks pass, then create the next beta release from the resulting master commit.",
+    "blocker": "Protected master requires the seven mandatory checks and PR merge before versioning and tagging.",
+    "evidence": "Staged snapshot: 50 focused tests passed; CoreApp Node typecheck and Vite build passed; Clipboard History plugin typecheck/build and 29-plugin validation passed."
+  }
+}

--- a/apps/core-app/src/main/modules/clipboard-tagging.test.ts
+++ b/apps/core-app/src/main/modules/clipboard-tagging.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { detectClipboardTags } from './clipboard-tagging'
+import { detectClipboardTags, getClipboardTagSearchTerms } from './clipboard-tagging'
 
 describe('detectClipboardTags', () => {
   it('detects url tags from text', () => {
@@ -27,6 +27,40 @@ describe('detectClipboardTags', () => {
       rawContent: null
     })
     expect(tags).toEqual(['token', 'email'])
+  })
+
+  it.each(['@wx', '@wechat', '微信'])('classifies the WeChat alias %s', (content) => {
+    expect(detectClipboardTags({ type: 'text', content })).toEqual(['wechat'])
+  })
+
+  it('projects every WeChat spelling into clipboard metadata search terms', () => {
+    expect(getClipboardTagSearchTerms(['wechat'])).toEqual(
+      expect.arrayContaining(['wx', 'wechat', '微信'])
+    )
+  })
+
+  it.each([
+    ['GitHub personal access token', `ghp_${'a'.repeat(36)}`, ['api_key', 'github']],
+    ['npm access token', `npm_${'a'.repeat(36)}`, ['api_key', 'npm']],
+    ['OpenAI project API key', `sk-proj-${'a'.repeat(20)}`, ['api_key', 'openai']],
+    ['Stripe test secret key', `sk_test_${'a'.repeat(16)}`, ['api_key', 'stripe']],
+    ['Google API key', `AIza${'a'.repeat(35)}`, ['api_key', 'google']],
+    ['AWS access key ID', `AKIA${'A'.repeat(16)}`, ['api_key', 'aws']],
+    ['Slack bot token', `xoxb-${'a'.repeat(10)}`, ['api_key', 'slack']]
+  ])('classifies a supported %s', (_name, content, expected) => {
+    expect(detectClipboardTags({ type: 'text', content })).toEqual(expected)
+  })
+
+  it.each([
+    ['short GitHub-like prefix', 'ghp_short'],
+    ['short npm-like prefix', 'npm_short'],
+    ['short OpenAI-like prefix', 'sk-short'],
+    ['short Stripe-like prefix', 'sk_test_short'],
+    ['short Google-like prefix', `AIza${'a'.repeat(34)}`],
+    ['short AWS-like prefix', `AKIA${'A'.repeat(15)}`],
+    ['short Slack-like prefix', 'xoxb-short']
+  ])('does not classify an ambiguous %s', (_name, content) => {
+    expect(detectClipboardTags({ type: 'text', content })).toEqual([])
   })
 
   it('ignores non-text clipboard items', () => {

--- a/apps/core-app/src/main/modules/clipboard-tagging.ts
+++ b/apps/core-app/src/main/modules/clipboard-tagging.ts
@@ -1,6 +1,35 @@
-export type ClipboardTag = 'url' | 'api_key' | 'password' | 'account' | 'email' | 'token'
+export type ClipboardTag =
+  | 'url'
+  | 'api_key'
+  | 'github'
+  | 'npm'
+  | 'openai'
+  | 'stripe'
+  | 'google'
+  | 'aws'
+  | 'slack'
+  | 'wechat'
+  | 'password'
+  | 'account'
+  | 'email'
+  | 'token'
 
-const TAG_ORDER: ClipboardTag[] = ['url', 'api_key', 'token', 'password', 'account', 'email']
+const TAG_ORDER: ClipboardTag[] = [
+  'url',
+  'api_key',
+  'github',
+  'npm',
+  'openai',
+  'stripe',
+  'google',
+  'aws',
+  'slack',
+  'wechat',
+  'token',
+  'password',
+  'account',
+  'email'
+]
 
 const URL_PATTERN = /\bhttps?:\/\/\S+/i
 const WWW_PATTERN = /\bwww\.\S+/i
@@ -8,8 +37,15 @@ const EMAIL_PATTERN = /\b[\w.%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i
 
 const API_KEY_FIELD_PATTERN =
   /\b(api[-_ ]?key|x-api-key|access[-_ ]?key|secret[-_ ]?key|client[-_ ]?secret)\b\s*(?:[:=]|is)\s*[\w\-]{8,}/i
-const API_KEY_PREFIX_PATTERN =
-  /\b(sk-[A-Za-z0-9]{16,}|ghp_[A-Za-z0-9]{36}|AIza[\w\-]{35}|AKIA[0-9A-Z]{16})\b/
+const GENERIC_API_KEY_PREFIX_PATTERN = /\bsk-[A-Za-z0-9]{16,}\b/
+const GITHUB_TOKEN_PATTERN = /\b(?:gh[pousr]_[A-Za-z0-9_]{36}|github_pat_[A-Za-z0-9_]{22,255})\b/
+const NPM_TOKEN_PATTERN = /\bnpm_[A-Za-z0-9]{36,}\b/
+const OPENAI_API_KEY_PATTERN = /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/
+const STRIPE_SECRET_KEY_PATTERN = /\bsk_(?:live|test)_[A-Za-z0-9]{16,}\b/
+const GOOGLE_API_KEY_PATTERN = /\bAIza[\w-]{35}\b/
+const AWS_ACCESS_KEY_PATTERN = /\bAKIA[0-9A-Z]{16}\b/
+const SLACK_TOKEN_PATTERN = /\b(?:xox[abprs]|xapp)-[A-Za-z0-9-]{10,}\b/
+const WECHAT_MENTION_PATTERN = /(?:@(?:wx|wechat)\b|微信)/iu
 
 const TOKEN_FIELD_PATTERN = /\b(token|bearer)\b\s*(?:[:=]|is)\s*[\w\-.=]{8,}/i
 const BEARER_PATTERN = /\bbearer\s+[\w\-.=]{8,}\b/i
@@ -38,9 +74,37 @@ export function detectClipboardTags(payload: {
     tags.add('email')
   }
 
-  if (API_KEY_FIELD_PATTERN.test(sample) || API_KEY_PREFIX_PATTERN.test(sample)) {
+  const hasGitHubToken = GITHUB_TOKEN_PATTERN.test(sample)
+  const hasNpmToken = NPM_TOKEN_PATTERN.test(sample)
+  const hasOpenAiApiKey = OPENAI_API_KEY_PATTERN.test(sample)
+  const hasStripeSecretKey = STRIPE_SECRET_KEY_PATTERN.test(sample)
+  const hasGoogleApiKey = GOOGLE_API_KEY_PATTERN.test(sample)
+  const hasAwsAccessKey = AWS_ACCESS_KEY_PATTERN.test(sample)
+  const hasSlackToken = SLACK_TOKEN_PATTERN.test(sample)
+  const hasWeChatMention = WECHAT_MENTION_PATTERN.test(sample)
+
+  if (
+    API_KEY_FIELD_PATTERN.test(sample) ||
+    GENERIC_API_KEY_PREFIX_PATTERN.test(sample) ||
+    hasGitHubToken ||
+    hasNpmToken ||
+    hasOpenAiApiKey ||
+    hasStripeSecretKey ||
+    hasGoogleApiKey ||
+    hasAwsAccessKey ||
+    hasSlackToken
+  ) {
     tags.add('api_key')
   }
+
+  if (hasGitHubToken) tags.add('github')
+  if (hasNpmToken) tags.add('npm')
+  if (hasOpenAiApiKey) tags.add('openai')
+  if (hasStripeSecretKey) tags.add('stripe')
+  if (hasGoogleApiKey) tags.add('google')
+  if (hasAwsAccessKey) tags.add('aws')
+  if (hasSlackToken) tags.add('slack')
+  if (hasWeChatMention) tags.add('wechat')
 
   if (TOKEN_FIELD_PATTERN.test(sample) || BEARER_PATTERN.test(sample)) {
     tags.add('token')
@@ -55,4 +119,18 @@ export function detectClipboardTags(payload: {
   }
 
   return TAG_ORDER.filter((tag) => tags.has(tag))
+}
+
+/**
+ * Search terms persist beside classification tags so a query can match a known software alias
+ * even when the copied text used another spelling.
+ */
+export function getClipboardTagSearchTerms(tags: readonly ClipboardTag[]): string[] {
+  const terms = new Set<string>(tags)
+  if (tags.includes('wechat')) {
+    terms.add('wx')
+    terms.add('wechat')
+    terms.add('微信')
+  }
+  return [...terms]
 }

--- a/apps/core-app/src/main/modules/clipboard.ts
+++ b/apps/core-app/src/main/modules/clipboard.ts
@@ -44,6 +44,7 @@ import { getPermissionModule } from './permission'
 import { pluginModule } from './plugin/plugin-module'
 import { getMainConfig, isMainStorageReady, subscribeMainConfig } from './storage'
 import { activeAppService } from './system/active-app'
+import { getLocale } from '../utils/i18n-helper'
 import { windowManager } from './box-tool/core-box/window'
 import {
   createIneligibleClipboardFreshnessState,
@@ -224,6 +225,7 @@ export class ClipboardModule extends BaseModule {
     getDatabase: () => this.db,
     getCachedItemById: (clipboardId) => this.historyPersistence.getCachedItemById(clipboardId),
     getActiveAppSnapshot: () => this.getActiveAppSnapshot(),
+    getAppLanguageHint: () => getLocale(),
     getLatestGeneration: () => this.clipboardStageBGeneration,
     enqueueOcr: async (job) => {
       await ocrService.enqueueFromClipboard(job)

--- a/apps/core-app/src/main/modules/clipboard/clipboard-capture-pipeline.test.ts
+++ b/apps/core-app/src/main/modules/clipboard/clipboard-capture-pipeline.test.ts
@@ -224,6 +224,23 @@ describe('clipboard-capture-pipeline', () => {
     )
   })
 
+  it('persists WeChat aliases with their metadata search terms', async () => {
+    const context = createPipeline()
+    mocks.readText.mockReturnValueOnce('previous').mockReturnValue('@wechat')
+
+    await context.pipeline.process('visible-poll')
+
+    expect(context.metaPersistence.persistMetaEntriesSafely).toHaveBeenCalledWith(
+      11,
+      expect.objectContaining({ tags: ['wechat'] }),
+      expect.arrayContaining([
+        { key: 'tags', value: ['wechat'] },
+        { key: 'tag_search_terms', value: ['wechat', 'wx', '微信'] }
+      ]),
+      { dropPolicy: 'drop', maxQueueWaitMs: 10_000 }
+    )
+  })
+
   it('captures a CoreBox show baseline image even when bootstrap already saw the same image', async () => {
     const image = createImage()
     mocks.availableFormats.mockReturnValue(['public.png'])

--- a/apps/core-app/src/main/modules/clipboard/clipboard-capture-pipeline.ts
+++ b/apps/core-app/src/main/modules/clipboard/clipboard-capture-pipeline.ts
@@ -17,7 +17,7 @@ import { clipboardHistory } from '../../db/schema'
 import { enterPerfContext } from '../../utils/perf-context'
 import { perfMonitor } from '../../utils/perf-monitor'
 import { windowManager } from '../box-tool/core-box/window'
-import { detectClipboardTags } from '../clipboard-tagging'
+import { detectClipboardTags, getClipboardTagSearchTerms } from '../clipboard-tagging'
 import {
   CLIPBOARD_HTML_FORMATS,
   CLIPBOARD_IMAGE_FORMATS,
@@ -493,6 +493,7 @@ export class ClipboardCapturePipeline {
     )
     if (tags.length > 0) {
       metaEntries.push({ key: 'tags', value: tags })
+      metaEntries.push({ key: 'tag_search_terms', value: getClipboardTagSearchTerms(tags) })
       for (const tag of tags) {
         metaEntries.push({ key: 'tag', value: tag })
       }

--- a/apps/core-app/src/main/modules/clipboard/clipboard-stage-b-enrichment.test.ts
+++ b/apps/core-app/src/main/modules/clipboard/clipboard-stage-b-enrichment.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolveAppSemanticAliases } from '../box-tool/addon/apps/app-semantic-catalog'
 import {
   ClipboardStageBEnrichment,
   buildActiveAppSourcePatch,
@@ -26,10 +27,14 @@ function createJob(overrides: Partial<ClipboardStageBJob> = {}): ClipboardStageB
 }
 
 function createDb() {
+  let persistedMetadata: string | undefined
   const where = vi.fn(async () => undefined)
-  const set = vi.fn(() => ({ where }))
+  const set = vi.fn((values: { metadata?: string }) => {
+    persistedMetadata = values.metadata
+    return { where }
+  })
   const update = vi.fn(() => ({ set }))
-  return { update, set, where }
+  return { update, set, where, getPersistedMetadata: () => persistedMetadata }
 }
 
 describe('clipboard-stage-b-enrichment', () => {
@@ -37,59 +42,66 @@ describe('clipboard-stage-b-enrichment', () => {
     vi.clearAllMocks()
   })
 
-  it('builds source patch from active app metadata', () => {
-    expect(
-      buildActiveAppSourcePatch(
-        {
-          bundleId: 'com.demo.app',
-          identifier: 'demo',
-          displayName: 'Demo',
-          processId: 42,
-          executablePath: '/Applications/Demo.app',
-          icon: null
-        },
+  it('projects source application aliases from the semantic catalog', () => {
+    const apps = [
+      {
+        bundleId: 'com.tencent.xin',
+        displayName: '微信',
+        executablePath: '/Applications/WeChat.app'
+      },
+      {
+        bundleId: 'com.bytedance.feishu',
+        displayName: '飞书',
+        executablePath: '/Applications/Feishu.app'
+      }
+    ]
+
+    for (const app of apps) {
+      const sourceSearchTerms = resolveAppSemanticAliases({
+        name: app.displayName,
+        displayName: app.displayName,
+        bundleId: app.bundleId,
+        path: app.executablePath
+      })
+
+      const patch = buildActiveAppSourcePatch(
+        { ...app, identifier: null, processId: 42, icon: null },
         'fallback'
       )
-    ).toEqual({
-      sourceApp: 'com.demo.app',
-      patch: {
-        source: {
-          bundleId: 'com.demo.app',
-          displayName: 'Demo',
-          processId: 42,
-          executablePath: '/Applications/Demo.app',
-          icon: null
-        },
-        source_bundleId: 'com.demo.app',
-        source_displayName: 'Demo',
-        source_processId: 42,
-        source_executablePath: '/Applications/Demo.app'
-      },
-      entries: expect.arrayContaining([
-        { key: 'source_bundleId', value: 'com.demo.app' },
-        { key: 'source_processId', value: 42 }
-      ])
-    })
+
+      expect(patch.patch.source_search_terms).toEqual(sourceSearchTerms)
+      expect(patch.entries).toContainEqual({
+        key: 'source_search_terms',
+        value: sourceSearchTerms
+      })
+    }
   })
 
   it('enqueues OCR and patches source metadata when generation is current', async () => {
     const db = createDb()
+    const sourceSearchTerms = resolveAppSemanticAliases({
+      name: '微信',
+      displayName: '微信',
+      bundleId: 'com.tencent.xin',
+      path: '/Applications/WeChat.app'
+    })
     const enqueueOcr = vi.fn(async () => undefined)
     const patchCachedMeta = vi.fn()
     const updateCachedSource = vi.fn()
     const persistMetaEntriesSafely = vi.fn()
-    const withDbWrite = vi.fn(async (_label, operation) => await operation())
+    const withDbWrite = vi.fn(async (_label, operation) => await operation(db))
     const enrichment = new ClipboardStageBEnrichment({
       getDatabase: () => db as never,
       getCachedItemById: () => createJob().item,
       getActiveAppSnapshot: () => ({
-        bundleId: null,
+        bundleId: 'com.tencent.xin',
         identifier: null,
-        displayName: 'Notes',
+        displayName: '微信',
         processId: 10,
-        executablePath: '/Applications/Notes.app',
+        executablePath: '/Applications/WeChat.app',
         icon: null
       }),
+      getAppLanguageHint: () => 'zh-CN',
       getLatestGeneration: () => 1,
       enqueueOcr,
       patchCachedMeta,
@@ -104,21 +116,32 @@ describe('clipboard-stage-b-enrichment', () => {
     expect(enqueueOcr).toHaveBeenCalledWith({
       clipboardId: 7,
       item: createJob().item,
-      formats: ['text/plain']
+      formats: ['text/plain'],
+      languageHint: 'zh-CN'
     })
     expect(withDbWrite).toHaveBeenCalledWith('clipboard.stage-b.source', expect.any(Function), {
       dropPolicy: 'drop',
       maxQueueWaitMs: 10_000
     })
-    expect(updateCachedSource).toHaveBeenCalledWith(7, 'Notes')
+    expect(updateCachedSource).toHaveBeenCalledWith(7, 'com.tencent.xin')
     expect(patchCachedMeta).toHaveBeenCalledWith(
       7,
-      expect.objectContaining({ source_displayName: 'Notes' })
+      expect.objectContaining({
+        source_displayName: '微信',
+        source_search_terms: sourceSearchTerms
+      })
     )
+    expect(JSON.parse(db.getPersistedMetadata() ?? '{}')).toMatchObject({
+      source: expect.objectContaining({ displayName: '微信' }),
+      source_search_terms: sourceSearchTerms
+    })
     expect(persistMetaEntriesSafely).toHaveBeenCalledWith(
       7,
-      expect.objectContaining({ source_displayName: 'Notes' }),
-      expect.any(Array),
+      expect.objectContaining({
+        source_displayName: '微信',
+        source_search_terms: sourceSearchTerms
+      }),
+      expect.arrayContaining([{ key: 'source_search_terms', value: sourceSearchTerms }]),
       { dropPolicy: 'drop', maxQueueWaitMs: 10_000 }
     )
   })
@@ -129,6 +152,7 @@ describe('clipboard-stage-b-enrichment', () => {
       getDatabase: () => undefined,
       getCachedItemById: () => undefined,
       getActiveAppSnapshot: () => null,
+      getAppLanguageHint: () => undefined,
       getLatestGeneration: () => 2,
       enqueueOcr,
       patchCachedMeta: vi.fn(),

--- a/apps/core-app/src/main/modules/clipboard/clipboard-stage-b-enrichment.ts
+++ b/apps/core-app/src/main/modules/clipboard/clipboard-stage-b-enrichment.ts
@@ -4,6 +4,7 @@ import type { LogOptions } from '../../utils/logger'
 import type { IClipboardItem } from './clipboard-history-persistence'
 import { eq } from 'drizzle-orm'
 import { clipboardHistory } from '../../db/schema'
+import { resolveAppSemanticAliases } from '../box-tool/addon/apps/app-semantic-catalog'
 import type { ClipboardMetaEntry, ClipboardMetaPersistence } from './clipboard-meta-persistence'
 
 export interface ClipboardActiveAppSnapshot {
@@ -26,11 +27,13 @@ export interface ClipboardStageBEnrichmentOptions {
   getDatabase: () => LibSQLDatabase<typeof schema> | undefined
   getCachedItemById: (clipboardId: number) => IClipboardItem | undefined
   getActiveAppSnapshot: () => ClipboardActiveAppSnapshot | null
+  getAppLanguageHint: () => string | undefined
   getLatestGeneration: () => number
   enqueueOcr: (job: {
     clipboardId: number
     item: IClipboardItem
     formats: string[]
+    languageHint?: string
   }) => Promise<void>
   patchCachedMeta: (clipboardId: number, patch: Record<string, unknown>) => void
   updateCachedSource: (clipboardId: number, sourceApp: string | null) => void
@@ -71,8 +74,15 @@ export function buildActiveAppSourcePatch(
     executablePath: activeApp.executablePath ?? null,
     icon: activeApp.icon ?? null
   }
+  const sourceSearchTerms = resolveAppSemanticAliases({
+    name: activeApp.displayName ?? undefined,
+    displayName: activeApp.displayName ?? undefined,
+    bundleId: activeApp.bundleId ?? activeApp.identifier ?? undefined,
+    path: activeApp.executablePath ?? undefined
+  })
   const patch: Record<string, unknown> = {
-    source: sourceMeta
+    source: sourceMeta,
+    ...(sourceSearchTerms.length > 0 ? { source_search_terms: sourceSearchTerms } : {})
   }
   for (const [key, value] of Object.entries(sourceMeta)) {
     if (value !== null && value !== undefined) {
@@ -100,7 +110,8 @@ export class ClipboardStageBEnrichment {
       await this.options.enqueueOcr({
         clipboardId: job.item.id,
         item: job.item,
-        formats: job.formats
+        formats: job.formats,
+        languageHint: this.options.getAppLanguageHint()
       })
     } catch (error) {
       this.options.logWarn('Failed to enqueue clipboard OCR', { error })

--- a/apps/core-app/src/main/modules/ocr/ocr-service.test.ts
+++ b/apps/core-app/src/main/modules/ocr/ocr-service.test.ts
@@ -3,6 +3,10 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
+const workerMocks = vi.hoisted(() => ({
+  instances: [] as Array<{ workerData: unknown }>
+}))
+
 const {
   ensureIntelligenceConfigLoadedMock,
   getCapabilityOptionsMock,
@@ -126,6 +130,33 @@ vi.mock('../ai/intelligence-sdk', () => ({
   }
 }))
 
+vi.mock('node:worker_threads', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:worker_threads')>()
+
+  return {
+    ...actual,
+    Worker: class {
+      private readonly listeners = new Map<string, (payload: unknown) => void>()
+
+      constructor(_workerPath: string, options: { workerData: unknown }) {
+        workerMocks.instances.push({ workerData: options.workerData })
+        queueMicrotask(() => {
+          this.listeners.get('message')?.({ status: 'success', result: { text: 'worker-path' } })
+        })
+      }
+
+      once(event: string, listener: (payload: unknown) => void) {
+        this.listeners.set(event, listener)
+        return this
+      }
+
+      terminate() {
+        return Promise.resolve(0)
+      }
+    }
+  }
+})
+
 import { ocrService } from './ocr-service'
 
 interface OcrServiceTestAccess {
@@ -143,7 +174,7 @@ interface OcrServiceTestAccess {
   buildJobPayload: (...args: unknown[]) => Promise<{
     clipboardId: number
     source: { type: string; dataUrl?: string; filePath?: string }
-    options: { language: string }
+    options: { language?: string }
     payloadHash: string | null
   } | null>
   buildAgentPrompt: (...args: unknown[]) => string
@@ -165,6 +196,7 @@ interface OcrServiceTestAccess {
 }
 
 afterEach(() => {
+  workerMocks.instances.length = 0
   vi.restoreAllMocks()
   ensureIntelligenceConfigLoadedMock.mockReset()
   getCapabilityOptionsMock.mockReset()
@@ -173,7 +205,7 @@ afterEach(() => {
 })
 
 describe('OcrService runAgentJob local-first options', () => {
-  it('prepends local system OCR provider and model preference', async () => {
+  it('preserves legacy persisted job language while prepending local OCR preferences', async () => {
     getCapabilityOptionsMock.mockReturnValue({
       allowedProviderIds: ['openai-default', 'anthropic-default'],
       modelPreference: ['gpt-4o']
@@ -206,13 +238,14 @@ describe('OcrService runAgentJob local-first options', () => {
       payloadHash: 'hash-1',
       meta: JSON.stringify({
         source: { type: 'clipboard' },
-        options: { language: 'eng' }
+        options: { language: 'fr-FR' }
       })
     })
 
     expect(aiInvokeMock).toHaveBeenCalledOnce()
     const call = aiInvokeMock.mock.calls[0]
     expect(call[0]).toBe('vision.ocr')
+    expect(call[1]).toMatchObject({ language: 'fr-FR' })
     expect(call[2].allowedProviderIds[0]).toBe('local-system-ocr')
     expect(call[2].modelPreference[0]).toBe('system-ocr')
   })
@@ -290,7 +323,58 @@ describe('OcrService runAgentJob local-first options', () => {
       expect(payload).not.toBeNull()
       expect(payload?.source.type).toBe('file')
       expect(payload?.source.filePath).toBe(imagePath)
+      expect(payload?.options).toEqual({})
       expect(typeof payload?.payloadHash).toBe('string')
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it.each([
+    { name: 'Chinese app locale', languageHint: 'zh-CN', expectedLanguage: 'zh-Hans' },
+    { name: 'English app locale', languageHint: 'en-US', expectedLanguage: 'en-US' },
+    { name: 'absent app locale', languageHint: undefined, expectedLanguage: undefined },
+    { name: 'unsupported app locale', languageHint: 'ja-JP', expectedLanguage: undefined }
+  ])(
+    'normalizes $name into the native OCR language hint',
+    async ({ languageHint, expectedLanguage }) => {
+      const service = ocrService as unknown as OcrServiceTestAccess
+
+      const payload = await service.buildJobPayload({
+        clipboardId: 1003,
+        item: {
+          type: 'image',
+          content: 'data:image/png;base64,AA==',
+          meta: null
+        },
+        formats: ['public.png'],
+        languageHint
+      })
+
+      expect(payload?.options.language).toBe(expectedLanguage)
+    }
+  )
+
+  it('creates unhinted OCR jobs for clipboard file images', async () => {
+    const service = ocrService as unknown as OcrServiceTestAccess
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'ocr-service-files-'))
+    const imagePath = path.join(tempDir, 'clipboard.png')
+    await writeFile(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+
+    try {
+      const payload = await service.buildJobPayload({
+        clipboardId: 1002,
+        item: {
+          type: 'files',
+          content: JSON.stringify([imagePath]),
+          meta: null
+        },
+        formats: ['public.file-url']
+      })
+
+      expect(payload).not.toBeNull()
+      expect(payload?.source).toEqual({ type: 'file', filePath: imagePath })
+      expect(payload?.options).toEqual({})
     } finally {
       await rm(tempDir, { recursive: true, force: true })
     }
@@ -355,7 +439,7 @@ describe('OcrService runAgentJob local-first options', () => {
         payloadHash: 'hash-worker',
         meta: JSON.stringify({
           source: { type: 'clipboard' },
-          options: { language: 'eng' }
+          options: {}
         })
       })
 
@@ -369,6 +453,33 @@ describe('OcrService runAgentJob local-first options', () => {
         process.env.TUFF_OCR_WORKER_ENABLED = previousWorkerEnv
       }
     }
+  })
+
+  it('forwards an unhinted clipboard OCR job to the native worker', async () => {
+    const service = ocrService as unknown as OcrServiceTestAccess
+
+    const response = await service.invokeWorkerOcr(
+      12,
+      {
+        clipboardId: 500,
+        payloadHash: 'worker-unhinted'
+      },
+      {
+        source: { type: 'file', filePath: '/tmp/clipboard-image.png' },
+        options: {}
+      },
+      {
+        type: 'file',
+        filePath: '/tmp/clipboard-image.png'
+      }
+    )
+
+    expect(response).toMatchObject({ result: { text: 'worker-path' } })
+    expect(workerMocks.instances).toHaveLength(1)
+    const workerData = workerMocks.instances[0]?.workerData as {
+      options: { language?: string }
+    }
+    expect(workerData.options.language).toBeUndefined()
   })
 
   it('falls back to provider invocation when worker path fails', async () => {
@@ -410,7 +521,7 @@ describe('OcrService runAgentJob local-first options', () => {
         payloadHash: 'hash-worker-fallback',
         meta: JSON.stringify({
           source: { type: 'clipboard' },
-          options: { language: 'eng' }
+          options: {}
         })
       })
 
@@ -423,6 +534,88 @@ describe('OcrService runAgentJob local-first options', () => {
       } else {
         process.env.TUFF_OCR_WORKER_ENABLED = previousWorkerEnv
       }
+    }
+  })
+})
+
+describe('OcrService clipboard metadata', () => {
+  it('merges OCR-detected tags and search terms with persisted clipboard metadata', async () => {
+    type MetaWriteService = OcrServiceTestAccess & {
+      withDbWrite: (
+        label: string,
+        operation: (db: {
+          transaction: (
+            callback: (tx: {
+              select: () => {
+                from: () => {
+                  where: () => {
+                    limit: () => Promise<Array<{ metadata: string }>>
+                  }
+                }
+              }
+              delete: () => { where: () => Promise<void> }
+              insert: () => {
+                values: (values: Array<{ key: string; value: string }>) => Promise<void>
+              }
+              update: () => {
+                set: (values: { metadata: string }) => { where: () => Promise<void> }
+              }
+            }) => Promise<void>
+          ) => Promise<void>
+        }) => Promise<void>
+      ) => Promise<void>
+    }
+
+    const service = ocrService as unknown as MetaWriteService
+    const originalDb = service.db
+    const originalWithDbWrite = service.withDbWrite
+    let persistedMetadata: string | null = null
+
+    const tx = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => [
+              {
+                metadata: JSON.stringify({
+                  tags: ['email', 'legacy_tag'],
+                  tag_search_terms: ['email', 'legacy-alias']
+                })
+              }
+            ]
+          })
+        })
+      }),
+      delete: () => ({ where: async () => undefined }),
+      insert: () => ({ values: async () => undefined }),
+      update: () => ({
+        set: ({ metadata }: { metadata: string }) => ({
+          where: async () => {
+            persistedMetadata = metadata
+          }
+        })
+      })
+    }
+
+    service.db = {}
+    service.withDbWrite = async (_label, operation) =>
+      operation({ transaction: async (callback) => callback(tx) })
+
+    try {
+      await service.updateClipboardMeta(7, {
+        ocr_status: 'done',
+        tags: ['api_key', 'github', 'api_key'],
+        tag_search_terms: ['wechat', 'wx', '微信', 'wx']
+      })
+
+      expect(JSON.parse(persistedMetadata ?? '{}')).toMatchObject({
+        ocr_status: 'done',
+        tags: ['email', 'legacy_tag', 'api_key', 'github'],
+        tag_search_terms: ['email', 'legacy-alias', 'wechat', 'wx', '微信']
+      })
+    } finally {
+      service.db = originalDb
+      service.withDbWrite = originalWithDbWrite
     }
   })
 })

--- a/apps/core-app/src/main/modules/ocr/ocr-service.ts
+++ b/apps/core-app/src/main/modules/ocr/ocr-service.ts
@@ -35,6 +35,7 @@ import {
 } from '../ai/intelligence-config'
 import { tuffIntelligence } from '../ai/intelligence-sdk'
 import { windowManager } from '../box-tool/core-box/window'
+import { detectClipboardTags, getClipboardTagSearchTerms } from '../clipboard-tagging'
 import { databaseModule } from '../database'
 import { notificationModule } from '../notification'
 import {
@@ -49,6 +50,7 @@ export interface ClipboardOcrPayload {
   clipboardId: number
   item: IClipboardItem
   formats: string[]
+  languageHint?: string
 }
 
 interface AgentJobPayload {
@@ -61,7 +63,7 @@ interface AgentJobPayload {
     filePath?: string
   }
   options: {
-    language: string
+    language?: string
     tesseditPagesegMode?: number
     config?: Record<string, string | number | boolean>
     prompt?: string
@@ -77,6 +79,13 @@ const coreBoxClipboardMetaUpdatedEvent = defineRawEvent<
   },
   void
 >('core-box:clipboard-meta-updated')
+
+function resolveClipboardOcrLanguageHint(languageHint: string | undefined): string | undefined {
+  if (!languageHint) return undefined
+  if (/^zh(?:[-_]|$)/i.test(languageHint)) return 'zh-Hans'
+  if (/^en(?:[-_]|$)/i.test(languageHint)) return 'en-US'
+  return undefined
+}
 const ocrDashboardEvent = defineRawEvent<
   { limit?: number },
   {
@@ -270,7 +279,7 @@ class OcrService {
           payloadHash: job.payloadHash ?? null,
           source: workerSource,
           options: {
-            language: parsed.options?.language || 'eng',
+            language: parsed.options?.language,
             tesseditPagesegMode: parsed.options?.tesseditPagesegMode,
             config: parsed.options?.config
           }
@@ -770,9 +779,7 @@ class OcrService {
             type: 'data-url',
             dataUrl: content
           },
-          options: {
-            language: 'eng'
-          },
+          options: { language: resolveClipboardOcrLanguageHint(payload.languageHint) },
           payloadHash: dataUrlToHash(content)
         }
       }
@@ -791,9 +798,7 @@ class OcrService {
           type: 'file',
           filePath: content
         },
-        options: {
-          language: 'eng'
-        },
+        options: { language: resolveClipboardOcrLanguageHint(payload.languageHint) },
         payloadHash: fileHashKey(content)
       }
     }
@@ -817,9 +822,7 @@ class OcrService {
             type: 'file',
             filePath: imagePath
           },
-          options: {
-            language: 'eng'
-          },
+          options: { language: resolveClipboardOcrLanguageHint(payload.languageHint) },
           payloadHash: fileHashKey(imagePath)
         }
       } catch (error) {
@@ -1263,6 +1266,7 @@ class OcrService {
     )
 
     if (job.clipboardId) {
+      const tags = detectClipboardTags({ type: 'text', content: result.text })
       await this.updateClipboardMeta(job.clipboardId, {
         ocr_status: 'done',
         ocr_text: trimmedTextForMeta,
@@ -1278,7 +1282,8 @@ class OcrService {
         ocr_usage_completion: invocation.usage.completionTokens,
         ocr_last_error: null,
         ocr_retry_count: job.attempts ?? 0,
-        ocr_embedding_status: embedding ? 'generated' : 'skipped'
+        ocr_embedding_status: embedding ? 'generated' : 'skipped',
+        ...(tags.length > 0 ? { tags, tag_search_terms: getClipboardTagSearchTerms(tags) } : {})
       })
 
       await this.upsertConfig('ocr:last-success', {
@@ -1540,52 +1545,56 @@ class OcrService {
       patch.ocr_updated_at = new Date().toISOString()
     }
 
-    const insertValues = Object.entries(patch).map(([key, value]) => ({
-      clipboardId,
-      key,
-      value: JSON.stringify(value ?? null)
-    }))
-
     await this.withDbWrite('ocr.clipboard.meta', async (db) =>
       db.transaction(async (tx) => {
-        if (insertValues.length > 0) {
-          // Same replace-not-append rule as clipboard-meta-persistence (#646). ocr_status walks
-          // queued -> processing -> retrying -> completed, so appending leaves four rows for one
-          // key and a stale 'processing' can win the read.
-          await tx.delete(clipboardHistoryMeta).where(
-            and(
-              eq(clipboardHistoryMeta.clipboardId, clipboardId),
-              inArray(
-                clipboardHistoryMeta.key,
-                insertValues.map((entry) => entry.key)
-              )
-            )
-          )
-          await tx.insert(clipboardHistoryMeta).values(insertValues)
-        }
-
         const existing = await tx
           .select({ metadata: clipboardHistory.metadata })
           .from(clipboardHistory)
           .where(eq(clipboardHistory.id, clipboardId))
           .limit(1)
 
-        if (existing.length > 0) {
-          let base: Record<string, unknown> = {}
-          if (existing[0].metadata) {
-            try {
-              base = JSON.parse(existing[0].metadata)
-            } catch {
-              base = {}
-            }
-          }
+        if (existing.length === 0) return
 
-          const merged = { ...base, ...patch }
-          await tx
-            .update(clipboardHistory)
-            .set({ metadata: JSON.stringify(merged) })
-            .where(eq(clipboardHistory.id, clipboardId))
+        let base: Record<string, unknown> = {}
+        if (existing[0].metadata) {
+          try {
+            base = JSON.parse(existing[0].metadata)
+          } catch {
+            base = {}
+          }
         }
+
+        for (const key of ['tags', 'tag_search_terms'] as const) {
+          if (!Array.isArray(patch[key])) continue
+          const existingValues = Array.isArray(base[key])
+            ? base[key].filter((value): value is string => typeof value === 'string')
+            : []
+          patch[key] = [...new Set([...existingValues, ...patch[key]])]
+        }
+        const insertValues = Object.entries(patch).map(([key, value]) => ({
+          clipboardId,
+          key,
+          value: JSON.stringify(value ?? null)
+        }))
+
+        // Same replace-not-append rule as clipboard-meta-persistence (#646). ocr_status walks
+        // queued -> processing -> retrying -> completed, so appending leaves four rows for one
+        // key and a stale 'processing' can win the read.
+        await tx.delete(clipboardHistoryMeta).where(
+          and(
+            eq(clipboardHistoryMeta.clipboardId, clipboardId),
+            inArray(
+              clipboardHistoryMeta.key,
+              insertValues.map((entry) => entry.key)
+            )
+          )
+        )
+        await tx.insert(clipboardHistoryMeta).values(insertValues)
+
+        await tx
+          .update(clipboardHistory)
+          .set({ metadata: JSON.stringify({ ...base, ...patch }) })
+          .where(eq(clipboardHistory.id, clipboardId))
       })
     )
 

--- a/apps/core-app/src/main/modules/ocr/ocr-worker.ts
+++ b/apps/core-app/src/main/modules/ocr/ocr-worker.ts
@@ -12,7 +12,7 @@ interface WorkerData {
     filePath?: string
   }
   options: {
-    language: string
+    language?: string
     tesseditPagesegMode?: number
     config?: Record<string, string | number | boolean>
   }
@@ -61,7 +61,7 @@ async function loadImageBuffer(source: WorkerData['source']): Promise<Buffer> {
 
 async function run(): Promise<void> {
   const payload = workerData as WorkerData
-  const language = payload.options.language || 'eng'
+  const language = payload.options.language ?? ''
   const buffer = await loadImageBuffer(payload.source)
 
   const support = getNativeOcrSupport()

--- a/plugins/clipboard-history/src/components/ClipboardDetail.vue
+++ b/plugins/clipboard-history/src/components/ClipboardDetail.vue
@@ -7,6 +7,7 @@ import {
   getClipboardColorTokens,
   getClipboardInfoRows,
   getClipboardOcrInsight,
+  getClipboardTagLabels,
   getClipboardTextInsight,
   getClipboardTitle,
   getClipboardTypeLabel,
@@ -29,6 +30,7 @@ const emit = defineEmits<{
 const textInsight = computed(() => getClipboardTextInsight(props.item))
 const colorTokens = computed(() => getClipboardColorTokens(props.item))
 const ocrInsight = computed(() => getClipboardOcrInsight(props.item))
+const tagLabels = computed(() => (props.item ? getClipboardTagLabels(props.item) : []))
 const failedImageSources = ref<ReadonlySet<string>>(new Set())
 const retriedImageSources = ref<ReadonlySet<string>>(new Set())
 const imageRetryNonce = ref(0)
@@ -143,6 +145,10 @@ function handleSourceIconError(event: Event): void {
           {{ getClipboardTypeLabel(item) }}
         </p>
         <h2>{{ getClipboardTitle(item) }}</h2>
+      </div>
+
+      <div v-if="tagLabels.length > 0" class="credential-tags" aria-label="内容标签">
+        <span v-for="label in tagLabels" :key="label" class="credential-tag">{{ label }}</span>
       </div>
 
       <div class="info-grid">
@@ -369,6 +375,23 @@ function handleSourceIconError(event: Event): void {
   letter-spacing: 0.08em;
   color: var(--clipboard-text-muted);
   text-transform: uppercase;
+}
+
+.credential-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 8px;
+}
+
+.credential-tag {
+  padding: 3px 6px;
+  border: 1px solid color-mix(in srgb, var(--clipboard-color-accent) 32%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--clipboard-color-accent) 10%, transparent);
+  color: var(--clipboard-color-accent);
+  font-size: 0.7rem;
+  font-weight: 600;
 }
 
 .info-grid {

--- a/plugins/clipboard-history/src/components/ClipboardSidebar.vue
+++ b/plugins/clipboard-history/src/components/ClipboardSidebar.vue
@@ -2,7 +2,7 @@
 import type { PluginClipboardItem } from '@talex-touch/utils/plugin/sdk/types'
 import type { ClipboardSection } from '~/utils/clipboard-items'
 import ClipboardGlyph from './ClipboardGlyph.vue'
-import { getClipboardSubtitle, getClipboardTitle, resolveListImageSrc } from '~/utils/clipboard-items'
+import { getClipboardSubtitle, getClipboardTagLabels, getClipboardTitle, resolveListImageSrc } from '~/utils/clipboard-items'
 
 defineProps<{
   sections: ClipboardSection[]
@@ -86,6 +86,9 @@ function onScroll(event: Event): void {
                 <p class="item-meta">
                   {{ getClipboardSubtitle(item) }}
                 </p>
+                <span v-if="getClipboardTagLabels(item).length > 0" class="item-tags">
+                  {{ getClipboardTagLabels(item).join(' · ') }}
+                </span>
               </div>
             </button>
           </li>
@@ -274,6 +277,15 @@ function onScroll(event: Event): void {
   white-space: nowrap;
   font-size: 0.72rem;
   color: var(--clipboard-text-muted);
+}
+
+.item-tags {
+  overflow: hidden;
+  color: var(--clipboard-color-accent);
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .list-footnote {

--- a/plugins/clipboard-history/src/utils/clipboard-items.test.ts
+++ b/plugins/clipboard-history/src/utils/clipboard-items.test.ts
@@ -5,6 +5,7 @@ import {
   getClipboardColorTokens,
   getClipboardOcrInsight,
   getClipboardSizeLabel,
+  getClipboardTagLabels,
   getClipboardTextInsight,
   parseFileList,
   resolveDetailImagePreview,
@@ -238,5 +239,62 @@ describe('clipboard-items helpers', () => {
       confidence: '88%',
       keywords: ['Invoice', 'total'],
     })
+  })
+
+  it.each([
+    ['api_key', 'API 密钥'],
+    ['github', 'GitHub'],
+    ['npm', 'npm'],
+    ['openai', 'OpenAI'],
+    ['stripe', 'Stripe'],
+    ['google', 'Google'],
+    ['aws', 'AWS'],
+    ['slack', 'Slack'],
+  ])('projects the known credential tag %s into its localized label', (tag, label) => {
+    const item: PluginClipboardItem = {
+      id: 18,
+      type: 'text',
+      content: 'synthetic credential note',
+      metadata: JSON.stringify({ tags: [tag] }),
+    }
+
+    expect(getClipboardTagLabels(item)).toEqual([label])
+  })
+
+  it('preserves an unknown credential tag label', () => {
+    const item: PluginClipboardItem = {
+      id: 19,
+      type: 'text',
+      content: 'synthetic credential note',
+      meta: { tags: ['openai', 'internal_service'] },
+    }
+
+    expect(getClipboardTagLabels(item)).toEqual(['OpenAI', 'internal_service'])
+  })
+
+  it.each([
+    ['absent tags', {}],
+    ['non-array tags', { tags: 'github' }],
+    ['mixed malformed tags', { tags: [null, 42, {}] }],
+  ])('omits %s metadata', (_name, meta) => {
+    const item: PluginClipboardItem = {
+      id: 20,
+      type: 'text',
+      content: 'synthetic credential note',
+      meta,
+    }
+
+    expect(getClipboardTagLabels(item)).toEqual([])
+  })
+
+  it('omits malformed serialized tag metadata', () => {
+    const item: PluginClipboardItem = {
+      id: 21,
+      type: 'text',
+      content: 'synthetic credential note',
+      metadata: '{not-json',
+    }
+
+    expect(getClipboardTagLabels(item)).toEqual([])
   })
 })

--- a/plugins/clipboard-history/src/utils/clipboard-items.ts
+++ b/plugins/clipboard-history/src/utils/clipboard-items.ts
@@ -145,6 +145,37 @@ function getMeta(item: PluginClipboardItem): Record<string, unknown> {
   }
 }
 
+const CLIPBOARD_TAG_LABELS: Record<string, string> = {
+  api_key: 'API 密钥',
+  github: 'GitHub',
+  npm: 'npm',
+  openai: 'OpenAI',
+  stripe: 'Stripe',
+  google: 'Google',
+  wechat: '微信',
+  aws: 'AWS',
+  slack: 'Slack',
+  token: '令牌',
+  password: '密码',
+  account: '账号',
+  email: '邮箱',
+  url: '链接',
+}
+
+export function getClipboardTagLabels(item: PluginClipboardItem): string[] {
+  const tags = getMeta(item).tags
+  if (!Array.isArray(tags)) {
+    return []
+  }
+
+  return unique(
+    tags.filter((tag): tag is string => typeof tag === 'string' && tag.trim().length > 0),
+    tag => tag,
+  )
+    .slice(0, 6)
+    .map(tag => CLIPBOARD_TAG_LABELS[tag] ?? tag)
+}
+
 function unique<T>(values: T[], getKey: (value: T) => string): T[] {
   const seen = new Set<string>()
   const result: T[] = []


### PR DESCRIPTION
## Summary
- classify copied credential formats locally without validation or network lookup
- persist searchable source-application aliases from the shared semantic catalog
- prioritize the Tuff app locale for new clipboard OCR jobs, then fall back to native system behavior

## Verification
- staged snapshot: 50 focused CoreApp tests passed
- CoreApp Node typecheck passed
- Clipboard History plugin typecheck/build and 29-plugin validation passed
- CoreApp Vite build passed

No credentials are persisted as derived metadata or logged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Clipboard content now recognizes common GitHub, npm, OpenAI, Stripe, Google, AWS, Slack, and WeChat credentials.
  - Credential and app-source aliases are preserved as searchable clipboard metadata.
  - OCR now uses the application’s language setting when available.
  - Clipboard History displays recognized credential tags in item lists and detail views.
- **Bug Fixes**
  - Clipboard metadata updates now merge and deduplicate existing tags and search terms.
  - OCR-derived tags are retained alongside previously detected clipboard metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->