### PR TITLE
fix(release): align CoreApp beta26 version

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/core-app",
-  "version": "2.4.14-beta.25",
+  "version": "2.4.14-beta.26",
   "private": true,
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",


### PR DESCRIPTION
The Beta26 merge restored apps/core-app/package.json to beta.25 while root package is beta.26, making the tag/version guard fail on macOS and Linux. Align CoreApp to 2.4.14-beta.26 before retrying the official tag build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the core app version to `2.4.14-beta.26`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->