### PR TITLE
fix(search): repair file previews and index freshness

### DIFF
--- a/.trellis/tasks/08-05-search-audit-remediation/research/audit-findings-digest.md
+++ b/.trellis/tasks/08-05-search-audit-remediation/research/audit-findings-digest.md
@@ -224,8 +224,9 @@ TalexDreamSoul/app-shell-v2 @ a1431ca42); verify before use.
   search-time filter counted as stale ⇒ REAL deletion from index during search;
   root: getIndexExclusionReason checks parent only, getSearchExclusionReason checks
   all ancestors (hasHiddenSegment).
-- F-M5 · 中 · bug · indexing-watch-path-policy.ts:41 — watch depth 5 vs scan depth 24:
-  deep files indexed but never watched; deletions persist until 24h reconcile.
+- F-M5 · 中 · bug · indexing-watch-path-policy.ts:41 — scan 深度仍为 24；2026-09-03
+  将 Darwin watch 深度从 5 提升至 8，并增加每进程一次的启动对账，补齐应用关闭期间新增文件。
+  第 9 层及以下仍不能实时监听，删除和修改需等待后续对账，因此本条保持 open。
 - F-M6 · 中 · 精准 — CJK infix unsearchable (unicode61 treats han run as one token,
   prefix-only match expr; index-side split only on [-_.\s]): 「会议」/「纪要」 cannot
   find 「2026年度会议纪要.docx」.

