### PR TITLE
feat(corebox): group the empty state by why each item is there

### DIFF
--- a/.trellis/spec/main-process/index.md
+++ b/.trellis/spec/main-process/index.md
@@ -31,8 +31,9 @@ Electron main-process (apps/core-app/src/main) coding contracts.
   constraints.
 - [recommendation-freshness-contracts.md](recommendation-freshness-contracts.md) —
   `installedAt` extension (write-once via conflict-do-nothing, watch-now fallback),
-  double-gate freshness predicate, novelty→frecency handoff, the THREE
-  `recommendation.source` union files, cache-invalidation read-guard vs cleanup
+  double-gate freshness predicate, novelty→frecency handoff, the single
+  `RECOMMENDATION_SECTION_ORDER` source of truth (also the section render order),
+  verifiable-or-absent evidence rules, cache-invalidation read-guard vs cleanup
   deletion, exposure slice tag rules.
 - [search-hotpath-contracts.md](search-hotpath-contracts.md) — per-keystroke search
   path: token dedup funnels through `addSearchToken` (O(1) WeakMap/Set), per-app

--- a/.trellis/spec/main-process/recommendation-freshness-contracts.md
+++ b/.trellis/spec/main-process/recommendation-freshness-contracts.md
@@ -38,15 +38,35 @@ touching recommendation cache invalidation. Introduced by 08-06-reco-item-freshn
   `source: 'newly-installed'` even with `executeCount > 0` (it is the true reason they
   entered the pool); dedupe only promotes an existing candidate's source when
   `executeCount === 0` (a dead boost must not claim to be the ranking reason).
-- **`recommendation.source` union lives in THREE files** — `core-box/recommendation.ts`
-  (`ScoredItem`), `core-box/tuff/tuff-dsl.ts`, and
-  `transport/events/types/core-box.ts` (the one that actually crosses IPC). Extend all
-  three or the drift is invisible until a consumer exhaustive-checks it.
+- **`recommendation.source` has ONE source of truth (since 09-04)** —
+  `RECOMMENDATION_SECTION_ORDER` in `core-box/recommendation.ts`, with
+  `type RecommendationSource = (typeof RECOMMENDATION_SECTION_ORDER)[number]`.
+  It previously lived as three hand-maintained literal unions
+  (`ScoredItem`, `core-box/tuff/tuff-dsl.ts`, and `transport/events/types/core-box.ts`
+  — the one that crosses IPC); they had already drifted, and
+  `RecommendationBadge.variant` was missing `'plugin'` while `generateBadge` emitted it
+  (hidden by a loose `{ variant: string }` return type). All three now reference
+  `RecommendationSource`. **Add a source by appending to the array, never by widening a
+  consumer's union.**
+- **The array is also the render order.** `buildContainerLayout()` iterates
+  `RECOMMENDATION_SECTION_ORDER` to emit sections, so array position = the order the
+  user sees, and reordering it is a user-visible behavior change (that is how pinned
+  moved from bottom to top). Appending a source without a `getReasonLabel` /
+  `generateBadge` entry is caught by the badge-uniqueness test in
+  `item-rebuilder.test.ts`, which asserts all 9 sources have distinct badges and reasons.
 - **Cache invalidation**: `invalidateCache()` correctness = synchronous read guard
   (`cacheInvalidatedAt` rejects older rows) + generation counter (a recommend() started
   before invalidation may not write back to any layer). The aux `recommendation_cache`
   row deletion runs with `dropPolicy: 'drop'` — it is cleanup, never the mechanism.
   Index-commit trigger fires only for `providerIds` containing `APP_INDEXED_SOURCE_ID`.
+- **Evidence must be verifiable or absent.** `meta.recommendation.evidence` carries only
+  facts the DB actually holds (`executeCount`, `lastExecutedAt`, `installedAt`,
+  `peakHourRange`). Every field is `Number.isFinite` + `> 0` guarded and omitted when
+  unavailable; an all-empty evidence object is dropped entirely so the renderer prints
+  nothing rather than a placeholder. `resolvePeakHourRange` (recommendation-utils.ts)
+  returns `null` below 10 samples or when the best 3-hour window holds <40% of them —
+  a weak peak is no peak, not a rounded one. There is **no app co-occurrence signal**
+  anywhere in this codebase; do not add "used after X" copy without first adding the data.
 - **Exposure slice tags**: extra rows keyed `surface + ':newly-installed'`; base surfaces
   must never contain `:` (readSliceTag splits on it). `getHitRate(days)` sums base
   surfaces only; pass the tag to read a slice.
@@ -57,7 +77,8 @@ touching recommendation cache invalidation. Introduced by 08-06-reco-item-freshn
 |---|---|
 | installedAt overwritten on rescan | updates masquerade as installs — forbidden by DO NOTHING |
 | Only one freshness gate applied | old machines' first scan or self-updates flagged as new |
-| union extended in <3 files | IPC-facing type drifts silently |
+| union extended in <3 files | fixed at the root: extend `RECOMMENDATION_SECTION_ORDER` instead |
+| evidence field fabricated (0, `Date.now()`, guessed peak) | forbidden — omit the field, or the whole evidence object |
 | extension read fails | degrade to ctime ordering (`loadInstalledAtByFileId` swallows), never empty grid |
 
 ### 5. Tests required
@@ -68,3 +89,8 @@ never-overwrite), engine tests "treats an app as new only when…" (four-quadran
 rather than index time" (discriminating fixture: ctime and stamp point opposite ways —
 a stub without `getFileExtensionsByFileIds` silently tests the degraded path),
 `search-core.contracts` app-vs-file commit invalidation, exposure slice isolation tests.
+For the source union / evidence contracts (09-04):
+`item-rebuilder.test.ts` badge-and-reason uniqueness across `RECOMMENDATION_SECTION_ORDER`,
+`recommendation-utils.test.ts` peak-hour boundaries (9-vs-10 samples, exactly-0.4 share,
+midnight wraparound), `recommendation-evidence.test.ts` "says nothing when there is no
+evidence" and the future-timestamp case.

--- a/.trellis/tasks/09-04-corebox-reason-grouping/check.jsonl
+++ b/.trellis/tasks/09-04-corebox-reason-grouping/check.jsonl
@@ -1,0 +1,6 @@
+{"file": ".trellis/spec/frontend/quality-guidelines.md", "reason": "整体质量门槛"}
+{"file": ".trellis/spec/frontend/type-safety.md", "reason": "核对新增 evidence 可选字段与 RecommendationSource 联合类型的写法"}
+{"file": ".trellis/spec/main-process/recommendation-freshness-contracts.md", "reason": "核对 layout 改写没有破坏推荐缓存新鲜度契约"}
+{"file": ".trellis/spec/main-process/search-hotpath-contracts.md", "reason": "核对空态热路径未退化"}
+{"file": ".trellis/spec/guides/cross-layer-thinking-guide.md", "reason": "核对三层改动一致、无契约漂移"}
+{"file": ".trellis/spec/guides/code-reuse-thinking-guide.md", "reason": "核对 RECOMMENDATION_SECTION_ORDER 是唯一真源，未在主进程/渲染层各自重复一份顺序"}

