### PR TITLE
fix(download): enforce chunk concurrency limit

### DIFF
--- a/apps/core-app/src/main/modules/download/download-worker-concurrency.test.ts
+++ b/apps/core-app/src/main/modules/download/download-worker-concurrency.test.ts
@@ -14,15 +14,18 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import '../ai/intelligence-test-harness'
 
 const requestStream = vi.hoisted(() => vi.fn())
+const downloadWorkerLog = vi.hoisted(() => ({
+  warn: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn()
+}))
 
 vi.mock('../network', () => ({
   getNetworkService: () => ({ requestStream })
 }))
 
-vi.mock('./logger', () => ({
-  downloadWorkerLog: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() }
-}))
-
+vi.mock('./logger', () => ({ downloadWorkerLog }))
 import { DownloadWorker } from './download-worker'
 import { ProgressTracker } from './progress-tracker'
 
@@ -30,8 +33,21 @@ const tempDirs: string[] = []
 
 afterEach(async () => {
   requestStream.mockReset()
+  downloadWorkerLog.error.mockReset()
   await Promise.all(
-    tempDirs.splice(0).map(async (dir) => await fs.rm(dir, { recursive: true, force: true }))
+    tempDirs.splice(0).map(async (dir) => {
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        try {
+          await fs.rm(dir, { recursive: true, force: true })
+          return
+        } catch (error: unknown) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOTEMPTY' || attempt === 2) {
+            throw error
+          }
+          await new Promise<void>((resolve) => setTimeout(resolve, 10))
+        }
+      }
+    })
   )
 })
 
@@ -124,5 +140,86 @@ describe('DownloadWorker chunk concurrency', () => {
       { downloaded: 1, size: 1, status: ChunkStatus.COMPLETED },
       { downloaded: 1, size: 1, status: ChunkStatus.COMPLETED }
     ])
+  })
+  it('keeps an active request owned until terminal failure can surface', async () => {
+    const dir = await createWorkspace()
+    const chunks = Array.from({ length: 3 }, (_, index) => chunk(dir, index))
+    const activeRequestStarted = Promise.withResolvers<void>()
+    const activeRequest = Promise.withResolvers<{
+      headers: Record<string, string>
+      stream: Readable
+    }>()
+    const activeRequestResolved = Promise.withResolvers<void>()
+    const terminalFailureLogged = Promise.withResolvers<void>()
+    const outerFailureSurfaced = Promise.withResolvers<void>()
+    const terminalFailure = new Error('first chunk failed permanently')
+    const requestRanges: string[] = []
+
+    activeRequest.promise.then(() => activeRequestResolved.resolve())
+
+    requestStream.mockImplementation(async (request: { headers: Record<string, string> }) => {
+      const range = request.headers.Range
+      requestRanges.push(range)
+
+      if (range === 'bytes=0-0') {
+        await activeRequestStarted.promise
+        throw terminalFailure
+      }
+
+      if (range === 'bytes=1-1') {
+        activeRequestStarted.resolve()
+        return await activeRequest.promise
+      }
+
+      throw new Error(`Queued chunk was claimed after terminal failure: ${range}`)
+    })
+    downloadWorkerLog.error.mockImplementationOnce(() => {
+      terminalFailureLogged.resolve()
+      queueMicrotask(() => {
+        queueMicrotask(() => {
+          activeRequest.resolve({ headers: {}, stream: Readable.from([Buffer.from('x')]) })
+        })
+      })
+    })
+
+    const worker = new DownloadWorker(
+      2,
+      {} as never,
+      {
+        getChunkProgress: (activeChunks: ChunkInfo[]) => ({
+          downloadedSize: activeChunks.reduce(
+            (sum, activeChunk) => sum + activeChunk.downloaded,
+            0
+          ),
+          totalSize: activeChunks.reduce((sum, activeChunk) => sum + activeChunk.size, 0)
+        })
+      } as never,
+      { chunk: { maxRetries: 0 }, network: { timeout: 5_000, retryDelay: 0 } } as never
+    )
+
+    const result = downloadChunks(worker, task(dir), chunks).then(
+      () => ({ error: undefined }),
+      (error: unknown) => {
+        outerFailureSurfaced.resolve()
+        return { error }
+      }
+    )
+
+    await terminalFailureLogged.promise
+
+    expect(downloadWorkerLog.error).toHaveBeenCalledWith(
+      'Chunk download failed',
+      expect.objectContaining({ meta: expect.objectContaining({ chunkIndex: 0 }) })
+    )
+    expect(requestRanges).toEqual(['bytes=0-0', 'bytes=1-1'])
+    await expect(
+      Promise.race([
+        activeRequestResolved.promise.then(() => 'active request resolved'),
+        outerFailureSurfaced.promise.then(() => 'outer failure surfaced')
+      ])
+    ).resolves.toBe('active request resolved')
+
+    const { error } = await result
+    expect(error).toMatchObject({ message: terminalFailure.message })
   })
 })

