### PR TITLE
release: publish Beta31 changed packages

### DIFF
--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@talex-touch/tuff-intelligence": "workspace:^",
     "@talex-touch/tuff-native": "workspace:^",
-    "@talex-touch/utils": "workspace:^1.0.0",
+    "@talex-touch/utils": "workspace:^",
     "ts-node": "^10.9.2",
     "vitest": "^3.2.7"
   }

--- a/packages/tuffex/package.json
+++ b/packages/tuffex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/tuffex",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "engines": {
     "node": ">=26.0.0"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/utils",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": false,
   "description": "Tuff series utils",
   "author": "TalexDreamSoul",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -917,7 +917,7 @@ importers:
         specifier: workspace:^
         version: link:../tuff-native
       '@talex-touch/utils':
-        specifier: workspace:^1.0.0
+        specifier: workspace:^
         version: link:../utils
       ts-node:
         specifier: ^10.9.2


### PR DESCRIPTION
## Summary
- bump `@talex-touch/utils` from `2.0.0` to `2.1.0` for the additive recommendation/file-index APIs shipped with Beta31
- bump `@talex-touch/tuffex` from `0.4.0` to `0.5.0` for the additive component APIs and behavior shipped with Beta31
- leave the lockfile unchanged because workspace package versions are not lockfile importer inputs

## Verification
- Utils: 192 files, 1490 tests (1 skipped), benchmark, lint, build/type declarations
- TuffEx: 197 files, 1941 tests, lint, typecheck, build, exports/README/types/size audits
- packed source manifests validate for both packages
- target npm versions confirmed unused before publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Tuffex package to version 0.5.0.
  * Updated the utilities package to version 2.1.0.
  * Aligned the test package with the current utilities workspace version.
  * These updates keep package versions and workspace references synchronized for the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->