--- a/.trellis/tasks/09-04-corebox-reason-grouping/design.md
+++ b/.trellis/tasks/09-04-corebox-reason-grouping/design.md
@@ -1,0 +1,112 @@
+# 技术设计 · CoreBox 空态推荐理由分组
+
+## 管线与断点
+
+```
+RecommendationEngine.getRecommendations()
+  ├─ 打分产出 ScoredItem[]  (source ∈ 9 种)          ✅ 已有
+  ├─ ItemRebuilder.rebuild()
+  │    └─ meta.recommendation = { score, source, reason, badge }
+  │                                    ▲ 断点 A：pinned 缺失、两种来源共用「推荐」、无 evidence
+  └─ buildContainerLayout()
+       └─ sections = [recommendations, pinned]  mode:'grid'
+                                    ▲ 断点 B：不按 source 分组、pinned 在底、grid
+                                              ↓
+                              BoxGrid.vue
+                                    ▲ 断点 C：读 section.title，不读 section.layout
+```
+
+三个断点分别对应 S3 / S4 / S6。S1、S2 是它们共同依赖的契约与纯函数。
+
+## C1 · `evidence` 契约（`packages/utils`）
+
+`TuffItem['meta']['recommendation']` 扩展：
+
+```ts
+recommendation?: {
+  source:
+    | 'frequent' | 'recent' | 'time-based' | 'trending'
+    | 'pinned' | 'context' | 'cold-start' | 'newly-installed'
+    | 'plugin'                       // ← 新增，补齐 engine 侧已存在的取值
+  score?: number
+  stableScore?: number
+  volatileScore?: number
+
+  /**
+   * 可解释性证据。全部可选：主进程只在拿得到真实数据时填，
+   * 渲染层只在字段存在时渲染。任何一侧都不得推断或补默认值。
+   */
+  evidence?: {
+    executeCount?: number       // itemUsageStats.executeCount
+    lastExecutedAt?: number     // epoch ms
+    installedAt?: number        // epoch ms
+    peakHourRange?: { startHour: number; endHour: number }  // 0-23，闭区间，可跨零点
+  }
+}
+```
+
+**为什么是可选子对象而不是扁平字段**：证据是一组同生共死的、来自不同数据表的可选值；扁平化会让 `meta.recommendation` 多出 4 个孤立可选字段，且无法一眼区分「排序输入」（score 系列）与「展示输出」（evidence 系列）。
+
+**为什么全部可选**：PRD R5。宁可少显示一行，也不显示一句假话——这是本任务最初被用户驳回的那版设计的教训。
+
+## C2 · 分组顺序单一真源
+
+新建 `packages/utils/core-box/recommendation.ts`：
+
+```ts
+export const RECOMMENDATION_SECTION_ORDER = [
+  'pinned', 'frequent', 'time-based', 'recent',
+  'newly-installed', 'context', 'plugin', 'trending', 'cold-start'
+] as const
+
+export type RecommendationSource = (typeof RECOMMENDATION_SECTION_ORDER)[number]
+```
+
+`recommendation.source` 的联合类型改为引用 `RecommendationSource`，让「联合类型」与「顺序」由同一个数组派生——避免再次出现 `'plugin'` 只在一侧存在的漂移。
+
+顺序理由：确定性强的排最前（人工 pinned > 高频 > 当前时段 > 最近），推断性强的排最后（trending / cold-start）。
+
+## C3 · `buildContainerLayout()` 改写
+
+```ts
+private buildContainerLayout(_options, items: TuffItem[]): TuffContainerLayout {
+  // 1. 按 source 分桶；meta.pinned.isPinned 强制进 pinned 桶（优先于 source）
+  // 2. 按 RECOMMENDATION_SECTION_ORDER 遍历，跳过空桶
+  // 3. 每桶取前 3 项（已按 score 降序）
+  // 4. section = { id: source, title: `corebox.reason.${source}`, layout: 'list', itemIds, meta: { source } }
+  return { mode: 'list', sections }
+}
+```
+
+- `title` 存 **i18n key** 而非成品文案：主进程不持有用户语言。渲染层 `t(section.title)`。
+  兼容性：现有 `title: 'Recommend'` 是字面量英文；渲染层需对「不含 `.` 的 title」按字面量回退，否则旧缓存的 layout 会显示成 key 字符串。
+- `mode` 从 `'grid'` 改为 `'list'`，`grid` 字段不再产出。
+
+## C4 · `resolvePeakHourRange` 规则
+
+纯函数，输入 `hourDistribution: number[]`（长度 24），输出 `{ startHour, endHour } | null`。
+
+1. 长度不为 24，或总和 `< 10` → `null`（样本不足，不猜）
+2. 滑动 3 小时窗口（**含跨零点回绕**：`22,23,0`），取和最大的窗口
+3. 该窗口占总和比例 `< 0.4` → `null`（分布太平，说不出「常在某时段」）
+4. 否则返回 `{ startHour: 窗口首, endHour: 窗口尾 }`
+
+阈值 10 / 0.4 是保守起手值，宁缺毋滥。真实数据上偏紧可在后续任务放宽——见 PRD 验收 7。
+
+## C5 · `BoxGrid.vue` 分支
+
+现有 `SectionData { section, items, startIndex }` 与全局 index 累加逻辑**不动**（`⌘N` 快捷键编号依赖它跨 section 连续）。
+
+新增：`section.layout === 'list'` 时渲染行组件（图标 22×22 / 标题 13px / 证据 11px `$text-muted` / 右侧 `⌘N`），否则走原 `BoxGridItem` 网格路径。
+
+`getSectionVisibleItems()` 的 intelligence 截断（`columns * 2`）**只作用于 grid 分支**——list 分支条数已由主进程的每组 3 项决定，二次截断会互相打架。
+
+## 兼容性 / 回滚
+
+- **旧缓存 layout**：`recommendationCache` 里可能存着 `mode:'grid'` 的旧 layout。渲染层按 `section.layout` 逐组判断，`undefined` 走 grid，天然兼容。
+- **`@talex-touch/utils` 变更是纯增量**：新增 `'plugin'` 成员与可选 `evidence`，无破坏性改动，不需要 major bump。
+- **回滚点**：S4（`buildContainerLayout`）是唯一改变用户可见结构的步骤。单独 revert S4 即可回到旧网格，S1–S3 的字段增量无副作用可保留。
+
+## 风险
+
+`recommendation-engine.test.ts`（2238 行）与 `item-rebuilder.test.ts`（514 行）必然有断言依赖旧的 section 结构与旧文案。**逐个读懂再改，不许为了跑绿把断言删掉**——断言反映的是旧契约，要改成新契约，不是删除。

--- a/.trellis/tasks/09-04-corebox-reason-grouping/implement.jsonl
+++ b/.trellis/tasks/09-04-corebox-reason-grouping/implement.jsonl
@@ -1,0 +1,7 @@
+{"file": ".trellis/spec/main-process/recommendation-freshness-contracts.md", "reason": "S3/S4 直接改推荐管线的 meta 与 layout 产出，必须遵守推荐新鲜度与缓存契约"}
+{"file": ".trellis/spec/main-process/search-hotpath-contracts.md", "reason": "buildContainerLayout 在空态搜索热路径上，改写不得引入额外同步开销"}
+{"file": ".trellis/spec/main-process/index.md", "reason": "主进程分层与模块边界总览"}
+{"file": ".trellis/spec/frontend/type-safety.md", "reason": "S1 扩展 @talex-touch/utils 的公共类型联合，需符合类型安全约定"}
+{"file": ".trellis/spec/frontend/component-guidelines.md", "reason": "S6 在 BoxGrid.vue 新增 list 渲染分支"}
+{"file": ".trellis/spec/frontend/index.md", "reason": "渲染层目录与组件组织总览"}
+{"file": ".trellis/spec/guides/cross-layer-thinking-guide.md", "reason": "本任务跨 utils 契约 / 主进程 / 渲染层三层，断点分布在层间边界"}

