### PR TITLE
chore: release v2.4.14-beta.27

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/core-app",
-  "version": "2.4.14-beta.26",
+  "version": "2.4.14-beta.27",
   "private": true,
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/notes/update_2.4.14-beta.27.en.md
+++ b/notes/update_2.4.14-beta.27.en.md
@@ -1,0 +1,13 @@
+# Tuff v2.4.14-beta.27 Release Notes
+
+## Summary Notes
+
+- This is the official post-fix follow-up to Beta26 for real macOS OTA N→N+1 acceptance.
+- The Beta26 updater preserves Nexus signed URLs as primary and switches once to the signed asset's GitHub fallback after HTTP 403 expiry while resuming the current ranged chunk.
+- The release remains subject to checksum, detached-signature, and startup health acknowledgement gates.
+
+## What's Changed
+
+- Provides the official Beta26 → Beta27 acceptance pair after the signed URL recovery fix.
+- Retains bounded ranged-download scheduling, terminal failure propagation, and cancellation handling.
+- Does not relax update integrity or release quality requirements.

--- a/notes/update_2.4.14-beta.27.en.md
+++ b/notes/update_2.4.14-beta.27.en.md
@@ -2,8 +2,7 @@
 
 ## Summary Notes
 
-- This is the official post-fix follow-up to Beta26 for real macOS OTA N→N+1 acceptance.
-- The Beta26 updater preserves Nexus signed URLs as primary and switches once to the signed asset's GitHub fallback after HTTP 403 expiry while resuming the current ranged chunk.
+- The Beta26 updater preserves Nexus-signed URLs as primary and switches once to the signed asset's GitHub fallback after HTTP 403 expiry while resuming the current ranged chunk.
 - The release remains subject to checksum, detached-signature, and startup health acknowledgement gates.
 
 ## What's Changed

--- a/notes/update_2.4.14-beta.27.en.md
+++ b/notes/update_2.4.14-beta.27.en.md
@@ -4,6 +4,7 @@
 
 - The Beta26 updater preserves Nexus-signed URLs as primary and switches once to the signed asset's GitHub fallback after HTTP 403 expiry while resuming the current ranged chunk.
 - The release remains subject to checksum, detached-signature, and startup health acknowledgement gates.
+- The package remains bound to the same checksum, detached signature, and release manifest contract.
 
 ## What's Changed
 

--- a/notes/update_2.4.14-beta.27.zh.md
+++ b/notes/update_2.4.14-beta.27.zh.md
@@ -1,0 +1,13 @@
+# Tuff v2.4.14-beta.27 更新说明
+
+## 摘要
+
+- 本版本作为 Beta26 修复版后的官方后续版本，用于真实验收 macOS OTA N→N+1。
+- Beta26 更新器优先使用 Nexus signed URL；HTTP 403 表示签名 URL 过期时，仅切换一次到同一资产的 GitHub fallback，并继续当前 Range 分块。
+- 继续执行 checksum、detached signature 与 startup health-ack 门禁。
+
+## 变更内容
+
+- 提供 signed URL 恢复修复后的官方 Beta26 → Beta27 OTA 验收版本对。
+- 保留受控分块调度、终端失败传播与取消处理。
+- 未放宽更新完整性或发布质量要求。

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@talex-touch/tuff",
   "homepage": "https://tuff.tagzxia.com",
   "type": "module",
-  "version": "2.4.14-beta.26",
+  "version": "2.4.14-beta.27",
   "packageManager": "pnpm@11.24.0",
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",


### PR DESCRIPTION
Release v2.4.14-beta.27 as the official post-fix N+1 for Beta26 OTA acceptance. Includes bilingual release notes and the signed URL fallback fix already merged in master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added English and Chinese release notes for Tuff v2.4.14-beta.27.
  - Documented macOS OTA recovery behavior, including one-time fallback handling for expired signed URLs and continuation of ranged downloads.
  - Documented checksum, signature, startup health, cancellation, failure-propagation, and release-quality requirements.

- **Chores**
  - Updated the application version to `2.4.14-beta.27`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->