--- a/.trellis/tasks/08-05-search-audit-remediation/research/realtime-chain-diagnosis.md
+++ b/.trellis/tasks/08-05-search-audit-remediation/research/realtime-chain-diagnosis.md
@@ -136,9 +136,9 @@ mdfind 原查询返回 **330** 个 `.app`，而目录只有 228 行。差额的�
 
 ```
 文件落盘
-  ├─① chokidar depth：darwin = 5（indexing-watch-path-policy.ts:41）
+  ├─① chokidar depth：darwin = 8（indexing-watch-path-policy.ts:41）
   │    awaitWriteFinish stabilityThreshold 2000ms 对 file 生效
-  │    ⚠ F-M5 仍然成立：scan 深度 24 vs watch 深度 5，第 6 层以下的文件进得了索引、收不到事件
+  │    ⚠ F-M5 部分缓解：2026-09-03 将 watch 深度从 5 提升至 8；scan 深度仍为 24，第 9 层以下仍收不到实时事件
   ├─② IndexedSourceEventRouter → FILE_INDEXED_SOURCE_ID（同样零防抖）
   ├─③ fileProvider.handleIndexedSourceWatchEvent   file-provider.ts:2340-2369
   │    isWithinWatchRoots 门（:3345）→ 不在 root 内静默 return []
@@ -378,6 +378,6 @@ sudo rm -rf /Applications/ZZTestProbe.app
 - **A-M8**（watch roots 缺 `/System/Applications` 与 CoreServices）：确认仍然成立
   （`app-scanner.ts:39` 只有 `/Applications` 与 `~/Applications`）。但这两个目录在
   非越狱的 macOS 上基本不会有用户级变更，优先级低于 F1–F4。
-- **F-M5**（watch 深度 5 vs scan 深度 24）：确认仍然成立，见 §3。
+- **F-M5**（watch 深度 8 vs scan 深度 24）：2026-09-03 已从 5 提升到 8，并补启动对账；第 9 层以下实时事件缺口仍成立。
 - **新增（本次）**：`last_indexed_at` app 侧从不写入（F5）；健康检查无文件系统口径（F4）；
   全链路无时间窗合并（F2）；索引期 / 搜索期两套独立的 app 过滤器口径未统一（§1.4）。

--- a/apps/core-app/src/main/channel/common.test.ts
+++ b/apps/core-app/src/main/channel/common.test.ts
@@ -298,6 +298,7 @@ vi.mock('../modules/box-tool/addon/files/file-provider', () => ({
     getFailedFiles: vi.fn(),
     addWatchPath: vi.fn(),
     rebuildIndex: vi.fn(),
+    resolvePreviewResourcePath: vi.fn(),
     registerProgressStream: vi.fn()
   }
 }))
@@ -852,6 +853,69 @@ describe('CommonChannelModule private helpers', () => {
     } finally {
       packagedFlag.isPackaged = false
     }
+  })
+
+  it('keeps preview-resource grants host-only and delegates issuance to the indexed-file resolver', async () => {
+    const handlers = new Map<string, (payload: unknown, context: unknown) => Promise<unknown>>()
+    const transport = {
+      on: vi.fn(
+        (
+          event: { toEventName: () => string },
+          handler: (payload: unknown, context: unknown) => Promise<unknown>
+        ) => {
+          handlers.set(event.toEventName(), handler)
+          return vi.fn()
+        }
+      ),
+      onStream: vi.fn(() => vi.fn()),
+      broadcastToWindow: vi.fn()
+    }
+    getTuffTransportMainMock.mockReturnValue(transport as never)
+
+    const { fileProvider } = await import('../modules/box-tool/addon/files/file-provider')
+    const fileProviderMock = fileProvider as unknown as {
+      resolvePreviewResourcePath: ReturnType<typeof vi.fn>
+    }
+    fileProviderMock.resolvePreviewResourcePath
+      .mockResolvedValueOnce('/Users/demo/Downloads/indexed-preview.txt')
+      .mockResolvedValueOnce(null)
+
+    const module = new CommonChannelModule()
+    await module.onInit({
+      app: {
+        window: { window: {}, onMaximizedChanged: () => () => {} },
+        app: { addListener: vi.fn() }
+      }
+    } as never)
+
+    const handler = handlers.get(AppEvents.fileIndex.previewResource.toEventName())
+    expect(handler).toBeTypeOf('function')
+
+    await expect(
+      handler?.(
+        { path: '/Users/demo/Downloads/indexed-preview.txt' },
+        { plugin: { name: 'third-party' } }
+      )
+    ).rejects.toThrow('HOST_ONLY_HANDLER')
+    expect(fileProviderMock.resolvePreviewResourcePath).not.toHaveBeenCalled()
+
+    await expect(
+      handler?.({ path: '/Users/demo/Downloads/indexed-preview.txt' }, {})
+    ).resolves.toMatchObject({
+      success: true,
+      tfileUrl: expect.stringContaining('previewGrant='),
+      expiresAt: expect.any(Number)
+    })
+    expect(fileProviderMock.resolvePreviewResourcePath).toHaveBeenCalledWith(
+      '/Users/demo/Downloads/indexed-preview.txt'
+    )
+
+    await expect(handler?.({ path: '/Users/demo/Downloads/not-indexed.txt' }, {})).resolves.toEqual(
+      {
+        success: false,
+        errorCode: 'FILE_INDEX_PREVIEW_NOT_AVAILABLE'
+      }
+    )
   })
 
   it('maps each supported desktop wallpaper backend output to a usable path', async () => {

--- a/apps/core-app/src/main/channel/common.ts
+++ b/apps/core-app/src/main/channel/common.ts
@@ -23,6 +23,8 @@ import type {
   BatteryStatusPayload,
   FileIndexAddPathRequest,
   FileIndexAddPathResult,
+  FileIndexPreviewResourceRequest,
+  FileIndexPreviewResourceResult,
   IndexedSourceDiagnosticsRequest,
   IndexedSourceDiagnosticsResponse,
   IndexedSourceReconcileRuntimeRequest,
@@ -65,6 +67,10 @@ import { defineRawEvent } from '@talex-touch/utils/transport/event/builder'
 import type { TuffEvent } from '@talex-touch/utils/transport/event/types'
 import { AppEvents, PlatformEvents, PluginEvents } from '@talex-touch/utils/transport/events'
 import { toTfileUrl } from '@talex-touch/utils/network'
+import {
+  hasTfilePreviewGrant,
+  issueTfilePreviewGrant
+} from '../modules/file-protocol/tfile-preview-grant'
 import {
   BrowserWindow,
   app,
@@ -1736,6 +1742,31 @@ export class CommonChannelModule extends BaseModule {
           return null
         }
       }),
+      transport.on<FileIndexPreviewResourceRequest, FileIndexPreviewResourceResult>(
+        AppEvents.fileIndex.previewResource,
+        async (payload, context) => {
+          this.assertHostOnly(context, 'fileIndex.previewResource')
+          const inputPath = getOptionalStringProp(payload, 'path')
+          if (!inputPath) {
+            return { success: false, errorCode: 'FILE_INDEX_PREVIEW_PATH_INVALID' }
+          }
+          try {
+            const previewPath = await fileProvider.resolvePreviewResourcePath(inputPath)
+            if (!previewPath) {
+              return { success: false, errorCode: 'FILE_INDEX_PREVIEW_NOT_AVAILABLE' }
+            }
+            const grant = issueTfilePreviewGrant(previewPath)
+            return { success: true, ...grant }
+          } catch (error) {
+            const report = reportFileIndexTransportFailure('PREVIEW_RESOURCE', error)
+            return {
+              success: false,
+              errorCode: report.code,
+              reportId: report.id
+            }
+          }
+        }
+      ),
       transport.on<FileIndexAddPathRequest, FileIndexAddPathResult>(
         AppEvents.fileIndex.addPath,
         async (payload) => {
@@ -2101,20 +2132,25 @@ export class CommonChannelModule extends BaseModule {
       throw new Error('Unsupported file source')
     }
 
-    const cached = getCachedReadFile(resolvedPath)
-    if (cached) {
-      return cached.content
-    }
+    // Preview grants are short-lived bearer capabilities. Never let the
+    // path-keyed cache or inflight map outlive or bypass their expiry.
+    const cacheAllowed = !hasTfilePreviewGrant(resolvedSource)
+    if (cacheAllowed) {
+      const cached = getCachedReadFile(resolvedPath)
+      if (cached) {
+        return cached.content
+      }
 
-    const inflight = readFileInflight.get(resolvedPath)
-    if (inflight) {
-      try {
-        return await inflight
-      } catch (error) {
-        if (allowMissing && isFileMissingError(error)) {
-          return ''
+      const inflight = readFileInflight.get(resolvedPath)
+      if (inflight) {
+        try {
+          return await inflight
+        } catch (error) {
+          if (allowMissing && isFileMissingError(error)) {
+            return ''
+          }
+          throw error
         }
-        throw error
       }
     }
 
@@ -2132,7 +2168,7 @@ export class CommonChannelModule extends BaseModule {
         timeoutMs: timeoutMs > 0 ? timeoutMs : undefined
       })
       .then((content) => {
-        setCachedReadFile(resolvedPath, content)
+        if (cacheAllowed) setCachedReadFile(resolvedPath, content)
         return content
       })
       .catch((error) => {
@@ -2145,11 +2181,11 @@ export class CommonChannelModule extends BaseModule {
         throw error
       })
       .finally(() => {
-        readFileInflight.delete(resolvedPath)
+        if (cacheAllowed) readFileInflight.delete(resolvedPath)
         dispose()
       })
 
-    readFileInflight.set(resolvedPath, task)
+    if (cacheAllowed) readFileInflight.set(resolvedPath, task)
     return await task
   }
 

--- a/apps/core-app/src/main/modules/box-tool/addon/files/file-provider-startup.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/file-provider-startup.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TuffItem } from '@talex-touch/utils'
+import type { FileIndexProgress as FileIndexProgressPayload } from '@talex-touch/utils/transport/events/types'
 import type { IndexedSourceResetReason } from '@talex-touch/utils/search'
 import type { FilePersistencePort } from '../../search-engine/search-index-writer'
 import { IndexedSourceResetReasons, IndexedSourceScanReasons } from '@talex-touch/utils/search'
@@ -143,7 +144,8 @@ vi.mock('./services/file-provider-watch-service', () => ({
     ensureFileSystemWatchers: watchServiceEnsure,
     recordUserActivity: vi.fn(),
     shouldRunAutoIndexing: vi.fn(async () => ({ allowed: false, reason: 'test' })),
-    applyWatchPaths: vi.fn()
+    applyWatchPaths: vi.fn(),
+    dispose: vi.fn()
   }))
 }))
 
@@ -185,6 +187,7 @@ vi.mock('./workers/thumbnail-worker-client', () => ({
 }))
 
 import { operationalErrorService } from '../../../observability'
+import { FileProviderEnrichmentResumeService } from './services/file-provider-enrichment-resume-service'
 import { fileProvider, resolveFileProviderBaseWatchPaths } from './file-provider'
 
 interface MutableFileProvider {
@@ -655,6 +658,41 @@ describe('file-provider startup readiness', () => {
         startupErrorCode: null
       })
     )
+  })
+
+  it('stops auto indexing when shutdown starts during watcher setup', async () => {
+    const provider = fileProvider as unknown as FileProviderShutdownTestApi & {
+      runAutoIndexing: () => Promise<boolean>
+      watchService: {
+        shouldRunAutoIndexing: () => Promise<{ allowed: boolean }>
+        dispose?: () => void
+      }
+    }
+    const watcherSetup = createDeferred<void>()
+    const originalShouldRunAutoIndexing = provider.watchService.shouldRunAutoIndexing
+    const originalDispose = provider.watchService.dispose
+    let autoIndexing: Promise<boolean> | null = null
+
+    resetProviderState(provider)
+    provider.watchService.shouldRunAutoIndexing = vi.fn(async () => ({ allowed: true }))
+    provider.watchService.dispose = vi.fn()
+    watchServiceEnsure.mockImplementationOnce(() => watcherSetup.promise as never)
+
+    try {
+      autoIndexing = provider.runAutoIndexing()
+      await vi.waitFor(() => expect(watchServiceEnsure).toHaveBeenCalledTimes(1))
+
+      await provider.prepareForSearchIndexShutdown()
+      watcherSetup.resolve(undefined)
+
+      await expect(autoIndexing).resolves.toBe(false)
+      expect(runtimeScanSource).not.toHaveBeenCalled()
+    } finally {
+      watcherSetup.resolve(undefined)
+      await autoIndexing?.catch(() => undefined)
+      provider.watchService.shouldRunAutoIndexing = originalShouldRunAutoIndexing
+      provider.watchService.dispose = originalDispose
+    }
   })
 
   it('waits for deferred startup and prevents post-shutdown worker or watcher initialization', async () => {
@@ -1371,6 +1409,86 @@ describe('file-provider startup readiness', () => {
     }
   })
 
+  it('resolves preview resources only for currently indexed ordinary files', async () => {
+    const provider = fileProvider as unknown as {
+      dbUtils: unknown
+      isWithinWatchRoots: (rawPath: string) => boolean
+      resolvePreviewResourcePath: (rawPath: string) => Promise<string | null>
+    }
+    const originalDbUtils = provider.dbUtils
+    const originalIsWithinWatchRoots = provider.isWithinWatchRoots
+    const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tuff-preview-resource-'))
+    const indexedFile = path.join(fixtureDir, 'indexed.txt')
+    const indexedDirectory = path.join(fixtureDir, 'indexed-directory')
+    const rows: Array<{ path: string; type: string }> = []
+    const limit = vi.fn(async () => rows)
+    const select = vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit }))
+      }))
+    }))
+
+    await fs.writeFile(indexedFile, 'fixture')
+    await fs.mkdir(indexedDirectory)
+    provider.dbUtils = {
+      getFileIndexReadDb: () => ({ select })
+    }
+    provider.isWithinWatchRoots = (candidate) => candidate.startsWith(fixtureDir)
+
+    try {
+      await expect(provider.resolvePreviewResourcePath(indexedFile)).resolves.toBeNull()
+
+      rows.splice(0, rows.length, { path: indexedDirectory, type: 'file' })
+      await expect(provider.resolvePreviewResourcePath(indexedDirectory)).resolves.toBeNull()
+
+      rows.splice(0, rows.length, { path: indexedFile, type: 'file' })
+      await expect(provider.resolvePreviewResourcePath(indexedFile)).resolves.toBe(
+        await fs.realpath(indexedFile)
+      )
+    } finally {
+      provider.dbUtils = originalDbUtils
+      provider.isWithinWatchRoots = originalIsWithinWatchRoots
+      await fs.rm(fixtureDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects an indexed symlink when its canonical target is absent from the index', async () => {
+    const provider = fileProvider as unknown as {
+      dbUtils: unknown
+      isWithinWatchRoots: (rawPath: string) => boolean
+      resolvePreviewResourcePath: (rawPath: string) => Promise<string | null>
+    }
+    const originalDbUtils = provider.dbUtils
+    const originalIsWithinWatchRoots = provider.isWithinWatchRoots
+    const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tuff-preview-symlink-'))
+    const canonicalTarget = path.join(fixtureDir, 'canonical-target.txt')
+    const indexedSymlink = path.join(fixtureDir, 'indexed-link.txt')
+    const limit = vi
+      .fn()
+      .mockResolvedValueOnce([{ path: indexedSymlink, type: 'file' }])
+      .mockResolvedValueOnce([])
+    const select = vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit }))
+      }))
+    }))
+
+    await fs.writeFile(canonicalTarget, 'fixture')
+    await fs.symlink(canonicalTarget, indexedSymlink)
+    provider.dbUtils = {
+      getFileIndexReadDb: () => ({ select })
+    }
+    provider.isWithinWatchRoots = (candidate) => candidate.startsWith(fixtureDir)
+
+    try {
+      await expect(provider.resolvePreviewResourcePath(indexedSymlink)).resolves.toBeNull()
+    } finally {
+      provider.dbUtils = originalDbUtils
+      provider.isWithinWatchRoots = originalIsWithinWatchRoots
+      await fs.rm(fixtureDir, { recursive: true, force: true })
+    }
+  })
+
   it('wires per-call split routing into the watch service for the failed-files cleanup task', async () => {
     // Regression for the 2d.3 cross-home hazard: without these deps the
     // cleanup task defaults to split-off and would read failed-file ids from
@@ -1739,7 +1857,7 @@ describe('file-provider startup readiness', () => {
     const originalCancelledLeases = provider.cancelledIndexWorkerMutationLeases
     const activeDispatchSettled = createDeferred<void>()
     const cancellationBegan = createDeferred<void>()
-    const timeout = new Error('lease A drain timed out')
+    const timeout = new Error('file-index-search-drain-timeout:indexed-source.scan')
     const events: string[] = []
     const reset = vi.fn(async () => {
       events.push('reset-progress')
@@ -1763,6 +1881,11 @@ describe('file-provider startup readiness', () => {
       })
     } as unknown as typeof provider.fileIndexWorker
     provider.resetIndexedSourceRuntimeState = reset
+    const resume = vi
+      .spyOn(FileProviderEnrichmentResumeService.prototype, 'resume')
+      .mockImplementation((reason) => {
+        events.push(`resume-enrichment:${reason}`)
+      })
     provider.pendingIndexWorkerResults = new Map([
       [1, { mutationLeaseId: 'lease-A' }],
       [2, { mutationLeaseId: 'lease-B' }]
@@ -1783,21 +1906,16 @@ describe('file-provider startup readiness', () => {
 
       activeDispatchSettled.resolve(undefined)
       events.push('active-dispatch-settled')
-      await expect(drain).rejects.toBe(timeout)
+      await expect(drain).resolves.toBeUndefined()
 
       expect(events).toEqual([
         'scheduler-cancel:lease-A',
         'worker-cancel:lease-A',
         'active-dispatch-settled',
-        'reset-progress'
+        'resume-enrichment:recovery.indexed-source.scan'
       ])
-      expect(reset).toHaveBeenCalledWith(
-        expect.objectContaining({
-          sourceId: 'file-provider',
-          clearSearchIndex: false,
-          clearScanProgress: true
-        })
-      )
+      expect(reset).not.toHaveBeenCalled()
+      expect(resume).toHaveBeenCalledWith('recovery.indexed-source.scan')
       expect(provider.pendingIndexWorkerResults.has(1)).toBe(false)
       expect(provider.inflightIndexWorkerResults.has(3)).toBe(false)
       expect(provider.pendingIndexWorkerResults.get(2)).toEqual({ mutationLeaseId: 'lease-B' })
@@ -1811,9 +1929,30 @@ describe('file-provider startup readiness', () => {
       provider.indexSchedulerService = originalScheduler
       provider.fileIndexWorker = originalWorker
       provider.resetIndexedSourceRuntimeState = originalReset
+      resume.mockRestore()
       provider.pendingIndexWorkerResults = originalPending
       provider.inflightIndexWorkerResults = originalInflight
       provider.cancelledIndexWorkerMutationLeases = originalCancelledLeases
+    }
+  })
+
+  it('propagates a drain failure that is not an enrichment timeout', async () => {
+    const provider = fileProvider as unknown as FileProviderLeaseRecoveryTestApi
+    const originalScheduler = provider.indexSchedulerService
+    const unexpected = new Error('SQLITE_BUSY: unrelated drain failure')
+    const cancelLease = vi.fn()
+    provider.indexSchedulerService = {
+      drain: vi.fn().mockRejectedValue(unexpected),
+      cancelLease
+    } as unknown as typeof provider.indexSchedulerService
+
+    try {
+      await expect(
+        provider.drainIndexedSourceMutations('indexed-source.scan', 'lease-unexpected')
+      ).rejects.toBe(unexpected)
+      expect(cancelLease).not.toHaveBeenCalled()
+    } finally {
+      provider.indexSchedulerService = originalScheduler
     }
   })
 
@@ -1852,6 +1991,87 @@ describe('file-provider startup readiness', () => {
     const notice = provider.buildStartupDegradedNotice({ text: 'report', inputs: [] })
 
     expect(notice).toBeNull()
+  })
+
+  it('never lets a throttled indexing payload overwrite completed or idle state, including for late subscribers', async () => {
+    type ProgressStream = {
+      emit: (payload: FileIndexProgressPayload) => void
+      isCancelled: () => boolean
+    }
+    const provider = fileProvider as unknown as {
+      progressStreamContexts: Set<ProgressStream>
+      lastProgressStreamPayload: FileIndexProgressPayload | null
+      lastProgressStreamEmitAt: number
+      pendingProgressStreamPayload: FileIndexProgressPayload | null
+      progressStreamFlushTimer: NodeJS.Timeout | null
+      registerProgressStream: (context: ProgressStream) => void
+      emitProgressStream: (payload: FileIndexProgressPayload) => void
+      clearProgressCleanupTimer: () => void
+    }
+    const originalLastPayload = provider.lastProgressStreamPayload
+    const originalLastEmitAt = provider.lastProgressStreamEmitAt
+    const originalPendingPayload = provider.pendingProgressStreamPayload
+    const originalFlushTimer = provider.progressStreamFlushTimer
+    const originalContexts = new Set(provider.progressStreamContexts)
+    const now = new Date('2026-09-03T00:00:00.000Z')
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+
+    const payload = (
+      stage: FileIndexProgressPayload['stage'],
+      current: number,
+      progress: number
+    ) => ({
+      stage,
+      current,
+      total: 100,
+      progress,
+      startTime: now.getTime(),
+      estimatedRemainingMs: null,
+      averageItemsPerSecond: 0
+    })
+
+    try {
+      for (const terminalStage of ['completed', 'idle'] as const) {
+        provider.progressStreamContexts.clear()
+        provider.lastProgressStreamPayload = null
+        provider.lastProgressStreamEmitAt = 0
+        provider.pendingProgressStreamPayload = null
+        if (provider.progressStreamFlushTimer) clearTimeout(provider.progressStreamFlushTimer)
+        provider.progressStreamFlushTimer = null
+
+        const subscriber: ProgressStream = { emit: vi.fn(), isCancelled: vi.fn(() => false) }
+        provider.registerProgressStream(subscriber)
+        provider.emitProgressStream(payload('indexing', 10, 0.1))
+        provider.emitProgressStream(payload('indexing', 11, 0.1))
+        provider.emitProgressStream(payload(terminalStage, 100, 1))
+
+        expect(vi.mocked(subscriber.emit).mock.calls.map(([update]) => update.stage)).toEqual([
+          'indexing',
+          terminalStage
+        ])
+        await vi.advanceTimersByTimeAsync(1_000)
+        expect(vi.mocked(subscriber.emit).mock.calls.map(([update]) => update.stage)).toEqual([
+          'indexing',
+          terminalStage
+        ])
+      }
+
+      const lateSubscriber: ProgressStream = { emit: vi.fn(), isCancelled: vi.fn(() => false) }
+      provider.registerProgressStream(lateSubscriber)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(vi.mocked(lateSubscriber.emit)).toHaveBeenCalledWith(
+        expect.objectContaining({ stage: 'idle', progress: 1 })
+      )
+    } finally {
+      provider.clearProgressCleanupTimer()
+      provider.progressStreamContexts.clear()
+      for (const context of originalContexts) provider.progressStreamContexts.add(context)
+      provider.lastProgressStreamPayload = originalLastPayload
+      provider.lastProgressStreamEmitAt = originalLastEmitAt
+      provider.pendingProgressStreamPayload = originalPendingPayload
+      provider.progressStreamFlushTimer = originalFlushTimer
+    }
   })
 })
 

--- a/apps/core-app/src/main/modules/box-tool/addon/files/file-provider.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/file-provider.ts
@@ -59,7 +59,6 @@ import {
   IndexedWriteRuntimeEmitterService,
   buildIndexedWriteFlushFailureSnapshot,
   buildIndexedWriteFlushResultSnapshot,
-  isIndexedWatchPathOwned,
   mapIndexedFileSourceRecord,
   resolveIndexedWatchRootSet
 } from '@talex-touch/utils/search'
@@ -149,8 +148,9 @@ import {
   FileProviderIntegrityService,
   type FileProviderIntegritySnapshot
 } from './services/file-provider-integrity-service'
-import { FileProviderScanProgressService } from './services/file-provider-scan-progress-service'
 import { FileProviderRuntimeResetService } from './services/file-provider-runtime-reset-service'
+import { FileProviderScanProgressService } from './services/file-provider-scan-progress-service'
+import { FileProviderEnrichmentResumeService } from './services/file-provider-enrichment-resume-service'
 import { shouldBootstrapFileReindex } from './services/file-provider-bootstrap-reindex'
 import {
   FileProviderPathNormalizationService,
@@ -174,6 +174,7 @@ import { FileProviderReconciliationDeleteService } from './services/file-provide
 import { FileProviderReconciliationDiffService } from './services/file-provider-reconciliation-diff-service'
 import {
   FileProviderReconciliationRunService,
+  getMissingReconciliationDbFiles,
   type FileProviderReconciliationDbRecord
 } from './services/file-provider-reconciliation-run-service'
 import { FileProviderReconciliationUpdateService } from './services/file-provider-reconciliation-update-service'
@@ -399,7 +400,6 @@ class FileProvider implements ISearchProvider<ProviderContext> {
   private initializationContext: ProviderContext | null = null
   private readonly baseWatchPaths: string[]
   private watchPaths: string[]
-  private normalizedWatchPaths: string[]
   private databaseFilePath: string | null = null
   private searchIndex: SearchIndexService | null = null
   private embeddingService: EmbeddingService | null = null
@@ -557,6 +557,7 @@ class FileProvider implements ISearchProvider<ProviderContext> {
     FileIndexRunOptions | undefined
   >
   private readonly indexSchedulerService: FileProviderIndexSchedulerService
+  private readonly enrichmentResumeService: FileProviderEnrichmentResumeService
   private readonly indexPersistEntryMapper: IndexedWorkerPersistEntryMapperService
   private readonly assetService: FileProviderAssetService
   private readonly searchResultService: FileProviderSearchResultService
@@ -627,7 +628,6 @@ class FileProvider implements ISearchProvider<ProviderContext> {
       normalizePath: (rawPath) => this.normalizePath(rawPath)
     })
     this.watchPaths = rootSet.paths
-    this.normalizedWatchPaths = rootSet.normalizedPaths
     this.watchService = new FileProviderWatchService({
       baseWatchPaths: this.baseWatchPaths,
       getDbUtils: () => this.dbUtils,
@@ -956,6 +956,16 @@ class FileProvider implements ISearchProvider<ProviderContext> {
         this.fileIndexWorker.indexFiles(dbPath, providerId, providerType, files),
       logWarn: (message, error, meta) => this.logWarn(message, error, meta)
     })
+    this.enrichmentResumeService = new FileProviderEnrichmentResumeService({
+      getDbUtils: () => this.dbUtils,
+      isSearchIndexAvailable: () => Boolean(this.searchIndex),
+      isShuttingDown: () => this.shuttingDown,
+      scheduleIndexing: (files, reason) => this.scheduleIndexing(files, reason),
+      waitForSearchIndexDrain: (reason) => this.waitForSearchIndexDrain(reason),
+      yieldToEventLoop: async () => await new Promise<void>((resolve) => setImmediate(resolve)),
+      logInfo: (message, meta) => this.logInfo(message, meta),
+      logWarn: (message, error, meta) => this.logWarn(message, error, meta)
+    })
     this.indexPersistEntryMapper = new IndexedWorkerPersistEntryMapperService()
     this.indexRuntimeService = new FileProviderIndexRuntimeService({
       flushBatchScheduler: this.flushBatchScheduler,
@@ -1068,6 +1078,7 @@ class FileProvider implements ISearchProvider<ProviderContext> {
 
   public async prepareForSearchIndexShutdown(): Promise<void> {
     this.shuttingDown = true
+    this.watchService.dispose()
     if (this.pathNormalizationTimer) {
       clearTimeout(this.pathNormalizationTimer)
       this.pathNormalizationTimer = null
@@ -1957,7 +1968,6 @@ class FileProvider implements ISearchProvider<ProviderContext> {
   private syncWatchServiceState(): void {
     this.fileIndexSettings = this.watchService.getCurrentSettings()
     this.watchPaths = this.watchService.getWatchPaths()
-    this.normalizedWatchPaths = this.watchService.getNormalizedWatchPaths()
     this.watchPathsRegistered = this.watchService.isWatchPathRegistered()
   }
 
@@ -2065,8 +2075,8 @@ class FileProvider implements ISearchProvider<ProviderContext> {
     })
   }
 
-  private async runAutoIndexing(): Promise<void> {
-    if (this.shuttingDown) return
+  private async runAutoIndexing(): Promise<boolean> {
+    if (this.shuttingDown) return false
     const decision = await this.shouldRunAutoIndexing()
     if (!decision.allowed) {
       this.logDebug('Auto index scan skipped', {
@@ -2074,18 +2084,20 @@ class FileProvider implements ISearchProvider<ProviderContext> {
         batteryLevel: decision.battery?.level ?? null,
         batteryCharging: decision.battery?.charging ?? null
       })
-      return
+      return false
     }
-    if (this.shuttingDown) return
+    if (this.shuttingDown) return false
 
     await this.ensureFileSystemWatchers()
+    if (this.shuttingDown) return false
     try {
       await this.requireRuntimeMutationDelegate().scanSource(IndexedSourceScanReasons.Startup)
+      return true
     } catch (error) {
       this.logWarn('Auto index scan aborted', error)
+      return false
     }
   }
-
   private async startIndexing(
     source: 'auto' | 'manual',
     options?: FileIndexRunOptions
@@ -2174,6 +2186,10 @@ class FileProvider implements ISearchProvider<ProviderContext> {
     return this.watchService.ownsWatchPath(rawPath)
   }
 
+  public async resolvePreviewResourcePath(rawPath: string): Promise<string | null> {
+    return await this.assetService.resolvePreviewResourcePath(rawPath)
+  }
+
   public async *streamIndexedSourceSnapshot(
     request: IndexedSourceScanRequest
   ): AsyncIterable<IndexedSourceRecordBatch> {
@@ -2251,20 +2267,15 @@ class FileProvider implements ISearchProvider<ProviderContext> {
   ): Promise<void> {
     try {
       await this.waitForSearchIndexDrain(reason, mutationLeaseId)
+      if (!this.shuttingDown) this.enrichmentResumeService.resume(reason)
     } catch (error) {
-      // Deliberate consistency lever, with a known cost: when post-scan
-      // content/embedding enrichment cannot drain within
-      // FILE_INDEX_SEARCH_DRAIN_TIMEOUT_MS (30s), the catch below CLEARS
-      // scan_progress so the next eligible scan re-runs and re-dispatches
-      // enrichment (there is no standalone resume-from-file_index_progress
-      // path). Consequence on a large first index: the scan-completion
-      // scan_progress rows written moments earlier are wiped again each run
-      // until enrichment fits the drain window, so every eligible auto-scan
-      // re-walks all roots (observed as sp=0 in the 2026-08-05 split
-      // validation runs). Not corruption — re-scan converges — but if this
-      // loop shows up in steady-state logs ('Search index drain timed out
-      // after indexed-source scan'), the fix belongs in the enrichment
-      // contract (resume from file_index_progress), not here.
+      const message = error instanceof Error ? error.message : String(error)
+      const timedOut =
+        message.startsWith('file-index-search-drain-timeout:') ||
+        message === 'FILE_INDEX_SCHEDULER_DRAIN_TIMEOUT'
+
+      if (!timedOut) throw error
+
       if (mutationLeaseId !== undefined) {
         this.cancelledIndexWorkerMutationLeases.add(mutationLeaseId)
         this.indexSchedulerService.cancelLease(mutationLeaseId)
@@ -2280,6 +2291,7 @@ class FileProvider implements ISearchProvider<ProviderContext> {
         this.indexSchedulerService.cancelPending()
         this.fileIndexWorker.shutdown()
       }
+
       for (const [fileId, result] of this.pendingIndexWorkerResults) {
         if (mutationLeaseId === undefined || result.mutationLeaseId === mutationLeaseId) {
           this.pendingIndexWorkerResults.delete(fileId)
@@ -2290,15 +2302,12 @@ class FileProvider implements ISearchProvider<ProviderContext> {
           this.inflightIndexWorkerResults.delete(fileId)
         }
       }
-      await this.resetIndexedSourceRuntimeState({
-        sourceId: this.id,
-        reason: IndexedSourceResetReasons.HealthRepair,
-        clearSearchIndex: false,
-        clearScanProgress: true
-      }).catch((resetError) => {
-        this.logWarn('Failed to clear scan progress after enrichment drain failure', resetError)
-      })
-      throw error
+
+      // scan_progress records filesystem coverage and must survive a later
+      // content-enrichment timeout. Resume only unfinished file_index_progress
+      // rows under a fresh, lease-free background run.
+      if (!this.shuttingDown) this.enrichmentResumeService.resume(`recovery.${reason}`)
+      return
     }
   }
 
@@ -2998,6 +3007,11 @@ class FileProvider implements ISearchProvider<ProviderContext> {
         lastEmitAt: this.lastProgressStreamEmitAt
       })
     ) {
+      // An immediate transition is newer than any throttled payload already
+      // waiting in the timer. Retire that payload before publishing so an old
+      // `indexing 100%` update can never overwrite `completed` or `idle`.
+      this.clearProgressStreamFlushTimer()
+      this.pendingProgressStreamPayload = null
       this.flushProgressStreamPayload(payload, now)
       return
     }
@@ -3246,26 +3260,7 @@ class FileProvider implements ISearchProvider<ProviderContext> {
   ): Promise<FileProviderReconciliationDbRecord[]> {
     options?.signal?.throwIfAborted()
     if (!this.dbUtils) throw new Error('FILE_PROVIDER_PERSISTENCE_UNAVAILABLE')
-    const queryRoot = path.normalize(rootPath)
-    const descendantPrefix = queryRoot.endsWith(path.sep) ? queryRoot : `${queryRoot}${path.sep}`
-    const escapedPrefix = descendantPrefix
-      .replace(/!/g, '!!')
-      .replace(/%/g, '!%')
-      .replace(/_/g, '!_')
-    return await this.dbUtils.getFileIndexReadDb().all<FileProviderReconciliationDbRecord>(sql`
-      SELECT f.id, f.path, f.mtime
-      FROM files AS f
-      WHERE f.type = 'file'
-        AND (f.path = ${queryRoot} OR f.path LIKE ${`${escapedPrefix}%`} ESCAPE '!')
-        AND f.id > ${afterId}
-        AND NOT EXISTS (
-          SELECT 1
-          FROM file_reconciliation_seen_paths AS seen
-          WHERE seen.path = f.path
-        )
-      ORDER BY f.id
-      LIMIT ${limit}
-    `)
+    return await getMissingReconciliationDbFiles(this.dbUtils, rootPath, afterId, limit)
   }
 
   /**
@@ -3340,14 +3335,8 @@ class FileProvider implements ISearchProvider<ProviderContext> {
   }
 
   private isWithinWatchRoots(rawPath: string): boolean {
-    return isIndexedWatchPathOwned({
-      rawPath,
-      normalizedWatchPaths: this.normalizedWatchPaths,
-      normalizePath: (path) => this.normalizePath(path),
-      pathSeparator: path.sep
-    })
+    return this.watchService.ownsWatchPath(rawPath)
   }
-
   /**
    * Single ingress for every non-scan path that reaches the index: watcher
    * events and manual adds both land here, and macOS hands them over

--- a/apps/core-app/src/main/modules/box-tool/addon/files/services/file-provider-asset-service.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/services/file-provider-asset-service.ts
@@ -1,8 +1,11 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
 import { Buffer } from 'node:buffer'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/sqlite-core/alias'
 import type { DbUtils } from '../../../../../db/utils'
 import { fileExtensions, files as filesSchema } from '../../../../../db/schema'
+import { normalizeFsPath } from '@talex-touch/utils/common/file-scan-utils'
 import {
   THUMBNAIL_EXTENSIONS,
   getThumbnailUnsupportedReason,
@@ -90,6 +93,41 @@ export class FileProviderAssetService {
     this.iconExtractionPending.set(filePath, task)
     task.finally(() => this.iconExtractionPending.delete(filePath))
     return task
+  }
+  /**
+   * Resolves only an indexed live ordinary file for a renderer preview grant.
+   * The database row is authoritative; the final stat closes the stale-path
+   * window before the protocol layer receives the resource path.
+   */
+  async resolvePreviewResourcePath(rawPath: string): Promise<string | null> {
+    const dbUtils = this.deps.getDbUtils()
+    if (!dbUtils || typeof rawPath !== 'string') return null
+
+    const candidate = normalizeFsPath(rawPath.trim())
+    if (!candidate || !path.isAbsolute(candidate)) return null
+
+    const indexed = await dbUtils
+      .getFileIndexReadDb()
+      .select({ path: filesSchema.path, type: filesSchema.type })
+      .from(filesSchema)
+      .where(eq(filesSchema.path, candidate))
+      .limit(1)
+      .then((rows) => rows[0])
+    if (!indexed || indexed.type !== 'file') return null
+
+    try {
+      const realPath = normalizeFsPath(await fs.realpath(indexed.path))
+      const canonical = await dbUtils
+        .getFileIndexReadDb()
+        .select({ type: filesSchema.type })
+        .from(filesSchema)
+        .where(eq(filesSchema.path, realPath))
+        .limit(1)
+        .then((rows) => rows[0])
+      return canonical?.type === 'file' && (await fs.stat(realPath)).isFile() ? realPath : null
+    } catch {
+      return null
+    }
   }
 
   async ensureIcon(fileId: number, filePath: string, file?: FileRecord): Promise<void> {

--- a/apps/core-app/src/main/modules/box-tool/addon/files/services/file-provider-enrichment-resume-service.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/services/file-provider-enrichment-resume-service.ts
@@ -1,0 +1,94 @@
+import { and, eq, gt, inArray, isNull, or } from 'drizzle-orm'
+import type { DbUtils } from '../../../../../db/utils'
+import { fileIndexProgress, files as filesSchema } from '../../../../../db/schema'
+
+const RESUME_BATCH_SIZE = 200
+
+type FileRecord = typeof filesSchema.$inferSelect
+
+export interface FileProviderEnrichmentResumeServiceDeps {
+  getDbUtils: () => DbUtils | null
+  isSearchIndexAvailable: () => boolean
+  isShuttingDown: () => boolean
+  scheduleIndexing: (files: FileRecord[], reason: string) => void
+  waitForSearchIndexDrain: (reason: string) => Promise<void>
+  yieldToEventLoop: () => Promise<void>
+  logInfo: (message: string, meta?: Record<string, unknown>) => void
+  logWarn: (message: string, error?: unknown, meta?: Record<string, unknown>) => void
+}
+
+/**
+ * Resumes post-scan content/embedding work from durable file_index_progress
+ * records. It deliberately does not alter scan_progress: that table proves
+ * filesystem coverage, while this service repairs only unfinished enrichment.
+ */
+export class FileProviderEnrichmentResumeService {
+  private resumePromise: Promise<void> | null = null
+
+  constructor(private readonly deps: FileProviderEnrichmentResumeServiceDeps) {}
+
+  resume(reason: string): void {
+    if (this.deps.isShuttingDown() || this.resumePromise) return
+
+    const run = this.run(reason)
+      .catch((error) => {
+        this.deps.logWarn('Deferred file enrichment recovery paused', error, { reason })
+      })
+      .finally(() => {
+        if (this.resumePromise === run) this.resumePromise = null
+      })
+    this.resumePromise = run
+  }
+
+  private async run(reason: string): Promise<void> {
+    const dbUtils = this.deps.getDbUtils()
+    if (!dbUtils || !this.deps.isSearchIndexAvailable()) return
+
+    let afterId = 0
+    let scheduled = 0
+    while (!this.deps.isShuttingDown()) {
+      const rows = await dbUtils
+        .getFileIndexReadDb()
+        .select({
+          id: filesSchema.id,
+          path: filesSchema.path,
+          name: filesSchema.name,
+          displayName: filesSchema.displayName,
+          extension: filesSchema.extension,
+          size: filesSchema.size,
+          mtime: filesSchema.mtime,
+          ctime: filesSchema.ctime,
+          lastIndexedAt: filesSchema.lastIndexedAt,
+          isDir: filesSchema.isDir,
+          type: filesSchema.type,
+          content: filesSchema.content,
+          embeddingStatus: filesSchema.embeddingStatus
+        })
+        .from(filesSchema)
+        .leftJoin(fileIndexProgress, eq(fileIndexProgress.fileId, filesSchema.id))
+        .where(
+          and(
+            eq(filesSchema.type, 'file'),
+            gt(filesSchema.id, afterId),
+            or(
+              isNull(fileIndexProgress.fileId),
+              inArray(fileIndexProgress.status, ['pending', 'processing'])
+            )
+          )
+        )
+        .orderBy(filesSchema.id)
+        .limit(RESUME_BATCH_SIZE)
+
+      if (rows.length === 0) break
+      this.deps.scheduleIndexing(rows, `enrichment-resume.${reason}`)
+      await this.deps.waitForSearchIndexDrain(`enrichment-resume.${reason}`)
+      scheduled += rows.length
+      afterId = rows[rows.length - 1]!.id
+      await this.deps.yieldToEventLoop()
+    }
+
+    if (scheduled > 0) {
+      this.deps.logInfo('Deferred file enrichment recovery completed', { reason, scheduled })
+    }
+  }
+}

--- a/apps/core-app/src/main/modules/box-tool/addon/files/services/file-provider-reconciliation-run-service.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/services/file-provider-reconciliation-run-service.ts
@@ -1,3 +1,6 @@
+import path from 'node:path'
+import { sql } from 'drizzle-orm'
+import type { DbUtils } from '../../../../../db/utils'
 import {
   mapIndexedWriteReconciliationDbPayload,
   mapIndexedWriteReconciliationDiskPayload,
@@ -15,6 +18,31 @@ export interface FileProviderReconciliationDbRecord {
   id: number
   path: string
   mtime: Date | number | string | null
+}
+
+export async function getMissingReconciliationDbFiles(
+  dbUtils: DbUtils,
+  rootPath: string,
+  afterId: number,
+  limit: number
+): Promise<FileProviderReconciliationDbRecord[]> {
+  const queryRoot = path.normalize(rootPath)
+  const descendantPrefix = queryRoot.endsWith(path.sep) ? queryRoot : `${queryRoot}${path.sep}`
+  const escapedPrefix = descendantPrefix.replace(/!/g, '!!').replace(/%/g, '!%').replace(/_/g, '!_')
+  return await dbUtils.getFileIndexReadDb().all<FileProviderReconciliationDbRecord>(sql`
+    SELECT f.id, f.path, f.mtime
+    FROM files AS f
+    WHERE f.type = 'file'
+      AND (f.path = ${queryRoot} OR f.path LIKE ${`${escapedPrefix}%`} ESCAPE '!')
+      AND f.id > ${afterId}
+      AND NOT EXISTS (
+        SELECT 1
+        FROM file_reconciliation_seen_paths AS seen
+        WHERE seen.path = f.path
+      )
+    ORDER BY f.id
+    LIMIT ${limit}
+  `)
 }
 
 export interface FileProviderReconciliationUpdateRecord {

--- a/apps/core-app/src/main/modules/box-tool/addon/files/services/file-provider-watch-service.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/services/file-provider-watch-service.test.ts
@@ -5,6 +5,13 @@ import { appTaskGate } from '../../../../../service/app-task-gate'
 import { deviceIdleService } from '../../../../../service/device-idle-service'
 import { isSearchRecentlyActive } from '../../../search-engine/search-activity'
 
+const backgroundTaskMocks = vi.hoisted(() => ({
+  registerTask: vi.fn(),
+  on: vi.fn(),
+  start: vi.fn(),
+  recordActivity: vi.fn()
+}))
+
 vi.mock('@talex-touch/utils', () => ({
   StorageList: {
     FILE_INDEX_SETTINGS: 'file-index-settings.json'
@@ -36,12 +43,7 @@ vi.mock('../../../../../service/background-task-service', () => ({
     }))
   },
   BackgroundTaskService: {
-    getInstance: vi.fn(() => ({
-      registerTask: vi.fn(),
-      on: vi.fn(),
-      start: vi.fn(),
-      recordActivity: vi.fn()
-    }))
+    getInstance: vi.fn(() => backgroundTaskMocks)
   }
 }))
 
@@ -141,6 +143,7 @@ function createService(
     baseWatchPaths?: string[]
     dbUtils?: unknown
     normalizePath?: (rawPath: string) => string
+    runAutoIndexing?: () => Promise<boolean>
   } = {}
 ) {
   return new FileProviderWatchService({
@@ -148,7 +151,7 @@ function createService(
     getDbUtils: () => (input.dbUtils ?? null) as never,
     getWatchDepthForPath: () => 1,
     normalizePath: input.normalizePath ?? ((rawPath) => rawPath),
-    runAutoIndexing: vi.fn(async () => undefined),
+    runAutoIndexing: input.runAutoIndexing ?? vi.fn(async () => true),
     logDebug: vi.fn(),
     logWarn: vi.fn(),
     logError: vi.fn()
@@ -300,38 +303,146 @@ describe('file-provider-watch-service', () => {
     expect(deviceIdleService.canRun).not.toHaveBeenCalled()
   })
 
-  it('skips auto indexing when no path is eligible by interval', async () => {
-    const freshTimestamp = Date.now()
-    const { dbUtils } = createDbUtils([
-      { path: '/tmp/tuff-index-a', lastScanned: freshTimestamp },
-      { path: '/tmp/tuff-index-b', lastScanned: freshTimestamp }
-    ])
-    const service = createService({ dbUtils })
+  it('schedules one startup reconcile at 2.5 seconds without duplicating or resetting it', async () => {
+    const freshTimestamp = new Date('2026-09-03T00:00:00.000Z').getTime()
+    vi.useFakeTimers()
+    vi.setSystemTime(freshTimestamp)
 
-    await expect(
-      service.shouldRunAutoIndexing({
-        isInitializing: false,
-        hasInitializationContext: true
-      })
-    ).resolves.toEqual({ allowed: false, reason: 'interval' })
-    expect(deviceIdleService.canRun).not.toHaveBeenCalled()
+    try {
+      const { dbUtils } = createDbUtils([
+        { path: '/tmp/tuff-index-a', lastScanned: freshTimestamp },
+        { path: '/tmp/tuff-index-b', lastScanned: freshTimestamp }
+      ])
+      const runAutoIndexing = vi.fn<() => Promise<boolean>>().mockResolvedValue(true)
+      const service = createService({ dbUtils, runAutoIndexing })
+
+      service.initializeBackgroundTaskService()
+      await vi.advanceTimersByTimeAsync(1_000)
+      service.initializeBackgroundTaskService()
+
+      await vi.advanceTimersByTimeAsync(1_499)
+      expect(runAutoIndexing).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(runAutoIndexing).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(runAutoIndexing).toHaveBeenCalledTimes(1)
+      await expect(
+        service.shouldRunAutoIndexing({
+          isInitializing: false,
+          hasInitializationContext: true
+        })
+      ).resolves.toEqual({ allowed: false, reason: 'interval' })
+      expect(deviceIdleService.canRun).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
-  it('runs idle gate when auto indexing preflight and interval pass', async () => {
-    const staleTimestamp = Date.now() - 25 * 60 * 60 * 1000
-    const { dbUtils } = createDbUtils([
-      { path: '/tmp/tuff-index-a', lastScanned: staleTimestamp },
-      { path: '/tmp/tuff-index-b', lastScanned: staleTimestamp }
-    ])
-    const service = createService({ dbUtils })
+  it('cancels the pending startup reconcile when disposed before the delay', async () => {
+    const freshTimestamp = new Date('2026-09-03T00:00:00.000Z').getTime()
+    vi.useFakeTimers()
+    vi.setSystemTime(freshTimestamp)
 
-    await expect(
-      service.shouldRunAutoIndexing({
-        isInitializing: false,
-        hasInitializationContext: true
-      })
-    ).resolves.toEqual({ allowed: true, battery: null })
-    expect(deviceIdleService.canRun).toHaveBeenCalledWith({ idleThresholdMs: 60 * 60 * 1000 })
+    try {
+      const { dbUtils } = createDbUtils([
+        { path: '/tmp/tuff-index-a', lastScanned: freshTimestamp },
+        { path: '/tmp/tuff-index-b', lastScanned: freshTimestamp }
+      ])
+      const runAutoIndexing = vi.fn<() => Promise<boolean>>().mockResolvedValue(true)
+      const service = createService({ dbUtils, runAutoIndexing })
+
+      service.initializeBackgroundTaskService()
+      service.dispose()
+
+      await vi.advanceTimersByTimeAsync(2_500)
+
+      expect(runAutoIndexing).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps the startup idle gate through a failed one-shot reconcile until the recurring scan succeeds', async () => {
+    const freshTimestamp = new Date('2026-09-03T00:00:00.000Z').getTime()
+    vi.useFakeTimers()
+    vi.setSystemTime(freshTimestamp)
+
+    try {
+      const { dbUtils } = createDbUtils([
+        { path: '/tmp/tuff-index-a', lastScanned: freshTimestamp },
+        { path: '/tmp/tuff-index-b', lastScanned: freshTimestamp }
+      ])
+      const runAutoIndexing = vi
+        .fn<() => Promise<boolean>>()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true)
+      const service = createService({ dbUtils, runAutoIndexing })
+
+      service.initializeBackgroundTaskService()
+      const autoTask = backgroundTaskMocks.registerTask.mock.calls
+        .map(([task]) => task as { id: string; execute: () => Promise<void> })
+        .find((task) => task.id === 'file-index.auto-scan')
+      expect(autoTask).toBeDefined()
+
+      await vi.advanceTimersByTimeAsync(2_499)
+      expect(runAutoIndexing).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(1)
+      expect(runAutoIndexing).toHaveBeenCalledTimes(1)
+
+      await expect(
+        service.shouldRunAutoIndexing({
+          isInitializing: false,
+          hasInitializationContext: true
+        })
+      ).resolves.toMatchObject({ allowed: true })
+      expect(deviceIdleService.canRun).toHaveBeenCalledTimes(1)
+      expect(deviceIdleService.canRun).toHaveBeenNthCalledWith(1, { idleThresholdMs: 0 })
+
+      await autoTask?.execute()
+      await expect(
+        service.shouldRunAutoIndexing({
+          isInitializing: false,
+          hasInitializationContext: true
+        })
+      ).resolves.toEqual({ allowed: false, reason: 'interval' })
+      expect(runAutoIndexing).toHaveBeenCalledTimes(2)
+      expect(deviceIdleService.canRun).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('uses the normal idle gate for stale scans after startup reconcile succeeds', async () => {
+    const currentTimestamp = new Date('2026-09-03T00:00:00.000Z').getTime()
+    vi.useFakeTimers()
+    vi.setSystemTime(currentTimestamp)
+
+    try {
+      const staleTimestamp = currentTimestamp - 25 * 60 * 60 * 1000
+      const { dbUtils } = createDbUtils([
+        { path: '/tmp/tuff-index-a', lastScanned: staleTimestamp },
+        { path: '/tmp/tuff-index-b', lastScanned: staleTimestamp }
+      ])
+      const runAutoIndexing = vi.fn<() => Promise<boolean>>().mockResolvedValue(true)
+      const service = createService({ dbUtils, runAutoIndexing })
+
+      service.initializeBackgroundTaskService()
+      await vi.advanceTimersByTimeAsync(2_500)
+      expect(runAutoIndexing).toHaveBeenCalledTimes(1)
+
+      await expect(
+        service.shouldRunAutoIndexing({
+          isInitializing: false,
+          hasInitializationContext: true
+        })
+      ).resolves.toEqual({ allowed: true, battery: null })
+      expect(deviceIdleService.canRun).toHaveBeenCalledTimes(1)
+      expect(deviceIdleService.canRun).toHaveBeenCalledWith({ idleThresholdMs: 60 * 60 * 1000 })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('uses shared auto scan preflight for app busy and search active reasons', async () => {
@@ -411,7 +522,7 @@ describe('file-provider-watch-service', () => {
       getDbUtils: () => null,
       getWatchDepthForPath: () => 1,
       normalizePath: (rawPath) => rawPath.toLowerCase(),
-      runAutoIndexing: vi.fn(async () => undefined),
+      runAutoIndexing: vi.fn(async () => true),
       logDebug: vi.fn(),
       logWarn: vi.fn(),
       logError: vi.fn()

--- a/apps/core-app/src/main/modules/box-tool/addon/files/services/file-provider-watch-service.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/services/file-provider-watch-service.ts
@@ -38,13 +38,14 @@ const DEFAULT_FILE_INDEX_SETTINGS: FileIndexSettings = {
   autoScanCheckIntervalMs: 5 * 60 * 1000,
   extraPaths: []
 }
+const STARTUP_RECONCILE_DELAY_MS = 2_500
 
 export interface FileProviderWatchServiceDeps {
   baseWatchPaths: string[]
   getDbUtils: () => DbUtils | null
   getWatchDepthForPath: (watchPath: string) => number
   normalizePath: (rawPath: string) => string
-  runAutoIndexing: () => Promise<void>
+  runAutoIndexing: () => Promise<boolean>
   logDebug: (message: string, meta?: Record<string, unknown>) => void
   logWarn: (message: string, error?: unknown, meta?: Record<string, unknown>) => void
   logError: (message: string, error?: unknown, meta?: Record<string, unknown>) => void
@@ -79,6 +80,9 @@ export class FileProviderWatchService {
   private autoIndexTaskRegistered = false
   private fsEventsSubscribed = false
   private watchPathsRegistered = false
+  /** Startup reconciliation covers files created while the app was offline. */
+  private startupReconcilePending = true
+  private startupReconcileTimer: NodeJS.Timeout | null = null
   private fileIndexSettings: FileIndexSettings = { ...DEFAULT_FILE_INDEX_SETTINGS }
 
   constructor(deps: FileProviderWatchServiceDeps) {
@@ -231,6 +235,18 @@ export class FileProviderWatchService {
     }
   }
 
+  private async runStartupReconcile(): Promise<boolean> {
+    const completed = await this.runAutoIndexing()
+    if (!completed) return false
+
+    this.startupReconcilePending = false
+    if (this.startupReconcileTimer) {
+      clearTimeout(this.startupReconcileTimer)
+      this.startupReconcileTimer = null
+    }
+    return true
+  }
+
   initializeBackgroundTaskService(): void {
     const dbUtils = this.getDbUtils()
     if (!dbUtils) {
@@ -277,7 +293,7 @@ export class FileProviderWatchService {
         canInterrupt: true,
         estimatedDuration: 15 * 60 * 1000,
         execute: async () => {
-          await this.runAutoIndexing()
+          await this.runStartupReconcile()
         }
       })
       this.autoIndexTaskRegistered = true
@@ -295,7 +311,25 @@ export class FileProviderWatchService {
 
     this.backgroundTaskService.start()
 
+    if (this.startupReconcilePending && !this.startupReconcileTimer) {
+      this.startupReconcileTimer = setTimeout(() => {
+        this.startupReconcileTimer = null
+        if (!this.startupReconcilePending) return
+        void this.runStartupReconcile().catch((error) => {
+          this.logWarn('Startup file reconciliation failed', error)
+        })
+      }, STARTUP_RECONCILE_DELAY_MS)
+      this.startupReconcileTimer.unref()
+    }
+
     this.logDebug('Background task service initialized')
+  }
+  dispose(): void {
+    this.startupReconcilePending = false
+    if (this.startupReconcileTimer) {
+      clearTimeout(this.startupReconcileTimer)
+      this.startupReconcileTimer = null
+    }
   }
 
   async getScanEligibility(): Promise<{
@@ -365,7 +399,10 @@ export class FileProviderWatchService {
     const eligibility = await this.getScanEligibility()
     const preflight = resolveIndexedAutoScanPreflight({
       ...basePreflightInput,
-      hasEligiblePaths: eligibility.newPaths.length > 0 || eligibility.stalePaths.length > 0
+      hasEligiblePaths:
+        this.startupReconcilePending ||
+        eligibility.newPaths.length > 0 ||
+        eligibility.stalePaths.length > 0
     })
 
     if (!preflight.allowed) {
@@ -373,7 +410,9 @@ export class FileProviderWatchService {
     }
 
     const decision = await deviceIdleService.canRun({
-      idleThresholdMs: this.fileIndexSettings.autoScanIdleThresholdMs
+      idleThresholdMs: this.startupReconcilePending
+        ? 0
+        : this.fileIndexSettings.autoScanIdleThresholdMs
     })
 
     const battery = decision.snapshot.battery

--- a/apps/core-app/src/main/modules/box-tool/addon/files/utils.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/utils.test.ts
@@ -95,4 +95,19 @@ describe('file provider utils', () => {
       }
     )
   })
+
+  it('preserves the file MIME type for preview consumers', () => {
+    const item = mapFileToTuffItem(
+      createFile({
+        name: 'cover.webp',
+        extension: '.webp',
+        path: '/Users/demo/Documents/cover.webp'
+      }),
+      {},
+      'file-provider',
+      'File Provider'
+    )
+
+    expect(item.meta?.file?.mime_type).toBe('image/webp')
+  })
 })

--- a/apps/core-app/src/main/modules/box-tool/addon/files/utils.ts
+++ b/apps/core-app/src/main/modules/box-tool/addon/files/utils.ts
@@ -86,6 +86,57 @@ export async function scanDirectoryBatches(
   )
 }
 
+const FILE_MIME_TYPES: Readonly<Record<string, string>> = {
+  aac: 'audio/aac',
+  avi: 'video/x-msvideo',
+  bmp: 'image/bmp',
+  cjs: 'text/javascript',
+  conf: 'text/plain',
+  csv: 'text/csv',
+  env: 'text/plain',
+  flac: 'audio/flac',
+  gif: 'image/gif',
+  gz: 'application/gzip',
+  htm: 'text/html',
+  html: 'text/html',
+  ico: 'image/x-icon',
+  ini: 'text/plain',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  js: 'text/javascript',
+  json: 'application/json',
+  jsx: 'text/javascript',
+  log: 'text/plain',
+  md: 'text/markdown',
+  mjs: 'text/javascript',
+  mkv: 'video/x-matroska',
+  mov: 'video/quicktime',
+  mp3: 'audio/mpeg',
+  mp4: 'video/mp4',
+  ogg: 'audio/ogg',
+  pdf: 'application/pdf',
+  png: 'image/png',
+  ps1: 'text/plain',
+  sh: 'text/x-shellscript',
+  svg: 'image/svg+xml',
+  tar: 'application/x-tar',
+  toml: 'application/toml',
+  ts: 'text/typescript',
+  tsx: 'text/typescript',
+  txt: 'text/plain',
+  wav: 'audio/wav',
+  webm: 'video/webm',
+  webp: 'image/webp',
+  xml: 'application/xml',
+  yaml: 'application/yaml',
+  yml: 'application/yaml',
+  zip: 'application/zip'
+}
+
+function resolveFileMimeType(extension: string): string {
+  return FILE_MIME_TYPES[extension] ?? 'application/octet-stream'
+}
+
 export function mapFileToTuffItem(
   file: typeof filesSchema.$inferSelect,
   _extensions: Record<string, string>,
@@ -173,6 +224,7 @@ export function mapFileToTuffItem(
       file: {
         path: file.path,
         size: file.size ?? undefined,
+        mime_type: resolveFileMimeType(extension),
         created_at: file.ctime.toISOString(),
         modified_at: file.mtime.toISOString(),
         extension: (file.extension || path.extname(file.name) || '')

--- a/apps/core-app/src/main/modules/box-tool/search-engine/file-index-public-projection.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/file-index-public-projection.ts
@@ -175,6 +175,7 @@ type FileIndexTransportOperation =
   | 'FAILED_FILES'
   | 'BATTERY_LEVEL'
   | 'ADD_PATH'
+  | 'PREVIEW_RESOURCE'
   | 'REBUILD'
   | 'SCAN'
   | 'RECONCILE'

--- a/apps/core-app/src/main/modules/file-protocol/index.test.ts
+++ b/apps/core-app/src/main/modules/file-protocol/index.test.ts
@@ -25,7 +25,10 @@ vi.mock('../../utils/local-file-policy', () => ({
   getAllowedLocalFileRoots: () => ['/allowed'],
   isAllowedLocalFilePath: (filePath: string, roots: string[]) =>
     roots.some((root) => filePath === root || filePath.startsWith(`${root}/`)),
-  normalizeDarwinUsersPath: (filePath: string) => filePath
+  normalizeDarwinUsersPath: (filePath: string) =>
+    process.platform === 'darwin' && filePath.toLowerCase().startsWith('/users/demo/')
+      ? `/Users/demo${filePath.slice('/users/demo'.length)}`
+      : filePath
 }))
 
 vi.mock('../../service/temp-file.service', () => ({
@@ -35,10 +38,16 @@ vi.mock('../../service/temp-file.service', () => ({
 }))
 
 import { __test__, fileProtocolModule } from './index'
+import {
+  __test__ as previewGrantTest,
+  clearTfilePreviewGrants,
+  issueTfilePreviewGrant
+} from './tfile-preview-grant'
 
 describe('file-protocol canonical tfile parsing', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    clearTfilePreviewGrants()
   })
   it('forwards allowlisted files through Electron built-in streaming fetch', async () => {
     const response = new Response('icon-bytes')
@@ -102,6 +111,79 @@ describe('file-protocol canonical tfile parsing', () => {
     expect(__test__.extractAbsolutePath('tfile:////server/share/icon.svg')).toBe(
       '//server/share/icon.svg'
     )
+  })
+
+  it('streams off-policy files only through their exact unexpired preview grant', async () => {
+    const now = 1_000
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now)
+
+    try {
+      const approvedPath = '/Users/demo/Downloads/approved.txt'
+      const grant = issueTfilePreviewGrant(approvedPath, now)
+      const response = new Response('approved preview')
+      fetchMock.mockResolvedValue(response)
+      fileProtocolModule.onInit()
+
+      const handler = handleMock.mock.calls.at(-1)?.[1] as
+        | ((request: { url: string }) => Promise<Response>)
+        | undefined
+      expect(handler).toBeTypeOf('function')
+
+      const valid = await handler?.({ url: grant.tfileUrl })
+      expect(valid).toBe(response)
+
+      const wrongPath = new URL(grant.tfileUrl)
+      wrongPath.pathname = '/Users/demo/Downloads/other.txt'
+      await expect(handler?.({ url: wrongPath.toString() })).resolves.toMatchObject({ status: 403 })
+
+      const expiredGrant = issueTfilePreviewGrant('/Users/demo/Downloads/expired.txt', now)
+      nowSpy.mockReturnValue(now + previewGrantTest.PREVIEW_GRANT_TTL_MS)
+      await expect(handler?.({ url: expiredGrant.tfileUrl })).resolves.toMatchObject({
+        status: 403
+      })
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('authorizes lower-case and canonical Darwin Users paths through one preview grant', async () => {
+    const now = 1_000
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now)
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+
+    try {
+      const grant = issueTfilePreviewGrant('/users/demo/Downloads/approved.txt', now)
+      const canonicalUrl = new URL(grant.tfileUrl)
+      canonicalUrl.pathname = '/Users/demo/Downloads/approved.txt'
+      const lowerCaseUrl = new URL(grant.tfileUrl)
+      lowerCaseUrl.pathname = '/users/demo/Downloads/approved.txt'
+      const response = new Response('canonical preview')
+      fetchMock.mockResolvedValue(response)
+      fileProtocolModule.onInit()
+
+      const handler = handleMock.mock.calls.at(-1)?.[1] as
+        | ((request: { url: string }) => Promise<Response>)
+        | undefined
+      expect(handler).toBeTypeOf('function')
+
+      await expect(handler?.({ url: canonicalUrl.toString() })).resolves.toBe(response)
+      await expect(handler?.({ url: lowerCaseUrl.toString() })).resolves.toBe(response)
+      expect(fetchMock).toHaveBeenCalledWith('file:///Users/demo/Downloads/approved.txt', {
+        bypassCustomProtocolHandlers: true
+      })
+      expect(fetchMock).toHaveBeenCalledWith('file:///Users/demo/Downloads/approved.txt', {
+        bypassCustomProtocolHandlers: true
+      })
+    } finally {
+      nowSpy.mockRestore()
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true
+      })
+    }
   })
 })
 

--- a/apps/core-app/src/main/modules/file-protocol/index.ts
+++ b/apps/core-app/src/main/modules/file-protocol/index.ts
@@ -2,6 +2,7 @@ import type { MaybePromise, ModuleKey } from '@talex-touch/utils'
 import { session } from 'electron'
 import { tempFileService } from '../../service/temp-file.service'
 import { createLogger } from '../../utils/logger'
+import { clearTfilePreviewGrants } from './tfile-preview-grant'
 import { BaseModule } from '../abstract-base-module'
 import {
   clearTfileProtocolLogState,
@@ -40,6 +41,7 @@ class FileProtocolModule extends BaseModule {
     this.releaseConfiguredRoots?.()
     this.releaseConfiguredRoots = null
     clearTfileProtocolLogState()
+    clearTfilePreviewGrants()
   }
 }
 

--- a/apps/core-app/src/main/modules/file-protocol/tfile-preview-grant.ts
+++ b/apps/core-app/src/main/modules/file-protocol/tfile-preview-grant.ts
@@ -1,0 +1,99 @@
+import { randomBytes } from 'node:crypto'
+import { normalizeAbsolutePath } from '@talex-touch/utils/common/utils/safe-path'
+import { toTfileUrl } from '@talex-touch/utils/network'
+import { normalizeDarwinUsersPath } from '../../utils/local-file-policy'
+
+const PREVIEW_GRANT_QUERY_KEY = 'previewGrant'
+const PREVIEW_GRANT_TTL_MS = 5 * 60 * 1000
+const PREVIEW_GRANT_LIMIT = 256
+
+interface PreviewGrantRecord {
+  path: string
+  expiresAt: number
+}
+
+export interface TfilePreviewGrant {
+  tfileUrl: string
+  expiresAt: number
+}
+
+const grants = new Map<string, PreviewGrantRecord>()
+
+function pruneExpiredGrants(now: number): void {
+  for (const [token, grant] of grants) {
+    if (grant.expiresAt <= now) grants.delete(token)
+  }
+}
+
+function normalizeGrantedPath(filePath: string): string | null {
+  const normalized = normalizeAbsolutePath(filePath)
+  return normalized && normalized.length > 0 ? normalizeDarwinUsersPath(normalized) : null
+}
+
+function readGrantToken(rawUrl: string): string | null {
+  try {
+    const parsed = new URL(rawUrl)
+    if (parsed.protocol !== 'tfile:') return null
+    const token = parsed.searchParams.get(PREVIEW_GRANT_QUERY_KEY)?.trim()
+    return token || null
+  } catch {
+    return null
+  }
+}
+
+export function hasTfilePreviewGrant(rawUrl: string): boolean {
+  return readGrantToken(rawUrl) !== null
+}
+
+export function issueTfilePreviewGrant(
+  filePath: string,
+  now: number = Date.now()
+): TfilePreviewGrant {
+  const normalizedPath = normalizeGrantedPath(filePath)
+  if (!normalizedPath) throw new Error('TFILE_PREVIEW_PATH_INVALID')
+
+  pruneExpiredGrants(now)
+  while (grants.size >= PREVIEW_GRANT_LIMIT) {
+    const oldest = grants.keys().next().value
+    if (typeof oldest !== 'string') break
+    grants.delete(oldest)
+  }
+
+  const token = `preview_${randomBytes(24).toString('base64url')}`
+  const expiresAt = now + PREVIEW_GRANT_TTL_MS
+  grants.set(token, { path: normalizedPath, expiresAt })
+
+  const tfileUrl = new URL(toTfileUrl(normalizedPath))
+  tfileUrl.searchParams.set(PREVIEW_GRANT_QUERY_KEY, token)
+  return { tfileUrl: tfileUrl.toString(), expiresAt }
+}
+
+export function isTfilePreviewGrantAuthorized(
+  rawUrl: string,
+  filePath: string,
+  now: number = Date.now()
+): boolean {
+  const token = readGrantToken(rawUrl)
+  if (!token) return false
+
+  const grant = grants.get(token)
+  if (!grant) return false
+  if (grant.expiresAt <= now) {
+    grants.delete(token)
+    return false
+  }
+
+  const normalizedPath = normalizeGrantedPath(filePath)
+  return normalizedPath !== null && normalizedPath === grant.path
+}
+
+export function clearTfilePreviewGrants(): void {
+  grants.clear()
+}
+
+export const __test__ = {
+  PREVIEW_GRANT_QUERY_KEY,
+  PREVIEW_GRANT_TTL_MS,
+  PREVIEW_GRANT_LIMIT,
+  grants
+}

--- a/apps/core-app/src/main/modules/file-protocol/tfile-session.ts
+++ b/apps/core-app/src/main/modules/file-protocol/tfile-session.ts
@@ -8,6 +8,7 @@ import {
   normalizeDarwinUsersPath
 } from '../../utils/local-file-policy'
 import { createLogger } from '../../utils/logger'
+import { isTfilePreviewGrantAuthorized } from './tfile-preview-grant'
 
 /**
  * Deduplicate error logs -- only log each failing path once, up to a bound.
@@ -135,15 +136,18 @@ export function registerTfileProtocolForSession(
     const extractedPath = extractAbsolutePath(request.url)
     if (!extractedPath) {
       fileProtocolLog.warn('Rejected non-canonical tfile URL', {
-        meta: {
-          requestUrl: request.url
-        }
+        meta: { scheme: FILE_SCHEMA }
       })
       return new Response('Bad Request', { status: 400 })
     }
     const filePath = normalizeDarwinUsersPath(extractedPath)
     const normalizedPath = normalizeAbsolutePath(filePath)
-    if (!normalizedPath || !isAllowedLocalFilePath(normalizedPath, allowedRoots)) {
+    const previewGrantAuthorized =
+      normalizedPath !== null && isTfilePreviewGrantAuthorized(request.url, normalizedPath)
+    if (
+      !normalizedPath ||
+      (!isAllowedLocalFilePath(normalizedPath, allowedRoots) && !previewGrantAuthorized)
+    ) {
       if (shouldLogPathOnce(filePath)) {
         fileProtocolLog.warn(`Blocked path: ${filePath}`)
       }
@@ -159,8 +163,7 @@ export function registerTfileProtocolForSession(
         fileProtocolLog.error('tfile request error', {
           meta: {
             filePath: normalizedPath,
-            fileUrl,
-            url: request.url
+            fileUrl
           },
           error: error instanceof Error ? error.message : String(error)
         })

--- a/apps/core-app/src/main/modules/network/network-service.test.ts
+++ b/apps/core-app/src/main/modules/network/network-service.test.ts
@@ -8,6 +8,15 @@ import { createServer } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NetworkService } from './network-service'
+import {
+  clearTfilePreviewGrants,
+  issueTfilePreviewGrant
+} from '../file-protocol/tfile-preview-grant'
+
+const localFileMocks = vi.hoisted(() => ({
+  isAllowedLocalFilePath: vi.fn(() => true),
+  readFile: vi.fn()
+}))
 
 const electronMocks = vi.hoisted(() => {
   const fetch = vi.fn()
@@ -40,9 +49,14 @@ vi.mock('../../utils/app-root-path', () => ({
   resolveRuntimeRootPath: vi.fn(() => '/tmp')
 }))
 
+vi.mock('node:fs', () => ({
+  promises: { readFile: localFileMocks.readFile }
+}))
+
 vi.mock('../../utils/local-file-policy', () => ({
   getAllowedLocalFileRoots: vi.fn(() => ['/tmp']),
-  isAllowedLocalFilePath: vi.fn(() => true)
+  isAllowedLocalFilePath: localFileMocks.isAllowedLocalFilePath,
+  normalizeDarwinUsersPath: (filePath: string) => filePath
 }))
 
 vi.mock('../../utils/logger', () => ({
@@ -64,6 +78,41 @@ describe('networkService cooldown policy', () => {
     electronMocks.setProxy.mockReset()
     electronMocks.session.fromPartition.mockClear()
     electronMocks.setProxy.mockResolvedValue(undefined)
+    localFileMocks.isAllowedLocalFilePath.mockReset()
+    localFileMocks.isAllowedLocalFilePath.mockReturnValue(true)
+    localFileMocks.readFile.mockReset()
+    clearTfilePreviewGrants()
+  })
+
+  it('requires the exact live preview grant before reading an otherwise forbidden download', async () => {
+    const service = new NetworkService()
+    const now = 1_000
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(now)
+    localFileMocks.isAllowedLocalFilePath.mockReturnValue(false)
+    localFileMocks.readFile.mockResolvedValue('approved preview')
+
+    try {
+      await expect(
+        service.readText('tfile:///Users/demo/Downloads/without-grant.txt')
+      ).rejects.toThrow('NETWORK_FILE_FORBIDDEN')
+
+      const grant = issueTfilePreviewGrant('/Users/demo/Downloads/approved.txt', now)
+      await expect(service.readText(grant.tfileUrl)).resolves.toBe('approved preview')
+
+      const wrongPath = new URL(grant.tfileUrl)
+      wrongPath.pathname = '/Users/demo/Downloads/other.txt'
+      await expect(service.readText(wrongPath.toString())).rejects.toThrow('NETWORK_FILE_FORBIDDEN')
+
+      const expiredGrant = issueTfilePreviewGrant('/Users/demo/Downloads/expired.txt', now)
+      clock.mockReturnValue(now + 5 * 60 * 1000)
+      await expect(service.readText(expiredGrant.tfileUrl)).rejects.toThrow(
+        'NETWORK_FILE_FORBIDDEN'
+      )
+    } finally {
+      clock.mockRestore()
+    }
+
+    expect(localFileMocks.readFile).toHaveBeenCalledTimes(1)
   })
 
   it('keeps plugin-facing requests on the no-redirect network path', async () => {

--- a/apps/core-app/src/main/modules/network/network-service.ts
+++ b/apps/core-app/src/main/modules/network/network-service.ts
@@ -37,6 +37,7 @@ import {
 import { app, session } from 'electron'
 import { resolveRuntimeRootPath } from '../../utils/app-root-path'
 import { getAllowedLocalFileRoots, isAllowedLocalFilePath } from '../../utils/local-file-policy'
+import { isTfilePreviewGrantAuthorized } from '../file-protocol/tfile-preview-grant'
 import { createLogger } from '../../utils/logger'
 import { getSecureStoreValue } from '../../utils/secure-store'
 import { getMainConfig, saveMainConfig } from '../storage'
@@ -615,7 +616,8 @@ export class NetworkService {
       throw new Error('NETWORK_UNSUPPORTED_FILE_SOURCE')
     }
 
-    if (!isAllowedLocalFilePath(localPath, this.allowedRoots)) {
+    const previewGrantAuthorized = isTfilePreviewGrantAuthorized(source, localPath)
+    if (!isAllowedLocalFilePath(localPath, this.allowedRoots) && !previewGrantAuthorized) {
       throw new Error('NETWORK_FILE_FORBIDDEN')
     }
 

--- a/apps/core-app/src/renderer/src/components/render/addon/TuffItemPreviewer.vue
+++ b/apps/core-app/src/renderer/src/components/render/addon/TuffItemPreviewer.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts" name="TuffItemPreviewer">
 import type { TuffItem } from '@talex-touch/utils'
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { isElectronRenderer } from '@talex-touch/utils/env'
+import { useTuffTransport } from '@talex-touch/utils/transport'
+import { AppEvents } from '@talex-touch/utils/transport/events'
+import { buildTfileUrl } from '~/utils/tfile-url'
 import {
   AudioPreview,
   CodePreview,
@@ -18,6 +22,7 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
+const transport = isElectronRenderer() ? useTuffTransport() : null
 
 type FilePreviewType =
   | 'image'
@@ -103,13 +108,67 @@ const previewComponent = computed(() => {
       return DefaultPreview
   }
 })
+
+const RESOURCE_PREVIEW_TYPES = new Set<FilePreviewType>([
+  'image',
+  'video',
+  'audio',
+  'code',
+  'markdown',
+  'text'
+])
+const previewResourceUrl = ref('')
+const previewResourceReady = ref(false)
+let previewRequestVersion = 0
+
+watch(
+  () => props.item.meta?.file?.path,
+  async (filePath) => {
+    const requestVersion = ++previewRequestVersion
+    previewResourceUrl.value = ''
+    previewResourceReady.value = false
+
+    if (!filePath || !RESOURCE_PREVIEW_TYPES.has(getFileType(filePath))) {
+      previewResourceReady.value = true
+      return
+    }
+
+    if (!isElectronRenderer() || !transport) {
+      previewResourceUrl.value = buildTfileUrl(filePath)
+      previewResourceReady.value = true
+      return
+    }
+
+    try {
+      const result = await transport.send(AppEvents.fileIndex.previewResource, { path: filePath })
+      if (requestVersion !== previewRequestVersion) return
+      if (result.success && result.tfileUrl) {
+        previewResourceUrl.value = result.tfileUrl
+      }
+    } catch {
+      if (requestVersion === previewRequestVersion) previewResourceUrl.value = ''
+    } finally {
+      if (requestVersion === previewRequestVersion) previewResourceReady.value = true
+    }
+  },
+  { immediate: true }
+)
 </script>
 
 <template>
   <div class="TuffItemPreviewer">
     <TxScroll class="h-full w-full">
       <div class="preview-area max-h-[60%]">
-        <component :is="previewComponent" :key="item.id" :item="item" :search-query="searchQuery" />
+        <DefaultPreview v-if="previewComponent === DefaultPreview" :item="item" />
+        <component
+          :is="previewComponent"
+          v-else-if="previewResourceReady && previewResourceUrl"
+          :key="`${item.id}:${previewResourceUrl}`"
+          :item="item"
+          :resource-url="previewResourceUrl"
+          :search-query="searchQuery"
+        />
+        <DefaultPreview v-else-if="previewResourceReady" :item="item" />
       </div>
       <div class="p-4 border-t border-gray-200 dark:border-gray-700">
         <h3 class="text-sm font-semibold mb-4">
@@ -144,26 +203,6 @@ const previewComponent = computed(() => {
             </div>
             <div class="w-[65%]">
               {{ item?.meta?.file?.mime_type }}
-            </div>
-          </div>
-          <div
-            class="flex justify-between gap-2 border-b border-gray-200 dark:border-gray-700 py-1"
-          >
-            <div class="w-[80px] text-right">
-              {{ t('fileInfo.characters') }}
-            </div>
-            <div class="w-[65%]">
-              {{ item?.render.basic?.title?.length || 0 }}
-            </div>
-          </div>
-          <div
-            class="flex justify-between gap-2 border-b border-gray-200 dark:border-gray-700 py-1"
-          >
-            <div class="w-[80px] text-right">
-              {{ t('fileInfo.words') }}
-            </div>
-            <div class="w-[65%]">
-              {{ item?.render.basic?.title.split(' ').length || 0 }}
             </div>
           </div>
           <div

--- a/apps/core-app/src/renderer/src/components/render/addon/preview/AudioPreview.vue
+++ b/apps/core-app/src/renderer/src/components/render/addon/preview/AudioPreview.vue
@@ -2,14 +2,14 @@
 import type { TuffItem } from '@talex-touch/utils'
 import { computed } from 'vue'
 import { createRendererLogger } from '~/utils/renderer-log'
-import { buildTfileUrl } from '~/utils/tfile-url'
 
 const props = defineProps<{
   item: TuffItem
+  resourceUrl: string
 }>()
 
 const audioPreviewLog = createRendererLogger('AudioPreview')
-const audioSrc = computed(() => buildTfileUrl(props.item.meta?.file?.path ?? ''))
+const audioSrc = computed(() => props.resourceUrl)
 
 function handleError(e: Event): void {
   audioPreviewLog.error('Audio load error:', e)

--- a/apps/core-app/src/renderer/src/components/render/addon/preview/CodePreview.vue
+++ b/apps/core-app/src/renderer/src/components/render/addon/preview/CodePreview.vue
@@ -9,11 +9,11 @@ import { useTuffTransport } from '@talex-touch/utils/transport'
 import { AppEvents } from '@talex-touch/utils/transport/events'
 import { TxCodeEditor } from '@talex-touch/tuffex/code-editor'
 import { createRendererLogger } from '~/utils/renderer-log'
-import { buildTfileUrl } from '~/utils/tfile-url'
 
 const props = defineProps<{
   item: TuffItem
   searchQuery?: string
+  resourceUrl: string
 }>()
 
 const { t } = useI18n()
@@ -80,16 +80,14 @@ onMounted(async () => {
 
   loading.value = true
   try {
+    const resourceUrl = props.resourceUrl
     if (isElectronRenderer() && transport) {
-      // Use IPC channel for file reading in Electron
-      const tfileUrl = buildTfileUrl(filePath)
       content.value = await transport.send(AppEvents.system.readFile, {
-        source: tfileUrl,
+        source: resourceUrl,
         timeoutMs: READ_TIMEOUT_MS
       })
     } else {
-      const url = buildTfileUrl(filePath)
-      content.value = await networkClient.readText(url)
+      content.value = await networkClient.readText(resourceUrl)
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : ''

--- a/apps/core-app/src/renderer/src/components/render/addon/preview/ImagePreview.vue
+++ b/apps/core-app/src/renderer/src/components/render/addon/preview/ImagePreview.vue
@@ -2,18 +2,18 @@
 import type { TuffItem } from '@talex-touch/utils'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { buildTfileUrl } from '~/utils/tfile-url'
 
 const { t } = useI18n()
 
 const props = defineProps<{
   item: TuffItem
+  resourceUrl: string
 }>()
 
 const imageError = ref(false)
 const imageLoading = ref(true)
 
-const imageSrc = computed(() => buildTfileUrl(props.item.meta?.file?.path ?? ''))
+const imageSrc = computed(() => props.resourceUrl)
 
 function handleError() {
   imageError.value = true

--- a/apps/core-app/src/renderer/src/components/render/addon/preview/MarkdownPreview.vue
+++ b/apps/core-app/src/renderer/src/components/render/addon/preview/MarkdownPreview.vue
@@ -8,11 +8,11 @@ import { useTuffTransport } from '@talex-touch/utils/transport'
 import { AppEvents } from '@talex-touch/utils/transport/events'
 import { TxMarkdownView } from '@talex-touch/tuffex/markdown-view'
 import { createRendererLogger } from '~/utils/renderer-log'
-import { buildTfileUrl } from '~/utils/tfile-url'
 
 const props = defineProps<{
   item: TuffItem
   searchQuery?: string
+  resourceUrl: string
 }>()
 
 const { t } = useI18n()
@@ -47,16 +47,14 @@ onMounted(async () => {
 
   loading.value = true
   try {
+    const resourceUrl = props.resourceUrl
     if (isElectronRenderer() && transport) {
-      // Use IPC channel for file reading in Electron
-      const tfileUrl = buildTfileUrl(filePath)
       content.value = await transport.send(AppEvents.system.readFile, {
-        source: tfileUrl,
+        source: resourceUrl,
         timeoutMs: READ_TIMEOUT_MS
       })
     } else {
-      const url = buildTfileUrl(filePath)
-      content.value = await networkClient.readText(url)
+      content.value = await networkClient.readText(resourceUrl)
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : ''

--- a/apps/core-app/src/renderer/src/components/render/addon/preview/TextPreview.vue
+++ b/apps/core-app/src/renderer/src/components/render/addon/preview/TextPreview.vue
@@ -7,11 +7,11 @@ import { networkClient } from '@talex-touch/utils/network'
 import { useTuffTransport } from '@talex-touch/utils/transport'
 import { AppEvents } from '@talex-touch/utils/transport/events'
 import { createRendererLogger } from '~/utils/renderer-log'
-import { buildTfileUrl } from '~/utils/tfile-url'
 
 const props = defineProps<{
   item: TuffItem
   searchQuery?: string
+  resourceUrl: string
 }>()
 
 const { t } = useI18n()
@@ -112,17 +112,14 @@ async function loadContent() {
 
   loading.value = true
   try {
-    const filePath = props.item.meta.file.path
+    const resourceUrl = props.resourceUrl
     if (isElectronRenderer() && transport) {
-      // Use IPC channel for file reading in Electron
-      const tfileUrl = buildTfileUrl(filePath)
       textContent.value = await transport.send(AppEvents.system.readFile, {
-        source: tfileUrl,
+        source: resourceUrl,
         timeoutMs: READ_TIMEOUT_MS
       })
     } else {
-      const url = buildTfileUrl(filePath)
-      textContent.value = await networkClient.readText(url)
+      textContent.value = await networkClient.readText(resourceUrl)
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : ''

--- a/apps/core-app/src/renderer/src/components/render/addon/preview/VideoPreview.vue
+++ b/apps/core-app/src/renderer/src/components/render/addon/preview/VideoPreview.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts" name="VideoPreview">
 import type { TuffItem } from '@talex-touch/utils'
 import { computed } from 'vue'
-import { buildTfileUrl } from '~/utils/tfile-url'
 
 const props = defineProps<{
   item: TuffItem
+  resourceUrl: string
 }>()
 
-const videoSrc = computed(() => buildTfileUrl(props.item.meta?.file?.path ?? ''))
+const videoSrc = computed(() => props.resourceUrl)
 </script>
 
 <template>

--- a/packages/utils/__tests__/search/indexing-watch-path-policy.test.ts
+++ b/packages/utils/__tests__/search/indexing-watch-path-policy.test.ts
@@ -19,19 +19,19 @@ describe("indexing watch path policy", () => {
         platform: "darwin",
         watchPath: "/Users/test/Downloads",
       }),
-    ).toBe(5);
+    ).toBe(8);
     expect(
       getIndexedWatchDepthForPath({
         platform: "darwin",
         watchPath: "/Applications",
       }),
-    ).toBe(5);
+    ).toBe(8);
     expect(
       getIndexedWatchDepthForPath({
         platform: "darwin",
         watchPath: "/Users/test/Documents",
       }),
-    ).toBe(5);
+    ).toBe(8);
   });
 
   it("uses platform defaults for non-macOS roots", () => {

--- a/packages/utils/search/indexing-watch-path-policy.ts
+++ b/packages/utils/search/indexing-watch-path-policy.ts
@@ -39,7 +39,7 @@ export function getIndexedWatchDepthForPath(
   const platform = input.platform ?? getCurrentPlatform();
 
   if (platform === "darwin") {
-    return 5;
+    return 8;
   }
 
   if (platform === "win32") {

--- a/packages/utils/transport/events/app.ts
+++ b/packages/utils/transport/events/app.ts
@@ -76,6 +76,8 @@ import type {
   FileIndexBatteryStatus,
   FileIndexFailedFilesResult,
   FileIndexProgress,
+  FileIndexPreviewResourceRequest,
+  FileIndexPreviewResourceResult,
   FileIndexRebuildRequest,
   FileIndexRebuildResult,
   FileIndexStats,
@@ -372,6 +374,14 @@ export const AppEvents = {
       .module('file-index')
       .event('failed-files')
       .define<void, FileIndexFailedFilesResult>(),
+
+    /**
+     * Issue a short-lived grant for previewing one indexed file.
+     */
+    previewResource: defineEvent('app')
+      .module('file-index')
+      .event('preview-resource')
+      .define<FileIndexPreviewResourceRequest, FileIndexPreviewResourceResult>(),
 
     /**
      * Add a path to file index watch list.

--- a/packages/utils/transport/events/types/file-index.ts
+++ b/packages/utils/transport/events/types/file-index.ts
@@ -93,6 +93,18 @@ export interface FileIndexAddPathResult {
   reportId?: string;
 }
 
+export interface FileIndexPreviewResourceRequest {
+  path: string;
+}
+
+export interface FileIndexPreviewResourceResult {
+  success: boolean;
+  tfileUrl?: string;
+  expiresAt?: number;
+  errorCode?: string;
+  reportId?: string;
+}
+
 export interface FileIndexRebuildRequest {
   force?: boolean;
 }


### PR DESCRIPTION
## Summary
- rebase the already-validated search preview and index freshness fix onto the current protected master

## Verification
- prior focused verification belongs to commit d0977d2a7; this PR is a one-commit rebase onto merged clipboard master
- required GitHub checks must pass before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - File previews now use short-lived, file-specific access grants.
  - Added preview support for audio, video, image, text, code, and Markdown files.
  - File metadata now includes MIME types for more accurate previews.
  - macOS file monitoring now covers directory levels up to 8.

- **Bug Fixes**
  - Startup reconciliation resumes incomplete file enrichment after interruptions or timeouts.
  - Improved indexing progress updates and retry behavior after reconciliation failures.
  - Preview access now rejects expired or mismatched file grants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->