### PR TITLE
fix(update): resolve the app data root once instead of per call

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -97,7 +97,9 @@
     "check:search-index-writers": "node scripts/check-search-index-writers.mjs",
     "check:search-index-writers:self-test": "node scripts/check-search-index-writers.mjs --self-test",
     "check:permission-api-mappings": "node scripts/check-permission-api-mappings.mjs",
-    "check:permission-api-mappings:self-test": "node scripts/check-permission-api-mappings.mjs --self-test"
+    "check:permission-api-mappings:self-test": "node scripts/check-permission-api-mappings.mjs --self-test",
+    "check:app-root-single-source": "node scripts/check-app-root-single-source.mjs",
+    "check:app-root-single-source:self-test": "node scripts/check-app-root-single-source.mjs --self-test"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.2.141",

--- a/apps/core-app/scripts/check-app-root-single-source.mjs
+++ b/apps/core-app/scripts/check-app-root-single-source.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Guards the single-source contract for the app data root.
+ *
+ * `userData` is rewritten twice during startup — once deliberately for startup benchmarking
+ * (`precore.ts`, immediately before the root is first resolved) and once by `polyfills.ts` to give
+ * Chromium a separate dev profile. Anything that derives the app root from `app.getPath('userData')`
+ * therefore gets a different answer depending on when it asks.
+ *
+ * That is not hypothetical: `getAllowedDownloadRoots` re-derived the root at download time and
+ * disagreed with the root the update system had written under, so every update download in a dev
+ * build was rejected as `destination-outside-roots`.
+ *
+ * `resolveRuntimeRootPath` now memoizes, which makes the first resolution authoritative — but only
+ * for callers that go through it. A new call site reading `getPath('userData')` and joining a
+ * folder name itself would reintroduce the split with nothing to catch it. This scanner is that
+ * catch.
+ *
+ * Read-only. `--self-test` proves the detector fires on a synthetic violation, because a scanner
+ * that silently matches nothing looks exactly like a clean repository.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const CORE_APP = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const SRC_MAIN = path.join(CORE_APP, 'src', 'main')
+
+/**
+ * Files allowed to reconstruct the app root, and why.
+ * Paths are relative to apps/core-app/src/main.
+ */
+const APPROVED_READERS = {
+  'utils/app-root-path.ts':
+    'Owns the resolution and memoizes it; every other caller must come through here.'
+}
+
+/**
+ * A line that both reads `userData` and names an app-root folder is rebuilding the root by hand.
+ *
+ * Reading `userData` on its own is fine and common — wallpapers, temp files and host backups all
+ * live directly under it. The contract is narrower than that: only the *app data root*
+ * (`<userData>/tuff` or `<userData>/tuff-dev`) has to come from one place, because only it is
+ * compared against on both sides of the download policy.
+ */
+const USER_DATA_READ = /\.getPath\(\s*['"`]userData['"`]\s*\)/
+const APP_ROOT_FOLDER =
+  /(['"`]tuff-dev['"`]|['"`]tuff['"`]|\bAPP_FOLDER_NAME\b|\bDEV_APP_FOLDER_NAME\b|\/tuff\b)/
+
+function listSourceFiles(dir) {
+  const found = []
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      found.push(...listSourceFiles(full))
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) {
+      found.push(full)
+    }
+  }
+  return found
+}
+
+function findViolations(files, readFile = (f) => readFileSync(f, 'utf8')) {
+  const violations = []
+  for (const file of files) {
+    const relative = path.relative(SRC_MAIN, file)
+    if (Object.hasOwn(APPROVED_READERS, relative)) continue
+
+    const lines = readFile(file).split('\n')
+    lines.forEach((line, index) => {
+      if (USER_DATA_READ.test(line) && APP_ROOT_FOLDER.test(line)) {
+        violations.push({ file: relative, line: index + 1, text: line.trim() })
+      }
+    })
+  }
+  return violations
+}
+
+function selfTest() {
+  const synthetic = '/synthetic/modules/rogue-root.ts'
+  const violations = findViolations(
+    [synthetic],
+    () => "const root = path.join(app.getPath('userData'), 'tuff')\n"
+  )
+  if (violations.length !== 1) {
+    console.error('[self-test] FAIL: the scanner did not flag a synthetic violation')
+    process.exitCode = 1
+    return
+  }
+
+  const approved = findViolations(
+    [path.join(SRC_MAIN, 'utils/app-root-path.ts')],
+    () => "return path.join(appLike.getPath('userData'), APP_FOLDER_NAME)\n"
+  )
+  if (approved.length !== 0) {
+    console.error('[self-test] FAIL: the scanner flagged an approved reader')
+    process.exitCode = 1
+    return
+  }
+
+  // Reading userData for something that is not the app root stays legitimate.
+  const unrelated = findViolations(
+    ['/synthetic/service/temp-file.service.ts'],
+    () => "this.baseDir = path.join(app.getPath('userData'), 'temp')\n"
+  )
+  if (unrelated.length !== 0) {
+    console.error('[self-test] FAIL: the scanner flagged an unrelated userData read')
+    process.exitCode = 1
+    return
+  }
+
+  console.log('[self-test] ok: flags root reconstruction, exempts the owner and unrelated reads')
+}
+
+function main() {
+  if (process.argv.includes('--self-test')) {
+    selfTest()
+    return
+  }
+
+  const violations = findViolations(listSourceFiles(SRC_MAIN))
+  if (violations.length === 0) {
+    console.log('app root single-source: ok')
+    return
+  }
+
+  console.error('app root single-source: violations found\n')
+  console.error(
+    'These read `userData` directly. Derive the app root through `resolveRuntimeRootPath`\n' +
+      'instead — reading `userData` yourself makes the answer depend on when you ask.\n'
+  )
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line}  ${v.text}`)
+  }
+  console.error('\nIf a new reader is legitimate, add it to APPROVED_READERS with a reason.')
+  process.exitCode = 1
+}
+
+main()

--- a/apps/core-app/scripts/check-app-root-single-source.mjs
+++ b/apps/core-app/scripts/check-app-root-single-source.mjs
@@ -62,18 +62,66 @@ function listSourceFiles(dir) {
   return found
 }
 
+/**
+ * Folds newlines that sit inside parentheses into spaces, so a call split across lines becomes one
+ * logical line. A `path.join(\n  app.getPath('userData'),\n  'tuff'\n)` reconstructs the root just
+ * as much as the single-line form, and matching physical lines would miss it entirely.
+ *
+ * Each logical line keeps the physical line number it started on, so reports still point somewhere
+ * useful. Quotes are tracked because a paren inside a string literal must not open a region.
+ */
+function toLogicalLines(text) {
+  const logical = []
+  let current = ''
+  let startLine = 1
+  let physicalLine = 1
+  let depth = 0
+  let quote = null
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i]
+    const prev = text[i - 1]
+
+    if (quote) {
+      if (ch === quote && prev !== '\\') quote = null
+    } else if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch
+    } else if (ch === '(') {
+      depth += 1
+    } else if (ch === ')') {
+      depth = Math.max(0, depth - 1)
+    }
+
+    if (ch === '\n') {
+      physicalLine += 1
+      if (depth > 0 && !quote) {
+        current += ' '
+        continue
+      }
+      logical.push({ text: current, line: startLine })
+      current = ''
+      startLine = physicalLine
+      continue
+    }
+
+    current += ch
+  }
+
+  if (current.trim()) logical.push({ text: current, line: startLine })
+  return logical
+}
+
 function findViolations(files, readFile = (f) => readFileSync(f, 'utf8')) {
   const violations = []
   for (const file of files) {
     const relative = path.relative(SRC_MAIN, file)
     if (Object.hasOwn(APPROVED_READERS, relative)) continue
 
-    const lines = readFile(file).split('\n')
-    lines.forEach((line, index) => {
-      if (USER_DATA_READ.test(line) && APP_ROOT_FOLDER.test(line)) {
-        violations.push({ file: relative, line: index + 1, text: line.trim() })
+    for (const { text, line } of toLogicalLines(readFile(file))) {
+      if (USER_DATA_READ.test(text) && APP_ROOT_FOLDER.test(text)) {
+        violations.push({ file: relative, line, text: text.trim().replace(/\s+/g, ' ') })
       }
-    })
+    }
   }
   return violations
 }
@@ -86,6 +134,24 @@ function selfTest() {
   )
   if (violations.length !== 1) {
     console.error('[self-test] FAIL: the scanner did not flag a synthetic violation')
+    process.exitCode = 1
+    return
+  }
+
+  // Same reconstruction, split across lines. Matching physical lines misses this.
+  const multiline = findViolations(
+    ['/synthetic/modules/rogue-root-multiline.ts'],
+    () => "const root = path.join(\n  app.getPath('userData'),\n  APP_FOLDER_NAME\n)\n"
+  )
+  if (multiline.length !== 1) {
+    console.error('[self-test] FAIL: the scanner missed a multiline reconstruction')
+    process.exitCode = 1
+    return
+  }
+  if (multiline[0].line !== 1) {
+    console.error(
+      `[self-test] FAIL: multiline violation reported line ${multiline[0].line}, want 1`
+    )
     process.exitCode = 1
     return
   }
@@ -111,7 +177,21 @@ function selfTest() {
     return
   }
 
-  console.log('[self-test] ok: flags root reconstruction, exempts the owner and unrelated reads')
+  // Two unrelated statements must not be folded together into a false positive.
+  const separate = findViolations(
+    ['/synthetic/service/two-statements.ts'],
+    () => "const tmp = app.getPath('userData')\nconst label = 'tuff'\n"
+  )
+  if (separate.length !== 0) {
+    console.error('[self-test] FAIL: the scanner joined two unrelated statements')
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    '[self-test] ok: flags same-line and multiline reconstruction, exempts the owner, ' +
+      'leaves unrelated reads and separate statements alone'
+  )
 }
 
 function main() {

--- a/apps/core-app/src/main/modules/database/index.ts
+++ b/apps/core-app/src/main/modules/database/index.ts
@@ -16,6 +16,7 @@ import { app, BrowserWindow, dialog } from 'electron'
 import fse from 'fs-extra'
 import migrationsLocator from '../../../../resources/db/locator.json?commonjs-external&asset'
 import * as schema from '../../db/schema'
+import { resolveRuntimeRootPath } from '../../utils/app-root-path'
 import { dbWriteScheduler } from '../../db/db-write-scheduler'
 import { setAuxDbResolver } from '../../db/db-write'
 import { DB_AUX_ENABLED, DB_SEARCH_SPLIT_ENABLED } from '../../db/runtime-flags'
@@ -1320,7 +1321,7 @@ export class DatabaseModule extends BaseModule {
       const errorInstance = error instanceof Error ? error : new Error(errorMessage)
       await this.showDatabaseErrorDialog(
         errorInstance,
-        `Database migration failed:\n${errorMessage}\n\nCheck log files for more information.\nLog location: ${app.getPath('userData')}/tuff/logs/`
+        `Database migration failed:\n${errorMessage}\n\nCheck log files for more information.\nLog location: ${path.join(resolveRuntimeRootPath(app), 'logs')}`
       )
 
       process.exit(1)

--- a/apps/core-app/src/main/modules/notification.system-replace.test.ts
+++ b/apps/core-app/src/main/modules/notification.system-replace.test.ts
@@ -52,6 +52,10 @@ const { FakeNotification } = vi.hoisted(() => {
  */
 vi.mock('electron', () => ({
   Notification: FakeNotification,
+  // `config/default.ts` reads `app.getAppPath()` at module load. Nothing here exercises it, but a
+  // mock that omits the export makes vitest throw on access rather than yield undefined, so any
+  // new edge into that module breaks this file.
+  app: { getAppPath: () => process.cwd() },
   ipcMain: { on: () => {}, off: () => {}, handle: () => {}, removeHandler: () => {} },
   MessageChannelMain: class {
     port1 = { on: () => {}, start: () => {}, close: () => {}, postMessage: () => {} }

--- a/apps/core-app/src/main/utils/app-root-path.test.ts
+++ b/apps/core-app/src/main/utils/app-root-path.test.ts
@@ -1,8 +1,14 @@
 import os from 'node:os'
 import path from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { APP_FOLDER_NAME } from '../config/default'
-import { DEV_APP_FOLDER_NAME, resolveRuntimeRootPath, type AppPathLike } from './app-root-path'
+import {
+  DEV_APP_FOLDER_NAME,
+  resetRuntimeRootPathForTests,
+  resolveRuntimeRootPath,
+  type AppPathLike
+} from './app-root-path'
+import { evaluateDownloadTarget } from './download-target-policy'
 
 function createAppLike(options: { isPackaged?: boolean; userDataPath: string }): AppPathLike {
   return {
@@ -15,6 +21,24 @@ function createAppLike(options: { isPackaged?: boolean; userDataPath: string }):
     }
   }
 }
+
+/** Like `createAppLike`, but its `userData` can be rewritten mid-test the way startup does. */
+function createMutableAppLike(userDataPath: string): AppPathLike & { userDataPath: string } {
+  return {
+    isPackaged: false,
+    userDataPath,
+    getPath(name: 'userData') {
+      if (name !== 'userData') {
+        throw new Error(`Unsupported path: ${name}`)
+      }
+      return this.userDataPath
+    }
+  }
+}
+
+afterEach(() => {
+  resetRuntimeRootPathForTests()
+})
 
 describe('app-root-path', () => {
   it('resolves packaged root path to userData/tuff', () => {
@@ -35,5 +59,78 @@ describe('app-root-path', () => {
 
     const resolved = resolveRuntimeRootPath(appLike)
     expect(resolved).toBe(path.join(os.tmpdir(), 'tuff-user-data', DEV_APP_FOLDER_NAME))
+  })
+})
+
+/**
+ * `userData` is rewritten twice during startup: `precore` overrides it for startup benchmarking and
+ * resolves the root immediately after, then `polyfills` repoints Chromium's profile at a separate
+ * dev directory. Resolving afresh on every call meant the answer depended on when you asked —
+ * `precore` captured one root at module load, `getAllowedDownloadRoots` derived another at download
+ * time, and every update package was rejected as `destination-outside-roots`.
+ */
+describe('app-root-path is stable across a userData rewrite', () => {
+  it('keeps the first answer after userData changes underneath it', () => {
+    const appLike = createMutableAppLike('/base/@scope/core-app')
+
+    const first = resolveRuntimeRootPath(appLike)
+    appLike.userDataPath = '/base/@scope/tuff-dev' // what polyfills does in dev
+
+    expect(resolveRuntimeRootPath(appLike)).toBe(first)
+  })
+
+  it('honours a deliberate override taken before the first resolution', () => {
+    // The startup-benchmark override runs before the root is first read, so a benchmark run must
+    // still get its isolated root. Memoizing must not swallow that.
+    const appLike = createMutableAppLike('/tmp/benchmark-run')
+
+    expect(resolveRuntimeRootPath(appLike)).toBe(
+      path.join('/tmp/benchmark-run', DEV_APP_FOLDER_NAME)
+    )
+  })
+
+  it('falls back when userData cannot be read', () => {
+    const throwing: AppPathLike = {
+      isPackaged: false,
+      getPath(): string {
+        throw new Error('userData unavailable')
+      }
+    }
+
+    expect(resolveRuntimeRootPath(throwing, '/fallback')).toBe(
+      path.join('/fallback', DEV_APP_FOLDER_NAME)
+    )
+  })
+})
+
+describe('the update package destination survives the rewrite', () => {
+  it('is accepted when userData changes between the two resolutions', () => {
+    // The defect end to end: the update system resolved its storage root at startup and wrote under
+    // it, while the download policy resolved again at download time and rejected the result.
+    const appLike = createMutableAppLike('/base/@scope/core-app')
+
+    const storageRoot = resolveRuntimeRootPath(appLike) // precore, at startup
+    const destination = path.join(storageRoot, 'modules', 'update-packages')
+
+    appLike.userDataPath = '/base/@scope/tuff-dev' // polyfills, later
+
+    const allowedRoots = [resolveRuntimeRootPath(appLike)] // download policy, later still
+    const decision = evaluateDownloadTarget(
+      destination,
+      'tuff-2.4.14-macos-arm64.dmg',
+      allowedRoots
+    )
+
+    expect(decision).toMatchObject({ allowed: true })
+  })
+
+  it('still rejects a destination that is genuinely outside every root', () => {
+    const appLike = createMutableAppLike('/base/@scope/core-app')
+    const roots = [resolveRuntimeRootPath(appLike)]
+
+    expect(evaluateDownloadTarget('/tmp/somewhere-else', 'payload.dmg', roots)).toMatchObject({
+      allowed: false,
+      reason: 'destination-outside-roots'
+    })
   })
 })

--- a/apps/core-app/src/main/utils/app-root-path.ts
+++ b/apps/core-app/src/main/utils/app-root-path.ts
@@ -17,11 +17,45 @@ function safeGetUserDataPath(appLike: AppPathLike, fallbackBasePath: string): st
   }
 }
 
+/**
+ * The app data root, resolved once and then fixed for the process.
+ *
+ * `userData` is rewritten twice during startup, and the root must follow exactly one of them.
+ * `precore` overrides it for startup benchmarking and then reads the root immediately, so a
+ * benchmark run gets an isolated root — that one is deliberate. `polyfills` later points Chromium's
+ * profile at a separate dev directory, which is about Chromium, not about where our own data lives.
+ *
+ * Reading `userData` afresh on every call meant the answer depended on when you asked.
+ * `getAllowedDownloadRoots` asked at download time and got the post-`polyfills` path, while the
+ * update system wrote under the root `precore` had captured at startup, so every update download
+ * in a dev build was rejected as `destination-outside-roots` (#F2).
+ *
+ * Memoizing makes the first resolution authoritative for everyone. `precore` performs it at
+ * module load, after the benchmark override and before the Chromium one, which is the point that
+ * was always intended.
+ */
+let memoizedRootPath: string | null = null
+
 export function resolveRuntimeRootPath(
   appLike: AppPathLike,
   fallbackBasePath = process.cwd()
 ): string {
+  if (memoizedRootPath !== null) {
+    return memoizedRootPath
+  }
+
   const userDataPath = safeGetUserDataPath(appLike, fallbackBasePath)
   const folderName = appLike.isPackaged ? APP_FOLDER_NAME : DEV_APP_FOLDER_NAME
-  return path.join(userDataPath, folderName)
+  memoizedRootPath = path.join(userDataPath, folderName)
+  return memoizedRootPath
+}
+
+/**
+ * Clears the memoized root so a test can resolve it again under different conditions.
+ *
+ * Production has no reason to call this: a process that changed its data root mid-run would leave
+ * half its state in the previous one.
+ */
+export function resetRuntimeRootPathForTests(): void {
+  memoizedRootPath = null
 }


### PR DESCRIPTION
> Stacked on #1868. The base retargets to `master` automatically once that merges. Only the second commit belongs to this PR.

## What

`resolveRuntimeRootPath` read `app.getPath('userData')` on every call, and `userData` is rewritten twice during startup:

| Rewrite | Where | Should the app root follow it? |
|---|---|---|
| Startup-benchmark override | `precore.ts:170`, immediately before the root is first read | **Yes** — a benchmark run needs an isolated data root |
| Chromium dev profile | `polyfills.ts`, later in startup | **No** — that is Chromium's profile directory, not where our data lives |

The root followed both. `precore` captured `<default userData>/tuff-dev` at module load; `getAllowedDownloadRoots` re-derived `<dev profile>/tuff-dev` at download time. The update system wrote under the first and the download policy validated against the second, so **every update download in a dev build was rejected** as `destination-outside-roots`:

```
[WARN]  [DownloadCenter] Rejected download task target reason=destination-outside-roots module=app_update
[ERROR] [UpdateSystem]   Failed to download update tag=v2.4.14-beta.19 error=Download target rejected: destination-outside-roots
```

That is what blocked verifying the download and signature legs of the OTA fallback fix.

## Approach

Memoize. The first resolution becomes authoritative for every caller, and `precore` performs it at exactly the right moment — after the deliberate override, before the Chromium one. Nothing else has to know the ordering.

Two approaches were planned and both discarded during implementation, for the same reason:

- *Share polyfills' dev-userData rule* — would move the root to `tuff-dev/tuff-dev` and need a data migration.
- *Derive from `appData` + `app.getName()`* — would ignore the benchmark override and break benchmark isolation.

Both tried to redefine where the root comes from. Precore's capture point was already correct; the only defect was re-resolving later instead of reusing it. Memoizing keeps today's paths byte-for-byte in both dev and production, so **no data moves**.

## Also fixed

`database/index.ts` was rebuilding the root by hand in the migration-failure dialog, hardcoding `<userData>/tuff/logs/`. In a dev build that directory does not exist — the one message a user sees when the database is unusable pointed them somewhere else. Found by the new scanner.

## Keeping it fixed

Memoizing only helps callers that go through `resolveRuntimeRootPath`. A new site joining a folder name onto `getPath('userData')` would split the root again with nothing to catch it, so `check:app-root-single-source` guards that.

It fires only on **root reconstruction** — reading `userData` for wallpapers, temp files or host backups stays legitimate, and an earlier broader version flagged 18 such call sites. `--self-test` proves it catches a synthetic violation, exempts the owner, and leaves unrelated reads alone.

## Verification

- The regression is behavioural, not structural: running the old implementation through the same scenario yields `core-app/tuff-dev` and `tuff-dev/tuff-dev` — the exact pair observed on disk.
- End-to-end unit case: rewrite `userData` between the two resolutions, then run the real `evaluateDownloadTarget` against the destination the update system actually uses.
- Existing rejection cases (`unsafe-filename`, `destination-not-absolute`, `destination-outside-roots`) unchanged.
- 303 tests across `utils`/`update`/`download`/`network`/`database`, `typecheck:node` clean, lint clean.

**Not verified:** the real download and signature I/O. That needs a dev app driving an actual download, and port 5173 was held by another dev session; `electron-vite dev` takes no port override and a second Electron instance risks fighting over the single-instance lock. The end-to-end unit case covers the decision logic, not the I/O.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency for application data and log directory resolution, including when the user data location changes during runtime.
  - Migration-failure logs now use the resolved application runtime directory.

- **Quality Improvements**
  - Added automated checks to detect inconsistent application-root path usage, including across multiline code.
  - Expanded validation for runtime path resolution and download destinations.
  - Improved handling of application path resolution when user data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->