### PR TITLE
fix(update): classify transport errors so the GitHub fallback fires

### DIFF
--- a/.trellis/tasks/09-04-ota-fallback-net-error-classification/check.jsonl
+++ b/.trellis/tasks/09-04-ota-fallback-net-error-classification/check.jsonl
@@ -1,0 +1,5 @@
+{"file": ".trellis/spec/guides/guard-thinking-guide.md", "reason": "验收重点：新增测试必须能在分类器真正失效时失败。须核查是否覆盖负例（HTTP 状态码/abort/timeout 不得被误判为传输失败）与三种方言"}
+{"file": ".trellis/spec/guides/cross-layer-thinking-guide.md", "reason": "核查三层改动一致性：utils 分类器、主进程归一化、渲染层判定；特别是渲染层在原型链丢失下仍须成立"}
+{"file": ".trellis/spec/frontend/quality-guidelines.md", "reason": "渲染层 GithubUpdateProvider 改动的质量基线"}
+{"file": ".trellis/spec/frontend/type-safety.md", "reason": "新增 NetworkTransportError 类型在渲染层的使用需符合类型安全约定"}
+{"file": ".trellis/spec/guides/index.md", "reason": "通用质量检查清单入口"}

--- a/.trellis/tasks/09-04-ota-fallback-net-error-classification/design.md
+++ b/.trellis/tasks/09-04-ota-fallback-net-error-classification/design.md
@@ -54,8 +54,7 @@ export function isTransportFailureError(error: unknown): boolean
 ```ts
 export const TRANSPORT_FAILURE_MARKERS = [
   // Chromium net stack (session.fetch，主进程)
-  'net::err_', 'err_connection_closed', 'err_connection_reset',
-  'err_connection_refused', 'err_connection_timed_out', 'err_connection_aborted',
+  'err_connection_',
   'err_name_not_resolved', 'err_internet_disconnected', 'err_network_changed',
   'err_address_unreachable', 'err_empty_response', 'err_failed',
   // TLS/证书（D1：与连接类同等对待）
@@ -69,7 +68,7 @@ export const TRANSPORT_FAILURE_MARKERS = [
 ]
 ```
 
-`'net::err_'` 作为前缀兜底，覆盖未来新增的 Chromium 错误码；后续具名项用于表达意图与被测试锁定。
+**刻意不设 `'net::err_'` 全量前缀兜底**（CodeRabbit review on PR #1864）：`isTransportFailureError` 走的是小写子串匹配，该前缀会同时命中 Chromium 归在同一前缀下的用户取消（`ERR_ABORTED`）、权限/策略拒绝（`ERR_ACCESS_DENIED`、`ERR_BLOCKED_BY_CLIENT`）与调用方 bug（`ERR_INVALID_URL`、`ERR_UNSAFE_PORT`）——这些既不该重试也不该换源。两种误判的代价不对称：漏掉一个新出现的传输错误码，只是该码退回本次修复前的行为；而命中一个取消错误，会把用户刚取消的动作重试一遍。故只保留具名项，`err_connection_` / `err_cert_` 以前缀形式保留，因为这两族的每个成员都确属传输失败。负向用例在 `network-transport-error.test.ts` 中锁定。
 
 **不纳入该表**的项（保持语义纯净）：`NETWORK_TIMEOUT`（归 `isTimeoutLikeError`）、`NETWORK_HTTP_STATUS_*`（归 `parseHttpStatusCode`）、`cloudflare` / `rate limit` / `localhost:3200`（属日志降噪范畴，非传输失败）。
 

--- a/.trellis/tasks/09-04-ota-fallback-net-error-classification/design.md
+++ b/.trellis/tasks/09-04-ota-fallback-net-error-classification/design.md
@@ -4,7 +4,7 @@
 
 改动分三层，依赖方向单向向下，无循环：
 
-```
+```text
 packages/utils/network/core/errors.ts        ← 唯一事实源：错误类型 + 分类器 + 标记表
         ↑                    ↑                     ↑
  network-service.ts   release-fetch-service.ts   GithubUpdateProvider.ts
