### PR TITLE
fix(release): install Linux musl runtime closure

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/core-app",
-  "version": "2.4.14-beta.21",
+  "version": "2.4.14-beta.22",
   "private": true,
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/notes/update_2.4.14-beta.22.en.md
+++ b/notes/update_2.4.14-beta.22.en.md
@@ -1,0 +1,13 @@
+# Tuff v2.4.14-beta.22 Release Notes
+
+## Summary Notes
+
+- Linux release installs now resolve optional native runtime dependencies for both glibc and musl.
+- The Linux musl LibSQL binary is included in the packaged runtime closure, preventing an official asset from missing its database runtime.
+- Release gates remain fail-closed: a missing platform runtime still blocks publishing rather than producing an incomplete package.
+
+## What's Changed
+
+- Declared `libc: [current, musl]` under pnpm workspace `supportedArchitectures`, allowing a glibc CI runner to install musl optional dependencies.
+- Retained the CoreApp `@libsql/linux-x64-musl` optional runtime declaration and will verify the complete runtime closure in the next official Linux build.
+- Official macOS, Windows, and Linux N→N+1 OTA health-ack acceptance remains a required release condition.

--- a/notes/update_2.4.14-beta.22.zh.md
+++ b/notes/update_2.4.14-beta.22.zh.md
@@ -1,0 +1,13 @@
+# Tuff v2.4.14-beta.22 更新说明
+
+## 摘要
+
+- Linux 发布安装现在同时解析 glibc 与 musl 的可选原生运行时依赖。
+- Linux musl 的 LibSQL 二进制将进入打包闭包，避免生成缺少数据库运行时的官方资产。
+- 发布门禁继续 fail-closed；缺失平台运行时仍会阻止发布而非降级为不完整包。
+
+## 变更内容
+
+- 在 pnpm workspace 的 `supportedArchitectures` 中显式声明 `libc: [current, musl]`，使 glibc CI runner 也安装 musl 可选依赖。
+- 保持 CoreApp 的 `@libsql/linux-x64-musl` 可选运行时声明，并在下一版官方 Linux build 中验证完整 runtime closure。
+- macOS、Windows 与 Linux N→N+1 OTA health-ack 验收仍是发布放行的后续条件。

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@talex-touch/tuff",
   "homepage": "https://tuff.tagzxia.com",
   "type": "module",
-  "version": "2.4.14-beta.21",
+  "version": "2.4.14-beta.22",
   "packageManager": "pnpm@11.24.0",
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,13 +36,16 @@ autoInstallPeers: false
 publicHoistPattern:
   - '*electron*'
 
-# macOS releases are built for arm64 and x64 on an arm64 runner.
+# Release builds package Linux glibc and musl runtime closures from a glibc runner.
 supportedArchitectures:
   os:
     - current
   cpu:
     - current
     - x64
+  libc:
+    - current
+    - musl
 catalog:
   '@floating-ui/vue': ^1.1.11
   '@iconify-json/cib': ^1.2.3


### PR DESCRIPTION
Fixes the official beta.21 Linux build failure. Although CoreApp declared @libsql/linux-x64-musl, the glibc GitHub runner did not install the musl optional package. The pnpm workspace now declares musl alongside the current libc under supportedArchitectures, so the Linux runtime closure can resolve both required variants. Versions advance to 2.4.14-beta.22 with verified bilingual release notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Linux release installations now support both glibc and musl environments by resolving the required native runtime dependencies.
  - Linux musl releases now include the LibSQL runtime, helping ensure database functionality is available after installation.
  - Release validation continues to block publishing when a required platform runtime is missing.
  - OTA health checks remain required across macOS, Windows, and Linux before release approval.

- **Release**
  - Updated the application version to **2.4.14-beta.22**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->