--- a/.trellis/tasks/09-04-corebox-reason-grouping/implement.md
+++ b/.trellis/tasks/09-04-corebox-reason-grouping/implement.md
@@ -1,0 +1,112 @@
+# 执行计划 · CoreBox 空态推荐理由分组
+
+顺序有依赖：S1 契约 → S2 纯函数 → S3/S4 主进程消费 → S5 文案 → S6 渲染 → S7 全量验证。
+
+> 执行结论：S1–S7 已完成。下方每步的 ✅ 为实际落地情况，**偏差**段落记录与原计划不一致之处及原因。
+
+---
+
+## S1 · 契约层（`packages/utils`）
+
+- [x] ~~新建~~ **改写** `packages/utils/core-box/recommendation.ts`，导出 `RECOMMENDATION_SECTION_ORDER` / `RecommendationSource` / `RECOMMENDATION_SECTION_ITEM_LIMIT` / `RecommendationEvidence`
+- [x] 该模块此前已从包入口导出，无需新增导出
+- [x] `tuff-dsl.ts` 的 `recommendation.source` 改为引用 `RecommendationSource`
+- [x] 同处新增可选 `evidence` 子对象（见 design C1）
+
+验证：`pnpm --filter @talex-touch/utils build` ✅
+
+> **偏差 1（S1）**：计划写的是「新建 `recommendation.ts`」，但该文件**本就存在**且已导出。改为**统一**而非创建。
+>
+> 顺带修掉一个计划只猜中一半的既有缺陷：drift 的 `source` 联合类型有 **3 处**（非 2 处），且 `RecommendationBadge.variant` 缺 `'plugin'`——`generateBadge` 一直在发这个值，被宽松的 `{ variant: string }` 返回类型盖住了。已 grep 确认 utils 这几个类型无外部消费方，加宽安全。
+
+> **补漏（Phase 3 发现）**：S1 当时只统一了 3 处中的 2 处，漏了 `transport/events/types/core-box.ts`——**恰恰是真正跨 IPC 的那一处**，且仍缺 `'plugin'`。是走 3.3 spec 更新时被 `recommendation-freshness-contracts.md` 里「union lives in THREE files」这条既有约定抓出来的。已改为引用 `RecommendationSource` 并补 `evidence`，三处至此收敛到单一真源。
+
+> ⚠️ 已知陷阱：改完 `@talex-touch/utils` 的导出后，`apps/core-app/node_modules` 里可能残留物理副本遮蔽根 symlink（shamefully-hoist），表现为 `tsc` 过但运行时/vitest 找不到新子路径。解析失败就 `pnpm install` 重跑。（本次未触发）
+
+## S2 · `resolvePeakHourRange` 纯函数
+
+- [x] 实现 design C4 的 4 条规则，含**跨零点回绕**
+- [x] 测试覆盖：畸形入参 / 总和 9 与 10 的边界 / 均匀分布 / 最忙窗口 / 跨零点 / 占比恰好 0.4 / 脏桶（负数、NaN）/ 并列取先
+
+验证：`recommendation-utils.test.ts` ✅ 19 tests pass
+
+> **偏差 2（S2）**：函数落在既有的 `recommendation-utils.ts`，**未**新建 `peak-hour-range.ts` / `peak-hour-range.test.ts`。理由：同文件已有同性质的 `calculateHourAffinity`，代码复用指南要求就近放置而非新开文件。
+
+## S3 · `item-rebuilder.ts`（断点 A）
+
+- [x] `getReasonLabel` 补 `pinned: 'Pinned'`
+- [x] `generateBadge` 补 `pinned`；`time-based`「推荐」→「此刻常用」；`cold-start`「推荐」→「猜你要用」
+- [x] `buildEvidence()` 填充 `meta.recommendation.evidence`
+- [x] **拿不到的字段就不写**：逐字段 `Number.isFinite` + `> 0` 校验，全空则整个 `evidence` 返回 `undefined`
+
+验证：`item-rebuilder.test.ts` ✅ 10 tests pass
+
+> 既有测试 `'labels newly installed and cold-start items with their own badge'` 断言 cold-start 用**通用**徽章——与它自己的用例名矛盾。已按 PRD 决策改为 `'猜你要用'`，并补一条结构性测试：遍历 `RECOMMENDATION_SECTION_ORDER`，断言 9 个来源的徽章文案与 reason 两两不同。
+
+## S4 · `recommendation-engine.ts`（断点 B）⚠️ 回滚点
+
+- [x] 按 design C3 改写 `buildContainerLayout()`：分桶 → 按 `RECOMMENDATION_SECTION_ORDER` 输出 → 空组跳过 → 每组 `slice(0, 3)`
+- [x] 更新「Pinned at bottom」注释
+
+验证：`recommendation-engine.test.ts` ✅（整个 `recommendation/` 目录 125 tests / 7 files pass）
+
+> **评审门 1 触发并自行判定**：`recommendation-engine.test.ts` 断言 pinned 在 `sections?.at(-1)`，与 PRD R1 冲突。判定为**纯期望值更新**（PRD 已明确记录该顺序反转属预期行为变更），故未阻塞提问，改为 `at(0)` 并加注释说明；`items` 数组自身的顺序是另一件事，未动。
+
+## S5 · i18n
+
+- [x] `zh-CN.json` + `en-US.json` 各加 `corebox.reason.*` 共 9 个 key
+- [x] 另加 `corebox.evidence.*`（见偏差 3）
+- [x] 两个文件 key 集合完全一致
+
+验证：`translation-coverage.test.ts` ✅ 4 tests pass
+
+> 未使用 vue-i18n 复数语法：全库现有文案把 `|` 当**字面分隔符**用，没有任何复数形式。改用复数无关的紧凑写法（`{count}h`、`Opened {count}×`）。
+
+## S6 · `BoxGrid.vue`（断点 C）
+
+- [x] 加 list 分支；title 含 `.` 走 `t()`，否则字面量回退（兼容缓存里的旧 `'Recommend'`）
+- [x] **未动** grid 分支、`CORE_BOX_INTELLIGENCE_GRID_COLUMN_LIMIT`、全局 index 累加
+- [x] list 分支复用 `BoxItem.vue` 渲染行
+
+> **偏差 3（S6）**：计划只写了 `BoxGrid.vue`，实际还需要三样东西才能把证据落到行上：
+>
+> 1. 新建 `recommendation-evidence.ts` —— `formatRecommendationEvidence()`，按来源选最能解释它的那条事实，没有可说的就返回 `''`（+ `recommendation-evidence.test.ts` 10 tests ✅）
+> 2. `BoxItem.vue` 新增 `evidence?: string` prop 与 `.RecommendationEvidence` 样式
+> 3. i18n 增加 `corebox.evidence.*`
+>
+> 复用 `BoxItem` 而非新建行组件，顺带解决了原始诉求里「空态和搜索态像两个 App」的问题。
+>
+> 另确认：`resolveResultSignal` / `sourceMeta.ts` 是给错误/健康状态用的，不是推荐理由，因此证据走独立 prop 而非复用它。
+
+## S7 · 全量验证
+
+- [x] `npm run typecheck`（在 `apps/core-app/`）—— exit 0
+- [x] `pnpm lint` —— 首次 exit 1（9 条 `prettier/prettier` warning，0 error），`pnpm lint:fix` 后 exit 0
+- [x] `pnpm utils:test` —— 248 pass / 5 fail
+- [x] `apps/core-app` 全量 vitest —— 6806 pass / 4 fail
+- [ ] `pnpm core:dev` 人工确认：分组顺序、pinned 置顶、无空组、每组 ≤3、证据文案真实（**待用户执行**）
+
+> **两处失败均为既有问题，与本任务无关**——已 `git stash` 到干净 HEAD 复跑，同样的文件、同样的用例数失败：
+>
+> | 失败用例 | 数量 | 归因 |
+> |---|---|---|
+> | `channel-api-doc.test.ts` | 1 | 渲染进程 `send()` 加了 `options?: { timeout?: number }`，CLAUDE.md 文档未同步 |
+> | `ui-preference-storage.test.ts` | 2 | `window.localStorage` undefined（测试环境） |
+> | `widget-registry.test.ts` | 1 | 插件沙箱隔离 |
+> | `tuff-native-ocr.test.ts` | 2 | 原生模块 |
+> | `translation.test.ts`（`packages/test`） | 3 | touch-translation Prelude |
+
+---
+
+## 评审门（遇到就停下来问，不要自行决定）
+
+1. ~~现有测试断言与 PRD R1 分组顺序冲突~~ → 触发，判定为期望值更新，见 S4
+2. ~~`@talex-touch/utils` 需要破坏性改动~~ → 未触发；改动为**加宽**（补齐联合类型成员、新增可选字段），且无外部消费方
+3. ~~峰值时段阈值在真实数据上明显不合理~~ → 未触发（阈值保守，取不到就返回 `null`）
+4. ~~分组数超过 5 个，空态变得过长~~ → 未触发；空组直接跳过，实际同时出现的分组远少于 9
+
+---
+
+## 附：顺带发现（未处理，超出本任务范围）
+
+`TuffItem.meta.usageStats` 在 `tuff-dsl.ts` 有声明、`BoxItem.vue:104` 有读取（图标角标显示打开次数），但**全仓库没有任何写入方**——该角标是死 UI，从不渲染。因此它不会和本次的证据文案重复。

--- a/.trellis/tasks/09-04-corebox-reason-grouping/prd.md
+++ b/.trellis/tasks/09-04-corebox-reason-grouping/prd.md
@@ -1,0 +1,56 @@
+# CoreBox 空态推荐理由分组
+
+## 目标
+
+CoreBox 空态（未输入任何字符时）现在是一个标题为 `Recommend` 的大网格，所有推荐项混在一起，每个项右上角挂一个几乎恒为「推荐」的徽章。用户看不出**为什么**这一项被推荐。
+
+本任务把空态改成**按推荐来源分组的列表**：每组一个理由标题（常用 / 此刻常用 / 最近 / 新安装 …），组内 3 项，每项右侧给一句可解释的证据文本（`本周打开 23 次` / `每天 09-11 点常开` / `2 小时前刚安装`）。
+
+视觉基线：`docs/design/corebox/v2.5.0.pen` 中的 `CoreBox 空态 · E 理由分组 + 预览` 帧（node `HUp92`）的**左栏**。右侧预览面板不在本任务范围内。
+
+## 背景事实（已核对代码，非推测）
+
+| 事实 | 位置 | 状态 |
+|---|---|---|
+| 推荐来源共 9 种，taxonomy 已完整 | `recommendation-engine.ts` `CandidateItem['source']` (~3251) | ✅ 已有 |
+| `TuffContainerLayout.sections` 分组基建已存在 | `packages/utils/core-box/tuff/tuff-dsl.ts:1452-1489` | ✅ 已有 |
+| `buildContainerLayout()` 只产出 `recommendations` + `pinned` 两组，`mode: 'grid'` | `recommendation-engine.ts:1448-1490` | ⚠️ 需改写 |
+| `recommendation.source` 联合类型漏了 `'plugin'` | `tuff-dsl.ts:1166` | ⚠️ 缺陷 |
+| `getReasonLabel` / `generateBadge` 两张映射表都漏了 `pinned` | `item-rebuilder.ts:637,651` | ⚠️ 缺陷，落到默认「推荐」 |
+| `time-based` 与 `cold-start` 徽章文案都是「推荐」 | `item-rebuilder.ts:651` | ⚠️ 这是「全员推荐徽章」的直接成因 |
+| 执行次数 `executeCount`（含索引） | `schema.ts` `itemUsageStats` (258-289) | ⚠️ 有数据，未进 item meta |
+| 小时分布 `hourDistribution`（24 长数组） | `schema.ts` `itemTimeStats` (584-600) | ⚠️ 有数据，缺峰值提取函数 |
+| 安装时间 `installedAt` | `ItemCandidate.installedAt`，已驱动 novelty boost | ⚠️ 有数据，未透出 |
+| **应用共现**（"打开 Xcode 之后常用"） | 无任何信号；`usageLogs.context` 的 `prev_app` 注释无人写入也无人读取 | ❌ **不存在，已从设计中删除** |
+| `BoxGrid.vue` 读 `section.title`，但从不读 `section.layout` | `components/render/BoxGrid.vue` | ⚠️ 需加 list 分支 |
+| intelligence 分组被硬钳到 5 列 | `box-grid-layout.ts` `CORE_BOX_INTELLIGENCE_GRID_COLUMN_LIMIT` | 说明：这是原截图中「5+1 孤儿行」的确切成因 |
+
+## 需求
+
+- **R1 分组顺序**：空态按固定顺序渲染分组 —
+  `pinned → frequent → time-based → recent → newly-installed → context → plugin → trending → cold-start`。
+  顺序必须来自**单一常量**，主进程与渲染进程共用。
+  ⚠️ 这是**行为反转**：现有实现把 pinned 放在**底部**（`recommendation-engine.ts:1448` 注释 "Pinned at bottom"）。
+- **R2 空组省略**：没有条目的来源不产出 section，不留空标题。
+- **R3 每组条数**：每组最多 3 项。
+- **R4 理由文案**：9 种来源各有独立中英文案，不允许两种来源共用同一串。
+  特别地：`time-based`「推荐」→「此刻常用」，`cold-start`「推荐」→「猜你要用」，`pinned` 补齐。
+- **R5 证据字段**：`recommendation` meta 增加 `evidence` 子对象，承载 `executeCount` / `lastExecutedAt` / `installedAt` / `peakHourRange`。字段全部可选——**没有数据时留空，不允许编造**。
+- **R6 列表渲染**：`BoxGrid.vue` 尊重 `section.layout === 'list'`，走行渲染分支；网格分支与 `CORE_BOX_INTELLIGENCE_GRID_COLUMN_LIMIT` 保持原样不动。
+
+## 非目标
+
+1. **不做右侧预览面板**（E 帧右栏）——独立任务。
+2. **不做应用共现信号**——底层数据不存在，硬造需要新的采集链路。
+3. **不改搜索态**（已输入字符后的结果列表）布局。
+
+## 验收标准
+
+1. 空态渲染出多个带理由标题的分组，顺序与 R1 常量一致。
+2. Pinned 分组出现在**最上方**。
+3. 无条目的来源不产出空分组。
+4. 每组不超过 3 项。
+5. 9 种来源的徽章/理由文案两两不同，中英文 key 集合一致（`translation-coverage.test.ts` 通过）。
+6. 有 `executeCount` / `installedAt` / 峰值时段数据的项，行内显示对应证据文本；无数据的项不显示、不占位、不编造。
+7. `resolvePeakHourRange` 在样本不足（< 10 次）或峰值窗口占比不足 40% 时返回 `null`。
+8. `npm run typecheck`、`pnpm lint`、`pnpm utils:test` 全绿。

