### PR TITLE
fix(update): give the renderer its window role back

### DIFF
--- a/apps/core-app/src/preload/index.ts
+++ b/apps/core-app/src/preload/index.ts
@@ -82,6 +82,10 @@ function resolvePreloadStartupContext(startupInfo: StartupInfo | null): StartupC
   return {
     startupInfo,
     metaOverlay,
+    // The composed `metaOverlay` above also folds in the hash check, so it is the authoritative
+    // one; carrying the raw argv value alongside it would give the renderer two answers to the
+    // same question. Callers read `metaOverlay` from the role, so it gets the composed value.
+    role: { ...role, metaOverlay },
     windowMode: resolveRendererWindowMode({
       ...role,
       metaOverlay

--- a/apps/core-app/src/renderer/src/modules/hooks/useStartupInfo.test.ts
+++ b/apps/core-app/src/renderer/src/modules/hooks/useStartupInfo.test.ts
@@ -38,6 +38,7 @@ function createStartupContext(overrides: Partial<StartupContext> = {}): StartupC
     startupInfo: createStartupInfo(),
     windowMode: 'MainApp',
     metaOverlay: false,
+    role: { touchType: 'main', metaOverlay: false },
     ...overrides
   }
 }

--- a/packages/utils/__tests__/arg-mapper-window-role.test.ts
+++ b/packages/utils/__tests__/arg-mapper-window-role.test.ts
@@ -1,0 +1,124 @@
+/**
+ * `useArgMapper` read the window role from `process.argv`, which the renderer's main world does not
+ * have — `contextIsolation` and `sandbox` are on for every window (`window-security-profile.ts`).
+ * Argv resolved to `[]` there, and because `{}` is truthy the empty parse was cached permanently,
+ * so `isMainWindow()` was always false in the renderer. That silently disabled the manual update
+ * check and, through the same gate, every update prompt the main process asked for.
+ *
+ * The preload already parses the role for `windowMode`; it now carries it across the contextBridge
+ * in `StartupContext.role`. These tests pin both halves: the bridge is preferred where it exists,
+ * and an empty parse is never cached — either alone leaves the bug reachable.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  isCoreBox,
+  isMainWindow,
+  isMetaOverlay,
+  useArgMapper,
+  useTouchType,
+} from '../renderer/hooks/arg-mapper'
+import type { WindowRole } from '../renderer/window-role'
+
+const REAL_PROCESS = (globalThis as any).process
+
+/** Renderer main world: a `window`, no `process`, and whatever the bridge exposed. */
+function asRenderer(role?: WindowRole): void {
+  delete (globalThis as any).process
+  const api = role
+    ? { getStartupContextSnapshot: () => ({ startupInfo: null, metaOverlay: false, windowMode: 'MainApp', role }) }
+    : undefined
+  ;(globalThis as any).window = { $argMapper: undefined, api }
+}
+
+/** Preload realm: `process.argv` is available and `window.api` is not. */
+function asPreload(argv: string[]): void {
+  ;(globalThis as any).process = { argv }
+  ;(globalThis as any).window = { $argMapper: undefined }
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals()
+})
+
+afterEach(() => {
+  ;(globalThis as any).process = REAL_PROCESS
+  delete (globalThis as any).window
+})
+
+describe('useArgMapper resolves the window role in the renderer', () => {
+  it('reads the role the preload published, with no process available', () => {
+    asRenderer({ touchType: 'main' })
+
+    expect(useArgMapper()).toMatchObject({ touchType: 'main' })
+    expect(useTouchType()).toBe('main')
+  })
+
+  it('identifies each window kind from the bridged role', () => {
+    asRenderer({ touchType: 'main' })
+    expect(isMainWindow()).toBe(true)
+    expect(isCoreBox()).toBe(false)
+
+    asRenderer({ touchType: 'core-box', coreType: 'division-box' })
+    expect(isCoreBox()).toBe(true)
+    expect(isMainWindow()).toBe(false)
+  })
+
+  it('carries metaOverlay across the bridge as the composed boolean', () => {
+    asRenderer({ touchType: 'main', metaOverlay: true })
+    expect(isMetaOverlay()).toBe(true)
+  })
+})
+
+describe('useArgMapper does not cache an empty parse', () => {
+  it('re-resolves after the bridge becomes available', () => {
+    // The regression in one test: with no source, the old implementation cached `{}` and the
+    // window stayed role-less for the rest of the session even once the bridge could answer.
+    asRenderer(undefined)
+    expect(useArgMapper()).toEqual({})
+    expect(isMainWindow()).toBe(false)
+
+    ;(globalThis as any).window.api = {
+      getStartupContextSnapshot: () => ({
+        startupInfo: null,
+        metaOverlay: false,
+        windowMode: 'MainApp',
+        role: { touchType: 'main' } satisfies WindowRole,
+      }),
+    }
+
+    expect(isMainWindow()).toBe(true)
+  })
+
+  it('leaves the cache unwritten while the result is empty', () => {
+    asRenderer(undefined)
+    useArgMapper()
+    expect((globalThis as any).window.$argMapper).toBeUndefined()
+  })
+})
+
+describe('useArgMapper keeps working where argv is the only source', () => {
+  it('parses argv in the preload realm, which has no window.api', () => {
+    asPreload(['electron', '--touch-type=core-box', '--core-type=omni-panel'])
+
+    expect(useArgMapper()).toMatchObject({ touchType: 'core-box', coreType: 'omni-panel' })
+    expect(isCoreBox()).toBe(true)
+  })
+
+  it('still records unknown values under their raw keys', () => {
+    asPreload(['electron', '--touch-type=not-a-real-type'])
+
+    const mapper = useArgMapper()
+    expect(mapper.touchType).toBeUndefined()
+    expect(mapper.rawTouchType).toBe('not-a-real-type')
+  })
+
+  it('caches a non-empty parse instead of re-reading argv', () => {
+    asPreload(['electron', '--touch-type=main'])
+    useArgMapper()
+
+    // Argv changing underneath must not matter: a resolved role is stable for the window's life.
+    ;(globalThis as any).process.argv = ['electron', '--touch-type=core-box']
+    expect(useTouchType()).toBe('main')
+  })
+})

