### PR TITLE
docs(release): record Beta33 OTA acceptance

### DIFF
--- a/.trellis/tasks/08-23-release-cicd-ota-acceptance/evidence/macos-ota-beta32-beta33.md
+++ b/.trellis/tasks/08-23-release-cicd-ota-acceptance/evidence/macos-ota-beta32-beta33.md
@@ -1,0 +1,43 @@
+# macOS OTA beta.32 -> beta.33
+
+## Classification
+
+- Result: **pass**. Official Beta32 discovered and downloaded official Beta33, verified the package, completed a real Settings UI `Restart to Update`, replaced the app without elevation, launched Beta33, and reached the attempt-bound startup health acknowledgement.
+- Scope: disposable official macOS arm64 app bundle and isolated profile under `/private/tmp`; the real `/Applications` bundle and normal user profile were not used.
+- Attempt: `99589c2a-a856-4704-8ac9-e7a6998f0096`; download task `8ff4068c-9430-43e1-b790-7ad4c25cc27b`.
+
+## Sanitized Timeline
+
+| UTC time | Evidence |
+| --- | --- |
+| 2026-09-08T11:36:50Z | Official Beta32 started in the isolated profile and passed packaged startup health. |
+| 2026-09-08T11:37:01.401Z | Nexus update discovery selected `v2.4.14-beta.33`; the macOS arm64 download task started. |
+| 2026-09-08T11:42:30.328Z | Download completed: `512650125 / 512650125` bytes, persisted with no error. |
+| 2026-09-08T12:11:52.853Z | The explicit Settings UI install action created the attempt and bound target version, task, package digest, and a 120 s health deadline. |
+| 2026-09-08T12:11:55Z | macOS handoff helper started after Beta32 teardown. |
+| 2026-09-08T12:13:12Z | Helper completed direct replacement without elevated privileges. |
+| 2026-09-08T12:13:16Z | LaunchServices started the replaced Beta33 bundle. |
+| 2026-09-08T12:13:17.920Z | Beta33 completed foreground startup health in `1.4 s`. |
+| 2026-09-08T12:13:18.182Z | Beta33 wrote the attempt-bound health acknowledgement with status `healthy` and version `2.4.14-beta.33`; SQLite reached revision 8 / `healthy` with no error code. |
+
+## Integrity And Handoff
+
+- Source: official signed/notarized `2.4.14-beta.32` macOS arm64 bundle with attestation commit `a0854d8a901dd0cd4db59ed725725554e7ee0af5`.
+- Target: official `v2.4.14-beta.33` macOS arm64 DMG, `512650125` bytes.
+- Target SHA-256: `7fcd24bb1b5c8164dacfb18402a5b4997077586ebf66fd18d47a555ab8514858`; manifest match and detached RSA/SHA-256 signature verification passed before install.
+- Replaced bundle: version `2.4.14-beta.33`, arm64, attestation commit `58e6a8da7e67d0cce530e865fc4afe100afb86b8`; deep strict codesign and Gatekeeper notarization assessment passed.
+- Helper log records `installed without elevated privileges`. No sudo, AppleScript, password prompt, or elevation dialog occurred.
+- The attempt used `rollbackCompatible=false`; no rollback was claimed or exercised.
+- No recovery marker or attempt-specific DMG mount remained after completion.
+
+## Packaged OCR Regression Smoke
+
+- A separate fresh Beta33 packaged instance ran with `TUFF_OCR_WORKER_ENABLED=1` and the real native OCR worker. Eleven queued image jobs using the project fixture all completed with status `completed`, one attempt each, and recognized `TUFF` (`11/11`).
+- The supervised packaged process remained alive after the OCR batch; no `Napi`, `SIGABRT`, or OCR failure record appeared in its isolated stderr/crash directory.
+- This runtime smoke complements the source regression suite (`20/20`) and verifies the fix is present in a published packaged build. It is not a claim that every possible native Vision input is crash-free.
+
+## Evidence Boundary
+
+- No token-bound health secret, signed URL query, cookie, credential, private key, complete log, minidump, downloaded package, or real user profile is stored in repository evidence.
+- This closes the macOS N/N+1 runtime evidence for Beta32 -> Beta33 and verifies the OCR lifecycle fix in the packaged target.
+- Windows and Linux N/N+1 runtime evidence remains open.