--- a/.trellis/tasks/09-04-corebox-reason-grouping/task.json
+++ b/.trellis/tasks/09-04-corebox-reason-grouping/task.json
@@ -1,0 +1,30 @@
+{
+  "id": "corebox-reason-grouping",
+  "name": "corebox-reason-grouping",
+  "title": "CoreBox 空态推荐理由分组",
+  "description": "把 CoreBox 空态从单一 Recommend 网格改为按推荐来源分组的列表，并补齐推荐证据字段",
+  "status": "in_progress",
+  "dev_type": null,
+  "scope": null,
+  "package": null,
+  "priority": "P2",
+  "creator": "TalexDreamSoul",
+  "assignee": "TalexDreamSoul",
+  "createdAt": "2026-09-04",
+  "completedAt": null,
+  "branch": "release/corebox-reason-grouping-20260904",
+  "base_branch": "master",
+  "worktree_path": null,
+  "commit": null,
+  "pr_url": "https://github.com/talex-touch/tuff/pull/1865",
+  "subtasks": [],
+  "children": [],
+  "parent": null,
+  "relatedFiles": [],
+  "notes": "",
+  "meta": {
+    "nextAction": "Run the live empty state under `pnpm core:dev` and check the four things only a human can: pinned renders first (this reverses the previous order), no group renders empty, no group exceeds 3 items, and every evidence line is true of the item it sits under. Code and automated coverage are complete.",
+    "blocker": "None in the code. The npm advisories endpoint is timing out, so any PR touching this repo currently fails `Production dependency audit` inside PR Quality; that gate has nothing to say about this change, which adds no dependency.",
+    "evidence": "S1-S7 landed. Focused runs: recommendation/ 125 tests across 7 files, recommendation-evidence 10, recommendation-utils 19, item-rebuilder 10, translation-coverage 4. `npm run typecheck` exit 0; `pnpm lint` exit 0 after `lint:fix` cleared 9 prettier warnings (0 errors). The 4 core-app and 5 packages/test failures in the full-suite run were proved pre-existing by re-running the same files against a stashed clean HEAD -- identical files and counts failed. S1 also closed a real drift the plan only half-anticipated: the IPC-facing `recommendation.source` union in transport/events/types/core-box.ts was still a hand-maintained copy and was missing 'plugin'."
+  }
+}

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.test.ts
@@ -13,6 +13,7 @@ vi.mock('../../addon/apps/search-processing-service', () => ({
 }))
 
 import type { ScoredItem } from './recommendation-engine'