@@ -63,18 +63,18 @@ export const TRANSPORT_FAILURE_MARKERS = [
   'failed to fetch',
   // Node / undici
   'fetch failed', 'econnreset', 'econnrefused', 'econnaborted',
-  'enotfound', 'etimedout', 'eai_again', 'epipe', 'socket hang up',
+  'enotfound', 'eai_again', 'epipe', 'socket hang up',
   'network socket disconnected',
 ]
 ```
 
 **刻意不设 `'net::err_'` 全量前缀兜底**（CodeRabbit review on PR #1864）：`isTransportFailureError` 走的是小写子串匹配，该前缀会同时命中 Chromium 归在同一前缀下的用户取消（`ERR_ABORTED`）、权限/策略拒绝（`ERR_ACCESS_DENIED`、`ERR_BLOCKED_BY_CLIENT`）与调用方 bug（`ERR_INVALID_URL`、`ERR_UNSAFE_PORT`）——这些既不该重试也不该换源。两种误判的代价不对称：漏掉一个新出现的传输错误码，只是该码退回本次修复前的行为；而命中一个取消错误，会把用户刚取消的动作重试一遍。故只保留具名项，`err_connection_` / `err_cert_` 以前缀形式保留，因为这两族的每个成员都确属传输失败。负向用例在 `network-transport-error.test.ts` 中锁定。
 
-**不纳入该表**的项（保持语义纯净）：`NETWORK_TIMEOUT`（归 `isTimeoutLikeError`）、`NETWORK_HTTP_STATUS_*`（归 `parseHttpStatusCode`）、`cloudflare` / `rate limit` / `localhost:3200`（属日志降噪范畴，非传输失败）。
+**不纳入该表**的项（保持语义纯净）：`NETWORK_TIMEOUT` 与 `etimedout`（归 `isTimeoutLikeError`，其正则为 `/timeout|etimedout/i`；若此处再列一次，同一个错误会同时落进两个语义不同的分类器）、`NETWORK_HTTP_STATUS_*`（归 `parseHttpStatusCode`）、`cloudflare` / `rate limit` / `localhost:3200`（属日志降噪范畴，非传输失败）。注意 Chromium 的 `ERR_CONNECTION_TIMED_OUT` 不属此列——该拼写两侧正则都不命中，正是本次要补的缺口。
 
 ## 数据流：一次官方源故障
 
-```
+```text
 session.fetch → 抛 Error('net::ERR_CONNECTION_CLOSED')
   ↓ network-service.ts:1214 catch
 projectNetworkRequestError(error, ctx)
@@ -96,7 +96,7 @@ fetchGitHub(channel, force, false) → 200 → 返回候选 release ✅
 
 | 位置 | 现状 | 改后 |
 |---|---|---|
-| `release-fetch-service.ts:471` `isOfficialFallbackEligible` | status 判定 + 正则 | status 判定不变；正则 → `isTransportFailureError(error)` |
+| `release-fetch-service.ts:471` `isOfficialFallbackEligible` | status 判定 + 正则 | status 判定不变；正则 → `isTimeoutLikeError(error) \|\| isTransportFailureError(error)` |
 | `release-fetch-service.ts:592` `isRetryable` | status 判定 + 正则 | status 判定不变；正则 → `isTimeoutLikeError(error) \|\| isTransportFailureError(error)` |
 | `GithubUpdateProvider.ts:540` `isRetryableError` | timeout + status + 正则 | 前两项不变；正则 → `isTransportFailureError(error)` |
 
@@ -107,8 +107,8 @@ fetchGitHub(channel, force, false) → 200 → 返回候选 release ✅
 ## 兼容性与迁移
 
 - **无数据迁移、无配置变更、无 IPC 协议变更。** 纯代码内分类逻辑修正。
-- **行为变化仅为扩大**："过去不回退/不重试"→"现在回退/重试"。不存在"过去成功现在失败"的路径，因此对现网是单向改善。
-- **`network-log-noise.ts`（R6）**：其列表改为 `[...TRANSPORT_FAILURE_MARKERS, ...本地特有标记]`，本地特有项（`cloudflare`、`rate limit`、`just a moment`、`network_http_status_403/429`、`localhost:3200`、`aborterror`、`network guard cooldown`）保留。这样补齐了它当前缺失的 `err_connection_closed` / `err_connection_reset`，且两份清单从此同源。
+- **相对 master，行为变化仅为扩大**："过去不回退/不重试"→"现在回退/重试"。master 上的原正则是 `/NETWORK_TIMEOUT|timeout|etimedout|enotfound|econnreset|eai_again|fetch failed|socket hang up/i`，`net::ERR_*` 系一个都不命中，所以本次收窄掉的 `ERR_ABORTED` / `ERR_ACCESS_DENIED` / `ERR_INVALID_URL` 等在 master 上本就不回退——收窄只相对本分支的中间提交而言，对现网没有"过去成功现在失败"的路径，是单向改善。
+- **`network-log-noise.ts`（R6）**：其列表改为 `[...TRANSPORT_FAILURE_MARKERS, ...本地特有标记]`，本地特有项（`cloudflare`、`rate limit`、`just a moment`、`network_http_status_403/429`、`localhost:3200`、`aborterror`、`network guard cooldown`）保留。`etimedout` 也留在本地：降噪没有"一个错误只归一个分类器"的约束，而 `'timed out'` 覆盖不到 errno 拼写。这样补齐了它当前缺失的 `err_connection_closed` / `err_connection_reset`，且传输部分从此与分类器同源。
 - **`packages/utils` 是发布包**：新增导出为纯增量，不改动既有导出签名，外部插件开发者无感知。
 
 ## 权衡

--- a/.trellis/tasks/09-04-ota-fallback-net-error-classification/design.md
+++ b/.trellis/tasks/09-04-ota-fallback-net-error-classification/design.md
@@ -1,0 +1,127 @@
+# Design — OTA 传输层错误分类修复
+
+## 架构与边界
+
+改动分三层，依赖方向单向向下，无循环：
+
+```
+packages/utils/network/core/errors.ts        ← 唯一事实源：错误类型 + 分类器 + 标记表
+        ↑                    ↑                     ↑
+ network-service.ts   release-fetch-service.ts   GithubUpdateProvider.ts
+   (主进程·归一化)        (主进程·回退/重试)        (渲染层·重试)
+                              ↑
+                   network-log-noise.ts (复用标记表)
+```
+
+`packages/utils` 是已发布的 npm 包，主进程与渲染层均已依赖它（`errors.ts` 现有的 `isTimeoutLikeError` / `parseHttpStatusCode` 就是这样被两侧共用的）。新增分类器沿用同一模式，不引入新的依赖方向。
+
+## 核心契约
+
+### 1. 新增传输层错误类型（`packages/utils/network/core/errors.ts`）
+
+```ts
+NETWORK_ERROR_CODE.TRANSPORT_FAILED = 'NETWORK_TRANSPORT_FAILED'
+
+class NetworkTransportError extends Error {
+  readonly code = NETWORK_ERROR_CODE.TRANSPORT_FAILED
+  readonly netErrorCode?: string     // 如 'ERR_CONNECTION_CLOSED'
+  constructor(originalMessage: string, options?: { cause?: unknown })
+}
+```
+
+**关键约束（R1）**：`message` 必须原样保留传入的原始文本（如 `net::ERR_CONNECTION_CLOSED`），**不得**改写成 `NETWORK_TRANSPORT_FAILED`。
+
+理由：约 25 个 `NetworkService` 调用方中已有基于 message 的字符串判定（如 `network-log-noise.ts`、`catalog-remote.ts` 附近的降级逻辑）。保留原文 ⇒ 既有判定行为零变化，新代码通过 `code` / `instanceof` 获得类型化能力。这与 `NetworkHttpStatusError` 的做法一致（它同样把 `message` 与 `code` 设为同一个可解析的串）。
+
+> 与 `NetworkTimeoutError` 的差异：后者会改写 message 为 `NETWORK_TIMEOUT after Nms`。这是既有行为，本次不动——现有正则正是靠它工作的，改了反而回归。
+
+### 2. 分类器：类型优先，字符串兜底
+
+```ts
+export function isTransportFailureError(error: unknown): boolean
+```
+
+判定顺序：
+
+1. `error instanceof NetworkTransportError` → `true`
+2. `(error as { code?: string })?.code === NETWORK_ERROR_CODE.TRANSPORT_FAILED` → `true`
+3. message 命中 `TRANSPORT_FAILURE_MARKERS` → `true`
+
+第 3 步不是冗余（R2）：错误跨 IPC 时原型链丢失，渲染层只拿得到普通 `Error` 与 message 字符串（`transport/prelude.ts:127` 以 `error.message` 回传）。因此渲染层**必须**保留字符串兜底，类型判定在渲染层不可依赖。
+
+### 3. 标记表：三方言合一，单一事实源
+
+```ts
+export const TRANSPORT_FAILURE_MARKERS = [
+  // Chromium net stack (session.fetch，主进程)
+  'net::err_', 'err_connection_closed', 'err_connection_reset',
+  'err_connection_refused', 'err_connection_timed_out', 'err_connection_aborted',
+  'err_name_not_resolved', 'err_internet_disconnected', 'err_network_changed',
+  'err_address_unreachable', 'err_empty_response', 'err_failed',
+  // TLS/证书（D1：与连接类同等对待）
+  'err_ssl_protocol_error', 'err_cert_',
+  // Chromium fetch（渲染层全局 fetch）
+  'failed to fetch',
+  // Node / undici
+  'fetch failed', 'econnreset', 'econnrefused', 'econnaborted',
+  'enotfound', 'etimedout', 'eai_again', 'epipe', 'socket hang up',
+  'network socket disconnected',
+]
+```
+
+`'net::err_'` 作为前缀兜底，覆盖未来新增的 Chromium 错误码；后续具名项用于表达意图与被测试锁定。
+
+**不纳入该表**的项（保持语义纯净）：`NETWORK_TIMEOUT`（归 `isTimeoutLikeError`）、`NETWORK_HTTP_STATUS_*`（归 `parseHttpStatusCode`）、`cloudflare` / `rate limit` / `localhost:3200`（属日志降噪范畴，非传输失败）。
+
+## 数据流：一次官方源故障
+
+```
+session.fetch → 抛 Error('net::ERR_CONNECTION_CLOSED')
+  ↓ network-service.ts:1214 catch
+projectNetworkRequestError(error, ctx)
+  ├─ getAbortError()      → null，继续
+  ├─ isTimeoutLikeError() → false（'TIMED_OUT' 不匹配 /timeout/），继续
+  └─ isTransportFailureError() → true
+       → new NetworkTransportError('net::ERR_CONNECTION_CLOSED', { cause: error })   ← 新增
+  ↓
+release-fetch-service.fetchOfficial() 抛出
+  ↓ fetch():139 catch (nexusError)
+isOfficialFallbackEligible(nexusError)
+  ├─ status(error) → undefined（非 HTTP 错误）
+  └─ isTransportFailureError() → true                                                ← 修复点
+  ↓
+fetchGitHub(channel, force, false) → 200 → 返回候选 release ✅
+```
+
+## 三处站点的改法
+
+| 位置 | 现状 | 改后 |
+|---|---|---|
+| `release-fetch-service.ts:471` `isOfficialFallbackEligible` | status 判定 + 正则 | status 判定不变；正则 → `isTransportFailureError(error)` |
+| `release-fetch-service.ts:592` `isRetryable` | status 判定 + 正则 | status 判定不变；正则 → `isTimeoutLikeError(error) \|\| isTransportFailureError(error)` |
+| `GithubUpdateProvider.ts:540` `isRetryableError` | timeout + status + 正则 | 前两项不变；正则 → `isTransportFailureError(error)` |
+
+`isRetryable` 需显式并上 `isTimeoutLikeError`：原正则含 `NETWORK_TIMEOUT|timeout|etimedout`，而新标记表已把 timeout 语义剥离出去，不并上会丢失既有的超时重试能力（R5 回归风险点）。
+
+`isOfficialFallbackEligible` 同理需要并上 `isTimeoutLikeError` —— 否则 8s 超时这条**当前唯一可用**的回退路径会被本次改动打断。这是本设计最容易踩的回归，AC5 专门覆盖。
+
+## 兼容性与迁移
+
+- **无数据迁移、无配置变更、无 IPC 协议变更。** 纯代码内分类逻辑修正。
+- **行为变化仅为扩大**："过去不回退/不重试"→"现在回退/重试"。不存在"过去成功现在失败"的路径，因此对现网是单向改善。
+- **`network-log-noise.ts`（R6）**：其列表改为 `[...TRANSPORT_FAILURE_MARKERS, ...本地特有标记]`，本地特有项（`cloudflare`、`rate limit`、`just a moment`、`network_http_status_403/429`、`localhost:3200`、`aborterror`、`network guard cooldown`）保留。这样补齐了它当前缺失的 `err_connection_closed` / `err_connection_reset`，且两份清单从此同源。
+- **`packages/utils` 是发布包**：新增导出为纯增量，不改动既有导出签名，外部插件开发者无感知。
+
+## 权衡
+
+**为什么不只加一个分类函数、不做 `NetworkService` 层归一化？**
+只加函数可行且改动更小，但上层仍在字符串匹配 —— 传输实现一换（本仓已有两套：`session.fetch` 与全局 `fetch`）就会重演本 bug。在服务边界归一化是把"识别方言"收敛到一处的唯一做法，且 `projectNetworkRequestError` 已在为 timeout 做同样的事，属于沿用既有模式而非新造抽象。
+
+**为什么不把 `ERR_CONNECTION_TIMED_OUT` 并入 `isTimeoutLikeError`？**
+更符合直觉，但 `isTimeoutLikeError` 还被 `plugin/providers/utils.ts`、`packages/utils/network/request.ts` 等消费，扩大其语义会外溢到本任务范围外的调用方。归入 transport 即可，因为两类在回退/重试上待遇相同。
+
+**为什么证书错误不 fail-closed？** 见 PRD D1。
+
+## 回滚
+
+改动集中在 4 个文件且相互独立，`git revert` 单个提交即可完整回滚，无残留状态。若仅需局部回退，可单独还原任一站点的判定表达式而不影响其余（分类器为纯函数、无副作用）。

--- a/.trellis/tasks/09-04-ota-fallback-net-error-classification/implement.jsonl
+++ b/.trellis/tasks/09-04-ota-fallback-net-error-classification/implement.jsonl
@@ -1,0 +1,5 @@
+{"file": ".trellis/spec/guides/guard-thinking-guide.md", "reason": "本 bug 的教科书案例：正则匹配的是错误串拼写而非'传输失败'这一属性，换传输实现即失效。新分类器必须按属性判定并配负例测试，避免重蹈覆辙"}
+{"file": ".trellis/spec/guides/cross-layer-thinking-guide.md", "reason": "改动跨 packages/utils → 主进程 → 渲染层三层，且错误需穿越 IPC 边界（原型链丢失）。分类器的三级判定设计正是为此边界服务"}
+{"file": ".trellis/spec/guides/code-reuse-thinking-guide.md", "reason": "R6 要求 network-log-noise 的标记表与新分类器同源；当前两份清单已漂移（前者缺 err_connection_closed），须按复用原则收敛为单一事实源"}
+{"file": ".trellis/spec/main-process/channel-transport-contracts.md", "reason": "渲染层更新检查经 networkSdk → IPC → 主进程 NetworkService；需确认错误跨通道传递时 message/code 的保真约定"}
+{"file": ".trellis/spec/main-process/index.md", "reason": "主进程改动（network-service.ts、release-fetch-service.ts）需遵循的通用约定入口"}

--- a/.trellis/tasks/09-04-ota-fallback-net-error-classification/implement.md
+++ b/.trellis/tasks/09-04-ota-fallback-net-error-classification/implement.md
@@ -1,0 +1,132 @@
+# Implement — OTA 传输层错误分类修复
+
+## 前置
+
+分支：当前在 `release/beta20-clean`。本改动是 bugfix，**不要**直接提交到发布候选分支——先确认与用户的分支策略（见"待确认"）。
+
+## 有序清单
+
+### 步骤 1 — utils 层：错误类型 + 分类器（无外部依赖，先做）
+
+文件：`packages/utils/network/core/errors.ts`
+
+1. 在 `NETWORK_ERROR_CODE` 增加 `TRANSPORT_FAILED: 'NETWORK_TRANSPORT_FAILED'`。
+2. 新增 `TRANSPORT_FAILURE_MARKERS`（内容见 design.md，全部小写）并导出。
+3. 新增 `NetworkTransportError`：`message` 原样保留传入文本，`code` 固定为 `TRANSPORT_FAILED`，解析并暴露 `netErrorCode`（从 `net::ERR_XXX` 提取 `ERR_XXX`，无则 `undefined`），`cause` 透传。
+4. 新增 `isTransportFailureError(error)`：`instanceof` → `code` 字段 → message 小写后命中标记表，三级判定。
+
+**约束提醒**：不要修改 `isTimeoutLikeError`（会外溢到 `plugin/providers/utils.ts`、`packages/utils/network/request.ts` 等范围外调用方）。
+
+新建 `packages/utils/__tests__/network-transport-error.test.ts`（该包测试统一放 `__tests__/`，参照既有 `network-http-status-error.test.ts`；`network/core/` 下不放测试），覆盖 **AC1**：
+- 三方言各自的代表串：`net::ERR_CONNECTION_CLOSED` / `Failed to fetch` / `fetch failed`
+- 现有正则的两处漏网：`net::ERR_CONNECTION_TIMED_OUT`、`Failed to fetch`
+- D1 相关：`net::ERR_SSL_PROTOCOL_ERROR`、`net::ERR_CERT_AUTHORITY_INVALID`
+- **负例**（防止过度匹配）：`NETWORK_HTTP_STATUS_500`、`NETWORK_TIMEOUT after 8000ms`、`NETWORK_ABORTED` 均须返回 `false`
+- 原型链丢失场景：`new Error('net::ERR_CONNECTION_CLOSED')`（纯 Error）须返回 `true`
+- `NetworkTransportError` 的 message 与传入原文严格相等（**AC5** 兼容性约束）
+
+验证：`pnpm -F @talex-touch/utils test`
+
+### 步骤 2 — 主进程：服务边界归一化
+
+文件：`apps/core-app/src/main/modules/network/network-service.ts`
+
+在 `projectNetworkRequestError`（`:424`）的 timeout 分支之后、`return error` 之前插入：
+
+```ts
+if (isTransportFailureError(error)) {
+  return new NetworkTransportError(error instanceof Error ? error.message : String(error), {
+    cause: error
+  })
+}
+```
+
+顺序必须是 abort → timeout → transport，不可调换（abort 与 timeout 有更强的语义，先匹配）。
+
+验证：`npx vitest run src/main/modules/network`
+
+### 步骤 3 — 主进程：回退与重试判定（核心修复）
+
+文件：`apps/core-app/src/main/modules/update/services/release-fetch-service.ts`
+
+1. `isOfficialFallbackEligible`（`:471`）：保留 status 分支；将 `:478` 正则替换为
+   `isTimeoutLikeError(error) || isTransportFailureError(error)`
+2. `isRetryable`（`:592`）：保留 status 分支；将 `:598` 正则替换为
+   `isTimeoutLikeError(error) || isTransportFailureError(error)`
+
+> ⚠️ **最高回归风险点**：两处都必须并上 `isTimeoutLikeError`。原正则含 `NETWORK_TIMEOUT`，而新标记表刻意不含 timeout 语义。漏并 = 打断当前**唯一**还能工作的回退路径（8s 超时），会把一个 bug 换成另一个。
+
+在 `release-fetch-service.test.ts` 追加 **AC2 / AC3 / AC5**：
+- 官方源抛 `net::ERR_CONNECTION_CLOSED` → 断言走到 `fetchGitHub` 并返回 GitHub 结果
+- 官方源抛 `NetworkTimeoutError` → 断言仍然回退（锁死上述回归点）
+- 两源皆抛传输错误 + 有 stale 缓存 → 命中 stale 分支
+- 两源皆抛传输错误 + 无 stale → 上抛 GitHub 错误
+- 既有 429 / 5xx / 403 用例行为不变
+
+验证：`npx vitest run src/main/modules/update`（须含既有 108 用例全绿）
+
+### 步骤 4 — 渲染层：重试判定
+
+文件：`apps/core-app/src/renderer/src/modules/update/GithubUpdateProvider.ts`
+
+`isRetryableError`（`:540` 附近）：保留 `isRequestTimeout` 与 status 分支，正则替换为 `isTransportFailureError(error)`。
+
+在 `GithubUpdateProvider.test.ts` 追加 **AC4**：`net::ERR_*` 与纯 `Error`（无原型链）两种形态均返回 `true`。
+
+验证：`npx vitest run src/renderer/src/modules/update`
+
+### 步骤 5 — 日志降噪表同源（R6）
+
+文件：`apps/core-app/src/main/utils/network-log-noise.ts`
+
+`DOWNGRADED_REMOTE_FAILURE_MARKERS` 改为 `[...TRANSPORT_FAILURE_MARKERS, ...本地特有项]`。本地特有项须**全部保留**：`localhost:3200`、`network timeout`、`network_timeout`、`request timeout`、`timed out`、`aborterror`、`network guard cooldown`、`network_http_status_403`、`network_http_status_429`、`rate limit`、`ratelimit`、`just a moment`、`cloudflare`、`challenge-platform`、`cf_chl`、`enable javascript and cookies to continue`。
+
+若该文件已有测试则跑，无则不新增（纯日志路径，非行为关键）。
+
+验证：`npx vitest run src/main/utils/network-log-noise.test.ts`（该测试已存在，须保持全绿——本步骤是扩大标记表，既有降噪断言不应被破坏）
+
+### 步骤 6 — 全量校验（AC6）
+
+```bash
+cd apps/core-app
+npx vitest run src/main/modules/update src/renderer/src/modules/update src/main/modules/network
+npm run typecheck
+cd ../.. && pnpm lint
+```
+
+### 步骤 7 — 本机完整触发一次真实 OTA（AC7 / AC8）
+
+**7a 快速探针（AC7）** —— 复用本次诊断的 Electron 探针思路，新建**临时**脚本（验证后删除，不入库）：对不可达地址发请求，断言归一化后 `isOfficialFallbackEligible` 为 `true`。
+
+**7b 完整链路（AC8）** —— 本机 darwin/arm64，dev 模式：
+
+1. **临时下调版本**：`apps/core-app/package.json` 与根 `package.json` 的 `version` 改为 `2.4.14-beta.17`（低于线上 `beta.19` 即可）。
+   > ⚠️ 验证完成后**必须还原为 `2.4.14-beta.20`**。此改动绝不可进提交——提交前用 `git diff` 确认两个 package.json 干净。
+2. **构造官方源不可达**：若 `tuff.tagzxia.com` 仍不可达则天然满足；若已恢复，在更新设置里把 `settings.source.url` 指向一个可控的不可达地址。
+3. `pnpm core:dev` 启动，在设置里触发"检查更新"。
+4. **逐段留证**（对照 AC8 六项）：
+   - 日志出现 `Nexus update lookup failed transiently; falling back to GitHub`
+     —— **这是修复生效的直接标志**；修复前该行不会出现，错误会直接上抛
+   - GitHub 返回 `v2.4.14-beta.19` 候选
+   - 下载 `macos-latest-beta-tuff-2.4.14-beta.19-macos-arm64.dmg`
+   - sha256 与 `.sig` 校验通过，生命周期进入 `ready`
+   - 触发安装 → 以 `MAC_UPDATE_BUILD_UNTRUSTED` 终止（**预期行为**，dev 构建本就不应被静默替换，不计为失败）
+5. **还原版本号**，确认工作区干净。
+
+> 边界说明：含"替换 App 并重启"的安装腿本机验不了——需官方 CI 私钥签发的 attestation（`build-verification/index.ts:93-104`），本地构建拿不到。详见 PRD Out of Scope。
+
+对照日志建议开 `updateSystemLog` / `releaseFetch` 相关命名空间；日志位置参考既有 dev 日志约定。
+
+## 风险文件与回滚点
+
+| 文件 | 风险 | 回滚点 |
+|---|---|---|
+| `packages/utils/network/core/errors.ts` | 发布包，标记表过宽会误吞 HTTP/abort 错误 | 步骤 1 后独立可回滚；负例测试是防线 |
+| `release-fetch-service.ts` | 漏并 `isTimeoutLikeError` → 打断现存唯一回退路径 | 步骤 3 后独立可回滚 |
+| `network-service.ts` | 归一化顺序错误会吞掉 abort/timeout 语义 | 步骤 2 后独立可回滚 |
+
+每步结束即为一个可回滚点；分类器为纯函数无副作用，单独还原任一站点表达式不影响其余。
+
+## 待确认
+
+- 提交分支：当前 `release/beta20-clean` 是 beta.20 发布候选。此修复应进该候选（OTA 回退是发版相关能力），还是另开分支走 master？—— 需用户确认后再提交。

--- a/.trellis/tasks/09-04-ota-fallback-net-error-classification/prd.md
+++ b/.trellis/tasks/09-04-ota-fallback-net-error-classification/prd.md
@@ -1,0 +1,126 @@
+# 修复 OTA 更新源传输层错误分类导致 GitHub 回退失效
+
+## Goal
+
+让 OTA 更新检查在官方源（Nexus）发生传输层故障时，能按设计回退到 GitHub 并正常重试。当前这条回退路径因错误分类与实际传输层错误格式不匹配而完全失效：官方源一挂，更新检查直接报错，即使 GitHub 完全可用。
+
+## Background
+
+### 故障复现（2026-09-04，本机实测）
+
+官方更新源 `https://tuff.tagzxia.com` 从本机不可达：DNS 正常解析到 Cloudflare（104.21.80.101 / 172.67.177.44，与 1.1.1.1 权威结果一致），TCP 连接成功（~5ms），但 TLS ClientHello 之后立即 EOF；HTTP 80 端口同样不通。同一网络下 `github.com`、`api.github.com`、`cloudflare.com` 均返回 200。
+
+用 Electron 探针脚本对该地址发真实请求，得到决定性证据：
+
+```
+[nexus-official] THREW
+  name    : Error
+  message : net::ERR_CONNECTION_CLOSED
+  code    : undefined
+  fallbackEligible(message) = false
+[github-control] OK status=200
+```
+
+> 注：`tuff.tagzxia.com` 究竟是链路干扰还是 Cloudflare 侧配置问题，单一出口无法定性，需换网络环境复验。**该定性结论不影响本任务** —— 客户端的错误分类缺陷独立存在，任何传输层故障都会触发它。
+
+### 根因
+
+传输层实际使用 Electron `session.fetch`（Chromium 网络栈），失败时抛出 `net::ERR_*` 形式的错误
+（`apps/core-app/src/main/modules/network/network-service.ts:1207`）。
+`projectNetworkRequestError`（同文件 `:424`）仅对 abort 与 timeout-like 错误做归一化，其余错误原样透传。
+
+但所有下游的"可回退/可重试"判定都是按 Node/undici 的错误串写的，两套命名体系不交叉：
+
+| 判定位置 | 现有正则 | 后果 |
+|---|---|---|
+| `release-fetch-service.ts:478` `isOfficialFallbackEligible` | `NETWORK_TIMEOUT\|timeout\|etimedout\|enotfound\|econnreset\|eai_again\|fetch failed\|socket hang up` | 官方源传输失败时 **GitHub 回退不触发**，错误直接上抛 |
+| `release-fetch-service.ts:598` `isRetryable` | 同上 | GitHub 拉取的**传输层重试不生效** |
+| `GithubUpdateProvider.ts:542` `isRetryableError`（渲染层） | `ENOTFOUND\|EAI_AGAIN\|ECONNRESET\|NETWORK_TIMEOUT` | 渲染层更新检查**重试不生效** |
+
+渲染层同样受影响：`UpdateProvider.request()`（`UpdateProvider.ts:44-50`）经 `networkSdk` → IPC → 主进程 `NetworkService` → `session.fetch`；错误跨 IPC 以 `error.message` 字符串透传，`net::ERR_CONNECTION_CLOSED` 原样到达渲染层判定。
+
+### 受影响的错误码范围
+
+不止一个错误码。几乎所有 Chromium 传输层错误都会被误判为"不可回退、不可重试"：
+
+- `ERR_CONNECTION_CLOSED`（已实测）、`ERR_CONNECTION_RESET`、`ERR_CONNECTION_REFUSED`
+- `ERR_CONNECTION_TIMED_OUT` —— 注意是 `TIMED_OUT`，正则要的是 `timeout`/`etimedout`，**不匹配**
+- `ERR_NAME_NOT_RESOLVED`（DNS）、`ERR_INTERNET_DISCONNECTED`
+- `ERR_SSL_PROTOCOL_ERROR`、`ERR_CERT_*`
+
+唯一仍能正常回退的是服务自身 8s 超时路径：`NetworkTimeoutError.message` 含 `NETWORK_TIMEOUT`（`packages/utils/network/core/errors.ts:18-26`），能匹配。但"秒断连"型故障走不到超时。
+
+### 实际存在三种错误方言
+
+代码库里并存两条传输实现，加上运行环境差异，共三种错误串格式，现有正则只覆盖其中一种：
+
+| 传输实现 | 运行环境 | 传输失败时的 message | 现有正则 |
+|---|---|---|---|
+| `session.fetch`（`network-service.ts:1207`） | 主进程 | `net::ERR_*` | ❌ 不匹配 |
+| 全局 `fetch()`（`packages/utils/network/request.ts:124`） | 渲染层 / Chromium | `Failed to fetch` | ❌ 不匹配（正则找的是词序相反的 `fetch failed`） |
+| 全局 `fetch()`（同上） | Node / undici | `fetch failed` | ✅ 匹配 |
+
+即：现有实现只在 Node/undici 环境下成立，而这恰恰是三者中唯一不跑生产 OTA 流程的环境。
+
+### 已有可复用资产
+
+- `packages/utils/network/core/errors.ts` 已有语义化错误码体系：`NETWORK_ERROR_CODE`、`NetworkAbortError`、`NetworkTimeoutError`、`NetworkHttpStatusError`，以及 `isTimeoutLikeError()` / `parseHttpStatusCode()` 两个分类器。缺的正是"传输层失败"这一类。
+- `apps/core-app/src/main/utils/network-log-noise.ts` 的 `DOWNGRADED_REMOTE_FAILURE_MARKERS` 已混列 Chromium 与 Node 两套错误串（含 `net::err_failed`、`err_connection_refused`）—— 说明代码库已知晓 Chromium 错误存在，但该知识只落在**日志降噪**工具里，未进入重试/回退分类器；且该列表也缺 `err_connection_closed` / `err_connection_reset`。
+
+### 不受影响的部分（已验证正常）
+
+- `src/main/modules/update` 单测 15 文件 108 用例全通过。
+- 发布产物合规：`v2.4.14-beta.19` 的 `tuff-release-manifest.json` 为 `schemaVersion: 2`，含 win32/x64、darwin/arm64、darwin/x64、linux/x64 四个 `core` 产物，每个均带 `sha256` 与 `.sig`。
+- 本地版本 `2.4.14-beta.20` 高于线上最新 `beta.19`（beta.20 为未发布候选版），因此本机"检查更新"必然返回"已是最新"——这是预期行为，非缺陷，但意味着**端到端安装链路无法在本机验证**。
+
+## Decisions
+
+- **D1** TLS/证书类错误（`ERR_SSL_PROTOCOL_ERROR`、`ERR_CERT_*`）与连接类错误同等对待，一律触发回退与重试，不做 fail-closed 特判。
+  依据：两个源的产物在下游都经 `sha256` + 签名校验（manifest 携带 `sha256`/`signature`，`update-system.ts` 与 `release-signature.ts` 强制验签，验签失败抛错而非降级），因此被动切换源不降低完整性门槛；反之若证书错误 fail closed，处于 TLS 拦截型企业代理后的用户将完全拿不到更新，长期停留在旧版本，是更差的安全结果。
+
+## Requirements
+
+- **R1** 传输层错误需在 `NetworkService` 层归一化为语义化错误类型，携带原始错误码，使上层不再依赖对 `error.message` 的正则匹配。归一化必须**保留原始 message 文本**，避免影响其余约 25 个 `NetworkService` 调用方中既有的字符串判定。
+- **R2** 分类器需同时识别三种方言（Chromium `net::ERR_*`、Chromium fetch `Failed to fetch`、Node/undici `fetch failed` 及 `ECONNRESET` 等），并在跨 IPC 丢失原型链的场景下仍能工作（渲染层拿到的是纯 `Error`，须能靠 message 兜底判定）。
+- **R3** 三处判定站点统一改用共享分类器：`release-fetch-service.ts:478`、`release-fetch-service.ts:598`、`GithubUpdateProvider.ts:542`。
+- **R4** 官方源发生传输层故障时，GitHub 回退必须触发；GitHub 亦不可用时，维持现有 stale-cache 兜底行为不变。
+- **R5** 现有 HTTP 状态码判定语义（429 / ≥500 可回退，≥500 / 403 / 429 可重试）保持不变，不得因重构回归。
+- **R6** `network-log-noise.ts` 的标记列表补齐缺失的 Chromium 错误码，与新分类器保持同源，避免两份清单再次漂移。
+- **R7** 本机（darwin/arm64）须能完整触发一次真实 OTA，走通"检查 → 回退 → 下载 → sha256 + 验签 → ready"全链路，且此过程验证的是本次修复后的代码。终点边界见下方"本机可触发的边界"。
+
+### 本机可触发的边界（darwin/arm64，已验证）
+
+macOS 静默安装有构建信任闸门：`assertPlatformInstallPreflight`（`update-platform-adapter.ts:74-91`）要求
+`isVerified && isOfficialBuild && !verificationFailed && hasOfficialKey`。
+
+- dev 运行（`!app.isPackaged`）被硬编码为 `isOfficialBuild: false, hasOfficialKey: false`（`build-verification/index.ts:60-69`）
+- 本地打包构建同样过不了：`verifyPackagedBuild` 要用官方私钥签发的 attestation 校验 `app.asar`（`index.ts:93-104`），该私钥在 CI
+
+但该闸门位于 `scheduleInstallNow` 内，而后者要求 `phase === 'ready'`（`update-install-coordinator.ts:79-88`）——**在下载与验签之后**。
+
+因此本机 dev 模式可完整跑通：检查 → 传输失败 → GitHub 回退 → 解析 beta.19 → 下载 arm64 dmg → sha256 + 签名校验 → 进入 `ready`，最终止于 `MAC_UPDATE_BUILD_UNTRUSTED`。**该终止是预期的正确行为**（dev 构建本就不应被静默替换），不计为失败。
+
+含"替换 App 并重启"的安装腿需官方 CI 签名构建，属发布后验证，见 Out of Scope。
+
+## Acceptance Criteria
+
+- [ ] **AC1** 给定 `new Error('net::ERR_CONNECTION_CLOSED')`，`isOfficialFallbackEligible` 返回 `true`；单测覆盖三种方言与 R2 列出的全部错误码，含 `ERR_CONNECTION_TIMED_OUT` 与 `Failed to fetch`（现有正则的两处漏网之鱼），以及 D1 涉及的 `ERR_SSL_PROTOCOL_ERROR` / `ERR_CERT_AUTHORITY_INVALID`。
+- [ ] **AC2** 单测：官方源抛 `net::ERR_CONNECTION_CLOSED` 时，`fetch()` 走到 `fetchGitHub` 并返回 GitHub 结果，而非上抛错误。
+- [ ] **AC3** 单测：官方源与 GitHub 均抛传输层错误时，命中 stale-cache 分支；无 stale 时上抛 GitHub 错误（行为与改动前一致）。
+- [ ] **AC4** 单测：渲染层 `GithubUpdateProvider.isRetryableError` 对 `net::ERR_*` 返回 `true`，且在错误已丢失原型链（纯 `Error`）时同样成立。
+- [ ] **AC5** 回归：既有 HTTP 状态码用例（429/5xx/403）行为不变，`src/main/modules/update` 108 个既有用例保持全绿；`NetworkTransportError` 归一化后原始 message 文本不变（覆盖 R1 的兼容性约束）。
+- [ ] **AC6** 全量校验通过：`npx vitest run src/main/modules/update src/renderer/src/modules/update`、`pnpm lint`、`npm run typecheck`。
+- [ ] **AC7** Electron 探针复现：官方源不可达时，更新检查返回 GitHub 的候选结果而非错误（需在能复现该网络故障的环境执行；若官方源已恢复，用可控的不可达地址覆盖 `settings.source.url` 模拟）。
+- [ ] **AC8**（R7）本机 dev 模式完整触发一次真实 OTA，逐段留证：
+  - 官方源传输失败 → 日志出现 `Nexus update lookup failed transiently; falling back to GitHub`（现状下该行**不会**出现，是修复生效的直接标志）
+  - GitHub 返回 `v2.4.14-beta.19` 候选
+  - 下载 `macos-latest-beta-tuff-2.4.14-beta.19-macos-arm64.dmg`
+  - sha256 与 `.sig` 校验通过，生命周期进入 `ready`
+  - 触发安装时以 `MAC_UPDATE_BUILD_UNTRUSTED` 终止（预期行为，非失败）
+  - 前置条件：本地版本须低于 `beta.19`，通过临时下调 `package.json` 版本号实现，验证完成后**必须还原**
+
+## Out of Scope
+
+- `tuff.tagzxia.com` 服务端可用性排查与修复（属运维，另行处理）。
+- 含"替换 App 并重启"的 macOS 安装腿真机验证：需官方 CI 签名构建（本地构建拿不到官方私钥签发的 attestation），属发布后验证。可选路径：装官方 `beta.18` dmg 升到 `beta.19`——但那跑的是已发布的旧代码，不含本次修复；真正覆盖本次修复的完整安装腿须待 `beta.20` 由 CI 签名发布后，从 `beta.19` 升级验证。
+- 更新源以外的其它 `NetworkService` 调用方的错误分类审查（本次仅在 utils 层留出共享分类器并保证向后兼容，不改其它调用方的判定逻辑）。