--- a/.trellis/tasks/08-23-release-cicd-ota-acceptance/evidence/release-matrix-beta33.md
+++ b/.trellis/tasks/08-23-release-cicd-ota-acceptance/evidence/release-matrix-beta33.md
@@ -1,0 +1,29 @@
+# Release Matrix v2.4.14-beta.33
+
+## Classification
+
+- Result: **pass**. The first macOS build attempt failed at DMG cleanup because the hosted runner could not eject a busy device; the failed run was not published. The failed macOS job was rerun, then the release was created and Nexus was synchronized successfully.
+- Scope: published GitHub release, same-SHA quality gate, three-platform builds, macOS signing/notarization, Nexus latest projection, manifest v2, preferred platform assets, and production Gate E.
+- Privacy: signed URL queries, credentials, cookies, tokens, complete remote payloads, full logs, and downloaded binaries are not retained here.
+
+## Release Identity And Workflow
+
+- GitHub release `v2.4.14-beta.33` is a published prerelease targeting master merge commit `58e6a8da7e67d0cce530e865fc4afe100afb86b8`; it contains 26 assets.
+- Build and Release workflow run `34205184498` completed successfully after the failed macOS job was rerun. Final jobs: Release Quality, Ubuntu 24.04, Windows 2022, macOS 26, Create Release, and Sync Nexus all passed.
+- The first macOS attempt failed only at `dmgbuild` detach with `hdiutil: couldn't eject ... Resource busy`; no release was created from that attempt. The rerun completed the same build, signing, notarization, artifact verification, and smoke steps.
+- The manifest identifies version `2.4.14-beta.33`, channel `BETA`, tag `v2.4.14-beta.33`, rollback source `2.4.14-beta.32`, and `rollbackCompatible=false`.
+- Nexus latest resolves the same tag/version and exposes all four preferred platform pairs with signed same-origin download projection plus GitHub fallback and signature metadata.
+
+## Gate E And Artifact Integrity
+
+- Command: `node scripts/check-release-gates.mjs --tag "v2.4.14-beta.33" --version "2.4.14-beta.33" --stage "gate-e" --manifest <downloaded-manifest> --base-url "https://tuff.tagzxia.com" --timeout-ms "60000"`.
+- Result: `pass`; status counts were `{ pass: 18 }`; no non-pass checks were returned.
+- The manifest and Nexus projection agree on the preferred asset sizes and SHA-256 values. The macOS arm64 DMG is `512650125` bytes with SHA-256 `7fcd24bb1b5c8164dacfb18402a5b4997077586ebf66fd18d47a555ab8514858`; its detached RSA/SHA-256 signature verifies with the repository release public key.
+- The macOS arm64 artifact contains version `2.4.14-beta.33`, arm64 executable metadata, and attestation commit `58e6a8da7e67d0cce530e865fc4afe100afb86b8`.
+- The installed target bundle passes `codesign --verify --deep --strict`; Gatekeeper reports `source=Notarized Developer ID`.
+
+## Boundary
+
+- This closes the Beta33 release-matrix and production Gate E evidence.
+- It does not substitute release metadata for N/N+1 runtime evidence; the actual Beta32 -> Beta33 transition is recorded separately.
+- Windows and Linux still require their own real N/N+1 runtime evidence before AC7 can pass.

--- a/.trellis/tasks/08-23-release-cicd-ota-acceptance/prd.md
+++ b/.trellis/tasks/08-23-release-cicd-ota-acceptance/prd.md
@@ -6,7 +6,7 @@
 
 ## Confirmed Facts
 
-- 最新已验证发布版本为 `2.4.14-beta.32`；该 tag 的 Windows、macOS arm64/x64 与 Linux 发布产物、签名、公证、同 SHA `release-quality` 和生产 Gate E 基线均已通过。`2.4.14-beta.33` 目前仅为未发布修复候选，不复用 Beta32 的发布或 OTA 证据。
+- 最新已验证发布版本为 `2.4.14-beta.33`；Beta33 的 Windows、macOS arm64/x64 与 Linux 发布产物、签名、公证、同 SHA `release-quality`、生产 Gate E 和 macOS arm64 N/N+1 OTA 均已通过。Beta32 的历史证据保持独立，不跨版本复用。
 - `ci.yml` 对 pull request 与 master push 无路径过滤；GitHub `master` 的经典 branch protection 已启用 7 个稳定 required checks，最近 5 个 PR SHA 与最近 6 个 master SHA 均完整产生这些 context。`enforce_admins=true`、conversation resolution 已启用、`strict=false`；唯一 ruleset 仍处于 disabled。脱敏证据见 `evidence/github-remote-baseline.md`。
 - `build-and-release.yml` 已增加同一 SHA 的 `release-quality` 硬依赖；workflow 合同与负向变异证明 build/create/sync 不能绕过失败 gate。
 - 当前工作区包含跨 CoreApp、Nexus、Utils 和三个插件的未提交批次，远端全绿不能证明这批代码可发布。