--- a/apps/core-app/src/main/modules/download/download-worker-concurrency.test.ts
+++ b/apps/core-app/src/main/modules/download/download-worker-concurrency.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression for the lane scheduler: every mapped chunk must await the promise currently assigned
+ * to its lane, rather than all observing the initially resolved placeholder. A one-microtask
+ * response delay keeps each range request active long enough to expose eager starts deterministically.
+ */
+import { ChunkStatus } from '@talex-touch/utils'
+import type { ChunkInfo, DownloadTask } from '@talex-touch/utils'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { Readable } from 'node:stream'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import '../ai/intelligence-test-harness'
+
+const requestStream = vi.hoisted(() => vi.fn())
+
+vi.mock('../network', () => ({
+  getNetworkService: () => ({ requestStream })
+}))
+
+vi.mock('./logger', () => ({
+  downloadWorkerLog: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}))
+
+import { DownloadWorker } from './download-worker'
+import { ProgressTracker } from './progress-tracker'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  requestStream.mockReset()
+  await Promise.all(
+    tempDirs.splice(0).map(async (dir) => await fs.rm(dir, { recursive: true, force: true }))
+  )
+})
+
+async function createWorkspace(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'download-concurrency-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+function task(destination: string): DownloadTask {
+  return {
+    id: 'task-1',
+    destination,
+    filename: 'payload.bin',
+    url: 'https://example.test/payload.bin'
+  } as unknown as DownloadTask
+}
+
+function chunk(dir: string, index: number): ChunkInfo {
+  return {
+    index,
+    start: index,
+    end: index,
+    size: 1,
+    downloaded: 0,
+    status: ChunkStatus.PENDING,
+    filePath: path.join(dir, `chunk-${index}`)
+  } as ChunkInfo
+}
+
+/** downloadChunksConcurrently is private; its range-request scheduling is the contract under test. */
+function downloadChunks(
+  worker: DownloadWorker,
+  downloadTask: DownloadTask,
+  chunks: ChunkInfo[]
+): Promise<void> {
+  const internals = worker as unknown as {
+    downloadChunksConcurrently: (
+      task: DownloadTask,
+      chunks: ChunkInfo[],
+      progressTracker: ProgressTracker
+    ) => Promise<void>
+  }
+  return internals.downloadChunksConcurrently(
+    downloadTask,
+    chunks,
+    new ProgressTracker(downloadTask.id)
+  )
+}
+
+describe('DownloadWorker chunk concurrency', () => {
+  it('never starts more ranged requests than the configured limit', async () => {
+    const concurrentLimit = 2
+    const dir = await createWorkspace()
+    const chunks = Array.from({ length: 4 }, (_, index) => chunk(dir, index))
+    let activeRequests = 0
+    let peakActiveRequests = 0
+
+    requestStream.mockImplementation(async () => {
+      activeRequests += 1
+      peakActiveRequests = Math.max(peakActiveRequests, activeRequests)
+      await new Promise<void>((resolve) => queueMicrotask(resolve))
+      activeRequests -= 1
+      return { headers: {}, stream: Readable.from([Buffer.from('x')]) }
+    })
+
+    const worker = new DownloadWorker(
+      concurrentLimit,
+      {} as never,
+      {
+        getChunkProgress: (activeChunks: ChunkInfo[]) => ({
+          downloadedSize: activeChunks.reduce(
+            (sum, activeChunk) => sum + activeChunk.downloaded,
+            0
+          ),
+          totalSize: activeChunks.reduce((sum, activeChunk) => sum + activeChunk.size, 0)
+        })
+      } as never,
+      { chunk: { maxRetries: 0 }, network: { timeout: 5_000, retryDelay: 0 } } as never
+    )
+
+    await downloadChunks(worker, task(dir), chunks)
+
+    expect(peakActiveRequests).toBeLessThanOrEqual(concurrentLimit)
+    expect(activeRequests).toBe(0)
+    expect(requestStream).toHaveBeenCalledTimes(chunks.length)
+    expect(chunks.map(({ downloaded, size, status }) => ({ downloaded, size, status }))).toEqual([
+      { downloaded: 1, size: 1, status: ChunkStatus.COMPLETED },
+      { downloaded: 1, size: 1, status: ChunkStatus.COMPLETED },
+      { downloaded: 1, size: 1, status: ChunkStatus.COMPLETED },
+      { downloaded: 1, size: 1, status: ChunkStatus.COMPLETED }
+    ])
+  })
+})

