### PR TITLE
fix(nexus): make primary sign-in actions visible

### DIFF
--- a/apps/nexus/app/pages/sign-in/components/SignInBindEmailStep.vue
+++ b/apps/nexus/app/pages/sign-in/components/SignInBindEmailStep.vue
@@ -24,10 +24,10 @@ const bindValue = computed({
 <template>
   <div class="auth-step">
     <Input v-model="bindValue" type="text" :placeholder="t('auth.email', '邮箱')" class="auth-input" />
-    <TxButton class="auth-button auth-button--primary" size="lg" block :loading="bindLoading" @click="emit('bind')">
+    <TxButton variant="primary" class="auth-button auth-button--primary" size="lg" block :loading="bindLoading" @click="emit('bind')">
       {{ t('auth.bindEmailConfirm', '绑定邮箱') }}
     </TxButton>
-    <TxButton class="auth-button auth-button--ghost" size="lg" block :loading="bindLoading" @click="emit('skip')">
+    <TxButton variant="ghost" class="auth-button auth-button--ghost" size="lg" block :loading="bindLoading" @click="emit('skip')">
       {{ t('auth.bindEmailSkip', '暂时跳过') }}
     </TxButton>
   </div>

--- a/apps/nexus/app/pages/sign-in/components/SignInEmailStep.vue
+++ b/apps/nexus/app/pages/sign-in/components/SignInEmailStep.vue
@@ -78,7 +78,7 @@ const lastUsedLabel = computed(() => props.t('auth.lastUsed', '上次使用'))
     <Input v-model="emailValue" type="text" :placeholder="t('auth.email', '邮箱')" class="auth-input" />
 
     <div class="auth-method auth-method--full">
-      <TxButton class="auth-button auth-button--ghost" size="lg" block :loading="emailCheckLoading" @click="emit('email-next')">
+      <TxButton variant="primary" class="auth-button auth-button--primary" size="lg" block :loading="emailCheckLoading" @click="emit('email-next')">
         {{ t('auth.continueWithEmail', 'Continue with Email') }}
       </TxButton>
       <TxBadge v-if="lastMethod === 'email'" class="auth-last-badge">

--- a/apps/nexus/app/pages/sign-in/components/SignInOauthStep.vue
+++ b/apps/nexus/app/pages/sign-in/components/SignInOauthStep.vue
@@ -64,7 +64,7 @@ const showRetry = computed(() => isError.value)
     </div>
 
     <div v-if="showRetry" class="auth-oauth-actions">
-      <TxButton class="auth-button auth-button--primary" size="lg" block @click="emit('retry')">
+      <TxButton variant="primary" class="auth-button auth-button--primary" size="lg" block @click="emit('retry')">
         {{ t('auth.oauthRetry', '重新尝试') }}
       </TxButton>
       <TxButton variant="ghost" size="sm" class="auth-text-button auth-oauth-back" @click="emit('back')">

--- a/apps/nexus/app/pages/sign-in/components/SignInPasskeyStep.vue
+++ b/apps/nexus/app/pages/sign-in/components/SignInPasskeyStep.vue
@@ -50,7 +50,7 @@ const showRetry = computed(() => isError.value)
     </div>
 
     <div class="auth-passkey-actions" :class="{ 'is-visible': showRetry }">
-      <TxButton class="auth-button auth-button--primary" size="lg" block @click="emit('retry')">
+      <TxButton variant="primary" class="auth-button auth-button--primary" size="lg" block @click="emit('retry')">
         {{ t('auth.passkeyRetry', '重新尝试') }}
       </TxButton>
     </div>


### PR DESCRIPTION
## Problem
Production visual verification after the passkey deployment showed that controls labelled as `auth-button--primary` never selected TuffEx's primary variant. On the intended dark auth surface, Continue / retry / bind actions rendered as the default low-emphasis button.

## Fix
Use the real `variant="primary"` contract for primary email, passkey, OAuth and bind actions; make the bind skip action explicitly ghost.

## Verification
- `pnpm lint:changed`
- `pnpm -C apps/nexus run typecheck`
- `pnpm -C apps/nexus run test` (227 files / 1421 tests)
- `pnpm -C apps/nexus run build`
- local Cloudflare Pages visual smoke: dark auth shell, visible blue-bordered primary action, legible inline error, zero horizontal overflow, no clipping or overlap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated sign-in buttons with clearer visual hierarchy.
  - Primary actions, including email continuation and retry options, now use the primary button style.
  - The email-binding confirmation and skip actions now use explicitly defined button styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->