### PR TITLE
fix(release): resolve rollback from published tags

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1320,11 +1320,18 @@ jobs:
       - name: Resolve same-channel rollback version
         id: rollback
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          curl -fsSL --retry 3 --retry-all-errors \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            | jq -r '.[] | select(.draft == false) | .tag_name' > /tmp/published-release-tags.txt
           rollback=$(node scripts/resolve-update-rollback-version.mjs \
             --tag "${{ steps.release-info.outputs.tag }}" \
-            --remote origin)
+            --tags-file /tmp/published-release-tags.txt)
           {
             echo "from_version=$(jq -er '.rollbackFromVersion' <<<"${rollback}")"
             echo "channel=$(jq -er '.channel' <<<"${rollback}")"
@@ -1628,9 +1635,18 @@ jobs:
       - name: Resolve same-channel rollback version
         id: sync-rollback
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          rollback=$(node scripts/resolve-update-rollback-version.mjs --tag "${TAG}" --remote origin)
+          curl -fsSL --retry 3 --retry-all-errors \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            | jq -r '.[] | select(.draft == false) | .tag_name' > /tmp/published-release-tags.txt
+          rollback=$(node scripts/resolve-update-rollback-version.mjs \
+            --tag "${TAG}" \
+            --tags-file /tmp/published-release-tags.txt)
           {
             echo "from_version=$(jq -er '.rollbackFromVersion' <<<"${rollback}")"
             echo "channel=$(jq -er '.channel' <<<"${rollback}")"

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1322,6 +1322,7 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release-info.outputs.tag }}
         run: |
           set -euo pipefail
           curl -fsSL --retry 3 --retry-all-errors \
