### PR TITLE
fix(core-app): let native OCR workers exit naturally

### DIFF
--- a/.trellis/spec/main-process/background-task-timeout-contracts.md
+++ b/.trellis/spec/main-process/background-task-timeout-contracts.md
@@ -133,7 +133,9 @@ posts one terminal success or error message to its parent.
 ### 2. Signatures
 
 ```ts
-type NativeWorkerMessage = { status: 'success'; result: unknown } | { status: 'error'; error: string }
+type NativeWorkerMessage =
+  | { status: 'success'; jobId: number; result: { text: string } }
+  | { status: 'error'; jobId: number; error: string }
 
 worker.once('message', settleFromMessage)
 worker.once('error', rejectFromWorker)
@@ -145,6 +147,9 @@ worker.once('exit', rejectUnexpectedExit)
 - Posting the terminal message does not prove the native completion callback has
   returned. Promise continuations can post to `parentPort` while
   `Napi::AsyncWorker::OnWorkComplete` is still unwinding.
+- Treat `message` as untrusted at the parent boundary. Its `jobId` must equal
+  the one worker-owned job; success requires an object result with string
+  `text`, and error requires a non-empty string `error`.
 - A terminal `message` settles the parent promise but must not call
   `worker.terminate()`. The one-shot worker returns from its entrypoint and exits
   naturally with code 0.
@@ -159,7 +164,7 @@ worker.once('exit', rejectUnexpectedExit)
 | --- | --- |
 | Native success message received | Resolve; no `terminate()`; natural exit |
 | Native error message received | Reject with the projected error; no `terminate()`; natural exit |
-| Malformed terminal message received | Reject as invalid; no immediate `terminate()` |
+| Missing/mismatched job id or malformed terminal payload | Reject as invalid; no immediate `terminate()` |
 | Parent deadline expires before a message | Terminate once; reject with the stable timeout error |
 | Worker exits nonzero before settlement | Reject as worker failure |
 
@@ -177,6 +182,8 @@ worker.once('exit', rejectUnexpectedExit)
 - The parent-worker unit test must observe `terminate()` calls and assert zero
   after a terminal success message; restoring the old immediate termination must
   turn the test red.
+- Cover missing/mismatched `jobId` and missing success `result.text`; neither
+  may persist a false successful job or force-terminate after delivery.
 - A runtime probe must execute the real native worker repeatedly and require a
   terminal result plus natural exit code 0 for every worker.
 - Timeout coverage must still prove that a silent worker is force-terminated.

--- a/.trellis/spec/main-process/background-task-timeout-contracts.md
+++ b/.trellis/spec/main-process/background-task-timeout-contracts.md
@@ -123,6 +123,78 @@ try {
 }
 ```
 
+## Scenario: One-shot native workers exit after terminal delivery
+
+### 1. Scope / Trigger
+
+This applies to a `worker_threads.Worker` that invokes a native/N-API addon and
+posts one terminal success or error message to its parent.
+
+### 2. Signatures
+
+```ts
+type NativeWorkerMessage = { status: 'success'; result: unknown } | { status: 'error'; error: string }
+
+worker.once('message', settleFromMessage)
+worker.once('error', rejectFromWorker)
+worker.once('exit', rejectUnexpectedExit)
+```
+
+### 3. Contracts
+
+- Posting the terminal message does not prove the native completion callback has
+  returned. Promise continuations can post to `parentPort` while
+  `Napi::AsyncWorker::OnWorkComplete` is still unwinding.
+- A terminal `message` settles the parent promise but must not call
+  `worker.terminate()`. The one-shot worker returns from its entrypoint and exits
+  naturally with code 0.
+- Force termination is reserved for a parent-owned timeout or cancellation that
+  occurs before terminal delivery. Keep that path bounded and idempotent.
+- `error` and `exit` are observations of a worker already failing or exiting;
+  they must not trigger a second termination attempt.
+
+### 4. Validation & Error Matrix
+
+| Condition | Required result |
+| --- | --- |
+| Native success message received | Resolve; no `terminate()`; natural exit |
+| Native error message received | Reject with the projected error; no `terminate()`; natural exit |
+| Malformed terminal message received | Reject as invalid; no immediate `terminate()` |
+| Parent deadline expires before a message | Terminate once; reject with the stable timeout error |
+| Worker exits nonzero before settlement | Reject as worker failure |
+
+### 5. Good / Base / Bad Cases
+
+- Good: OCR posts its result, the parent resolves immediately, and the child
+  exits after the N-API completion callback returns.
+- Base: a pure-JavaScript one-shot worker follows the same natural-exit path.
+- Bad: the parent receives a valid result and immediately terminates the child;
+  the process can abort in `Napi::Error::ThrowAsJavaScriptException` even though
+  application logs already reported the native call as successful.
+
+### 6. Tests Required
+
+- The parent-worker unit test must observe `terminate()` calls and assert zero
+  after a terminal success message; restoring the old immediate termination must
+  turn the test red.
+- A runtime probe must execute the real native worker repeatedly and require a
+  terminal result plus natural exit code 0 for every worker.
+- Timeout coverage must still prove that a silent worker is force-terminated.
+
+### 7. Wrong vs Correct
+
+```ts
+// Wrong: the native completion callback may still be on the child stack.
+worker.once('message', (message) => {
+  void worker.terminate()
+  settle(message)
+})
+
+// Correct: terminal delivery owns settlement; the one-shot entrypoint owns exit.
+worker.once('message', settle)
+timeout = setTimeout(() => void worker.terminate(), WORKER_TIMEOUT_MS)
+```
+
 ## PollingService: bounded by default
 
 `packages/utils/common/utils/polling.ts`