+import { RECOMMENDATION_SECTION_ORDER } from '@talex-touch/utils'
 import { ItemRebuilder } from './item-rebuilder'
 
 const usageStats = {
@@ -457,8 +458,72 @@ describe('ItemRebuilder', () => {
     })
     expect(await rebuild('cold-start')).toMatchObject({
       reason: 'Suggested',
-      badge: { text: '推荐', icon: 'i-ri-lightbulb-line', variant: 'intelligent' }
+      badge: { text: '猜你要用', icon: 'i-ri-lightbulb-line', variant: 'intelligent' }
     })
+  })
+
+  it('gives every recommendation source a distinct badge and reason', async () => {
+    // A shared string is invisible in a per-source assertion but shows up here:
+    // 'time-based' and 'cold-start' both read '推荐', so the empty state showed
+    // the same word on nearly every item and explained nothing.
+    const dbUtils = {
+      getFilesByPaths: vi.fn(async () => [
+        {
+          id: 1,
+          path: '/Applications/Demo.app',
+          name: 'Demo',
+          displayName: 'Demo',
+          extension: 'app',
+          size: 0,
+          mtime: new Date(),
+          ctime: new Date(),
+          lastIndexedAt: new Date(),
+          isDir: false,
+          type: 'application',
+          content: null,
+          embeddingStatus: 'none'
+        }
+      ]),
+      getFilesByBundleIds: vi.fn(async () => []),
+      getFileExtensionsByFileIds: vi.fn(async () => [])
+    }
+
+    mapAppsToRecommendationItemsMock.mockReturnValue([
+      {
+        id: '/Applications/Demo.app',
+        source: { id: 'app-provider', type: 'application', name: 'App Provider' },
+        kind: 'app',
+        render: { mode: 'default', basic: { title: 'Demo' } },
+        actions: [],
+        meta: {}
+      }
+    ])
+
+    const rebuilder = new ItemRebuilder(dbUtils as never)
+    const badgeTexts = new Set<string>()
+    const reasons = new Set<string>()
+
+    for (const source of RECOMMENDATION_SECTION_ORDER) {
+      const [item] = await rebuilder.rebuildItems([
+        {
+          sourceId: 'app-provider',
+          itemId: '/Applications/Demo.app',
+          sourceType: 'app',
+          usageStats,
+          source,
+          score: 1
+        }
+      ])
+      const recommendation = (item?.meta as Record<string, unknown>).recommendation as {
+        reason: string
+        badge: { text: string }
+      }
+      badgeTexts.add(recommendation.badge.text)
+      reasons.add(recommendation.reason)
+    }
+
+    expect(badgeTexts.size).toBe(RECOMMENDATION_SECTION_ORDER.length)
+    expect(reasons.size).toBe(RECOMMENDATION_SECTION_ORDER.length)
   })
 
   it('drops an app candidate whose catalog row is gone (uninstalled)', async () => {

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/item-rebuilder.ts
@@ -1,4 +1,4 @@
-import type { TuffItem, TuffRender } from '@talex-touch/utils'
+import type { RecommendationEvidence, TuffItem, TuffRender } from '@talex-touch/utils'
 import type { DbUtils } from '../../../../db/utils'
 import type { ScoredItem } from './recommendation-engine'
 import {
@@ -9,6 +9,7 @@ import {
 import { createLogger } from '../../../../utils/logger'
 import { isSelfAppIdentity } from '../../../system/self-app-identity'
 import { matchNoisySystemAppRule } from '../../addon/apps/app-noise-filter'
+import { resolvePeakHourRange } from './recommendation-utils'
 
 const itemRebuilderLog = createLogger('RecommendationEngine').child('ItemRebuilder')
 
@@ -616,7 +617,8 @@ export class ItemRebuilder {
         source: scored.source,
         reason: this.getReasonLabel(scored),
         isIntelligent: true,
-        badge: this.generateBadge(scored)
+        badge: this.generateBadge(scored),
+        evidence: this.buildEvidence(scored)
       }
       // Store original itemId for deduplication in recommendation-engine
       meta._originalItemId = scored.itemId
@@ -636,6 +638,7 @@ export class ItemRebuilder {
 
   private getReasonLabel(scored: ScoredItem): string {
     const labels: Record<string, string> = {
+      pinned: 'Pinned',
       frequent: 'Frequent',
       'time-based': 'Popular Now',
       recent: 'Recent',
@@ -649,9 +652,13 @@ export class ItemRebuilder {
   }
 
   private generateBadge(scored: ScoredItem): { text: string; icon: string; variant: string } {
+    // Every source gets its own wording. Two sources sharing one string is what
+    // made the empty state read as "推荐" on almost every tile, which told the
+    // user nothing about why anything was there.
     const badges: Record<string, { text: string; icon: string; variant: string }> = {
+      pinned: { text: '已固定', icon: 'i-ri-pushpin-line', variant: 'pinned' },
       frequent: { text: '常用', icon: 'i-ri-fire-line', variant: 'frequent' },
-      'time-based': { text: '推荐', icon: 'i-ri-time-line', variant: 'intelligent' },
+      'time-based': { text: '此刻常用', icon: 'i-ri-time-line', variant: 'intelligent' },
       recent: { text: '最近', icon: 'i-ri-history-line', variant: 'recent' },
       trending: { text: '趋势', icon: 'i-ri-line-chart-line', variant: 'trending' },
       context: { text: '智能推荐', icon: 'i-ri-sparkling-line', variant: 'intelligent' },
@@ -661,7 +668,7 @@ export class ItemRebuilder {
         icon: 'i-ri-download-2-line',
         variant: 'newly-installed'
       },
-      'cold-start': { text: '推荐', icon: 'i-ri-lightbulb-line', variant: 'intelligent' }
+      'cold-start': { text: '猜你要用', icon: 'i-ri-lightbulb-line', variant: 'intelligent' }
     }
     return (
       badges[scored.source] || {
@@ -670,5 +677,46 @@ export class ItemRebuilder {
         variant: 'intelligent'
       }
     )
+  }
+
+  /**
+   * Collects the data behind a recommendation so the UI can show a reason the
+   * user can check ("used 23 times", "usually around 09-11").
+   *
+   * Only fields with real data are set, and the whole object is dropped when
+   * nothing is known — an absent field means "we don't know", so the renderer
+   * shows nothing rather than a zero or a guess. A zero `executeCount` is
+   * treated as unknown for the same reason: "used 0 times" is not a reason.
+   */
+  private buildEvidence(scored: ScoredItem): RecommendationEvidence | undefined {
+    const evidence: RecommendationEvidence = {}
+
+    const executeCount = scored.usageStats?.executeCount
+    if (typeof executeCount === 'number' && Number.isFinite(executeCount) && executeCount > 0) {
+      evidence.executeCount = executeCount
+    }
+
+    // Drizzle hands back a Date for `mode: 'timestamp'` columns, but synthesized
+    // rows (plugin candidates) carry a raw epoch, so accept both.
+    const lastExecuted = scored.usageStats?.lastExecuted as Date | number | null | undefined
+    const lastExecutedAt =
+      lastExecuted instanceof Date ? lastExecuted.getTime() : (lastExecuted ?? undefined)
+    if (
+      typeof lastExecutedAt === 'number' &&
+      Number.isFinite(lastExecutedAt) &&
+      lastExecutedAt > 0
+    ) {
+      evidence.lastExecutedAt = lastExecutedAt
+    }
+
+    const { installedAt } = scored
+    if (typeof installedAt === 'number' && Number.isFinite(installedAt) && installedAt > 0) {
+      evidence.installedAt = installedAt
+    }
+
+    const peakHourRange = resolvePeakHourRange(scored.timeStats?.hourDistribution)
+    if (peakHourRange) evidence.peakHourRange = peakHourRange
+
+    return Object.keys(evidence).length > 0 ? evidence : undefined
   }
 }

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.test.ts
@@ -654,7 +654,10 @@ describe('RecommendationEngine', () => {
     expect(ids).toContain('pinned-app')
     expect(ids).toHaveLength(10)
     expect(ids.at(-1)).toBe('pinned-app')
-    expect(result.containerLayout?.sections?.at(-1)).toMatchObject({
+    // Pinned leads the reason sections now (it used to trail them): an explicit
+    // pin is the strongest statement of intent on the panel. The item order in
+    // `items` above is a separate concern and still puts it last.
+    expect(result.containerLayout?.sections?.at(0)).toMatchObject({
       id: 'pinned',
       itemIds: ['pinned-app']
     })

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-engine.ts
@@ -1,11 +1,19 @@
 import type { TuffContainerLayout, TuffItem } from '@talex-touch/utils'
-import type { PluginRecommendCandidate, RecommendProvider } from '@talex-touch/utils/core-box'
+import type {
+  PluginRecommendCandidate,
+  RecommendProvider,
+  RecommendationSource
+} from '@talex-touch/utils/core-box'
 import type { AppSetting } from '@talex-touch/utils/common/storage/entity/app-settings'
 import type { DbUtils } from '../../../../db/utils'
 import type { ParsedItemTimeStats } from '../time-stats-aggregator'
 import type { ContextSignal, TimePattern } from './context-provider'
 import { createHash } from 'node:crypto'
 import { StorageList } from '@talex-touch/utils'
+import {
+  RECOMMENDATION_SECTION_ITEM_LIMIT,
+  RECOMMENDATION_SECTION_ORDER
+} from '@talex-touch/utils/core-box'
 import { PollingService } from '@talex-touch/utils/common/utils/polling'
 import { appTaskGate } from '../../../../service/app-task-gate'
 import { and, desc, eq, gte, inArray, lt, sql } from 'drizzle-orm'
@@ -1445,48 +1453,53 @@ export class RecommendationEngine {
     return true
   }
 
-  /** Build container layout: Recommend on top, Pinned at bottom (if exists) */
+  /**
+   * Groups the empty state by *why* each item is there, in
+   * `RECOMMENDATION_SECTION_ORDER`.
+   *
+   * This used to emit a single `Recommend` grid plus a `Pinned` grid at the
+   * bottom, so every item carried a badge that read the same and the panel said
+   * nothing about why anything was on it. Pinned now leads, because an explicit
+   * pin is the strongest statement of intent on the list.
+   *
+   * `title` is an i18n key, not a finished string — the main process has no
+   * business knowing the user's language, so the renderer resolves it.
+   */
   private buildContainerLayout(
     _options: RecommendationOptions,
     items: TuffItem[]
   ): TuffContainerLayout {
-    const pinnedItems = items.filter((item) => item.meta?.pinned?.isPinned)
-    const recommendItems = items.filter((item) => !item.meta?.pinned?.isPinned)
-    const totalCount = items.length
+    const buckets = new Map<RecommendationSource, string[]>()
+
+    for (const item of items) {
+      // An explicit pin outranks whatever the scorer attributed the item to:
+      // the user said so themselves. Items that somehow arrive without a source
+      // fall back to 'cold-start' ("suggested", no stronger claim) rather than
+      // being dropped, so nothing can silently vanish from the panel.
+      const source: RecommendationSource = item.meta?.pinned?.isPinned
+        ? 'pinned'
+        : (item.meta?.recommendation?.source ?? 'cold-start')
+
+      const bucket = buckets.get(source)
+      if (bucket) bucket.push(item.id)
+      else buckets.set(source, [item.id])
+    }
 
     const sections: TuffContainerLayout['sections'] = []
+    for (const source of RECOMMENDATION_SECTION_ORDER) {
+      const itemIds = buckets.get(source)
+      if (!itemIds?.length) continue
 
-    // Recommend section on top
-    if (recommendItems.length > 0) {
       sections.push({
-        id: 'recommendations',
-        title: 'Recommend',
-        layout: 'grid',
-        itemIds: recommendItems.map((item) => item.id),
-        meta: { intelligence: true }
+        id: source,
+        title: `corebox.reason.${source}`,
+        layout: 'list',
+        itemIds: itemIds.slice(0, RECOMMENDATION_SECTION_ITEM_LIMIT),
+        meta: { intelligence: source !== 'pinned', pinned: source === 'pinned', source }
       })
     }
 
-    // Pinned section at bottom (only if has pinned items)
-    if (pinnedItems.length > 0) {
-      sections.push({
-        id: 'pinned',
-        title: 'Pinned',
-        layout: 'grid',
-        itemIds: pinnedItems.map((item) => item.id),
-        meta: { pinned: true }
-      })
-    }
-
-    return {
-      mode: 'grid',
-      grid: {
-        columns: Math.min(8, totalCount || 8),
-        gap: 12,
-        itemSize: 'medium'
-      },
-      sections
-    }
+    return { mode: 'list', sections }
   }
 
   private combineRecommendedWithPinned(

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-utils.test.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-utils.test.ts
@@ -1,7 +1,12 @@
 import type { ParsedItemTimeStats } from '../time-stats-aggregator'
 import type { TimePattern } from './context-provider'
 import { describe, expect, it } from 'vitest'
-import { calculateHourAffinity, calculateTimeRelevanceScore } from './recommendation-utils'
+import {
+  calculateHourAffinity,
+  calculateTimeRelevanceScore,
+  PEAK_HOUR_MIN_SAMPLES,
+  resolvePeakHourRange
+} from './recommendation-utils'
 
 const morningNine: TimePattern = {
   hourOfDay: 9,
@@ -152,5 +157,61 @@ describe('calculateTimeRelevanceScore weekday evidence', () => {
 
     for (let index = 1; index < scores.length; index++)
       expect(scores[index]).toBeGreaterThan(scores[index - 1]!)
+  })
+})
+
+describe('resolvePeakHourRange', () => {
+  it('reports no peak when the distribution is missing or malformed', () => {
+    expect(resolvePeakHourRange(undefined)).toBeNull()
+    expect(resolvePeakHourRange([])).toBeNull()
+    expect(resolvePeakHourRange([1, 2, 3])).toBeNull()
+  })
+
+  it('needs at least PEAK_HOUR_MIN_SAMPLES executions before claiming a pattern', () => {
+    expect(resolvePeakHourRange(hourDistribution({ 9: 9 }))).toBeNull()
+    expect(resolvePeakHourRange(hourDistribution({ 9: PEAK_HOUR_MIN_SAMPLES }))).toEqual({
+      startHour: 7,
+      endHour: 9
+    })
+  })
+
+  it('reports no peak when usage is spread evenly across the day', () => {
+    // Every window holds 3/24 = 12.5%, far under the 40% bar.
+    expect(resolvePeakHourRange(Array.from({ length: 24 }, () => 5))).toBeNull()
+  })
+
+  it('returns the busiest three-hour window', () => {
+    expect(resolvePeakHourRange(hourDistribution({ 9: 8, 10: 9, 11: 7, 15: 2 }))).toEqual({
+      startHour: 9,
+      endHour: 11
+    })
+  })
+
+  it('wraps the window past midnight', () => {
+    expect(resolvePeakHourRange(hourDistribution({ 22: 5, 23: 6, 0: 4 }))).toEqual({
+      startHour: 22,
+      endHour: 0
+    })
+  })
+
+  it('accepts a window sitting exactly on the share threshold', () => {
+    // 8 of 20 executions = 0.4 exactly, which is not below the bar.
+    const distribution = hourDistribution({ 9: 4, 10: 4, 15: 4, 18: 4, 21: 4 })
+
+    expect(resolvePeakHourRange(distribution)).toEqual({ startHour: 8, endHour: 10 })
+  })
+
+  it('treats corrupt buckets as absent rather than trusting them', () => {
+    const distribution = hourDistribution({ 9: 12 })
+    distribution[3] = Number.NaN
+    distribution[4] = -50
+
+    expect(resolvePeakHourRange(distribution)).toEqual({ startHour: 7, endHour: 9 })
+  })
+
+  it('keeps the earliest start when two windows tie', () => {
+    const distribution = hourDistribution({ 6: 10, 18: 10 })
+
+    expect(resolvePeakHourRange(distribution)).toEqual({ startHour: 4, endHour: 6 })
   })
 })

--- a/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-utils.ts
+++ b/apps/core-app/src/main/modules/box-tool/search-engine/recommendation/recommendation-utils.ts
@@ -82,6 +82,65 @@ export function calculateHourAffinity(
   return Math.max(0, Math.min(1, currentHourUsage / peak))
 }
 
+/** Below this many recorded executions there is no pattern worth claiming, only noise. */
+export const PEAK_HOUR_MIN_SAMPLES = 10
+/** Width of the peak window, in hours. Three reads naturally as "09-11". */
+export const PEAK_HOUR_WINDOW_SIZE = 3
+/**
+ * Share of total usage the window must hold before we call it a peak. A flat
+ * distribution puts 3/24 = 12.5% in every window; demanding 40% means the item
+ * is genuinely concentrated there.
+ */
+export const PEAK_HOUR_MIN_SHARE = 0.4
+
+/**
+ * The hours of day an item clusters around, for showing a human reason like
+ * "usually around 09-11". Both bounds inclusive; the range may wrap past
+ * midnight (`{ startHour: 22, endHour: 0 }`).
+ *
+ * Returns null whenever the data cannot support the claim — too few samples, or
+ * usage too evenly spread. That null is the point: the empty state renders no
+ * reason at all rather than a plausible-looking one, so every reason a user sees
+ * is backed by real history.
+ *
+ * Unlike {@link calculateHourAffinity} this is a display concern, not a scoring
+ * one, so it is deliberately stricter: a weak signal is still useful for ranking
+ * but must not be turned into a sentence.
+ */
+export function resolvePeakHourRange(
+  hourDistribution: number[] | undefined
+): { startHour: number; endHour: number } | null {
+  if (!Array.isArray(hourDistribution) || hourDistribution.length !== 24) return null
+
+  // Negative and non-finite buckets are treated as absent rather than trusted,
+  // so a corrupt row degrades to "no reason" instead of a wrong one.
+  const at = (hour: number): number => {
+    const count = hourDistribution[hour % 24]
+    return typeof count === 'number' && Number.isFinite(count) && count > 0 ? count : 0
+  }
+
+  let total = 0
+  for (let hour = 0; hour < 24; hour++) total += at(hour)
+  if (total < PEAK_HOUR_MIN_SAMPLES) return null
+
+  let bestStart = 0
+  let bestSum = -1
+  for (let start = 0; start < 24; start++) {
+    let sum = 0
+    // `at` wraps, so the window starting at 22 covers 22, 23, 0.
+    for (let offset = 0; offset < PEAK_HOUR_WINDOW_SIZE; offset++) sum += at(start + offset)
+    // Strict `>` keeps the earliest start on ties, so the result is stable.
+    if (sum > bestSum) {
+      bestSum = sum
+      bestStart = start
+    }
+  }
+
+  if (bestSum / total < PEAK_HOUR_MIN_SHARE) return null
+
+  return { startHour: bestStart, endHour: (bestStart + PEAK_HOUR_WINDOW_SIZE - 1) % 24 }
+}
+
 /**
  * Time relevance blends the coarse slot/weekday signal with hour-of-day
  * affinity. `item_time_stats.hourDistribution` had been aggregated since the

--- a/apps/core-app/src/renderer/src/components/render/BoxGrid.vue
+++ b/apps/core-app/src/renderer/src/components/render/BoxGrid.vue
@@ -1,8 +1,17 @@
 <script setup lang="ts">
-import type { TuffContainerLayout, TuffItem, TuffSection } from '@talex-touch/utils'
+import type {
+  RecommendationEvidence,
+  RecommendationSource,
+  TuffContainerLayout,
+  TuffItem,
+  TuffSection
+} from '@talex-touch/utils'
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { resolveBoxGridColumnCount } from './box-grid-layout'
 import BoxGridItem from './BoxGridItem.vue'
+import BoxItem from './BoxItem.vue'
+import { formatRecommendationEvidence } from './recommendation-evidence'
 
 interface Props {
   items: TuffItem[]
@@ -17,6 +26,8 @@ interface SectionData {
 }
 
 const props = defineProps<Props>()
+
+const { t } = useI18n()
 
 const emit = defineEmits<{
   (e: 'select', index: number, item: TuffItem): void
@@ -73,6 +84,34 @@ function isPinnedSection(section: TuffSection): boolean {
   return section.meta?.pinned === true
 }
 
+function isListSection(section: TuffSection): boolean {
+  return section.layout === 'list'
+}
+
+/**
+ * Section titles arrive from the main process as i18n keys (`corebox.reason.*`)
+ * because the main process has no idea what language the user reads. Older
+ * cached layouts still carry finished English literals like `Recommend`, which
+ * have no dot and must be shown as-is rather than as a missing key.
+ */
+function getSectionTitle(section: TuffSection): string {
+  const title = section.title
+  if (!title) return ''
+  return title.includes('.') ? t(title) : title
+}
+
+function getItemEvidence(section: TuffSection, item: TuffItem): string {
+  const recommendation = item.meta?.recommendation
+  if (!recommendation) return ''
+
+  const source = (section.meta?.source ?? recommendation.source) as RecommendationSource | undefined
+  return formatRecommendationEvidence(
+    source,
+    recommendation.evidence as RecommendationEvidence | undefined,
+    t
+  )
+}
+
 function getSectionColumnCount(sectionData: SectionData): number {
   return resolveBoxGridColumnCount(
     sectionData.section,
@@ -83,6 +122,9 @@ function getSectionColumnCount(sectionData: SectionData): number {
 
 /** Intelligence tray shows at most two rows: a full first row, then the rest. */
 function getSectionVisibleItems(sectionData: SectionData): TuffItem[] {
+  // List sections are already capped to RECOMMENDATION_SECTION_ITEM_LIMIT by the
+  // main process; truncating again here would fight that budget.
+  if (isListSection(sectionData.section)) return sectionData.items
   if (!isIntelligenceSection(sectionData.section)) return sectionData.items
   return sectionData.items.slice(0, getSectionColumnCount(sectionData) * 2)
 }
@@ -97,14 +139,32 @@ function getSectionVisibleItems(sectionData: SectionData): TuffItem[] {
         :key="sectionData.section.id"
         class="BoxGridWrapper"
         :class="{
-          'is-intelligence': isIntelligenceSection(sectionData.section),
-          'is-pinned': isPinnedSection(sectionData.section)
+          'is-list': isListSection(sectionData.section),
+          'is-intelligence':
+            isIntelligenceSection(sectionData.section) && !isListSection(sectionData.section),
+          'is-pinned': isPinnedSection(sectionData.section) && !isListSection(sectionData.section)
         }"
       >
         <div v-if="sectionData.section.title" class="BoxGridTitle">
-          {{ sectionData.section.title }}
+          {{ getSectionTitle(sectionData.section) }}
         </div>
+
+        <!-- Reason-grouped list: one row per item, with the reason it is here -->
+        <div v-if="isListSection(sectionData.section)" class="BoxReasonList">
+          <BoxItem
+            v-for="(item, localIndex) in getSectionVisibleItems(sectionData)"
+            :key="item.id"
+            :item="item"
+            :active="focus === sectionData.startIndex + localIndex"
+            :render="item.render"
+            :quick-key="getQuickKey(sectionData.startIndex + localIndex)"
+            :evidence="getItemEvidence(sectionData.section, item)"
+            @click="emit('select', sectionData.startIndex + localIndex, item)"
+          />
+        </div>
+
         <div
+          v-else
           class="BoxGrid p-4"
           :style="{
             '--grid-cols': getSectionColumnCount(sectionData),
@@ -162,6 +222,13 @@ function getSectionVisibleItems(sectionData: SectionData): TuffItem[] {
   position: relative;
 
   margin: 0.5rem;
+
+  // Reason sections stack down the panel, so the animated tray border that
+  // frames a single intelligence grid would repeat up to nine times. They carry
+  // their own heading instead.
+  &.is-list {
+    margin: 0 0.5rem;
+  }
 
   &.is-intelligence {
     &::before {
@@ -229,6 +296,19 @@ function getSectionVisibleItems(sectionData: SectionData): TuffItem[] {
   font-weight: 500;
   color: var(--tx-text-color-secondary);
   opacity: 0.7;
+}
+
+.is-list > .BoxGridTitle {
+  padding: 10px 12px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  opacity: 0.6;
+}
+
+.BoxReasonList {
+  display: flex;
+  flex-direction: column;
 }
 
 .BoxGrid {

--- a/apps/core-app/src/renderer/src/components/render/BoxItem.vue
+++ b/apps/core-app/src/renderer/src/components/render/BoxItem.vue
@@ -20,6 +20,11 @@ interface Props {
   active: boolean
   render: TuffRender
   quickKey?: string
+  /**
+   * Why this item is being recommended, already localized. Only the CoreBox
+   * empty state passes it; search results leave it unset.
+   */
+  evidence?: string
 }
 
 interface MatchAliasRange {
@@ -207,6 +212,9 @@ const shouldShowNoticeReason = computed(
     </div>
 
     <div class="BoxItemSignals ml-auto flex items-center gap-2">
+      <span v-if="evidence && !isNoticeItem" class="RecommendationEvidence" :title="evidence">
+        {{ evidence }}
+      </span>
       <span
         v-if="resultSignal && !isNoticeItem"
         class="ResultSignal"
@@ -308,6 +316,20 @@ const shouldShowNoticeReason = computed(
   font-weight: 600;
   background: var(--tx-fill-color-dark);
   color: var(--tx-text-color-primary);
+}
+
+.RecommendationEvidence {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--tx-text-color-secondary);
+  opacity: 0.75;
 }
 
 .SourceBadge {

--- a/apps/core-app/src/renderer/src/components/render/recommendation-evidence.test.ts
+++ b/apps/core-app/src/renderer/src/components/render/recommendation-evidence.test.ts
@@ -1,0 +1,110 @@
+import type { ComposerTranslation } from 'vue-i18n'
+import { describe, expect, it } from 'vitest'
+import { formatRecommendationEvidence } from './recommendation-evidence'
+
+/**
+ * Renders `key(param=value, …)` so assertions read as "which fact was chosen,
+ * with which numbers" without depending on the wording of either locale.
+ */
+const t = ((key: string, params?: Record<string, unknown>) => {
+  if (!params || Object.keys(params).length === 0) return key
+  const rendered = Object.entries(params)
+    .map(([name, value]) => `${name}=${value}`)
+    .join(',')
+  return `${key}(${rendered})`
+}) as unknown as ComposerTranslation
+
+const NOW = Date.UTC(2026, 8, 4, 12, 0, 0)
+const HOUR = 3_600_000
+const DAY = 86_400_000
+
+describe('formatRecommendationEvidence', () => {
+  it('says nothing when there is no evidence at all', () => {
+    expect(formatRecommendationEvidence('frequent', undefined, t, NOW)).toBe('')
+    expect(formatRecommendationEvidence('frequent', {}, t, NOW)).toBe('')
+  })
+
+  it('justifies each source with the fact that explains it', () => {
+    const evidence = {
+      executeCount: 23,
+      peakHourRange: { startHour: 9, endHour: 11 },
+      lastExecutedAt: NOW - 3 * HOUR,
+      installedAt: NOW - 2 * HOUR
+    }
+
+    expect(formatRecommendationEvidence('frequent', evidence, t, NOW)).toBe(
+      'corebox.evidence.opened(count=23)'
+    )
+    expect(formatRecommendationEvidence('time-based', evidence, t, NOW)).toBe(
+      'corebox.evidence.peakHours(start=09,end=11)'
+    )
+    expect(formatRecommendationEvidence('recent', evidence, t, NOW)).toBe(
+      'corebox.evidence.lastUsed(age=corebox.evidence.age.hours(count=3))'
+    )
+    expect(formatRecommendationEvidence('newly-installed', evidence, t, NOW)).toBe(
+      'corebox.evidence.installed(age=corebox.evidence.age.hours(count=2))'
+    )
+  })
+
+  it('falls back to any available fact when the preferred one is missing', () => {
+    // A 'time-based' item with no hour peak still has something true to say.
+    expect(formatRecommendationEvidence('time-based', { executeCount: 5 }, t, NOW)).toBe(
+      'corebox.evidence.opened(count=5)'
+    )
+  })
+
+  it('uses the fallback order for sources with no preferred fact', () => {
+    expect(formatRecommendationEvidence('cold-start', { installedAt: NOW - 5 * DAY }, t, NOW)).toBe(
+      'corebox.evidence.installed(age=corebox.evidence.age.days(count=5))'
+    )
+  })
+
+  it('treats a zero execute count as no evidence, not as "opened 0 times"', () => {
+    expect(formatRecommendationEvidence('frequent', { executeCount: 0 }, t, NOW)).toBe('')
+  })
+
+  it('collapses very recent timestamps instead of reporting "0h ago"', () => {
+    expect(formatRecommendationEvidence('recent', { lastExecutedAt: NOW - 60_000 }, t, NOW)).toBe(
+      'corebox.evidence.justUsed'
+    )
+    expect(
+      formatRecommendationEvidence('newly-installed', { installedAt: NOW - 60_000 }, t, NOW)
+    ).toBe('corebox.evidence.justInstalled')
+  })
+
+  it('ignores timestamps in the future rather than printing a negative age', () => {
+    expect(formatRecommendationEvidence('recent', { lastExecutedAt: NOW + DAY }, t, NOW)).toBe('')
+  })
+
+  it('scales the age unit with the gap', () => {
+    const at = (ageMs: number) =>
+      formatRecommendationEvidence('recent', { lastExecutedAt: NOW - ageMs }, t, NOW)
+
+    expect(at(5 * HOUR)).toContain('age.hours(count=5)')
+    expect(at(3 * DAY)).toContain('age.days(count=3)')
+    expect(at(14 * DAY)).toContain('age.weeks(count=2)')
+    expect(at(90 * DAY)).toContain('age.months(count=3)')
+  })
+
+  it('pads single-digit peak hours so the range stays aligned', () => {
+    expect(
+      formatRecommendationEvidence(
+        'time-based',
+        { peakHourRange: { startHour: 8, endHour: 10 } },
+        t,
+        NOW
+      )
+    ).toBe('corebox.evidence.peakHours(start=08,end=10)')
+  })
+
+  it('renders a peak range that wraps past midnight', () => {
+    expect(
+      formatRecommendationEvidence(
+        'time-based',
+        { peakHourRange: { startHour: 22, endHour: 0 } },
+        t,
+        NOW
+      )
+    ).toBe('corebox.evidence.peakHours(start=22,end=00)')
+  })
+})

--- a/apps/core-app/src/renderer/src/components/render/recommendation-evidence.ts
+++ b/apps/core-app/src/renderer/src/components/render/recommendation-evidence.ts
@@ -1,0 +1,129 @@
+import type { RecommendationEvidence, RecommendationSource } from '@talex-touch/utils'
+import type { ComposerTranslation } from 'vue-i18n'
+
+const HOUR_MS = 3_600_000
+const DAY_MS = 86_400_000
+const WEEK_MS = DAY_MS * 7
+const MONTH_MS = DAY_MS * 30
+
+/** Anything more recent than this reads as "just now" rather than "0h ago". */
+const JUST_NOW_MS = HOUR_MS
+
+/**
+ * Coarse age label ("3h", "2d"). Compact units are deliberate: they read the
+ * same at any count, which keeps the strings free of plural forms — this
+ * codebase uses `|` as a literal separator in messages, so vue-i18n
+ * pluralization is not available.
+ */
+function formatAge(ageMs: number, t: ComposerTranslation): string {
+  if (ageMs >= MONTH_MS) {
+    return t('corebox.evidence.age.months', { count: Math.floor(ageMs / MONTH_MS) })
+  }
+  if (ageMs >= WEEK_MS) {
+    return t('corebox.evidence.age.weeks', { count: Math.floor(ageMs / WEEK_MS) })
+  }
+  if (ageMs >= DAY_MS) {
+    return t('corebox.evidence.age.days', { count: Math.floor(ageMs / DAY_MS) })
+  }
+  return t('corebox.evidence.age.hours', { count: Math.max(1, Math.floor(ageMs / HOUR_MS)) })
+}
+
+const padHour = (hour: number): string => String(hour).padStart(2, '0')
+
+function formatExecuteCount(
+  evidence: RecommendationEvidence,
+  t: ComposerTranslation
+): string | null {
+  const { executeCount } = evidence
+  if (typeof executeCount !== 'number' || executeCount <= 0) return null
+  return t('corebox.evidence.opened', { count: executeCount })
+}
+
+function formatPeakHours(evidence: RecommendationEvidence, t: ComposerTranslation): string | null {
+  const range = evidence.peakHourRange
+  if (!range) return null
+  return t('corebox.evidence.peakHours', {
+    start: padHour(range.startHour),
+    end: padHour(range.endHour)
+  })
+}
+
+function formatLastUsed(
+  evidence: RecommendationEvidence,
+  t: ComposerTranslation,
+  now: number
+): string | null {
+  const { lastExecutedAt } = evidence
+  if (typeof lastExecutedAt !== 'number') return null
+
+  const age = now - lastExecutedAt
+  if (age < 0) return null
+  if (age < JUST_NOW_MS) return t('corebox.evidence.justUsed')
+  return t('corebox.evidence.lastUsed', { age: formatAge(age, t) })
+}
+
+function formatInstalled(
+  evidence: RecommendationEvidence,
+  t: ComposerTranslation,
+  now: number
+): string | null {
+  const { installedAt } = evidence
+  if (typeof installedAt !== 'number') return null
+
+  const age = now - installedAt
+  if (age < 0) return null
+  if (age < JUST_NOW_MS) return t('corebox.evidence.justInstalled')
+  return t('corebox.evidence.installed', { age: formatAge(age, t) })
+}
+
+type EvidenceFormatter = (
+  evidence: RecommendationEvidence,
+  t: ComposerTranslation,
+  now: number
+) => string | null
+
+/**
+ * Which fact best explains each source. An item in the "frequently used" group
+ * should be justified by its count, one in "popular right now" by its hours —
+ * showing the install date under "frequently used" would be true but beside the
+ * point.
+ */
+const PREFERRED_BY_SOURCE: Partial<Record<RecommendationSource, EvidenceFormatter[]>> = {
+  frequent: [formatExecuteCount],
+  'time-based': [formatPeakHours],
+  recent: [formatLastUsed],
+  'newly-installed': [formatInstalled],
+  trending: [formatExecuteCount]
+}
+
+/** Used when the source has no preferred fact, or its preferred fact is missing. */
+const FALLBACK_ORDER: EvidenceFormatter[] = [
+  formatExecuteCount,
+  formatPeakHours,
+  formatLastUsed,
+  formatInstalled
+]
+
+/**
+ * One short, checkable sentence for why an item is being recommended.
+ *
+ * Returns an empty string when the backing data does not exist. That is the
+ * point of the whole feature: the empty state shows a reason only when there is
+ * one, rather than padding every row with a plausible-sounding line.
+ */
+export function formatRecommendationEvidence(
+  source: RecommendationSource | undefined,
+  evidence: RecommendationEvidence | undefined,
+  t: ComposerTranslation,
+  now: number = Date.now()
+): string {
+  if (!evidence) return ''
+
+  const formatters = source ? PREFERRED_BY_SOURCE[source] : undefined
+  for (const format of [...(formatters ?? []), ...FALLBACK_ORDER]) {
+    const text = format(evidence, t, now)
+    if (text) return text
+  }
+
+  return ''
+}

--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -5470,6 +5470,31 @@
     "confirmAndSend": "Authorize and send"
   },
   "corebox": {
+    "reason": {
+      "pinned": "Pinned",
+      "frequent": "Frequently used",
+      "time-based": "Popular right now",
+      "recent": "Recently used",
+      "newly-installed": "Newly installed",
+      "context": "From your clipboard",
+      "plugin": "From plugins",
+      "trending": "Trending up",
+      "cold-start": "You might need"
+    },
+    "evidence": {
+      "opened": "Opened {count}×",
+      "peakHours": "Usually {start}–{end}",
+      "justUsed": "Just used",
+      "lastUsed": "Used {age} ago",
+      "justInstalled": "Just installed",
+      "installed": "Installed {age} ago",
+      "age": {
+        "hours": "{count}h",
+        "days": "{count}d",
+        "weeks": "{count}w",
+        "months": "{count}mo"
+      }
+    },
     "actionUnsupported": "This action isn't supported yet",
     "opacity": "Opacity",
     "debug": "Debug",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -5470,6 +5470,31 @@
     "confirmAndSend": "授权并发送"
   },
   "corebox": {
+    "reason": {
+      "pinned": "已固定",
+      "frequent": "常用",
+      "time-based": "此刻常用",
+      "recent": "最近使用",
+      "newly-installed": "新安装",
+      "context": "与剪贴板相关",
+      "plugin": "插件推荐",
+      "trending": "最近变多",
+      "cold-start": "猜你要用"
+    },
+    "evidence": {
+      "opened": "打开过 {count} 次",
+      "peakHours": "常在 {start}–{end} 点使用",
+      "justUsed": "刚刚用过",
+      "lastUsed": "{age}前用过",
+      "justInstalled": "刚刚安装",
+      "installed": "{age}前安装",
+      "age": {
+        "hours": "{count} 小时",
+        "days": "{count} 天",
+        "weeks": "{count} 周",
+        "months": "{count} 个月"
+      }
+    },
     "actionUnsupported": "暂不支持该操作",
     "opacity": "透明度",
     "debug": "调试",

--- a/packages/utils/core-box/recommendation.ts
+++ b/packages/utils/core-box/recommendation.ts
@@ -1,4 +1,76 @@
 /**
+ * Recommendation sources in the order their sections are rendered in the
+ * CoreBox empty state.
+ *
+ * This array is the single source of truth for both the `RecommendationSource`
+ * union and the section ordering: the main process groups by it, the renderer
+ * renders in it. Three separate copies of this union used to drift apart (one
+ * here, one in `TuffItem.meta.recommendation`, one on the engine's
+ * `CandidateItem`), each missing a different member.
+ *
+ * Ordering rationale: the more certain the signal, the earlier it appears.
+ * Explicit user intent (`pinned`) first, then observed behaviour
+ * (`frequent` / `time-based` / `recent`), then inference (`trending` /
+ * `cold-start`) last.
+ */
+export const RECOMMENDATION_SECTION_ORDER = [
+  /** Explicitly pinned by the user */
+  'pinned',
+  /** High lifetime execute count */
+  'frequent',
+  /** Usually used around the current hour */
+  'time-based',
+  /** Executed recently */
+  'recent',
+  /** Installed within the novelty window and never executed yet */
+  'newly-installed',
+  /** Matched against the current context signal (currently clipboard URLs only) */
+  'context',
+  /** Supplied by a plugin recommend provider */
+  'plugin',
+  /** Rising usage across the recent window */
+  'trending',
+  /** Catalog ordering used when there is no usage history at all */
+  'cold-start'
+] as const
+
+/** A recommendation source. Derived from {@link RECOMMENDATION_SECTION_ORDER}. */
+export type RecommendationSource = (typeof RECOMMENDATION_SECTION_ORDER)[number]
+
+/**
+ * Items shown per reason section in the empty state.
+ *
+ * Deliberately small: the point of grouping is that a user can read the reasons
+ * at a glance. Nine sections of ten items is just the old undifferentiated grid
+ * with headers in it.
+ */
+export const RECOMMENDATION_SECTION_ITEM_LIMIT = 3
+
+/**
+ * Human-explainable evidence behind a recommendation, used to render a short
+ * reason next to the item ("used 23 times this week", "usually around 09-11").
+ *
+ * Every field is optional and is only present when the backing data actually
+ * exists. Neither producer nor consumer may substitute a default: an absent
+ * field means "we don't know", and the UI must then render nothing rather than
+ * a fabricated reason.
+ */
+export interface RecommendationEvidence {
+  /** Lifetime execute count from `item_usage_stats.execute_count` */
+  executeCount?: number
+  /** Epoch ms of the last execution */
+  lastExecutedAt?: number
+  /** Epoch ms the item was installed */
+  installedAt?: number
+  /**
+   * Hours of day this item clusters around, derived from
+   * `item_time_stats.hour_distribution`. Both bounds inclusive, 0-23, and the
+   * range may wrap past midnight (e.g. `{ startHour: 22, endHour: 0 }`).
+   */
+  peakHourRange?: { startHour: number; endHour: number }
+}
+
+/**
  * Time-based usage pattern context for recommendation matching.
  */
 export interface TimePattern {
@@ -80,17 +152,7 @@ export interface ScoredItem {
   sourceId: string
   itemId: string
   score: number
-  source:
-    | 'frequent'
-    | 'time-based'
-    | 'recent'
-    | 'trending'
-    | 'context'
-    | 'plugin'
-    /** Installed within the novelty window and never executed yet */
-    | 'newly-installed'
-    /** Catalog ordering used when there is no usage history at all */
-    | 'cold-start'
+  source: RecommendationSource
   reason?: string
 }
 
@@ -137,7 +199,18 @@ export interface RecommendProvider {
 export interface RecommendationBadge {
   text: string
   icon: string
-  variant: 'frequent' | 'intelligent' | 'recent' | 'trending' | 'newly-installed'
+  /**
+   * Styling bucket, deliberately coarser than {@link RecommendationSource}:
+   * several inferred sources share the `intelligent` look.
+   */
+  variant:
+    | 'frequent'
+    | 'intelligent'
+    | 'recent'
+    | 'trending'
+    | 'newly-installed'
+    | 'plugin'
+    | 'pinned'
 }
 
 /**
@@ -146,8 +219,9 @@ export interface RecommendationBadge {
  */
 export interface RecommendationMetadata {
   score: number
-  source: ScoredItem['source']
+  source: RecommendationSource
   reason: string
   isIntelligent: boolean
   badge: RecommendationBadge
+  evidence?: RecommendationEvidence
 }

--- a/packages/utils/core-box/tuff/tuff-dsl.ts
+++ b/packages/utils/core-box/tuff/tuff-dsl.ts
@@ -18,6 +18,8 @@
 
 // import { TalexTouch } from "packages/utils/types";
 
+import type { RecommendationEvidence, RecommendationSource } from '../recommendation'
+
 /**
  * 定义高亮范围
  * @description 右开区间 [start, end)
@@ -1164,15 +1166,7 @@ export interface TuffMeta {
 
   /** 推荐来源标记 */
   recommendation?: {
-    source:
-      | 'frequent'
-      | 'recent'
-      | 'time-based'
-      | 'trending'
-      | 'pinned'
-      | 'context'
-      | 'cold-start'
-      | 'newly-installed'
+    source: RecommendationSource
     score?: number
     /**
      * Ranking split: `stableScore` is the cacheable half (time/frequency/
@@ -1181,6 +1175,12 @@ export interface TuffMeta {
      */
     stableScore?: number
     volatileScore?: number
+    /**
+     * Why this item was recommended, in data the UI can turn into a sentence.
+     * Absent fields mean the data does not exist — render nothing, never a
+     * placeholder or a guess.
+     */
+    evidence?: RecommendationEvidence
   }
 
   /**

--- a/packages/utils/transport/events/types/core-box.ts
+++ b/packages/utils/transport/events/types/core-box.ts
@@ -4,6 +4,10 @@
  */
 
 import type {
+  RecommendationEvidence,
+  RecommendationSource,
+} from '../../../core-box/recommendation'
+import type {
   IProviderActivate,
   TuffContext,
   TuffItem,
@@ -445,19 +449,14 @@ export interface TuffMeta {
   }
 
   /**
-   * Recommendation source.
+   * Recommendation source. Mirrors `TuffItemMeta['recommendation']` in tuff-dsl;
+   * both reference `RecommendationSource` so the union cannot drift across the
+   * IPC boundary.
    */
   recommendation?: {
-    source:
-      | 'frequent'
-      | 'recent'
-      | 'time-based'
-      | 'trending'
-      | 'pinned'
-      | 'context'
-      | 'cold-start'
-      | 'newly-installed'
+    source: RecommendationSource
     score?: number
+    evidence?: RecommendationEvidence
   }
 
   /**


### PR DESCRIPTION
The CoreBox empty state was a single undifferentiated "Recommend" grid. It now renders reason-grouped lists, each headed by why its items are there, with a short verifiable evidence line per row ("打开过 23 次", "常在 09–11 点使用", "2 小时前安装").

## Decisions

1. **Section order** — `pinned → frequent → time-based → recent → newly-installed → context → plugin → trending → cold-start`. This is a deliberate behavior change: pinned items used to render last.
2. **Badge renames** — `time-based` 推荐 → 此刻常用; `cold-start` 推荐 → 猜你要用.
3. **Cap of 3 items per section.**
4. **Conservative peak-hour thresholds** — `resolvePeakHourRange` returns `null` below 10 samples, or when the best 3-hour window holds under 40% of executions, rather than fabricating a range.

## Evidence must be verifiable or absent

Any evidence field without a backing signal renders nothing — never a placeholder or a guess. App co-occurrence copy ("打开 Xcode 之后常用") has no backing signal anywhere in this codebase and was removed from the design rather than faked.

## Single source of truth for `recommendation.source`

The union previously lived in three hand-maintained copies. `RECOMMENDATION_SECTION_ORDER` in `core-box/recommendation.ts` is now the only one, with `type RecommendationSource = (typeof RECOMMENDATION_SECTION_ORDER)[number]`; `tuff-dsl.ts` and `transport/events/types/core-box.ts` both reference it. The IPC-facing copy had already drifted — it was missing `'plugin'`.

The same array is also the render order, so reordering it is a user-visible change. `.trellis/spec/main-process/recommendation-freshness-contracts.md` is updated to record both rules.