--- a/apps/core-app/src/main/modules/download/download-worker.ts
+++ b/apps/core-app/src/main/modules/download/download-worker.ts
@@ -463,51 +463,50 @@ export class DownloadWorker {
     }
 
     const concurrentLimit = Math.min(this.maxConcurrent, runnableChunks.length)
-    const lanes: Promise<void>[] = Array.from({ length: concurrentLimit }, () => Promise.resolve())
+    let nextChunkIndex = 0
     let completedChunks = chunks.filter(
       (chunk) => chunk.status === ChunkStatus.COMPLETED || chunk.downloaded >= chunk.size
     ).length
     const completionCheckpoint = Math.max(1, Math.floor(chunks.length / 10))
 
-    const downloadPromises = runnableChunks.map(async (chunk, index) => {
-      if (abortSignal?.aborted) {
-        throw new Error('Task was cancelled')
-      }
-
-      const laneIndex = index % concurrentLimit
-      await lanes[laneIndex]
-
-      const downloadPromise = this.downloadChunk(chunk, task, progressTracker, abortSignal)
-      lanes[laneIndex] = downloadPromise
-
-      try {
-        await downloadPromise
-
+    const runLane = async (): Promise<void> => {
+      while (nextChunkIndex < runnableChunks.length) {
         if (abortSignal?.aborted) {
           throw new Error('Task was cancelled')
         }
 
-        completedChunks += 1
+        const chunk = runnableChunks[nextChunkIndex]
+        nextChunkIndex += 1
 
-        const progress = this.chunkManager.getChunkProgress(chunks)
-        progressTracker.updateProgress(progress.downloadedSize, progress.totalSize)
+        try {
+          await this.downloadChunk(chunk, task, progressTracker, abortSignal)
 
-        if (completedChunks % completionCheckpoint === 0 || completedChunks === chunks.length) {
-          progressTracker.forceUpdate()
+          if (abortSignal?.aborted) {
+            throw new Error('Task was cancelled')
+          }
+
+          completedChunks += 1
+
+          const progress = this.chunkManager.getChunkProgress(chunks)
+          progressTracker.updateProgress(progress.downloadedSize, progress.totalSize)
+
+          if (completedChunks % completionCheckpoint === 0 || completedChunks === chunks.length) {
+            progressTracker.forceUpdate()
+          }
+        } catch (error) {
+          if (abortSignal?.aborted) {
+            return
+          }
+          downloadWorkerLog.error('Chunk download failed', {
+            error,
+            meta: { taskId: task.id, chunkIndex: chunk.index }
+          })
+          throw error
         }
-      } catch (error) {
-        if (abortSignal?.aborted) {
-          return
-        }
-        downloadWorkerLog.error('Chunk download failed', {
-          error,
-          meta: { taskId: task.id, chunkIndex: chunk.index }
-        })
-        throw error
       }
-    })
+    }
 
-    await Promise.all(downloadPromises)
+    await Promise.all(Array.from({ length: concurrentLimit }, runLane))
   }
 
   // 下载单个切片


### PR DESCRIPTION
Fixes the macOS Beta23 OTA download failure observed at 75%. The prior modulo-lane scheduler let every task observe an initially resolved lane promise and start its ranged request concurrently, causing a request burst and HTTP/2 protocol errors. The new worker-pool scheduler limits active chunk requests to the configured bound. A deterministic regression test asserts the maximum active ranged requests never exceeds that bound.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent download scheduling by dynamically assigning available chunks while respecting the configured request limit.
  * Preserved progress reporting and error handling during concurrent transfers.
  * Ensured active requests complete and report terminal failures correctly before queued work proceeds.

* **Tests**
  * Added regression coverage for chunk scheduling, concurrency behavior, download completion, expected file sizes, error handling, and temporary workspace cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->