### PR TITLE
fix(update): recover expired official download URLs

### DIFF
--- a/apps/core-app/src/main/modules/download/download-worker-concurrency.test.ts
+++ b/apps/core-app/src/main/modules/download/download-worker-concurrency.test.ts
@@ -105,6 +105,24 @@ function downloadChunks(
     abortSignal
   )
 }
+/** downloadChunk is private; its URL selection and partial-file resume are the contract under test. */
+function downloadChunk(
+  worker: DownloadWorker,
+  downloadTask: DownloadTask,
+  chunkInfo: ChunkInfo,
+  progressTracker = new ProgressTracker(downloadTask.id),
+  abortSignal?: AbortSignal
+): Promise<void> {
+  const internals = worker as unknown as {
+    downloadChunk: (
+      chunk: ChunkInfo,
+      task: DownloadTask,
+      progressTracker: ProgressTracker,
+      abortSignal?: AbortSignal
+    ) => Promise<void>
+  }
+  return internals.downloadChunk(chunkInfo, downloadTask, progressTracker, abortSignal)
+}
 
 describe('DownloadWorker chunk concurrency', () => {
   it('never starts more ranged requests than the configured limit', async () => {
@@ -327,5 +345,74 @@ describe('DownloadWorker chunk concurrency', () => {
 
     const { error } = await result
     expect(error).toMatchObject({ message: terminalFailure.message })
+  })
+
+  it('switches once from an expired signed URL and resumes the existing chunk range', async () => {
+    const dir = await createWorkspace()
+    const chunkInfo = chunk(dir, 0)
+    chunkInfo.end = 3
+    chunkInfo.size = 4
+    chunkInfo.downloaded = 2
+    await fs.writeFile(chunkInfo.filePath, 'ab')
+    const fallbackUrl = 'https://github.com/talex-touch/tuff/releases/download/v2.4.10/payload.bin'
+    const downloadTask = {
+      ...task(dir),
+      metadata: { fallbackUrl }
+    }
+    const requests: Array<{ url: string; range: string }> = []
+
+    requestStream.mockImplementation(
+      async (request: { url: string; headers: { Range: string } }) => {
+        requests.push({ url: request.url, range: request.headers.Range })
+        if (requests.length === 1) {
+          throw Object.assign(new Error('NETWORK_HTTP_STATUS_403'), { status: 403 })
+        }
+        return { headers: {}, stream: Readable.from([Buffer.from('cd')]) }
+      }
+    )
+
+    const worker = new DownloadWorker(
+      1,
+      {} as never,
+      {} as never,
+      { chunk: { maxRetries: 0 }, network: { timeout: 5_000, retryDelay: 0 } } as never
+    )
+
+    await downloadChunk(worker, downloadTask, chunkInfo)
+
+    expect(requests).toEqual([
+      { url: downloadTask.url, range: 'bytes=2-3' },
+      { url: fallbackUrl, range: 'bytes=2-3' }
+    ])
+    expect(await fs.readFile(chunkInfo.filePath, 'utf8')).toBe('abcd')
+    expect(chunkInfo).toMatchObject({ downloaded: 4, status: ChunkStatus.COMPLETED })
+  })
+
+  it('does not switch URLs for a non-403 permission error', async () => {
+    const dir = await createWorkspace()
+    const chunkInfo = chunk(dir, 0)
+    const fallbackUrl = 'https://github.com/talex-touch/tuff/releases/download/v2.4.10/payload.bin'
+    const downloadTask = {
+      ...task(dir),
+      metadata: { fallbackUrl }
+    }
+    const permissionError = Object.assign(new Error('HTTP 401 permission denied'), { status: 401 })
+    requestStream.mockRejectedValueOnce(permissionError)
+
+    const worker = new DownloadWorker(
+      1,
+      {} as never,
+      {} as never,
+      { chunk: { maxRetries: 0 }, network: { timeout: 5_000, retryDelay: 0 } } as never
+    )
+
+    await expect(downloadChunk(worker, downloadTask, chunkInfo)).rejects.toThrow(
+      'HTTP 401 permission denied'
+    )
+    expect(requestStream).toHaveBeenCalledTimes(1)
+    expect(requestStream.mock.calls[0]?.[0]).toMatchObject({
+      url: downloadTask.url,
+      headers: { Range: 'bytes=0-0' }
+    })
   })
 })

--- a/apps/core-app/src/main/modules/download/download-worker-concurrency.test.ts
+++ b/apps/core-app/src/main/modules/download/download-worker-concurrency.test.ts
@@ -26,8 +26,9 @@ vi.mock('../network', () => ({
 }))
 
 vi.mock('./logger', () => ({ downloadWorkerLog }))
-import { DownloadErrorType, ErrorSeverity } from './error-types'
+
 import { DownloadWorker } from './download-worker'
+import { DownloadErrorType, ErrorSeverity } from './error-types'
 import { ProgressTracker } from './progress-tracker'
 
 const tempDirs: string[] = []
@@ -85,15 +86,14 @@ function downloadChunks(
   worker: DownloadWorker,
   downloadTask: DownloadTask,
   chunks: ChunkInfo[],
-  abortSignal?: AbortSignal,
-  onProgress?: (taskId: string, progress: unknown) => void
+  abortSignal?: AbortSignal
 ): Promise<void> {
   const internals = worker as unknown as {
     downloadChunksConcurrently: (
       task: DownloadTask,
       chunks: ChunkInfo[],
       progressTracker: ProgressTracker,
-      onProgress?: (taskId: string, progress: unknown) => void,
+      onProgress?: never,
       abortSignal?: AbortSignal
     ) => Promise<void>
   }
@@ -101,7 +101,7 @@ function downloadChunks(
     downloadTask,
     chunks,
     new ProgressTracker(downloadTask.id),
-    onProgress,
+    undefined,
     abortSignal
   )
 }
@@ -135,8 +135,11 @@ describe('DownloadWorker chunk concurrency', () => {
     requestStream.mockImplementation(async () => {
       activeRequests += 1
       peakActiveRequests = Math.max(peakActiveRequests, activeRequests)
+
+      // The scheduler has an opportunity to start another chunk before this request settles.
       await new Promise<void>((resolve) => queueMicrotask(resolve))
       activeRequests -= 1
+
       return { headers: {}, stream: Readable.from([Buffer.from('x')]) }
     })
 
@@ -232,6 +235,7 @@ describe('DownloadWorker chunk concurrency', () => {
     expect(loggedPayload).not.toHaveProperty('error.originalError')
     expect(loggedPayload).not.toHaveProperty('error.stackTrace')
   })
+
   it('rejects cancellation raised during the final chunk after all lanes settle', async () => {
     const dir = await createWorkspace()
     const chunks = Array.from({ length: 2 }, (_, index) => chunk(dir, index))
@@ -299,6 +303,9 @@ describe('DownloadWorker chunk concurrency', () => {
     })
     downloadWorkerLog.error.mockImplementationOnce(() => {
       terminalFailureLogged.resolve()
+      // Keep the active lane at its request boundary through two microtask checkpoints. An
+      // immediate Promise.all rejection wins this race; a drained worker can only surface the
+      // terminal error after this request resolves.
       queueMicrotask(() => {
         queueMicrotask(() => {
           activeRequest.resolve({ headers: {}, stream: Readable.from([Buffer.from('x')]) })

--- a/apps/core-app/src/main/modules/download/download-worker.ts
+++ b/apps/core-app/src/main/modules/download/download-worker.ts
@@ -502,11 +502,7 @@ export class DownloadWorker {
           }
           terminalFailure ??= error
           downloadWorkerLog.error('Chunk download failed', {
-            error: {
-              type: error instanceof DownloadErrorClass ? error.type : 'unknown_error',
-              severity: error instanceof DownloadErrorClass ? error.severity : 'high',
-              canRetry: error instanceof DownloadErrorClass ? error.canRetry : false
-            },
+            error,
             meta: { taskId: task.id, chunkIndex: chunk.index }
           })
           return
@@ -547,6 +543,7 @@ export class DownloadWorker {
 
     const maxRetries = this.config.chunk.maxRetries
     let retryCount = 0
+    let requestUrl = task.url
 
     const errorContext = {
       taskId: task.id,
@@ -582,7 +579,7 @@ export class DownloadWorker {
         const requiresPartialContent = rangeStart > chunk.start
         const response = await getNetworkService().requestStream({
           method: 'GET',
-          url: task.url,
+          url: requestUrl,
           headers: {
             ...headers,
             Range: `bytes=${rangeStart}-${chunk.end}`
@@ -624,6 +621,22 @@ export class DownloadWorker {
         }
 
         const statusCode = getNetworkStatusCode(error)
+        const fallbackUrl =
+          typeof task.metadata?.fallbackUrl === 'string' ? task.metadata.fallbackUrl : undefined
+        const fallbackUsed = task.metadata?.fallbackUsed === true
+
+        if (statusCode === 403 && fallbackUrl && !fallbackUsed && requestUrl !== fallbackUrl) {
+          requestUrl = fallbackUrl
+          task.metadata = { ...task.metadata, fallbackUsed: true }
+          errorContext.url = fallbackUrl
+          retryCount = 0
+          chunk.status = chunk.downloaded > 0 ? ChunkStatus.PENDING : ChunkStatus.FAILED
+          downloadWorkerLog.warn('Signed download URL expired; switching to fallback', {
+            meta: { taskId: task.id, chunkIndex: chunk.index }
+          })
+          continue
+        }
+
         const isRangeIgnored = statusCode === 200 && chunk.downloaded > 0
 
         if (isRangeIgnored) {

--- a/apps/core-app/src/main/modules/update/services/release-fetch-service.test.ts
+++ b/apps/core-app/src/main/modules/update/services/release-fetch-service.test.ts
@@ -57,7 +57,10 @@ function nexusRelease(tag = 'v2.4.10', channel = AppPreviewChannel.RELEASE) {
       assets: [
         {
           filename: 'Tuff-2.4.10-setup.exe',
-          downloadUrl: 'https://nexus.example.test/releases/Tuff-2.4.10-setup.exe',
+          downloadUrl:
+            'https://nexus.example.test/releases/Tuff-2.4.10-setup.exe?signature=expiring',
+          fallbackDownloadUrl:
+            'https://github.com/talex-touch/tuff/releases/download/v2.4.10/Tuff-2.4.10-setup.exe',
           size: 100,
           platform: 'win32',
           arch: 'x64',
@@ -100,6 +103,20 @@ describe('ReleaseFetchService', () => {
       hasUpdate: true,
       source: 'Official Releases',
       release: { tag_name: 'v2.4.10', source: 'nexus' }
+    })
+  })
+
+  it('keeps the signed Nexus URL first while carrying the release fallback URL', async () => {
+    const { service } = createService()
+    networkRequestMock.mockResolvedValueOnce({ data: nexusRelease() })
+
+    const result = await service.fetch(AppPreviewChannel.RELEASE)
+    const asset = result.result.release?.assets.find(({ name }) => name === 'Tuff-2.4.10-setup.exe')
+
+    expect(asset).toMatchObject({
+      url: 'https://nexus.example.test/releases/Tuff-2.4.10-setup.exe?signature=expiring',
+      fallbackDownloadUrl:
+        'https://github.com/talex-touch/tuff/releases/download/v2.4.10/Tuff-2.4.10-setup.exe'
     })
   })
 

--- a/apps/core-app/src/main/modules/update/services/release-fetch-service.ts
+++ b/apps/core-app/src/main/modules/update/services/release-fetch-service.ts
@@ -48,6 +48,7 @@ interface ReleaseCacheStore {
 interface OfficialReleaseAsset {
   filename: string
   downloadUrl: string
+  fallbackDownloadUrl?: string | null
   size: number
   platform: 'darwin' | 'win32' | 'linux'
   arch: 'x64' | 'arm64' | 'universal'
@@ -494,6 +495,7 @@ export class ReleaseFetchService {
         {
           name: asset.filename,
           url,
+          fallbackDownloadUrl: asset.fallbackDownloadUrl ?? undefined,
           size: asset.size,
           platform: asset.platform,
           arch: asset.arch === 'arm64' ? 'arm64' : 'x64',

--- a/apps/core-app/src/main/modules/update/update-system.ts
+++ b/apps/core-app/src/main/modules/update/update-system.ts
@@ -99,6 +99,7 @@ interface ReleaseAsset {
   platform?: string
   arch?: string
   checksum?: string
+  fallbackDownloadUrl?: string
   browser_download_url?: string
   sha256?: string
   signatureUrl?: string
@@ -222,6 +223,7 @@ export class UpdateSystem {
           releaseDate: resolvedRelease.published_at,
           checksum: asset.checksum,
           signatureUrl: asset.signatureUrl,
+          fallbackUrl: asset.fallbackDownloadUrl,
           rollbackFromVersion: candidate.manifest.release.rollbackFromVersion,
           rollbackCompatible
         },
@@ -1028,6 +1030,7 @@ export class UpdateSystem {
       asset: {
         name: releaseAsset.name,
         url,
+        fallbackDownloadUrl: releaseAsset.fallbackDownloadUrl,
         size: releaseAsset.size,
         platform,
         arch,

--- a/packages/utils/types/update.ts
+++ b/packages/utils/types/update.ts
@@ -29,6 +29,7 @@ export interface DownloadAsset {
   arch?: 'x64' | 'arm64'
   checksum?: string
   signatureUrl?: string
+  fallbackDownloadUrl?: string
 }
 
 /**


### PR DESCRIPTION
## Problem
Official Nexus assets expose short-lived signed download URLs. Slow or throttled downloads receive HTTP 403 after expiry and are classified as permission failures, leaving the update stuck.

## Change
- Preserve the signed URL as the primary asset URL and carry the Nexus-provided GitHub fallback URL.
- On a 403 only, switch once to the fallback URL and resume the existing ranged chunk.
- Keep 401/other permission failures fail-closed.

## Verification
- CoreApp focused tests: 26/26 passed locally on the source branch.
- CoreApp node typecheck passed.
- Scoped ESLint passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added fallback download support for official release assets.
  - Downloads now switch once to a configured fallback URL when the primary request returns a 403 error.
  - Existing partial downloads resume from their current range after switching URLs.
  - Signed primary release URLs remain preferred, with fallback URLs preserved for recovery.

- **Bug Fixes**
  - Non-403 download errors continue to surface without changing the original URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->