### PR TITLE
fix(release): package Linux musl LibSQL runtime

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -158,6 +158,7 @@
   },
   "optionalDependencies": {
     "@crosscopy/clipboard": "^0.3.6",
+    "@libsql/linux-x64-musl": "0.5.29",
     "bufferutil": "^4.1.0",
     "extract-file-icon": "^0.3.2",
     "uiohook-napi": "^1.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -596,6 +596,9 @@ importers:
       '@crosscopy/clipboard':
         specifier: ^0.3.6
         version: 0.3.6
+      '@libsql/linux-x64-musl':
+        specifier: 0.5.29
+        version: 0.5.29
       bufferutil:
         specifier: ^4.1.0
         version: 4.1.0


### PR DESCRIPTION
Fixes the Beta20 Linux package failure where after-pack could not resolve @libsql/linux-x64-musl. The CoreApp now declares the required musl runtime binary explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added support for Linux x64 systems using the musl build of the libSQL client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->