--- a/.trellis/spec/main-process/index.md
+++ b/.trellis/spec/main-process/index.md
@@ -48,10 +48,10 @@ Electron main-process (apps/core-app/src/main) coding contracts.
 - [background-task-timeout-contracts.md](background-task-timeout-contracts.md) —
   main-thread liveness: streaming requests default to a fetch-through-EOF
   deadline, caller-owned idle streams opt in explicitly, caller cancellation is
-  source-provenanced and cooldown-neutral, and protocol completion/cancellation
-  use controlled lifecycle methods; PollingService defaults, outbox round
-  budgets, child-process backoff, bounded interactive `waitForIdle()`, and
-  `[Perf:EventLoop]` diagnosis.
+  source-provenanced and cooldown-neutral, protocol completion/cancellation use
+  controlled lifecycle methods, one-shot native workers exit naturally after
+  terminal delivery; PollingService defaults, outbox round budgets, child-process
+  backoff, bounded interactive `waitForIdle()`, and `[Perf:EventLoop]` diagnosis.
 - [search-charset-and-identity-contracts.md](search-charset-and-identity-contracts.md)
   — charset rules import from search-charset only; SEARCH_KEYWORD_SCHEMA_VERSION
   bump semantics (app auto / file via bound backfill, never through the disk-reading

--- a/.trellis/tasks/08-23-release-cicd-ota-acceptance/evidence/macos-ota-beta24-beta25-signed-url-expiry.md
+++ b/.trellis/tasks/08-23-release-cicd-ota-acceptance/evidence/macos-ota-beta24-beta25-signed-url-expiry.md
@@ -1,0 +1,35 @@
+# macOS OTA beta.24 -> beta.25 (signed URL expiry attempt)
+
+## Classification
+
+- Result: **fail before install**. Official source discovery and signed package download started; the signed Nexus URL expired during the ranged download and the task terminated at 53%. No install handoff, replacement, startup, or health acknowledgement occurred.
+- Scope: disposable app bundle copied from the official Beta24 arm64 DMG and isolated profile under `/tmp`; no real `/Applications` bundle or user profile was used.
+- Attempt: `b0b73f87-1c35-47c6-aa66-9b2e05f2e4a7`; download task `27273f16-d9c4-4ae0-b7e8-f4caf72d8b75`.
+
+## Sanitized Timeline
+
+| Local time | Evidence |
+| --- | --- |
+| 2026-09-05 17:08 | Isolated Beta24 app passed packaged startup and official build attestation; update check selected published `v2.4.14-beta.25` from Nexus. |
+| 2026-09-05 17:08 | Download task entered `downloading`; target asset size was `512612996` bytes and manifest SHA-256 was `7cce7efd00f8d4968bc271a8d5ad857aa8f15d9f09deea1f52db668877abc352`. |
+| 2026-09-05 17:17 | Ranged download reached approximately 53%; the signed URL's bounded expiry elapsed before the remaining chunks completed. |
+| 2026-09-05 17:18 | Requests returned HTTP 403. DownloadCenter persisted the task as failed with a permission-style user error; no `ready` lifecycle transition was emitted. |
+
+## Root Cause And Fix
+
+1. Nexus exposes a short-lived signed `downloadUrl` plus a non-expiring GitHub `fallbackDownloadUrl` for the same release asset.
+2. The updater preserved only the signed URL. After expiry, HTTP 403 was classified as a terminal permission error even though the package had a verified fallback source.
+3. PR #1873 carries the fallback URL through release mapping and update-task metadata. On HTTP 403 only, the worker switches once to the fallback URL and resumes the current ranged chunk; HTTP 401 and unrelated permission failures remain terminal.
+4. Focused source-branch tests pass: signed URL mapping, 403 fallback with partial Range resume, non-403 fail-closed behavior, and worker cancellation propagation. CoreApp node typecheck and scoped ESLint pass.
+
+## Integrity Boundary
+
+- Source app: official `2.4.14-beta.24` macOS arm64 bundle; packaged attestation passed before the attempt.
+- Target manifest: official `v2.4.14-beta.25`; target package was not completed, so no target SHA/signature verification or replacement claim is made.
+- No token, signed URL query, cookie, full log, downloaded package, or real user profile is retained in this evidence.
+
+## Re-Acceptance Gate
+
+- Merge and publish a release containing PR #1873.
+- Re-run fresh official N -> N+1 macOS acceptance with the fallback path available.
+- Required terminal evidence remains `ready -> install-scheduled -> handoff-started -> awaiting-health -> healthy`, matching target version, package checksum/signature verification, no elevation prompt, no mounted DMG, and removable stage data.

--- a/.trellis/tasks/08-23-release-cicd-ota-acceptance/evidence/macos-ota-beta31-beta32.md
+++ b/.trellis/tasks/08-23-release-cicd-ota-acceptance/evidence/macos-ota-beta31-beta32.md
@@ -35,7 +35,7 @@
 
 - Before the install action, the long-running Beta31 source process aborted after a clipboard `vision.ocr` invocation. The minidump resolves the native frames to `tuff_native_ocr.node`, `Napi::AsyncWorker::OnWorkComplete`, and `Napi::Error::ThrowAsJavaScriptException`.
 - The parent called `worker.terminate()` as soon as the one-shot child posted its terminal result, even though the native completion callback could still be unwinding. The fix lets terminal success/error messages settle the promise and leaves forced termination to the pre-message timeout path.
-- Focused CoreApp OCR tests pass `18/18`; the regression turns red when immediate terminal-message termination is restored. A real Electron probe completed 200 native OCR workers with a result and natural exit code 0 for every worker. Beta32 still contains the old lifecycle, so this remains a promotion risk until a later official build carries the fix.
+- Focused CoreApp OCR tests pass `20/20`; the regression turns red when immediate terminal-message termination is restored. A real Electron probe completed 200 native OCR workers with a result and natural exit code 0 for every worker. Beta32 still contains the old lifecycle, so this remains a promotion risk until a later official build carries the fix.
 - This crash is not counted as an OTA transition failure: the persisted `ready` task survived, Beta31 restarted cleanly, and the subsequent handoff reached `healthy`.
 
 ## Evidence Boundary

--- a/.trellis/tasks/08-23-release-cicd-ota-acceptance/evidence/macos-ota-beta31-beta32.md
+++ b/.trellis/tasks/08-23-release-cicd-ota-acceptance/evidence/macos-ota-beta31-beta32.md
@@ -1,0 +1,45 @@
+# macOS OTA beta.31 -> beta.32
+
+## Classification
+
+- Result: **pass**. Official Beta31 discovered and downloaded official Beta32, resumed from the persisted ready state after a separate source-process crash, completed an explicit Settings UI install, replaced the app without elevation, launched Beta32, and reached token-bound startup health.
+- Scope: disposable official macOS arm64 app bundle and isolated profile under `/private/tmp`; the real `/Applications` bundle and normal user profile were not used.
+- Attempt: `d372f6b1-6b18-4325-8fc5-8f1a3e4a9358`; download task `be8d181e-cbfc-42f5-97ef-17e8a8353aec`.
+
+## Sanitized Timeline
+
+| UTC time | Evidence |
+| --- | --- |
+| 2026-09-07T19:36:48.942Z | Official Beta31 created the persisted update attempt for Nexus `v2.4.14-beta.32`. |
+| 2026-09-07T19:36:52.254Z | Download entered `downloading` for the macOS arm64 DMG. |
+| 2026-09-07T19:41:44.721Z | Download completed: `512529137 / 512529137` bytes, no persisted error, duration `292 s`. The lifecycle reached `ready`. |
+| 2026-09-08T05:21:55.729Z | Real Settings UI action `Restart to Update` was clicked after a fresh Beta31 restart recovered the same ready task. |
+| 2026-09-08T05:21:59.372Z | Install attempt committed `install-now`; the handoff plan bound Beta31, Beta32, the cached task, package digest, and a 120 s health deadline. |
+| 2026-09-08T05:22:00.968Z | Beta31 completed module teardown and started the update helper. |
+| 2026-09-08T05:23:50Z | Helper finished direct replacement without elevated privileges. |
+| 2026-09-08T05:23:56.956Z | LaunchServices started the replaced Beta32 bundle. |
+| 2026-09-08T05:23:59.093Z | Beta32 completed foreground startup health in `2.0 s`. |
+| 2026-09-08T05:24:00.278Z | Beta32 wrote the attempt-bound health acknowledgement with status `healthy` and version `2.4.14-beta.32`; SQLite reached revision 8 / `healthy` with no error code. |
+
+## Integrity And Handoff
+
+- Source: official signed/notarized `2.4.14-beta.31` macOS arm64 bundle with attestation commit `2dc227ed1e9785e872f0257650149308d2c80b74`.
+- Target: official `v2.4.14-beta.32` macOS arm64 DMG, `512529137` bytes.
+- Target SHA-256: `f5a3add492f860be642cfdd6818eace2ed0af4a5186228d8aaf110afcdad89d1`; manifest match and detached RSA/SHA-256 signature verification both passed before install.
+- Replaced bundle: version `2.4.14-beta.32`, arm64, attestation commit `a0854d8a901dd0cd4db59ed725725554e7ee0af5`; deep strict codesign and Gatekeeper notarization assessment passed.
+- Helper log records `installed without elevated privileges`. No sudo, AppleScript, password prompt, or UAC-style confirmation occurred.
+- The attempt used `rollbackCompatible=false`; no rollback was claimed or exercised.
+- No attempt-specific DMG mount remained after completion.
+
+## Separate Soak Finding
+
+- Before the install action, the long-running Beta31 source process aborted after a clipboard `vision.ocr` invocation. The minidump resolves the native frames to `tuff_native_ocr.node`, `Napi::AsyncWorker::OnWorkComplete`, and `Napi::Error::ThrowAsJavaScriptException`.
+- The parent called `worker.terminate()` as soon as the one-shot child posted its terminal result, even though the native completion callback could still be unwinding. The fix lets terminal success/error messages settle the promise and leaves forced termination to the pre-message timeout path.
+- Focused CoreApp OCR tests pass `18/18`; the regression turns red when immediate terminal-message termination is restored. A real Electron probe completed 200 native OCR workers with a result and natural exit code 0 for every worker. Beta32 still contains the old lifecycle, so this remains a promotion risk until a later official build carries the fix.
+- This crash is not counted as an OTA transition failure: the persisted `ready` task survived, Beta31 restarted cleanly, and the subsequent handoff reached `healthy`.
+
+## Evidence Boundary
+
+- No token-bound health secret, signed URL query, cookie, credential, private key, complete log, minidump, downloaded package, or real user profile is stored in repository evidence.
+- This closes the official macOS N/N+1 requirement in AC6 for Beta31 -> Beta32.
+- Windows and Linux N/N+1 runtime evidence remains open.

--- a/.trellis/tasks/08-23-release-cicd-ota-acceptance/evidence/release-matrix-beta32.md
+++ b/.trellis/tasks/08-23-release-cicd-ota-acceptance/evidence/release-matrix-beta32.md
@@ -1,0 +1,28 @@
+# Release Matrix v2.4.14-beta.32
+
+## Classification
+
+- Result: **pass**. Strict production Gate E completed with `18/18` checks passing.
+- Scope: published GitHub release, release workflow, Nexus latest projection, manifest v2, preferred platform assets, canonical download routes, package integrity, macOS native trust, and packaged attestation.
+- Privacy: signed URL queries, credentials, cookies, tokens, complete remote payloads, full logs, and downloaded binaries are not retained here.
+
+## Release Identity And Workflow
+
+- GitHub release `v2.4.14-beta.32` is a published prerelease targeting commit `a0854d8a901dd0cd4db59ed725725554e7ee0af5`; it contains 26 assets.
+- Build and Release run `34152177281` completed successfully. The same-SHA Release Quality job, macOS, Windows, and Linux build jobs, and Create Release job all passed.
+- The manifest identifies version `2.4.14-beta.32`, channel `BETA`, tag `v2.4.14-beta.32`, rollback source `2.4.14-beta.31`, and `rollbackCompatible=false`.
+- Nexus latest resolves the same tag/version and projects all four preferred platform pairs with signed same-origin download routes plus immutable GitHub fallback routes.
+
+## Gate E And Artifact Integrity
+
+- Command: `node scripts/check-release-gates.mjs --tag "v2.4.14-beta.32" --version "2.4.14-beta.32" --stage "gate-e" --manifest <downloaded-manifest> --base-url "https://tuff.tagzxia.com" --timeout-ms "60000"`.
+- Result: `pass`; status counts were `{ pass: 18 }`; no non-pass checks were returned.
+- The official macOS arm64 updater asset is `512529137` bytes. Its downloaded SHA-256 is `f5a3add492f860be642cfdd6818eace2ed0af4a5186228d8aaf110afcdad89d1`, matching the manifest, and its detached RSA/SHA-256 signature verifies with the repository release public key.
+- The installed target bundle reports `2.4.14-beta.32`, arm64, and attestation commit `a0854d8a901dd0cd4db59ed725725554e7ee0af5`.
+- The replaced bundle passes `codesign --verify --deep --strict` and Gatekeeper reports `source=Notarized Developer ID`.
+
+## Boundary
+
+- This closes the release-matrix portion of AC5 for Beta32.
+- It does not substitute static release metadata for N/N+1 runtime evidence; the macOS runtime transition is recorded separately.
+- Windows and Linux still require their own real N/N+1 runtime evidence before AC7 can pass.

--- a/.trellis/tasks/08-23-release-cicd-ota-acceptance/prd.md
+++ b/.trellis/tasks/08-23-release-cicd-ota-acceptance/prd.md
@@ -21,7 +21,7 @@
 - Beta29 -> Beta30 的新鲜隔离 macOS arm64 OTA 已完成 signed URL 403 fallback、SHA-256 校验、DMG 原位替换、无提权 handoff、Beta30 官方 attestation 和 startup health；但目标进程仍从 workspace 根 package metadata 解析为 Beta29，启动时进入 recovery-required 且未写入 healthy ack，另暴露 release notes catalog 版本不一致。根因是主进程 `polyfills.ts`/`version-util.ts` 读取根 `package.json`，而 Builder 打包的 CoreApp metadata 已是 Beta30；已切换为 `apps/core-app/package.json`，需包含该修复的新官方版本重新执行 AC6。
 - Beta32 的 GitHub release、Nexus latest、manifest v2、四个首选平台资产、签名下载路由与回退路由已收敛；严格生产 Gate E `18/18` 通过，macOS arm64 OTA 下载包 SHA-256 和 detached RSA 签名与 manifest 一致，详见 `evidence/release-matrix-beta32.md`。
 - 官方 macOS arm64 Beta31 -> Beta32 已从隔离 profile 完成发现、下载、校验、Settings UI `Restart to Update`、无提权 helper、DMG 原位替换、Beta32 官方 attestation、startup health 和 attempt-bound `healthy` ack；SQLite 终态 revision 8 / `healthy`，详见 `evidence/macos-ota-beta31-beta32.md`。
-- 同一隔离源进程在安装前的 clipboard `vision.ocr` 成功返回后 abort；minidump 指向 `tuff_native_ocr.node` 的 N-API AsyncWorker 完成路径。根因是父进程在 terminal message 到达时立即 `worker.terminate()`，可能在 native completion callback 尚未退栈时销毁环境；本地已改为 terminal message 后自然退出，聚焦测试 `18/18`、负向变异和 200 个真实 Electron native worker 自然退出 smoke 通过。Beta32 仍含旧实现，修复必须随下一官方版本发布后再解除推广风险。
+- 同一隔离源进程在安装前的 clipboard `vision.ocr` 成功返回后 abort；minidump 指向 `tuff_native_ocr.node` 的 N-API AsyncWorker 完成路径。根因是父进程在 terminal message 到达时立即 `worker.terminate()`，可能在 native completion callback 尚未退栈时销毁环境；本地已改为 terminal message 后自然退出，并验证 jobId/result/error 消息边界，聚焦测试 `20/20`、负向变异和 200 个真实 Electron native worker 自然退出 smoke 通过。Beta32 仍含旧实现，修复必须随下一官方版本发布后再解除推广风险。
 
 ## Requirements
 

--- a/.trellis/tasks/08-23-release-cicd-ota-acceptance/prd.md
+++ b/.trellis/tasks/08-23-release-cicd-ota-acceptance/prd.md
@@ -6,7 +6,7 @@
 
 ## Confirmed Facts
 
-- 当前真实版本为 `2.4.14-beta.32`；该 tag 的 Windows、macOS arm64/x64 与 Linux 发布产物、签名、公证、同 SHA `release-quality` 和生产 Gate E 基线均已通过。
+- 最新已验证发布版本为 `2.4.14-beta.32`；该 tag 的 Windows、macOS arm64/x64 与 Linux 发布产物、签名、公证、同 SHA `release-quality` 和生产 Gate E 基线均已通过。`2.4.14-beta.33` 目前仅为未发布修复候选，不复用 Beta32 的发布或 OTA 证据。
 - `ci.yml` 对 pull request 与 master push 无路径过滤；GitHub `master` 的经典 branch protection 已启用 7 个稳定 required checks，最近 5 个 PR SHA 与最近 6 个 master SHA 均完整产生这些 context。`enforce_admins=true`、conversation resolution 已启用、`strict=false`；唯一 ruleset 仍处于 disabled。脱敏证据见 `evidence/github-remote-baseline.md`。
 - `build-and-release.yml` 已增加同一 SHA 的 `release-quality` 硬依赖；workflow 合同与负向变异证明 build/create/sync 不能绕过失败 gate。
 - 当前工作区包含跨 CoreApp、Nexus、Utils 和三个插件的未提交批次，远端全绿不能证明这批代码可发布。

--- a/.trellis/tasks/08-23-release-cicd-ota-acceptance/prd.md
+++ b/.trellis/tasks/08-23-release-cicd-ota-acceptance/prd.md
@@ -6,7 +6,7 @@
 
 ## Confirmed Facts
 
-- 当前真实版本为 `2.4.14-beta.14`；该 tag 的 Windows、macOS arm64/x64 与 Linux 发布产物、签名和公证基线已存在。
+- 当前真实版本为 `2.4.14-beta.32`；该 tag 的 Windows、macOS arm64/x64 与 Linux 发布产物、签名、公证、同 SHA `release-quality` 和生产 Gate E 基线均已通过。
 - `ci.yml` 对 pull request 与 master push 无路径过滤；GitHub `master` 的经典 branch protection 已启用 7 个稳定 required checks，最近 5 个 PR SHA 与最近 6 个 master SHA 均完整产生这些 context。`enforce_admins=true`、conversation resolution 已启用、`strict=false`；唯一 ruleset 仍处于 disabled。脱敏证据见 `evidence/github-remote-baseline.md`。
 - `build-and-release.yml` 已增加同一 SHA 的 `release-quality` 硬依赖；workflow 合同与负向变异证明 build/create/sync 不能绕过失败 gate。
 - 当前工作区包含跨 CoreApp、Nexus、Utils 和三个插件的未提交批次，远端全绿不能证明这批代码可发布。
@@ -17,6 +17,11 @@
 - 本地 Nexus 下载 resolver 已修复 `allowUnsignedFallback=false` 时 `missing-secret` 错误放行：GET/HEAD 现在均 fail-closed 返回 `403`，聚焦回归 `14/14`、Nexus typecheck 与 scoped ESLint 通过。该改动尚未部署，不改变 beta.14 生产 Gate E 的失败结论。
 - beta.14 的远端 release workflow 已在 GitHub-hosted `windows-2022`、`ubuntu-24.04`、`macos-26` runner 完成三平台构建与 packaged-launch smoke；release summary 同时明确 downgrade/OTA 证据仍为 `static-only`，因此该运行不能关闭 AC6/AC7。当前本地新增的 `release-quality` 尚未进入远端 workflow，最近发布运行也没有该 job。
 - Linux packaged updater 的两个源码缺陷已在本地修复：apply helper 进入 `extraResources`，hosted runner 的官方 no-FUSE 环境会跨 helper 继承到更新后重启；脚本不再从 `APPDIR` 猜测模式，AppImage/deb 失败日志也不泄漏完整路径。受控脚本、adapter、handoff 与 workflow tests 全绿，负向变异可拦截配置回退；但尚无包含修复的官方 Linux N -> N+1 runtime 证据，详见 `evidence/linux-packaged-updater-controlled.md`。
+- Beta24 -> Beta25 的新鲜隔离尝试在下载达到约 53% 后因 Nexus signed URL 短时过期返回 HTTP 403 而失败，未进入安装；PR #1873 保留 `fallbackDownloadUrl` 并仅在 403 时恢复同一分块，需随新官方版本复验。证据见 `evidence/macos-ota-beta24-beta25-signed-url-expiry.md`。
+- Beta29 -> Beta30 的新鲜隔离 macOS arm64 OTA 已完成 signed URL 403 fallback、SHA-256 校验、DMG 原位替换、无提权 handoff、Beta30 官方 attestation 和 startup health；但目标进程仍从 workspace 根 package metadata 解析为 Beta29，启动时进入 recovery-required 且未写入 healthy ack，另暴露 release notes catalog 版本不一致。根因是主进程 `polyfills.ts`/`version-util.ts` 读取根 `package.json`，而 Builder 打包的 CoreApp metadata 已是 Beta30；已切换为 `apps/core-app/package.json`，需包含该修复的新官方版本重新执行 AC6。
+- Beta32 的 GitHub release、Nexus latest、manifest v2、四个首选平台资产、签名下载路由与回退路由已收敛；严格生产 Gate E `18/18` 通过，macOS arm64 OTA 下载包 SHA-256 和 detached RSA 签名与 manifest 一致，详见 `evidence/release-matrix-beta32.md`。
+- 官方 macOS arm64 Beta31 -> Beta32 已从隔离 profile 完成发现、下载、校验、Settings UI `Restart to Update`、无提权 helper、DMG 原位替换、Beta32 官方 attestation、startup health 和 attempt-bound `healthy` ack；SQLite 终态 revision 8 / `healthy`，详见 `evidence/macos-ota-beta31-beta32.md`。
+- 同一隔离源进程在安装前的 clipboard `vision.ocr` 成功返回后 abort；minidump 指向 `tuff_native_ocr.node` 的 N-API AsyncWorker 完成路径。根因是父进程在 terminal message 到达时立即 `worker.terminate()`，可能在 native completion callback 尚未退栈时销毁环境；本地已改为 terminal message 后自然退出，聚焦测试 `18/18`、负向变异和 200 个真实 Electron native worker 自然退出 smoke 通过。Beta32 仍含旧实现，修复必须随下一官方版本发布后再解除推广风险。
 
 ## Requirements
 
@@ -36,8 +41,8 @@
 - [x] release 构建明确 `needs` 同 SHA quality gate，且负向测试证明 gate 失败时 build/create-release 不可运行。
 - [x] master required checks 已启用并指向无路径过滤的确定性 job；远端状态有可核对证据。
 - [x] 每个 package CI/publish workflow 与包脚本/依赖一致，关键 package 的 build/typecheck/test 不再软跳过。
-- [ ] 当前发布 tag 的 GitHub/Nexus/latest/manifest/rollback/签名/架构矩阵一致，真实 host 下载 SHA-256 与 manifest/GitHub 一致。
-- [ ] 官方 macOS N/N+1 一键静默替换和 health ack 真机通过，记录 bounded timestamps 与失败恢复状态。
+- [x] 当前发布 tag 的 GitHub/Nexus/latest/manifest/rollback/签名/架构矩阵一致，真实 host 下载 SHA-256 与 manifest/GitHub 一致。
+- [x] 官方 macOS N/N+1 一键静默替换和 health ack 真机通过，记录 bounded timestamps 与失败恢复状态。
 - [ ] Windows/Linux 真实平台 workflow 或宿主 smoke 通过；不能执行的项明确 blocked/static-only，不伪造完成。
 - [ ] actionlint、release acceptance tests、构建前置检查、release summary 和文档同步全部通过。
 
@@ -49,10 +54,10 @@
 | AC2 | pass | 同 SHA release gate 已形成硬依赖，合同测试与负向变异通过。 |
 | AC3 | pass | `master` 已启用 7 个 GitHub Actions required checks；最近 5 个 PR SHA 与最近 6 个 master SHA 均完整产生，失败提交也真实呈现失败或取消。`strict=false` 作为非阻塞限制保留。 |
 | AC4 | pass | tuff-cli CI/publish 假绿已修复，workflow contracts `33/33` 与 CLI tests `6/6` 通过。 |
-| AC5 | partial | 资产、manifest、签名、宿主 macOS 信任通过；生产 Nexus 同源签名下载投影缺失，严格 Gate E 失败。 |
-| AC6 | blocked | beta.13 -> beta.14 在目标 startup health 失败；需官方 post-fix N -> N+1 复验。 |
-| AC7 | blocked | Linux helper 打包、替换/恢复与 no-FUSE 重启源码缺陷已修并通过受控测试；Windows/Linux 远端 release summary 仍为 `static-only`，尚无官方 N/N+1 的发现、下载、替换、handoff 与 health-ack 证据。 |
-| AC8 | partial | actionlint、release checks、本地 `quality:release` 和 Linux updater 聚焦门禁通过，见 `evidence/local-release-preflight.md` 与 `evidence/linux-packaged-updater-controlled.md`；Gate E、新 `release-quality` 的远端运行、跨平台/双版本真机及最终文档收尾未闭环。 |
+| AC5 | pass | Beta32 GitHub/Nexus/latest/manifest/rollback/签名/架构矩阵一致；严格生产 Gate E `18/18`，真实 macOS arm64 下载 SHA-256 与 detached 签名通过。 |
+| AC6 | pass | 官方 Beta31 -> Beta32 完成 ready、Settings UI install、无提权 handoff、原位替换、Beta32 startup health 与 attempt-bound `healthy` ack。 |
+| AC7 | blocked | Linux helper 打包、替换/恢复与 no-FUSE 重启源码缺陷已修并通过受控测试；Windows/Linux 尚无官方 N/N+1 的发现、下载、替换、handoff 与 health-ack 真机证据。 |
+| AC8 | partial | actionlint、release checks、本地 `quality:release`、Beta32 同 SHA `release-quality`、严格 Gate E 和 macOS N/N+1 已通过；Windows/Linux 真机及最终文档收尾未闭环。 |
 
 ## Out of Scope
 

--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/core-app",
-  "version": "2.4.14-beta.32",
+  "version": "2.4.14-beta.33",
   "private": true,
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/apps/core-app/src/main/modules/ocr/ocr-service.test.ts
+++ b/apps/core-app/src/main/modules/ocr/ocr-service.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 const workerMocks = vi.hoisted(() => ({
-  instances: [] as Array<{ workerData: unknown }>
+  instances: [] as Array<{ workerData: unknown; terminateCalls: number }>
 }))
 
 const {
@@ -137,9 +137,11 @@ vi.mock('node:worker_threads', async (importOriginal) => {
     ...actual,
     Worker: class {
       private readonly listeners = new Map<string, (payload: unknown) => void>()
+      private readonly instance: { workerData: unknown; terminateCalls: number }
 
       constructor(_workerPath: string, options: { workerData: unknown }) {
-        workerMocks.instances.push({ workerData: options.workerData })
+        this.instance = { workerData: options.workerData, terminateCalls: 0 }
+        workerMocks.instances.push(this.instance)
         queueMicrotask(() => {
           this.listeners.get('message')?.({ status: 'success', result: { text: 'worker-path' } })
         })
@@ -151,6 +153,7 @@ vi.mock('node:worker_threads', async (importOriginal) => {
       }
 
       terminate() {
+        this.instance.terminateCalls += 1
         return Promise.resolve(0)
       }
     }
@@ -455,7 +458,7 @@ describe('OcrService runAgentJob local-first options', () => {
     }
   })
 
-  it('forwards an unhinted clipboard OCR job to the native worker', async () => {
+  it('lets the worker exit after a success message instead of terminating during N-API completion', async () => {
     const service = ocrService as unknown as OcrServiceTestAccess
 
     const response = await service.invokeWorkerOcr(
@@ -480,6 +483,7 @@ describe('OcrService runAgentJob local-first options', () => {
       options: { language?: string }
     }
     expect(workerData.options.language).toBeUndefined()
+    expect(workerMocks.instances[0]?.terminateCalls).toBe(0)
   })
 
   it('falls back to provider invocation when worker path fails', async () => {

--- a/apps/core-app/src/main/modules/ocr/ocr-service.test.ts
+++ b/apps/core-app/src/main/modules/ocr/ocr-service.test.ts
@@ -4,7 +4,8 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 const workerMocks = vi.hoisted(() => ({
-  instances: [] as Array<{ workerData: unknown; terminateCalls: number }>
+  instances: [] as Array<{ workerData: unknown; terminateCalls: number }>,
+  terminalMessage: undefined as unknown
 }))
 
 const {
@@ -139,11 +140,17 @@ vi.mock('node:worker_threads', async (importOriginal) => {
       private readonly listeners = new Map<string, (payload: unknown) => void>()
       private readonly instance: { workerData: unknown; terminateCalls: number }
 
-      constructor(_workerPath: string, options: { workerData: unknown }) {
+      constructor(_workerPath: string, options: { workerData: { jobId: number } }) {
         this.instance = { workerData: options.workerData, terminateCalls: 0 }
         workerMocks.instances.push(this.instance)
         queueMicrotask(() => {
-          this.listeners.get('message')?.({ status: 'success', result: { text: 'worker-path' } })
+          this.listeners.get('message')?.(
+            workerMocks.terminalMessage ?? {
+              status: 'success',
+              jobId: options.workerData.jobId,
+              result: { text: 'worker-path' }
+            }
+          )
         })
       }
 
@@ -200,6 +207,7 @@ interface OcrServiceTestAccess {
 
 afterEach(() => {
   workerMocks.instances.length = 0
+  workerMocks.terminalMessage = undefined
   vi.restoreAllMocks()
   ensureIntelligenceConfigLoadedMock.mockReset()
   getCapabilityOptionsMock.mockReset()
@@ -483,6 +491,66 @@ describe('OcrService runAgentJob local-first options', () => {
       options: { language?: string }
     }
     expect(workerData.options.language).toBeUndefined()
+    expect(workerMocks.instances[0]?.terminateCalls).toBe(0)
+  })
+
+  it('rejects malformed success messages without terminating during N-API completion', async () => {
+    const service = ocrService as unknown as OcrServiceTestAccess
+    workerMocks.terminalMessage = {
+      status: 'success',
+      jobId: 13,
+      result: { text: 42 }
+    }
+
+    await expect(
+      service.invokeWorkerOcr(
+        13,
+        {
+          clipboardId: 501,
+          payloadHash: 'worker-malformed-success'
+        },
+        {
+          source: { type: 'file', filePath: '/tmp/clipboard-image.png' },
+          options: {}
+        },
+        {
+          type: 'file',
+          filePath: '/tmp/clipboard-image.png'
+        }
+      )
+    ).rejects.toThrow('[OCR Worker] Invalid success response payload')
+
+    expect(workerMocks.instances).toHaveLength(1)
+    expect(workerMocks.instances[0]?.terminateCalls).toBe(0)
+  })
+
+  it('rejects success messages for another job without terminating during N-API completion', async () => {
+    const service = ocrService as unknown as OcrServiceTestAccess
+    workerMocks.terminalMessage = {
+      status: 'success',
+      jobId: 15,
+      result: { text: 'worker-path' }
+    }
+
+    await expect(
+      service.invokeWorkerOcr(
+        14,
+        {
+          clipboardId: 502,
+          payloadHash: 'worker-mismatched-job'
+        },
+        {
+          source: { type: 'file', filePath: '/tmp/clipboard-image.png' },
+          options: {}
+        },
+        {
+          type: 'file',
+          filePath: '/tmp/clipboard-image.png'
+        }
+      )
+    ).rejects.toThrow('[OCR Worker] Invalid worker response payload')
+
+    expect(workerMocks.instances).toHaveLength(1)
     expect(workerMocks.instances[0]?.terminateCalls).toBe(0)
   })
 

--- a/apps/core-app/src/main/modules/ocr/ocr-service.ts
+++ b/apps/core-app/src/main/modules/ocr/ocr-service.ts
@@ -309,11 +309,12 @@ class OcrService {
         finishReject(new Error(`[OCR Worker] Timeout after ${OCR_WORKER_TIMEOUT_MS}ms`))
       }, OCR_WORKER_TIMEOUT_MS)
 
+      // A terminal message can be posted while native OCR is still unwinding its N-API
+      // completion callback. Let the worker exit naturally instead of terminating that callback.
       worker.once('message', (message: unknown) => {
         const payload =
           message && typeof message === 'object' ? (message as Record<string, unknown>) : null
         if (!payload) {
-          void worker.terminate().catch(() => {})
           finishReject(new Error('[OCR Worker] Invalid worker response payload'))
           return
         }
@@ -323,7 +324,6 @@ class OcrService {
             payload.result && typeof payload.result === 'object'
               ? (payload.result as Record<string, unknown>)
               : {}
-          void worker.terminate().catch(() => {})
           finishResolve({
             text: typeof resultPayload.text === 'string' ? resultPayload.text : '',
             confidence:
@@ -350,7 +350,6 @@ class OcrService {
           typeof payload.error === 'string'
             ? payload.error
             : `[OCR Worker] Unknown worker error for job ${jobId}`
-        void worker.terminate().catch(() => {})
         finishReject(new Error(messageText))
       })
 

--- a/apps/core-app/src/main/modules/ocr/ocr-service.ts
+++ b/apps/core-app/src/main/modules/ocr/ocr-service.ts
@@ -313,19 +313,25 @@ class OcrService {
       // completion callback. Let the worker exit naturally instead of terminating that callback.
       worker.once('message', (message: unknown) => {
         const payload =
-          message && typeof message === 'object' ? (message as Record<string, unknown>) : null
-        if (!payload) {
+          message && typeof message === 'object' && !Array.isArray(message)
+            ? (message as Record<string, unknown>)
+            : null
+        if (!payload || payload.jobId !== jobId) {
           finishReject(new Error('[OCR Worker] Invalid worker response payload'))
           return
         }
 
         if (payload.status === 'success') {
           const resultPayload =
-            payload.result && typeof payload.result === 'object'
+            payload.result && typeof payload.result === 'object' && !Array.isArray(payload.result)
               ? (payload.result as Record<string, unknown>)
-              : {}
+              : null
+          if (!resultPayload || typeof resultPayload.text !== 'string') {
+            finishReject(new Error('[OCR Worker] Invalid success response payload'))
+            return
+          }
           finishResolve({
-            text: typeof resultPayload.text === 'string' ? resultPayload.text : '',
+            text: resultPayload.text,
             confidence:
               typeof resultPayload.confidence === 'number' ? resultPayload.confidence : undefined,
             language:
@@ -346,11 +352,11 @@ class OcrService {
           return
         }
 
-        const messageText =
-          typeof payload.error === 'string'
-            ? payload.error
-            : `[OCR Worker] Unknown worker error for job ${jobId}`
-        finishReject(new Error(messageText))
+        if (payload.status !== 'error' || typeof payload.error !== 'string' || !payload.error) {
+          finishReject(new Error('[OCR Worker] Invalid error response payload'))
+          return
+        }
+        finishReject(new Error(payload.error))
       })
 
       worker.once('error', (error) => {

--- a/notes/update_2.4.14-beta.33.en.md
+++ b/notes/update_2.4.14-beta.33.en.md
@@ -1,0 +1,12 @@
+# Tuff v2.4.14-beta.33 Release Notes
+
+## Summary Notes
+
+- Clipboard image OCR no longer risks terminating the application after native recognition succeeds.
+- One-shot OCR workers now finish their native completion callbacks and exit naturally after delivering a result.
+- Hung OCR workers remain bounded by the existing timeout and are still force-terminated before terminal delivery.
+
+## What's Changed
+
+- Fixed a packaged macOS crash whose minidump ended in `tuff_native_ocr.node` while the parent terminated a worker during `Napi::AsyncWorker::OnWorkComplete`.
+- Terminal OCR worker messages now settle the parent request without calling `worker.terminate()`; only the pre-message timeout retains forced termination.

--- a/notes/update_2.4.14-beta.33.zh.md
+++ b/notes/update_2.4.14-beta.33.zh.md
@@ -1,0 +1,12 @@
+# Tuff v2.4.14-beta.33 更新说明
+
+## 摘要
+
+- 剪贴板图片 OCR 在原生识别成功后，不再因 worker 退出竞态导致应用终止。
+- 一次性 OCR worker 交付结果后，会等待原生完成回调退栈并自然退出。
+- 无响应的 OCR worker 仍受现有超时约束，并会在尚未交付终态时被强制终止。
+
+## 变更内容
+
+- 修复打包 macOS 进程在父进程于 `Napi::AsyncWorker::OnWorkComplete` 期间终止 worker 时，崩溃栈落入 `tuff_native_ocr.node` 的问题。
+- OCR worker 的终态消息现在只负责结算父请求，不再调用 `worker.terminate()`；强制终止仅保留在终态消息到达前的超时路径。

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@talex-touch/tuff",
   "homepage": "https://tuff.tagzxia.com",
   "type": "module",
-  "version": "2.4.14-beta.32",
+  "version": "2.4.14-beta.33",
   "packageManager": "pnpm@11.24.0",
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",


### PR DESCRIPTION
## Problem
A long-running packaged Beta31 process aborted immediately after clipboard OCR succeeded. The minidump resolves the native frames to `tuff_native_ocr.node`, `Napi::AsyncWorker::OnWorkComplete`, and `Napi::Error::ThrowAsJavaScriptException`. The parent terminated the one-shot worker as soon as its terminal message arrived, while the native completion callback could still be unwinding.

## Change
- Settle terminal success/error/malformed messages without `worker.terminate()`; retain forced termination for the pre-message timeout.
- Validate exact `jobId`, success `result.text`, and error message shape before settlement.
- Add regressions for natural success delivery, malformed success payloads, and cross-job messages.
- Record the one-shot native worker lifecycle contract and Beta32 Gate E/macOS OTA evidence.

## Verification
- `pnpm exec vitest run src/main/modules/ocr/ocr-service.test.ts` — 20/20 pass
- `pnpm run typecheck:node` — pass
- scoped ESLint — pass
- negative mutation: restoring immediate termination fails the natural-exit assertion (`1` vs `0`)
- real Electron probe: 200 native OCR workers each returned `TUFF` and exited naturally with code 0

## Release note
Beta32 still contains the old worker lifecycle; this fix ships as the Beta33 candidate and requires packaged runtime verification before the OCR promotion risk is cleared.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved clipboard image OCR reliability on macOS by preventing app crashes after native recognition completes.
  - OCR workers now finish native callbacks and exit cleanly after delivering results.
  - Added stricter validation for OCR responses to prevent invalid or mismatched results from being accepted.
  - Unresponsive OCR operations remain protected by timeout handling and are force-terminated when no result is delivered.

- **Release**
  - Updated the application to version 2.4.14-beta.33.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->