--- a/.trellis/tasks/09-04-ota-fallback-net-error-classification/task.json
+++ b/.trellis/tasks/09-04-ota-fallback-net-error-classification/task.json
@@ -1,0 +1,30 @@
+{
+  "id": "ota-fallback-net-error-classification",
+  "name": "ota-fallback-net-error-classification",
+  "title": "修复 OTA 更新源传输层错误分类导致 GitHub 回退失效",
+  "description": "Electron session.fetch 抛出的 net::ERR_* 传输层错误无法被 release-fetch-service 的 isOfficialFallbackEligible/isRetryable 正则识别，导致官方源不可达时 GitHub 回退与重试均不触发",
+  "status": "in_progress",
+  "dev_type": null,
+  "scope": null,
+  "package": null,
+  "priority": "P1",
+  "creator": "TalexDreamSoul",
+  "assignee": "TalexDreamSoul",
+  "createdAt": "2026-09-04",
+  "completedAt": null,
+  "branch": "release/ota-transport-error-classification-20260904",
+  "base_branch": "release/beta20-clean",
+  "worktree_path": null,
+  "commit": null,
+  "pr_url": "https://github.com/talex-touch/tuff/pull/1864",
+  "subtasks": [],
+  "children": [],
+  "parent": null,
+  "relatedFiles": [],
+  "notes": "",
+  "meta": {
+    "nextAction": "AC7/AC8 -- drive one full OTA round on this machine against an unreachable official source and capture the `Nexus update lookup failed transiently; falling back to GitHub` log line, which is the direct signal the fallback fired and does not exist before this fix. AC1-AC6 are covered automatically. Note that beta.20 has since shipped, so the version used to force an update must be re-picked; the temporary downgrade must not reach a commit.",
+    "blocker": "PR #1864 is red on `Production dependency audit` because npm's advisories endpoint is timing out -- `pnpm audit --prod --json` returns `{\"error\":{\"code\":23,\"message\":\"The operation was aborted due to timeout\"}}`, a payload with neither advisories nor metadata, which check-prod-audit.mjs fails closed on by design. Reproduced locally and unrelated to this change, which adds no dependency.",
+    "evidence": "Root cause captured live on 2026-09-04: an Electron probe against the official update host threw `net::ERR_CONNECTION_CLOSED` with `fallbackEligible(message) = false`, while the GitHub control returned 200 on the same network. After the fix: `pnpm -F @talex-touch/utils test` 190 files / 1448 tests; `npx vitest run src/main/modules/update src/renderer/src/modules/update src/main/modules/network src/main/utils/network-log-noise.test.ts` 22 files / 176 tests; `npm run typecheck` exit 0; `pnpm lint` exit 0. New tests cover all three transport dialects, both codes the old regex missed (ERR_CONNECTION_TIMED_OUT and 'Failed to fetch'), the three identity-degradation tiers, and negative cases proving HTTP-status, timeout and abort errors are not claimed."
+  }
+}

