### PR TITLE
chore: release v2.4.14-beta.26

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/core-app",
-  "version": "2.4.14-beta.26",
+  "version": "2.4.14-beta.25",
   "private": true,
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/core-app",
-  "version": "2.4.14-beta.25",
+  "version": "2.4.14-beta.26",
   "private": true,
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/notes/update_2.4.14-beta.26.en.md
+++ b/notes/update_2.4.14-beta.26.en.md
@@ -1,0 +1,14 @@
+# Tuff v2.4.14-beta.26 Release Notes
+
+## Summary Notes
+
+- This is the official follow-up to Beta25 after the signed Nexus download URL expiry fix.
+- Official update assets retain the Nexus signed URL as the primary path and can resume the verified GitHub fallback after an HTTP 403 expiry.
+- The fallback is limited to signed-URL expiry; unrelated permission failures remain fail-closed.
+
+## What's Changed
+
+- Carries forward the Beta25 bounded worker-pool scheduling and terminal-failure handling.
+- Preserves partial ranged chunks when switching from an expired signed URL to the fallback asset.
+- Enables the next official Beta25 → Beta26 OTA N→N+1 acceptance attempt.
+- Does not relax checksum, detached-signature, release-gate, or startup health-ack requirements.

--- a/notes/update_2.4.14-beta.26.zh.md
+++ b/notes/update_2.4.14-beta.26.zh.md
@@ -1,0 +1,14 @@
+# Tuff v2.4.14-beta.26 更新说明
+
+## 摘要
+
+- 本版本作为 Beta25 后续官方更新包，用于复验 Nexus signed URL 过期后的 OTA 下载恢复、替换和启动健康确认。
+- 官方更新资产优先使用 Nexus signed URL；HTTP 403 表示签名 URL 过期时，客户端可切换到已验证的 GitHub fallback 并继续已有分块。
+- fallback 仅用于 signed URL 过期；其他权限错误继续 fail-closed。
+
+## 变更内容
+
+- 延续 Beta25 的受控 worker-pool 调度与终端失败收敛实现。
+- 从过期 signed URL 切换 fallback 时保留已完成的 Range 分块和断点进度。
+- 提供下一组官方 Beta25 → Beta26 OTA N→N+1 验收包。
+- 未放宽 checksum、detached signature、发布门禁或 startup health-ack 要求。

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@talex-touch/tuff",
   "homepage": "https://tuff.tagzxia.com",
   "type": "module",
-  "version": "2.4.14-beta.25",
+  "version": "2.4.14-beta.26",
   "packageManager": "pnpm@11.24.0",
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",


### PR DESCRIPTION
Release v2.4.14-beta.26 after merging the signed URL fallback fix in #1873. This release is required for official Beta25 -> Beta26 OTA re-acceptance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to `2.4.14-beta.26`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->