--- a/packages/utils/preload/loading.ts
+++ b/packages/utils/preload/loading.ts
@@ -1,4 +1,4 @@
-import type { RendererWindowMode } from '../renderer/window-role'
+import type { RendererWindowMode, WindowRole } from '../renderer/window-role'
 import type { StartupInfo } from '../types/startup-info'
 
 export const PRELOAD_LOADING_CHANNEL = '@talex-touch/preload'
@@ -17,6 +17,19 @@ export interface StartupContext {
   startupInfo: StartupInfo | null
   windowMode: RendererWindowMode
   metaOverlay: boolean
+
+  /**
+   * The window's role as parsed from `process.argv` in the preload.
+   *
+   * The renderer cannot parse this itself: `contextIsolation` and `sandbox` are on for every
+   * window, so its main world has no `process`, and `useArgMapper` there resolved argv to `[]` and
+   * cached the empty result — leaving `isMainWindow()` permanently false and the update prompt
+   * unreachable. The preload already parses the role for `windowMode`; carrying it through is what
+   * gives the renderer a source at all.
+   *
+   * Only the validated `WindowRole` crosses the bridge, never raw argv.
+   */
+  role: WindowRole
 }
 
 export interface PreloadAPI {

--- a/packages/utils/renderer/hooks/arg-mapper.ts
+++ b/packages/utils/renderer/hooks/arg-mapper.ts
@@ -42,13 +42,55 @@ declare global {
 }
 
 /**
+ * Reads the window role the preload published over the contextBridge.
+ *
+ * Undefined in the preload's own realm — `window.api` is what it exposes to the main world, not
+ * something it can read back — so callers must keep the argv path as a fallback.
+ */
+function readBridgedWindowRole(): WindowRole | undefined {
+  const api = (window as unknown as { api?: { getStartupContextSnapshot?: () => unknown } }).api
+  const snapshot = api?.getStartupContextSnapshot?.()
+  if (!snapshot || typeof snapshot !== 'object') {
+    return undefined
+  }
+  const role = (snapshot as { role?: WindowRole }).role
+  return role && typeof role === 'object' ? role : undefined
+}
+
+function roleToArgMapper(role: WindowRole): IArgMapperOptions {
+  const mapper: IArgMapperOptions = {}
+  if (role.touchType) mapper.touchType = role.touchType
+  if (role.coreType) mapper.coreType = role.coreType
+  if (role.assistantType) mapper.assistantType = role.assistantType
+  if (typeof role.metaOverlay === 'boolean') {
+    mapper.metaOverlay = role.metaOverlay ? 'true' : 'false'
+  }
+  return mapper
+}
+
+/**
  * Converts environment arguments into a structured mapper object
+ *
+ * Resolution order is bridge-then-argv, and an empty result is never cached. Both matter: the
+ * renderer's main world has no `process` (contextIsolation + sandbox are on for every window), so
+ * argv resolved to `[]` there, and because `{}` is truthy the empty parse was cached permanently —
+ * turning a missing source into a stuck answer. `isMainWindow()` was therefore always false in the
+ * renderer, which silently disabled the manual update check and every update prompt.
+ *
  * @param args - Array of command line arguments (defaults to process.argv)
  * @returns Mapped command line arguments as key-value pairs
  */
 export function useArgMapper(args: string[] = (globalThis as any)?.process?.argv ?? []): IArgMapperOptions {
-  if (window.$argMapper)
-    return window.$argMapper
+  const cached = window.$argMapper
+  if (cached && Object.keys(cached).length > 0)
+    return cached
+
+  const bridgedRole = readBridgedWindowRole()
+  if (bridgedRole) {
+    const bridged = roleToArgMapper(bridgedRole)
+    if (Object.keys(bridged).length > 0)
+      return window.$argMapper = bridged
+  }
 
   const mapper: IArgMapperOptions = {}
   for (const arg of args) {
@@ -87,6 +129,11 @@ export function useArgMapper(args: string[] = (globalThis as any)?.process?.argv
   if (typeof role.metaOverlay === 'boolean') {
     mapper.metaOverlay = role.metaOverlay ? 'true' : 'false'
   }
+
+  // An empty parse means the source was unavailable, not that this window has no role. Caching it
+  // would make the next call — possibly after the bridge is ready — return the same empty answer.
+  if (Object.keys(mapper).length === 0)
+    return mapper
 
   return window.$argMapper = mapper
 }


### PR DESCRIPTION
## What

The renderer could not tell which window it was running in, which silently disabled both update entrypoints.

`useArgMapper` read the window role from `process.argv`. Every window runs with `contextIsolation` and `sandbox` on (`window-security-profile.ts`), so the renderer's main world has no `process` and argv resolved to `[]`. Because `{}` is truthy, that empty parse was then cached permanently — a missing source became a stuck answer for the rest of the session.

## Why it matters

`isMainWindow()` guards both paths into the update system:

| Path | Gate | Result |
|---|---|---|
| Manual check button | `checkApplicationUpgrade` → `canShowUpdatePrompt()` (`useUpdateRuntime.ts:410`) | returned before issuing a request |
| Main-process auto-check finds an update | `presentUpdateDialog` → same gate (`:351`) | dialog never presented |

So users could neither check for updates nor be told one existed. The main process kept polling; nothing it found could reach the UI.

**This was not dev-only.** Nothing about it depends on `app.isPackaged`.

`isCoreBox()` and `useTouchType()` share the same path and were equally broken — six call sites had been silently reading `false`, including the CoreBox lightweight-window branch and the telemetry `windowType` label, which reported every window as `main`.

## Approach

The preload already parses the role for `windowMode` and runs where `process` exists. It now carries the parsed `WindowRole` through `StartupContext`, which the renderer reads over the existing **synchronous** `getStartupContextSnapshot()` bridge.

- No new global exposure — an existing object gains a field.
- Only the validated `WindowRole` crosses; never raw argv.
- Security baseline untouched; `window-security-profile.contract.test.ts` still passes.

Two details that are easy to get wrong:

- **Resolution is bridge-then-argv, not bridge-only.** The preload calls `useArgMapper` itself, and `window.api` is what it *exposes to* the main world, not something it can read back. Dropping the argv path would break the side that currently works.
- **Empty results are no longer cached at all**, so a caller that runs before the bridge is ready does not poison later ones.

`StartupContext.role` is required rather than optional, so the type catches a preload that forgets to populate it; `role.metaOverlay` carries the composed value (including the hash check) rather than the raw argv one, so the renderer never gets two answers to the same question.

## Verification

Driven over CDP against the running app, **with no injected fixture**:

- main window resolves `touchType: 'main'`, CoreBox resolves `'core-box'` (both were `{}` before)
- the check button reaches `[UpdateService] Update check fetched … hasUpdate=true tag=v2.4.14-beta.22`, where it was previously silent
- the update dialog is presented once a check finds a version

Automated: `packages/utils` 1465 tests, `apps/core-app` update/preload/security suites, `typecheck:node` and `vue-tsc` clean, both packages lint clean.

**Five of the eight new tests fail against the previous implementation** — verified by reverting the fix and re-running, so they pin behaviour rather than just passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved window-role detection so application windows are identified correctly across supported startup configurations.
  - Renderer components now use the authoritative startup context when available, with fallback handling for command-line data.
  - Prevented temporary missing startup information from being cached as a permanent empty result.
  - Preserved unrecognized window-role values instead of discarding them.

- **Tests**
  - Added coverage for startup-context resolution, retries, fallback behavior, overlays, and caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->