@@ -1330,7 +1331,7 @@ jobs:
             "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
             | jq -r '.[] | select(.draft == false) | .tag_name' > /tmp/published-release-tags.txt
           rollback=$(node scripts/resolve-update-rollback-version.mjs \
-            --tag "${{ steps.release-info.outputs.tag }}" \
+            --tag "${RELEASE_TAG}" \
             --tags-file /tmp/published-release-tags.txt)
           {
             echo "from_version=$(jq -er '.rollbackFromVersion' <<<"${rollback}")"

--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/core-app",
-  "version": "2.4.14-beta.22",
+  "version": "2.4.14-beta.23",
   "private": true,
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/notes/update_2.4.14-beta.23.en.md
+++ b/notes/update_2.4.14-beta.23.en.md
@@ -1,0 +1,13 @@
+# Tuff v2.4.14-beta.23 Release Notes
+
+## Summary Notes
+
+- Release manifests now select their rollback predecessor only from published releases in the same channel.
+- Failed or unpublished candidates that already have Git tags no longer contaminate rollback metadata for the next release.
+- Release gates continue to require rollback ancestry, GitHub Release data, Nexus metadata, and the download matrix to agree.
+
+## What's Changed
+
+- The release workflow derives rollback candidate tags from GitHub's published-release list instead of all git tags.
+- The rollback resolver adds `--tags-file` and fails closed when its input cannot be read.
+- The beta.22 Linux musl runtime-closure fix remains included; this version regenerates a trustworthy release manifest.

--- a/notes/update_2.4.14-beta.23.zh.md
+++ b/notes/update_2.4.14-beta.23.zh.md
@@ -1,0 +1,13 @@
+# Tuff v2.4.14-beta.23 更新说明
+
+## 摘要
+
+- 发布清单的回滚前驱现在只从已发布的同通道版本中选择。
+- 失败或尚未发布但已存在 Git tag 的候选版本不再污染下一版本的回滚元数据。
+- 发布门禁继续要求回滚前驱、GitHub Release、Nexus metadata 与下载矩阵保持一致。
+
+## 变更内容
+
+- 发布 workflow 从 GitHub 已发布 Release 列表生成回滚候选标签，而非从全部 git tags 推断。
+- 回滚版本解析器新增 `--tags-file` 输入，并在文件不可读取时 fail-closed。
+- beta.22 的 Linux musl runtime closure 修复仍包含在本候选版本中；本版用于重新生成可信发布清单。

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@talex-touch/tuff",
   "homepage": "https://tuff.tagzxia.com",
   "type": "module",
-  "version": "2.4.14-beta.22",
+  "version": "2.4.14-beta.23",
   "packageManager": "pnpm@11.24.0",
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/scripts/resolve-update-rollback-version.mjs
+++ b/scripts/resolve-update-rollback-version.mjs
@@ -117,7 +117,7 @@ export function getTagsFromFile(tagsFile) {
 function main() {
   const argv = process.argv.slice(2)
   const tag = getArgValue(argv, '--tag')
-  const remote = getArgValue(argv, '--remote', 'origin')
+  const remote = getArgValue(argv, '--remote')
   const tagsFile = getArgValue(argv, '--tags-file')
   if (!tag || (!remote && !tagsFile)) {
     throw new Error(

--- a/scripts/resolve-update-rollback-version.mjs
+++ b/scripts/resolve-update-rollback-version.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 import { getArgValue } from './lib/argv-utils.mjs'
@@ -99,21 +100,33 @@ export function getRemoteTags(remote) {
     .map(ref => ref.slice('refs/tags/'.length))
 }
 
+export function getTagsFromFile(tagsFile) {
+  try {
+    return readFileSync(tagsFile, 'utf8')
+      .split('\n')
+      .map(tag => tag.trim())
+      .filter(Boolean)
+  }
+  catch (error) {
+    throw new Error(
+      `Could not read --tags-file ${tagsFile}: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}
+
 function main() {
   const argv = process.argv.slice(2)
   const tag = getArgValue(argv, '--tag')
   const remote = getArgValue(argv, '--remote', 'origin')
-  if (!tag || !remote) {
+  const tagsFile = getArgValue(argv, '--tags-file')
+  if (!tag || (!remote && !tagsFile)) {
     throw new Error(
-      'Usage: node scripts/resolve-update-rollback-version.mjs --tag <tag> [--remote <remote>]',
+      'Usage: node scripts/resolve-update-rollback-version.mjs --tag <tag> [--remote <remote>] [--tags-file <file>]',
     )
   }
 
-  console.log(
-    JSON.stringify(
-      resolveSameChannelRollbackVersion({ tag, tags: getRemoteTags(remote) }),
-    ),
-  )
+  const tags = tagsFile ? getTagsFromFile(tagsFile) : getRemoteTags(remote)
+  console.log(JSON.stringify(resolveSameChannelRollbackVersion({ tag, tags })))
 }
 
 if (

--- a/scripts/resolve-update-rollback-version.test.mjs
+++ b/scripts/resolve-update-rollback-version.test.mjs
@@ -1,4 +1,9 @@
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, it } from 'vitest'
 
 import {
@@ -9,6 +14,25 @@ import {
   FIRST_RELEASE_ROLLBACK_VERSION,
   resolveSameChannelRollbackVersion,
 } from './resolve-update-rollback-version.mjs'
+
+const scriptPath = fileURLToPath(new URL('./resolve-update-rollback-version.mjs', import.meta.url))
+
+function withTempDir(run) {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'resolve-update-rollback-version-'))
+  try {
+    return run(root)
+  }
+  finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+function runResolver(args, env = process.env) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    encoding: 'utf8',
+    env,
+  })
+}
 
 describe('resolveSameChannelRollbackVersion', () => {
   it('selects the highest lower same-channel version from unsorted tags when the current tag is absent', () => {
@@ -119,5 +143,73 @@ describe('resolveSameChannelRollbackVersion', () => {
       () => resolveSameChannelRollbackVersion({ tag: 'manual-build-20260811', tags: [] }),
       /must contain a supported semantic version/,
     )
+  })
+})
+
+function fakeGitPath(root, tags) {
+  const bin = path.join(root, 'bin')
+  const git = path.join(bin, 'git')
+  mkdirSync(bin, { recursive: true })
+  writeFileSync(
+    git,
+    ['#!/bin/sh', ...tags.map(tag => `printf '%s\n' '0000000 refs/tags/${tag}'`)].join('\n'),
+  )
+  chmodSync(git, 0o755)
+  return bin
+}
+
+describe('resolve-update-rollback-version CLI', () => {
+  it('uses published tags rather than a higher unpublished beta returned by the remote', () => {
+    withTempDir((root) => {
+      const tagsFile = path.join(root, 'published-tags.txt')
+      writeFileSync(
+        tagsFile,
+        ['v2.4.12-beta.8', 'v2.4.13-beta.1', 'v2.4.13-beta.10'].join('\n'),
+      )
+      const gitBin = fakeGitPath(root, ['v2.4.13-beta.99'])
+
+      const result = runResolver(
+        [
+          '--tag',
+          'v2.4.13-beta.11',
+          '--tags-file',
+          tagsFile,
+          '--remote',
+          'origin',
+        ],
+        { ...process.env, PATH: `${gitBin}${path.delimiter}${process.env.PATH}` },
+      )
+
+      assert.equal(result.status, 0, result.stderr)
+      assert.deepEqual(JSON.parse(result.stdout), {
+        channel: 'BETA',
+        rollbackFromVersion: '2.4.13-beta.10',
+        rollbackTag: 'v2.4.13-beta.10',
+        targetVersion: '2.4.13-beta.11',
+        isFirstInChannel: false,
+      })
+    })
+  })
+
+  it('fails clearly when its published-tags file cannot be read', () => {
+    withTempDir((root) => {
+      const gitBin = fakeGitPath(root, ['v2.4.13-beta.99'])
+      const missingTagsFile = path.join(root, 'does-not-exist.txt')
+
+      const result = runResolver(
+        [
+          '--tag',
+          'v2.4.13-beta.11',
+          '--tags-file',
+          missingTagsFile,
+          '--remote',
+          'origin',
+        ],
+        { ...process.env, PATH: `${gitBin}${path.delimiter}${process.env.PATH}` },
+      )
+
+      assert.notEqual(result.status, 0)
+      assert.match(result.stderr, /--tags-file|tags file/i)
+    })
   })
 })

--- a/scripts/resolve-update-rollback-version.test.mjs
+++ b/scripts/resolve-update-rollback-version.test.mjs
@@ -159,7 +159,7 @@ function fakeGitPath(root, tags) {
 }
 
 describe('resolve-update-rollback-version CLI', () => {
-  it('uses published tags rather than a higher unpublished beta returned by the remote', () => {
+  it('uses the published tags file and ignores the remote tag set when provided', () => {
     withTempDir((root) => {
       const tagsFile = path.join(root, 'published-tags.txt')
       writeFileSync(


### PR DESCRIPTION
Fixes the beta.22 Gate E rollback mismatch. The release workflow now derives rollback predecessors from published GitHub releases instead of all git tags, preventing failed or unpublished candidates from becoming the manifest predecessor. Includes deterministic resolver CLI coverage, workflow updates, and beta.23 bilingual notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rollback information now selects only published releases from the same release channel.
  - Failed, draft, or unpublished releases no longer affect rollback metadata.
  - Release validation continues to verify consistency across rollback data, release records, package metadata, and downloads.
  - Includes the Linux musl runtime-closure fix from beta.22.

- **Bug Fixes**
  - Prevents invalid rollback candidates from being used when generating release information.
  - Improves handling when published-release data is unavailable or unreadable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->