### PR TITLE
release: v2.4.14-beta.21

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/core-app",
-  "version": "2.4.14-beta.20",
+  "version": "2.4.14-beta.21",
   "private": true,
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/notes/update_2.4.14-beta.21.en.md
+++ b/notes/update_2.4.14-beta.21.en.md
@@ -1,0 +1,12 @@
+# Tuff v2.4.14-beta.21 Release Notes
+
+## Summary Notes
+
+- Linux x64 musl packages now explicitly include the LibSQL native runtime dependency, preventing the database-client binary from being omitted during packaging.
+- This version re-establishes a candidate asset chain for the official three-platform release and OTA acceptance.
+- Release gates remain fail-closed: a missing platform binary stops packaging before an incomplete official asset can be produced.
+
+## What's Changed
+
+- Pinned `@libsql/linux-x64-musl` as an optional CoreApp runtime dependency so the Linux packaged-build runtime closure resolves the platform binary.
+- The updater health state machine, signature verification, and fail-closed release gates are unchanged; official Windows, macOS, and Linux N→N+1 acceptance remains required.

--- a/notes/update_2.4.14-beta.21.zh.md
+++ b/notes/update_2.4.14-beta.21.zh.md
@@ -1,0 +1,12 @@
+# Tuff v2.4.14-beta.21 更新说明
+
+## 摘要
+
+- Linux x64 musl 发布包现在显式包含 LibSQL 原生运行时依赖，避免打包阶段缺失数据库客户端二进制。
+- 此版本用于重新建立三平台官方发布与 OTA 验收的候选资产链路。
+- 发布门禁继续保持 fail-closed：缺失平台二进制会在打包阶段阻止生成不完整的官方资产。
+
+## 变更内容
+
+- 将 `@libsql/linux-x64-musl` 固定为 CoreApp 的可选运行时依赖；Linux packaged build 的 runtime closure 因此可以完整解析该平台二进制。
+- 未修改更新健康状态机、签名校验或发布 fail-closed 门禁；后续仍须通过官方 Windows、macOS、Linux N→N+1 验收。

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@talex-touch/tuff",
   "homepage": "https://tuff.tagzxia.com",
   "type": "module",
-  "version": "2.4.14-beta.20",
+  "version": "2.4.14-beta.21",
   "packageManager": "pnpm@11.24.0",
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/scripts/check-prod-audit.mjs
+++ b/scripts/check-prod-audit.mjs
@@ -65,6 +65,34 @@ export function collectBlockingAdvisories(payload) {
   return found
 }
 
+/**
+ * Runs a potentially transient audit command until it emits a structurally valid payload.
+ *
+ * A valid audit response may exit nonzero because it contains advisories, so success here
+ * means that JSON parsing and structural validation succeeded. Advisory policy remains in
+ * `evaluate`; an exhausted retry budget always fails closed.
+ */
+export function runAuditWithRetry(runAudit, attempts = 3) {
+  if (!Number.isInteger(attempts) || attempts < 1)
+    throw new Error('audit retry attempts must be a positive integer')
+
+  let lastError
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const payload = JSON.parse(runAudit())
+      const found = collectBlockingAdvisories(payload)
+      return { payload, found, attempts: attempt }
+    }
+    catch (error) {
+      lastError = error
+    }
+  }
+
+  throw new Error(
+    `audit did not produce structurally valid JSON after ${attempts} attempt(s): ${lastError.message}`,
+  )
+}
+
 /** Compares the audit against the allowlist and returns every reason this run should fail. */
 export function evaluate(found, allowlist, today) {
   const problems = []
@@ -148,6 +176,16 @@ function selfTest() {
   /** The same entry with one field changed, which is how every real mistake here has looked. */
   const withOnly = patch => ({ advisories: [{ ...entry, ...patch }] })
 
+  const retryPayload = {
+    advisories: {
+      retry: {
+        severity: 'high',
+        github_advisory_id: 'GHSA-retry',
+        module_name: 'retry-package',
+        findings: [{ version: '1.0.0' }],
+      },
+    },
+  }
   const cases = [
     {
       name: 'a matching, unexpired allowlist entry passes',
@@ -253,6 +291,37 @@ function selfTest() {
       expected: true,
     },
     {
+      name: 'malformed and incomplete audit attempts retry until a later valid payload is evaluated',
+      actual: (() => {
+        const responses = ['{', '{}', JSON.stringify(retryPayload)]
+        let invocations = 0
+        const result = runAuditWithRetry(() => {
+          invocations += 1
+          return responses.shift()
+        }, 3)
+        return `${invocations}:${result.attempts}:${result.payload.advisories.retry.github_advisory_id}:${result.found.get('GHSA-retry')?.module}`
+      })(),
+      expected: '3:3:GHSA-retry:retry-package',
+    },
+    {
+      name: 'exhausted incomplete audit attempts fail after the configured bound',
+      actual: (() => {
+        let invocations = 0
+        let outcome = 'returned'
+        try {
+          runAuditWithRetry(() => {
+            invocations += 1
+            return '{}'
+          }, 2)
+        }
+        catch {
+          outcome = 'threw'
+        }
+        return `${outcome}:${invocations}`
+      })(),
+      expected: 'threw:2',
+    },
+    {
       name: 'a real audit shape with zero advisories is a clean pass, not a throw',
       actual: collectBlockingAdvisories({ advisories: {}, metadata: { vulnerabilities: {} } }).size,
       expected: 0,
@@ -280,31 +349,16 @@ if (process.argv.includes('--self-test'))
 // pnpm audit exits non-zero whenever it finds anything, so the exit code says nothing about
 // whether the run succeeded. The JSON shape is the signal, and collectBlockingAdvisories throws
 // when it is missing.
-const run = spawnSync('pnpm', ['audit', '--prod', '--json'], {
-  cwd: repoRoot,
-  encoding: 'utf8',
-  maxBuffer: 64 * 1024 * 1024,
+const result = runAuditWithRetry(() => {
+  const run = spawnSync('pnpm', ['audit', '--prod', '--json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  })
+  return run.stdout ?? ''
 })
 
-let payload
-try {
-  payload = JSON.parse(run.stdout ?? '')
-}
-catch {
-  console.error('\x1B[31mCould not parse `pnpm audit --prod --json` output.\x1B[0m')
-  console.error((run.stderr || run.stdout || '').split('\n').slice(-15).join('\n'))
-  process.exit(1)
-}
-
-let found
-try {
-  found = collectBlockingAdvisories(payload)
-}
-catch (error) {
-  console.error(`\x1B[31m${error.message}\x1B[0m`)
-  process.exit(1)
-}
-
+const { payload, found } = result
 const allowlist = JSON.parse(fs.readFileSync(allowlistPath, 'utf8'))
 const today = new Date().toISOString().slice(0, 10)
 const problems = evaluate(found, allowlist, today)


### PR DESCRIPTION
Creates a fresh official release candidate after beta.20's Linux packaging failure. The candidate includes the merged Linux musl LibSQL runtime closure fix and advances both authoritative package versions to 2.4.14-beta.21. Bilingual release notes are included and locally verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Published version 2.4.14-beta.21.
  - Linux x64 musl packages now include the required LibSQL native runtime dependency.
  - Re-established candidate assets for official three-platform release and OTA validation.
  - Release checks continue to stop incomplete official packages from being produced.
- **Documentation**
  - Added English and Chinese release notes covering packaging, OTA validation, and unchanged update-health and signature-verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->