--- a/apps/core-app/src/main/modules/network/network-service.ts
+++ b/apps/core-app/src/main/modules/network/network-service.ts
@@ -27,10 +27,12 @@ import {
   createNetworkGuard,
   isHttpSource,
   isTimeoutLikeError,
+  isTransportFailureError,
   NetworkAbortError,
   NetworkCooldownError,
   NetworkHttpStatusError,
   NetworkTimeoutError,
+  NetworkTransportError,
   resolveLocalFilePath,
   toTfileUrl
 } from '@talex-touch/utils/network'
@@ -425,6 +427,14 @@ function projectNetworkRequestError(error: unknown, context: NetworkAbortContext
   const abortError = context.getAbortError()
   if (abortError) return abortError
   if (isTimeoutLikeError(error)) return new NetworkTimeoutError(context.timeoutMs)
+  // Chromium reports connection failures as `net::ERR_*`, which no caller can classify by string
+  // without knowing which transport ran. Normalizing here keeps that knowledge in one place; the
+  // message is passed through untouched so callers that still match on it are unaffected.
+  if (isTransportFailureError(error)) {
+    return new NetworkTransportError(error instanceof Error ? error.message : String(error), {
+      cause: error
+    })
+  }
   return error
 }
 

--- a/apps/core-app/src/main/modules/update/services/release-fetch-service.test.ts
+++ b/apps/core-app/src/main/modules/update/services/release-fetch-service.test.ts
@@ -121,7 +121,19 @@ describe('ReleaseFetchService', () => {
   it.each([
     ['a timeout', new Error('NETWORK_TIMEOUT')],
     ['an HTTP 429', new Error('NETWORK_HTTP_STATUS_429')],
-    ['an HTTP 5xx', new Error('NETWORK_HTTP_STATUS_503')]
+    ['an HTTP 5xx', new Error('NETWORK_HTTP_STATUS_503')],
+    // Electron's session.fetch reports connection failures as `net::ERR_*`. Classifying these as
+    // permanent kept the fallback from firing at all while GitHub was reachable (2026-09-04).
+    ['a Chromium connection close', new Error('net::ERR_CONNECTION_CLOSED')],
+    ['a Chromium connection reset', new Error('net::ERR_CONNECTION_RESET')],
+    ['a Chromium DNS failure', new Error('net::ERR_NAME_NOT_RESOLVED')],
+    // Spelled TIMED_OUT, so neither the old regex nor isTimeoutLikeError ever matched it.
+    ['a Chromium connect timeout', new Error('net::ERR_CONNECTION_TIMED_OUT')],
+    // TLS failures fall back too: artifacts are signature-verified whichever source serves them.
+    ['a Chromium TLS failure', new Error('net::ERR_SSL_PROTOCOL_ERROR')],
+    ['a Chromium certificate failure', new Error('net::ERR_CERT_AUTHORITY_INVALID')],
+    // The renderer-side global fetch spells it in the opposite word order from undici.
+    ['a Chromium fetch failure', new Error('Failed to fetch')]
   ])('falls back to GitHub after Nexus reports %s', async (_name, nexusError) => {
     const { service } = createService()
     networkRequestMock
@@ -197,5 +209,37 @@ describe('ReleaseFetchService', () => {
     expect(requestUrls()).toHaveLength(2)
     expect(requestUrls()[0]).toContain('/api/releases/latest')
     expect(requestUrls()[1]).toContain('api.github.com')
+  })
+
+  it('uses a stale verified cache when both providers fail at the transport layer', async () => {
+    const { service } = createService()
+    networkRequestMock.mockResolvedValueOnce({ data: nexusRelease('v2.4.10') })
+    await service.fetch(AppPreviewChannel.RELEASE)
+
+    networkRequestMock
+      .mockReset()
+      .mockRejectedValueOnce(new Error('net::ERR_CONNECTION_CLOSED'))
+      .mockRejectedValueOnce(new Error('net::ERR_CONNECTION_CLOSED'))
+
+    const result = await service.fetch(AppPreviewChannel.RELEASE, true)
+
+    expect(result).toMatchObject({
+      usedNetwork: false,
+      result: { hasUpdate: true, release: { tag_name: 'v2.4.10', source: 'nexus' } }
+    })
+  })
+
+  it('surfaces the GitHub error when both providers fail with no cache to fall back on', async () => {
+    const { service } = createService()
+    networkRequestMock
+      .mockRejectedValueOnce(new Error('net::ERR_CONNECTION_CLOSED'))
+      .mockRejectedValue(new Error('net::ERR_NAME_NOT_RESOLVED'))
+
+    await expect(service.fetch(AppPreviewChannel.RELEASE)).rejects.toThrow(
+      'net::ERR_NAME_NOT_RESOLVED'
+    )
+
+    expect(requestUrls()[0]).toContain('/api/releases/latest')
+    expect(requestUrls().at(-1)).toContain('api.github.com')
   })
 })

--- a/apps/core-app/src/main/modules/update/services/release-fetch-service.ts
+++ b/apps/core-app/src/main/modules/update/services/release-fetch-service.ts
@@ -19,6 +19,7 @@ import {
   selectLatestUpdateRelease
 } from '../../../../shared/update/version'
 import { NEXUS_BASE_URL } from '@talex-touch/utils/env'
+import { isTimeoutLikeError, isTransportFailureError } from '@talex-touch/utils/network'
 import { getNetworkService } from '../../network'
 import { shouldDowngradeRemoteFailure } from '../../../utils/network-log-noise'
 import type { LogOptions } from '../../../utils/logger'
@@ -473,12 +474,10 @@ export class ReleaseFetchService {
     if (status !== undefined) {
       return status === 429 || status >= 500
     }
-    return (
-      error instanceof Error &&
-      /NETWORK_TIMEOUT|timeout|etimedout|enotfound|econnreset|eai_again|fetch failed|socket hang up/i.test(
-        error.message
-      )
-    )
+    // Both classifiers are required: the transport marker list deliberately excludes timeout
+    // spellings, so matching only transport failures would drop the timeout path that was, until
+    // this fix, the one kind of official-source failure that still reached GitHub.
+    return isTimeoutLikeError(error) || isTransportFailureError(error)
   }
 
   private officialBaseUrl(): string {
@@ -593,12 +592,7 @@ export class ReleaseFetchService {
     if (status !== undefined) {
       return status >= 500 || status === 403 || status === 429
     }
-    return (
-      error instanceof Error &&
-      /NETWORK_TIMEOUT|timeout|etimedout|enotfound|econnreset|eai_again|fetch failed|socket hang up/i.test(
-        error.message
-      )
-    )
+    return isTimeoutLikeError(error) || isTransportFailureError(error)
   }
 
   private retryDelay(attempt: number, baseDelay: number): number {

--- a/apps/core-app/src/main/utils/network-log-noise.test.ts
+++ b/apps/core-app/src/main/utils/network-log-noise.test.ts
@@ -18,6 +18,19 @@ describe('network-log-noise', () => {
     expect(shouldDowngradeRemoteFailure('NETWORK_HTTP_STATUS_500')).toBe(false)
   })
 
+  /*
+   * Transport markers are shared with the classifier in @talex-touch/utils, which deliberately
+   * omits `etimedout` so that isTimeoutLikeError owns it alone. Noise suppression has no such
+   * ownership rule, so it keeps a local entry — and 'timed out' does not cover the errno spelling.
+   */
+  it.each([
+    'connect ETIMEDOUT 140.82.121.6:443',
+    'net::ERR_CONNECTION_CLOSED',
+    'getaddrinfo ENOTFOUND tuff.tagzxia.com'
+  ])('downgrades the connection-level failure %s', (message) => {
+    expect(shouldDowngradeRemoteFailure('Update lookup failed', new Error(message))).toBe(true)
+  })
+
   it('summarizes cloudflare html payloads', () => {
     const html = '<!DOCTYPE html><html><head><title>Just a moment...</title></head></html>'
     expect(summarizeRemoteFailurePayload(html)).toBe('cloudflare_challenge')

--- a/apps/core-app/src/main/utils/network-log-noise.ts
+++ b/apps/core-app/src/main/utils/network-log-noise.ts
@@ -16,6 +16,10 @@ const DOWNGRADED_REMOTE_FAILURE_MARKERS = [
   'network_timeout',
   'request timeout',
   'timed out',
+  // Not spelled with a space, so 'timed out' above does not cover it. It is deliberately absent
+  // from TRANSPORT_FAILURE_MARKERS so that isTimeoutLikeError owns it alone; noise suppression has
+  // no such ownership rule and wants both.
+  'etimedout',
   'aborterror',
   'network guard cooldown',
   'network_http_status_403',

--- a/apps/core-app/src/main/utils/network-log-noise.ts
+++ b/apps/core-app/src/main/utils/network-log-noise.ts
@@ -1,12 +1,17 @@
+import { TRANSPORT_FAILURE_MARKERS } from '@talex-touch/utils/network'
+
+/**
+ * Failures that are expected enough to log below error severity.
+ *
+ * Transport failures come from the shared classifier rather than a second hand-maintained copy:
+ * this list had drifted from it and was missing `err_connection_closed`, the code the official
+ * update host actually produces. The entries below are the ones that are noise for logging but not
+ * transport failures — challenge pages, rate limits, cooldowns, dev-server misses — so they stay
+ * local.
+ */
 const DOWNGRADED_REMOTE_FAILURE_MARKERS = [
-  'err_connection_refused',
-  'net::err_failed',
-  'err_failed',
-  'econnrefused',
+  ...TRANSPORT_FAILURE_MARKERS,
   'localhost:3200',
-  'eai_again',
-  'enotfound',
-  'etimedout',
   'network timeout',
   'network_timeout',
   'request timeout',

--- a/apps/core-app/src/renderer/src/modules/update/GithubUpdateProvider.test.ts
+++ b/apps/core-app/src/renderer/src/modules/update/GithubUpdateProvider.test.ts
@@ -45,3 +45,32 @@ describe('GithubUpdateProvider release integrity metadata', () => {
     ])
   })
 })
+
+/**
+ * Requests here travel renderer -> networkSdk -> IPC -> main-process NetworkService ->
+ * `session.fetch`, so a connection failure arrives as a Chromium `net::ERR_*` string that the
+ * previous Node-only regex never matched, and the retry never happened.
+ */
+describe('GithubUpdateProvider retry classification', () => {
+  const isRetryableError = (error: unknown): boolean =>
+    (
+      new GithubUpdateProvider() as unknown as { isRetryableError(error: unknown): boolean }
+    ).isRetryableError(error)
+
+  it.each([
+    'net::ERR_CONNECTION_CLOSED',
+    'net::ERR_CONNECTION_RESET',
+    'net::ERR_NAME_NOT_RESOLVED',
+    'net::ERR_CONNECTION_TIMED_OUT',
+    'Failed to fetch',
+    'getaddrinfo ENOTFOUND api.github.com'
+  ])('retries after %s', (message) => {
+    // A plain Error is what the renderer actually receives: the IPC hop projects errors down to
+    // their message, so neither the class nor the code survives the trip.
+    expect(isRetryableError(new Error(message))).toBe(true)
+  })
+
+  it('does not retry a permanent failure', () => {
+    expect(isRetryableError(new Error('Repository not found'))).toBe(false)
+  })
+})

--- a/apps/core-app/src/renderer/src/modules/update/GithubUpdateProvider.ts
+++ b/apps/core-app/src/renderer/src/modules/update/GithubUpdateProvider.ts
@@ -12,6 +12,7 @@ import {
   type UpdateReleaseArtifact,
   type UpdateReleaseManifest
 } from '@talex-touch/utils'
+import { isTransportFailureError } from '@talex-touch/utils/network'
 import { compareVersions } from '~/composables/store/useVersionCompare'
 import { getBuildInfo } from '~/utils/build-info'
 import { createRendererLogger } from '~/utils/renderer-log'
@@ -537,10 +538,10 @@ export class GithubUpdateProvider extends UpdateProvider {
       return true
     }
 
-    if (
-      error instanceof Error &&
-      /(ENOTFOUND|EAI_AGAIN|ECONNRESET|NETWORK_TIMEOUT)/i.test(error.message)
-    ) {
+    // Errors arrive here across IPC, so the class and code are gone and only the message remains;
+    // the shared classifier keeps the Chromium and Node dialects in one place rather than growing
+    // a second copy of the marker list here.
+    if (isTransportFailureError(error)) {
       return true
     }
 

--- a/packages/utils/__tests__/network-transport-error.test.ts
+++ b/packages/utils/__tests__/network-transport-error.test.ts
@@ -94,6 +94,21 @@ describe('isTransportFailureError leaves other classifiers their errors', () => 
     expect(isTransportFailureError(timeout)).toBe(false)
   })
 
+  /*
+   * The mirror image of the case above, and the reason `etimedout` is not in the marker list.
+   * `isTimeoutLikeError` matches `/timeout|etimedout/i`, so a marker would put one error in two
+   * classifiers — exactly what the list's doc comment says it will not do. Both update call sites
+   * OR the two classifiers, so ETIMEDOUT stays retryable and fallback-eligible either way.
+   */
+  it.each([
+    'connect ETIMEDOUT',
+    'connect ETIMEDOUT 140.82.121.6:443',
+  ])('leaves %s to the timeout classifier alone', (message) => {
+    const error = new Error(message)
+    expect(isTimeoutLikeError(error)).toBe(true)
+    expect(isTransportFailureError(error)).toBe(false)
+  })
+
   it('returns false for non-Error values', () => {
     expect(isTransportFailureError('net::ERR_CONNECTION_CLOSED')).toBe(false)
     expect(isTransportFailureError(null)).toBe(false)

--- a/packages/utils/__tests__/network-transport-error.test.ts
+++ b/packages/utils/__tests__/network-transport-error.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The update system classified connection failures by matching Node/undici error strings, but the
+ * transport that actually runs OTA is Electron `session.fetch`, which emits Chromium `net::ERR_*`.
+ * `net::ERR_CONNECTION_CLOSED` therefore read as a permanent failure and the GitHub fallback never
+ * fired — reproduced against the official update host on 2026-09-04 while GitHub answered 200.
+ *
+ * These tests pin the property (is this a connection-level failure?) rather than any one spelling,
+ * and the negative cases below are the load-bearing half: a marker list that matches everything
+ * would pass every positive case here while quietly stealing errors from the timeout and
+ * HTTP-status classifiers, which carry different retry semantics.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  isTimeoutLikeError,
+  isTransportFailureError,
+  NETWORK_ERROR_CODE,
+  NetworkAbortError,
+  NetworkHttpStatusError,
+  NetworkTimeoutError,
+  NetworkTransportError,
+} from '../network/core/errors'
+
+describe('isTransportFailureError recognises every transport dialect', () => {
+  it.each([
+    // Chromium net stack — the dialect the old regex missed entirely.
+    'net::ERR_CONNECTION_CLOSED',
+    'net::ERR_CONNECTION_RESET',
+    'net::ERR_CONNECTION_REFUSED',
+    'net::ERR_NAME_NOT_RESOLVED',
+    'net::ERR_INTERNET_DISCONNECTED',
+    'net::ERR_FAILED',
+    // Not covered by /timeout|etimedout/: the code spells it TIMED_OUT.
+    'net::ERR_CONNECTION_TIMED_OUT',
+    // TLS/certificate failures fall back like any other connection failure (decision D1).
+    'net::ERR_SSL_PROTOCOL_ERROR',
+    'net::ERR_CERT_AUTHORITY_INVALID',
+    // Chromium global fetch — word order is the reverse of undici's, so the old regex missed it.
+    'Failed to fetch',
+    // Node / undici
+    'fetch failed',
+    'read ECONNRESET',
+    'connect ECONNREFUSED 127.0.0.1:443',
+    'getaddrinfo ENOTFOUND tuff.tagzxia.com',
+    'getaddrinfo EAI_AGAIN tuff.tagzxia.com',
+    'socket hang up',
+    'Client network socket disconnected before secure TLS connection was established',
+  ])('treats %s as a transport failure', (message) => {
+    expect(isTransportFailureError(new Error(message))).toBe(true)
+  })
+
+  it('matches an unenumerated Chromium code through the net:: prefix', () => {
+    expect(isTransportFailureError(new Error('net::ERR_SOMETHING_NEW_IN_A_FUTURE_CHROMIUM'))).toBe(
+      true,
+    )
+  })
+})
+
+describe('isTransportFailureError leaves other classifiers their errors', () => {
+  it.each([
+    ['an HTTP status error', new NetworkHttpStatusError(500, 'Server Error', 'https://x.test')],
+    ['a rate-limit status error', new NetworkHttpStatusError(429, 'Too Many', 'https://x.test')],
+    ['a timeout', new NetworkTimeoutError(8000)],
+    ['an abort', new NetworkAbortError()],
+    ['an unrelated failure', new Error('Update package signature verification failed')],
+  ])('does not claim %s', (_label, error) => {
+    expect(isTransportFailureError(error)).toBe(false)
+  })
+
+  it('does not steal ERR_CONNECTION_TIMED_OUT from... nothing: isTimeoutLikeError never had it', () => {
+    // Documents why isRetryable must OR both classifiers rather than relying on either alone.
+    const timedOut = new Error('net::ERR_CONNECTION_TIMED_OUT')
+    expect(isTimeoutLikeError(timedOut)).toBe(false)
+    expect(isTransportFailureError(timedOut)).toBe(true)
+
+    const timeout = new NetworkTimeoutError(8000)
+    expect(isTimeoutLikeError(timeout)).toBe(true)
+    expect(isTransportFailureError(timeout)).toBe(false)
+  })
+
+  it('returns false for non-Error values', () => {
+    expect(isTransportFailureError('net::ERR_CONNECTION_CLOSED')).toBe(false)
+    expect(isTransportFailureError(null)).toBe(false)
+    expect(isTransportFailureError(undefined)).toBe(false)
+  })
+})
+
+describe('isTransportFailureError survives the loss of error identity', () => {
+  it('classifies a NetworkTransportError by type', () => {
+    expect(isTransportFailureError(new NetworkTransportError('net::ERR_CONNECTION_CLOSED'))).toBe(
+      true,
+    )
+  })
+
+  it('classifies by code when the prototype chain is gone but the code survives', () => {
+    const overIpc = Object.assign(new Error('something the renderer cannot parse'), {
+      code: NETWORK_ERROR_CODE.TRANSPORT_FAILED,
+    })
+    expect(isTransportFailureError(overIpc)).toBe(true)
+  })
+
+  it('classifies by message when only the string survives, as in the renderer', () => {
+    // transport/prelude.ts projects errors across IPC as `error.message`; the renderer gets a
+    // plain Error with no code and no prototype. This tier is the only one left there.
+    expect(isTransportFailureError(new Error('net::ERR_CONNECTION_CLOSED'))).toBe(true)
+  })
+})
+
+describe('NetworkTransportError stays compatible with message-matching callers', () => {
+  it('preserves the original message verbatim', () => {
+    // ~25 NetworkService callers still match on message text (network-log-noise.ts among them).
+    // Rewriting the message to the code, as NetworkTimeoutError does, would change their behaviour.
+    const original = 'net::ERR_CONNECTION_CLOSED'
+    expect(new NetworkTransportError(original).message).toBe(original)
+  })
+
+  it('exposes the code additively', () => {
+    expect(new NetworkTransportError('net::ERR_CONNECTION_CLOSED').code).toBe(
+      NETWORK_ERROR_CODE.TRANSPORT_FAILED,
+    )
+  })
+
+  it('extracts the Chromium code when present, and omits it otherwise', () => {
+    expect(new NetworkTransportError('net::ERR_CONNECTION_CLOSED').netErrorCode).toBe(
+      'ERR_CONNECTION_CLOSED',
+    )
+    expect(new NetworkTransportError('fetch failed').netErrorCode).toBeUndefined()
+  })
+
+  it('retains the originating error as cause', () => {
+    const cause = new Error('net::ERR_CONNECTION_CLOSED')
+    expect(new NetworkTransportError(cause.message, { cause }).cause).toBe(cause)
+  })
+})

--- a/packages/utils/__tests__/network-transport-error.test.ts
+++ b/packages/utils/__tests__/network-transport-error.test.ts
@@ -49,10 +49,26 @@ describe('isTransportFailureError recognises every transport dialect', () => {
     expect(isTransportFailureError(new Error(message))).toBe(true)
   })
 
-  it('matches an unenumerated Chromium code through the net:: prefix', () => {
-    expect(isTransportFailureError(new Error('net::ERR_SOMETHING_NEW_IN_A_FUTURE_CHROMIUM'))).toBe(
-      true,
-    )
+  it('matches an unenumerated code in the connection family through its prefix', () => {
+    expect(isTransportFailureError(new Error('net::ERR_CONNECTION_SOMETHING_NEW'))).toBe(true)
+  })
+
+  /*
+   * Chromium files cancellation, permission refusals and caller bugs under the same `net::ERR_`
+   * prefix as connection failures. A blanket prefix marker matched all of them, which would have
+   * retried work the user had just cancelled — the renderer call site sees only the message string
+   * across IPC, so it has nothing else to discriminate on.
+   */
+  it.each([
+    'net::ERR_ABORTED',
+    'net::ERR_ACCESS_DENIED',
+    'net::ERR_BLOCKED_BY_CLIENT',
+    'net::ERR_BLOCKED_BY_ADMINISTRATOR',
+    'net::ERR_UNSAFE_PORT',
+    'net::ERR_INVALID_URL',
+    'net::ERR_UNKNOWN_URL_SCHEME',
+  ])('does not treat %s as a transport failure', (message) => {
+    expect(isTransportFailureError(new Error(message))).toBe(false)
   })
 })
 

--- a/packages/utils/network/core/errors.ts
+++ b/packages/utils/network/core/errors.ts
@@ -19,15 +19,18 @@ export const NETWORK_ERROR_CODE = {
  * Timeout and HTTP-status markers are deliberately absent — `isTimeoutLikeError` and
  * `parseHttpStatusCode` own those, and duplicating them here would make a single error match two
  * classifiers with different retry semantics.
+ *
+ * There is deliberately no blanket `net::err_` entry. Chromium files user cancellation
+ * (`ERR_ABORTED`), permission and policy refusals (`ERR_ACCESS_DENIED`, `ERR_BLOCKED_BY_CLIENT`)
+ * and caller bugs (`ERR_INVALID_URL`, `ERR_UNSAFE_PORT`) under the same prefix, none of which get
+ * better by retrying or by asking a different host. Missing a novel transport code degrades to the
+ * behaviour this fix replaced, for that one code; matching a cancellation would retry work the user
+ * just cancelled. `err_connection_` and `err_cert_` stay prefixes because every member of those two
+ * families qualifies.
  */
 export const TRANSPORT_FAILURE_MARKERS = [
-  // Chromium net stack (session.fetch). The prefix covers codes not yet enumerated below.
-  'net::err_',
-  'err_connection_closed',
-  'err_connection_reset',
-  'err_connection_refused',
-  'err_connection_timed_out',
-  'err_connection_aborted',
+  // Chromium net stack (session.fetch).
+  'err_connection_',
   'err_name_not_resolved',
   'err_internet_disconnected',
   'err_network_changed',

--- a/packages/utils/network/core/errors.ts
+++ b/packages/utils/network/core/errors.ts
@@ -4,7 +4,55 @@ export const NETWORK_ERROR_CODE = {
   COOLDOWN_ACTIVE: 'NETWORK_COOLDOWN_ACTIVE',
   FILE_FORBIDDEN: 'NETWORK_FILE_FORBIDDEN',
   FILE_UNSUPPORTED_SOURCE: 'NETWORK_UNSUPPORTED_FILE_SOURCE',
+  TRANSPORT_FAILED: 'NETWORK_TRANSPORT_FAILED',
 } as const
+
+/**
+ * Substrings identifying a connection-level failure, across every transport this repo ships.
+ *
+ * Three dialects coexist and callers cannot tell which one produced an error: `session.fetch`
+ * (main process) emits Chromium `net::ERR_*`, the global `fetch()` in `../request.ts` emits
+ * `Failed to fetch` under Chromium and `fetch failed` under Node/undici. The update system used to
+ * match the Node dialect alone, so `net::ERR_CONNECTION_CLOSED` was classified as permanent and the
+ * GitHub fallback never fired while GitHub was reachable the whole time.
+ *
+ * Timeout and HTTP-status markers are deliberately absent — `isTimeoutLikeError` and
+ * `parseHttpStatusCode` own those, and duplicating them here would make a single error match two
+ * classifiers with different retry semantics.
+ */
+export const TRANSPORT_FAILURE_MARKERS = [
+  // Chromium net stack (session.fetch). The prefix covers codes not yet enumerated below.
+  'net::err_',
+  'err_connection_closed',
+  'err_connection_reset',
+  'err_connection_refused',
+  'err_connection_timed_out',
+  'err_connection_aborted',
+  'err_name_not_resolved',
+  'err_internet_disconnected',
+  'err_network_changed',
+  'err_address_unreachable',
+  'err_empty_response',
+  'err_failed',
+  // TLS/certificate failures are treated as transport failures: artifacts from either source are
+  // sha256- and signature-verified downstream, so switching source cannot lower the integrity bar,
+  // while failing closed would strand every user behind a TLS-intercepting proxy on a stale build.
+  'err_ssl_protocol_error',
+  'err_cert_',
+  // Chromium global fetch (renderer). Note the word order differs from undici's.
+  'failed to fetch',
+  // Node / undici
+  'fetch failed',
+  'econnreset',
+  'econnrefused',
+  'econnaborted',
+  'enotfound',
+  'etimedout',
+  'eai_again',
+  'epipe',
+  'socket hang up',
+  'network socket disconnected',
+] as const
 
 export class NetworkAbortError extends Error {
   readonly code = NETWORK_ERROR_CODE.ABORTED
@@ -22,6 +70,27 @@ export class NetworkTimeoutError extends Error {
     const detail = typeof timeoutMs === 'number' ? ` after ${timeoutMs}ms` : ''
     super(`${NETWORK_ERROR_CODE.TIMEOUT}${detail}`)
     this.name = 'NetworkTimeoutError'
+  }
+}
+
+/**
+ * A connection-level failure, normalized at the NetworkService boundary.
+ *
+ * Unlike {@link NetworkTimeoutError}, this preserves the original message verbatim rather than
+ * replacing it with its own code. Roughly two dozen NetworkService callers still match on message
+ * text, so rewriting it here would silently change their behaviour; `code` is the additive part
+ * that lets new callers classify by type instead.
+ */
+export class NetworkTransportError extends Error {
+  readonly code = NETWORK_ERROR_CODE.TRANSPORT_FAILED
+
+  /** The Chromium error code (`ERR_CONNECTION_CLOSED`), when the message carried one. */
+  readonly netErrorCode?: string
+
+  constructor(originalMessage: string, options?: { cause?: unknown }) {
+    super(originalMessage, options)
+    this.name = 'NetworkTransportError'
+    this.netErrorCode = originalMessage.match(/net::(ERR_[A-Z0-9_]+)/)?.[1]
   }
 }
 
@@ -55,6 +124,36 @@ export function isTimeoutLikeError(error: unknown): boolean {
   }
 
   return /timeout|etimedout/i.test(error.message)
+}
+
+/**
+ * Whether an error is a connection-level failure, and so worth retrying or falling back from.
+ *
+ * Three tiers, because error identity degrades as the error travels. In-process the class survives;
+ * across the transport SDK only `code` survives; across a raw IPC hop that projects errors to
+ * `error.message` (`transport/prelude.ts`) the renderer receives a plain `Error` and the string is
+ * all that is left. Dropping the string tier would make this classifier silently useless in the
+ * renderer, which is one of the three call sites it exists for.
+ */
+export function isTransportFailureError(error: unknown): boolean {
+  if (error instanceof NetworkTransportError) {
+    return true
+  }
+
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { code?: unknown }).code === NETWORK_ERROR_CODE.TRANSPORT_FAILED
+  ) {
+    return true
+  }
+
+  if (!(error instanceof Error)) {
+    return false
+  }
+
+  const message = error.message.toLowerCase()
+  return TRANSPORT_FAILURE_MARKERS.some(marker => message.includes(marker))
 }
 
 export function parseHttpStatusCode(error: unknown): number | null {

--- a/packages/utils/network/core/errors.ts
+++ b/packages/utils/network/core/errors.ts
@@ -18,7 +18,11 @@ export const NETWORK_ERROR_CODE = {
  *
  * Timeout and HTTP-status markers are deliberately absent — `isTimeoutLikeError` and
  * `parseHttpStatusCode` own those, and duplicating them here would make a single error match two
- * classifiers with different retry semantics.
+ * classifiers with different retry semantics. `etimedout` is the one that has to be named to be
+ * kept out: `isTimeoutLikeError` matches `/timeout|etimedout/i`, so listing it here too would put
+ * one error in both. Both update call sites already OR the two classifiers, so leaving it out
+ * changes nothing there. Chromium's `ERR_CONNECTION_TIMED_OUT` is not the same case — that spelling
+ * matches neither half of the timeout regex, which is precisely the gap this fix closes.
  *
  * There is deliberately no blanket `net::err_` entry. Chromium files user cancellation
  * (`ERR_ABORTED`), permission and policy refusals (`ERR_ACCESS_DENIED`, `ERR_BLOCKED_BY_CLIENT`)
@@ -50,7 +54,6 @@ export const TRANSPORT_FAILURE_MARKERS = [
   'econnrefused',
   'econnaborted',
   'enotfound',
-  'etimedout',
   'eai_again',
   'epipe',
   'socket hang up',


### PR DESCRIPTION
Electron `session.fetch` reports connection failures as `net::ERR_*`, but every downstream "can we fall back / retry" check was written against the Node/undici spelling. `net::ERR_CONNECTION_CLOSED` was classified as permanent, so when the official update host became unreachable the GitHub fallback never fired — even though GitHub was reachable the whole time.

Three error dialects coexist in this repo and the old regex matched only one:

| transport | environment | message | old regex |
|---|---|---|---|
| `session.fetch` | main | `net::ERR_*` | no |
| global `fetch()` | renderer | `Failed to fetch` | no (word order is reversed) |
| global `fetch()` | Node/undici | `fetch failed` | yes |

## Changes

- `packages/utils/network/core/errors.ts` — add `TRANSPORT_FAILURE_MARKERS`, `NetworkTransportError`, `isTransportFailureError`. The classifier degrades in three tiers (class → `code` → message) because error identity is lost across IPC, which is exactly where the renderer call site reads it.
- `network-service.ts` — normalize at the `projectNetworkRequestError` boundary, after abort and timeout so their stronger semantics win. The message is passed through verbatim: ~two dozen callers still match on it.
- `release-fetch-service.ts` — `isOfficialFallbackEligible` / `isRetryable` now `isTimeoutLikeError(error) || isTransportFailureError(error)`.
- `GithubUpdateProvider.ts` — same classifier in the renderer instead of a second copy of the marker list.
- `network-log-noise.ts` — the downgrade table now spreads the shared markers; it had drifted and was missing `err_connection_closed`, the code the official host actually produces.

## Note on the OR

Both classifiers are required. The marker list deliberately excludes timeout spellings (`isTimeoutLikeError` owns those), and the 8s timeout path was the *one* official-source failure that still reached GitHub. Matching transport failures alone would have swapped one bug for another.

## Verification

- `pnpm -F @talex-touch/utils test` — 190 files, 1448 passed
- `npx vitest run src/main/modules/update src/renderer/src/modules/update src/main/modules/network src/main/utils/network-log-noise.test.ts` — 22 files, 176 passed
- `npm run typecheck` — exit 0
- `pnpm lint` — exit 0

New tests cover the three dialects, both codes the old regex missed (`ERR_CONNECTION_TIMED_OUT`, `Failed to fetch`), all three degradation tiers, and negative cases proving HTTP-status / timeout / abort errors are not claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTA update fallback and retry handling for connection failures across Chromium, Node, and renderer fetch errors.
  * Preserved stale-cache fallback when both update sources experience transport failures.
  * Ensured HTTP status, timeout, and abort errors retain their existing handling.
  * Preserved original network error details for clearer reporting.
  * Improved consistency when network failures pass between update components.
* **Tests**
  * Added coverage for DNS, connection, TLS, fetch, timeout, cache fallback, and permanent repository failures across update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->