### PR TITLE
fix(nexus): apply auth theme to global toasts

### DIFF
--- a/apps/nexus/app/app.vue
+++ b/apps/nexus/app/app.vue
@@ -487,7 +487,7 @@ watchEffect(() => {
 <template>
   <NexusPwaManifest />
   <NuxtLoadingIndicator color="#ffffff" />
-  <LazyToastContainer v-if="toastHostMounted" />
+  <LazyToastContainer v-if="toastHostMounted" :class="{ dark: isAuthShellRoute }" />
   <ClientOnly>
     <LazySearchGlobalSearch v-if="!isAuthShellRoute && globalSearchOpen" />
   </ClientOnly>


### PR DESCRIPTION
## Problem
The global toast host is a sibling of the route's dark `AuthVisualShell`, so its `dark:*` text colors did not activate on sign-in routes. Warning/error notifications used dark ink over dark translucent surfaces.

## Fix
Forward the existing `isAuthShellRoute` state as a `dark` class to the lazy toast container. The class falls through to the fixed toast host and themes its descendants without changing non-auth routes.

## Verification
- `pnpm lint:changed`
- `pnpm -C apps/nexus run typecheck`
- focused Nexus guard test
- `pnpm -C apps/nexus run build`
- local Cloudflare Pages visual smoke: toast host carries `dark`, toast title computes to `rgb(255, 255, 255)`, auth background remains `rgb(8, 8, 13)`, zero horizontal overflow
- visual confirmation: toast and primary retry action are readable with no clipping or overlap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved toast appearance on authentication screens by applying the appropriate dark styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->