### PR TITLE
fix(nexus): stop toast hover CSS from overriding dark pages

### DIFF
--- a/apps/nexus/app/components/ui/ToastHost.vue
+++ b/apps/nexus/app/components/ui/ToastHost.vue
@@ -70,10 +70,10 @@ function toneClass(type: string) {
   outline: none;
 }
 
-:global(.dark) .toast-dismiss:hover,
-:global([data-theme='dark']) .toast-dismiss:hover,
-:global(.dark) .toast-dismiss:focus-visible,
-:global([data-theme='dark']) .toast-dismiss:focus-visible {
+:global(.dark .toast-dismiss:hover),
+:global([data-theme='dark'] .toast-dismiss:hover),
+:global(.dark .toast-dismiss:focus-visible),
+:global([data-theme='dark'] .toast-dismiss:focus-visible) {
   background: rgba(255, 255, 255, 0.12);
 }
 


### PR DESCRIPTION
## Problem
A scoped selector list in `ToastHost.vue` compiled to a standalone `.dark, [data-theme=dark] { background: #ffffff1f }` rule. Because the auth shell itself carries `.dark`, that rule overrode `bg-[#08080d]` and made the production sign-in page pale while its content stayed white.

## Fix
Scope the complete dark-theme hover/focus selectors with `:global(...)`, matching the repository's documented Vue scoped-style convention.

## Verification
- `pnpm lint:changed`
- `pnpm -C apps/nexus run test` (227 files / 1421 tests)
- `pnpm -C apps/nexus run build`
- built CSS contains `.dark .toast-dismiss:hover` and no standalone `.dark,[data-theme=dark]{background:#ffffff1f}`
- local Cloudflare Pages runtime: auth shell computed background `rgb(8, 8, 13)`, white text, zero horizontal overflow
- visual screenshot: passkey title, message and actions render on the intended dark surface without clipping or overlap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved toast dismissal button styling in dark themes.
  - Dark background states now apply correctly when the theme is set on an ancestor element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->