@@ -22,6 +22,8 @@
 - Beta32 的 GitHub release、Nexus latest、manifest v2、四个首选平台资产、签名下载路由与回退路由已收敛；严格生产 Gate E `18/18` 通过，macOS arm64 OTA 下载包 SHA-256 和 detached RSA 签名与 manifest 一致，详见 `evidence/release-matrix-beta32.md`。
 - 官方 macOS arm64 Beta31 -> Beta32 已从隔离 profile 完成发现、下载、校验、Settings UI `Restart to Update`、无提权 helper、DMG 原位替换、Beta32 官方 attestation、startup health 和 attempt-bound `healthy` ack；SQLite 终态 revision 8 / `healthy`，详见 `evidence/macos-ota-beta31-beta32.md`。
 - 同一隔离源进程在安装前的 clipboard `vision.ocr` 成功返回后 abort；minidump 指向 `tuff_native_ocr.node` 的 N-API AsyncWorker 完成路径。根因是父进程在 terminal message 到达时立即 `worker.terminate()`，可能在 native completion callback 尚未退栈时销毁环境；本地已改为 terminal message 后自然退出，并验证 jobId/result/error 消息边界，聚焦测试 `20/20`、负向变异和 200 个真实 Electron native worker 自然退出 smoke 通过。Beta32 仍含旧实现，修复必须随下一官方版本发布后再解除推广风险。
+- Beta33 的 GitHub release、Nexus latest、manifest v2、四个首选平台资产、签名下载路由与回退路由已收敛；严格生产 Gate E `18/18` 通过，详见 `evidence/release-matrix-beta33.md`。
+- 官方 macOS arm64 Beta32 -> Beta33 已从隔离 profile 完成发现、下载、校验、Settings UI `Restart to Update`、无提权 helper、DMG 原位替换、Beta33 官方 attestation、startup health 和 attempt-bound `healthy` ack；同一发布包的 11 个真实 OCR worker 任务全部完成且进程保持存活，详见 `evidence/macos-ota-beta32-beta33.md`。
 
 ## Requirements
 
@@ -54,10 +56,10 @@
 | AC2 | pass | 同 SHA release gate 已形成硬依赖，合同测试与负向变异通过。 |
 | AC3 | pass | `master` 已启用 7 个 GitHub Actions required checks；最近 5 个 PR SHA 与最近 6 个 master SHA 均完整产生，失败提交也真实呈现失败或取消。`strict=false` 作为非阻塞限制保留。 |
 | AC4 | pass | tuff-cli CI/publish 假绿已修复，workflow contracts `33/33` 与 CLI tests `6/6` 通过。 |
-| AC5 | pass | Beta32 GitHub/Nexus/latest/manifest/rollback/签名/架构矩阵一致；严格生产 Gate E `18/18`，真实 macOS arm64 下载 SHA-256 与 detached 签名通过。 |
-| AC6 | pass | 官方 Beta31 -> Beta32 完成 ready、Settings UI install、无提权 handoff、原位替换、Beta32 startup health 与 attempt-bound `healthy` ack。 |
+| AC5 | pass | Beta33 GitHub/Nexus/latest/manifest/rollback/签名/架构矩阵一致；严格生产 Gate E `18/18`，真实 macOS arm64 下载 SHA-256 与 detached 签名通过。 |
+| AC6 | pass | 官方 Beta32 -> Beta33 完成 ready、Settings UI install、无提权 handoff、原位替换、Beta33 startup health 与 attempt-bound `healthy` ack；Beta33 packaged OCR smoke `11/11` 完成且无 crashpad/N-API 崩溃。 |
 | AC7 | blocked | Linux helper 打包、替换/恢复与 no-FUSE 重启源码缺陷已修并通过受控测试；Windows/Linux 尚无官方 N/N+1 的发现、下载、替换、handoff 与 health-ack 真机证据。 |
-| AC8 | partial | actionlint、release checks、本地 `quality:release`、Beta32 同 SHA `release-quality`、严格 Gate E 和 macOS N/N+1 已通过；Windows/Linux 真机及最终文档收尾未闭环。 |
+| AC8 | partial | actionlint、release checks、本地 `quality:release`、Beta33 同 SHA `release-quality`、严格 Gate E、macOS N/N+1 和 packaged OCR smoke 已通过；Windows/Linux 真机及最终文档收尾未闭环。
 
 ## Out of Scope
 


### PR DESCRIPTION
## Scope
Record the completed Beta33 production release and official macOS Beta32 -> Beta33 OTA acceptance without attributing evidence to the wrong version.

## Evidence
- Beta33 three-platform workflow: Release Quality, Ubuntu, Windows, macOS rerun, Create Release, and Nexus Sync all passed.
- Strict production Gate E: 18/18 checks passed.
- macOS arm64 package SHA-256 and detached signature verified.
- Isolated Settings UI OTA reached attempt-bound Beta33 `healthy` acknowledgement with no elevation or recovery marker.
- Published Beta33 packaged OCR smoke completed 11/11 image jobs and the process remained alive without N-API/crashpad failure.

## Checks
- `pnpm test:release-acceptance` — 11/11 pass
- `pnpm release:notes:verify` — pass
- `git diff --check` — pass

Windows/Linux runtime N/N+1 remains explicitly blocked in the matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added evidence documenting a successful macOS arm64 OTA update from Beta32 to Beta33, including integrity, signing, and OCR smoke-test verification.
  * Added release-matrix evidence confirming Beta33 production Gate E passed with verified artifacts and release metadata.
  * Updated the acceptance documentation to establish Beta33 as the verified release baseline, including release, OTA, and OCR validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->