### PR TITLE
feat(nexus): quiet the dashboard surface and split the asset views

### DIFF
--- a/apps/nexus/app/components/dashboard/DashboardNav.vue
+++ b/apps/nexus/app/components/dashboard/DashboardNav.vue
@@ -363,7 +363,7 @@ useHead(() => ({
       <span class="dashboard-nav-summary-chevron i-carbon-chevron-down text-[15px]" aria-hidden="true" />
     </summary>
     <nav class="relative p-4" aria-label="Dashboard workspace sections">
-      <p class="apple-section-title mb-4 px-3">
+      <p class="dashboard-nav-section-title mb-4 px-3">
         {{ t('dashboard.sections.menu.workspaceTitle', '工作台') }}
       </p>
       <ul class="flex flex-col list-none gap-1 p-0 text-sm" role="listbox" aria-label="Dashboard workspace panels">
@@ -387,7 +387,7 @@ useHead(() => ({
     <div class="mx-4 border-t border-black/[0.04] dark:border-white/[0.06]" />
 
     <nav class="relative p-4 pt-0" aria-label="Account settings">
-      <p class="apple-section-title mb-4 px-3">
+      <p class="dashboard-nav-section-title mb-4 px-3">
         {{ t('dashboard.sections.menu.accountTitle', '账户') }}
       </p>
       <ul class="flex flex-col list-none gap-1 p-0 text-sm" role="listbox" aria-label="Account panels">
@@ -418,7 +418,7 @@ useHead(() => ({
     <div v-show="adminMenuItems.length > 0" class="mx-4 border-t border-black/[0.04] dark:border-white/[0.06]" />
 
     <nav v-show="adminMenuItems.length > 0" class="relative p-4 pt-0" aria-label="Admin panels">
-      <p class="apple-section-title mb-4 px-3">
+      <p class="dashboard-nav-section-title mb-4 px-3">
         {{ t('dashboard.sections.menu.adminTitle', '管理员') }}
       </p>
       <ul class="flex flex-col list-none gap-1 p-0 text-sm" role="listbox" aria-label="Admin panels">
@@ -481,6 +481,14 @@ useHead(() => ({
   }
 }
 
+.dashboard-nav-section-title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--tx-text-color-secondary, rgba(0, 0, 0, 0.45));
+  opacity: 0.75;
+}
+
 .dashboard-nav-link {
   color: var(--tx-text-color-secondary, rgba(0, 0, 0, 0.55));
 }
@@ -501,17 +509,22 @@ useHead(() => ({
   background: rgba(255, 255, 255, 0.05);
 }
 
+/**
+ * The active row is a neutral pill, not a tinted one: with three groups open at
+ * once a coloured fill on the selected row competed with the status colours in
+ * the panel beside it. The accent survives on the icon alone.
+ */
 .dashboard-nav-link--active,
 .dashboard-nav-link--active:hover,
 .dashboard-nav-link--active:focus-visible {
-  color: var(--tx-color-primary, #1BB5F4);
-  background: rgba(27, 181, 244, 0.06);
-  font-weight: 500;
+  color: var(--tx-text-color-primary, #000);
+  background: rgba(0, 0, 0, 0.05);
+  font-weight: 600;
 }
 
 :root.dark .dashboard-nav-link--active,
 :root.dark .dashboard-nav-link--active:hover {
-  background: rgba(27, 181, 244, 0.1);
+  background: rgba(255, 255, 255, 0.07);
 }
 
 .dashboard-nav-link--active .dashboard-nav-icon {

--- a/apps/nexus/app/layouts/dashboard.vue
+++ b/apps/nexus/app/layouts/dashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen from-white via-white to-slate-100 bg-gradient-to-br text-black dark:from-dark dark:via-dark/95 dark:to-dark/85 dark:text-light">
+  <div class="dashboard-shell min-h-screen from-white via-white to-slate-100 bg-gradient-to-br text-black dark:from-dark dark:via-dark/95 dark:to-dark/85 dark:text-light">
     <TheHeader class="z-10 border-b border-transparent" />
     <main class="mx-auto max-w-7xl w-full flex flex-1 flex-col gap-8 px-4 py-20 lg:px-12 sm:px-8">
       <slot />
@@ -7,3 +7,40 @@
     <TuffFooter />
   </div>
 </template>
+
+<style>
+/**
+ * Dashboard surface treatment. Every rule is prefixed with `.dashboard-shell`
+ * so the store, docs and marketing pages keep the bordered card look — the
+ * shortcuts themselves (`apple-card`, `tx-button`) are shared, and rewriting
+ * them in uno.config.ts would have restyled all of those too.
+ *
+ * The panels drop their hairline border and lean on surface + shadow instead:
+ * on a dashboard route there are enough nested rows that a border on every
+ * card reads as a grid of boxes rather than as grouping.
+ */
+.dashboard-shell .apple-card,
+.dashboard-shell .apple-card-lg {
+  border-color: transparent;
+  border-radius: 22px;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 4%), 0 12px 32px -20px rgb(0 0 0 / 18%);
+}
+
+:root.dark .dashboard-shell .apple-card,
+:root.dark .dashboard-shell .apple-card-lg {
+  background-color: rgb(255 255 255 / 4.5%);
+  box-shadow: none;
+}
+
+/* Page headings sit directly on the page, with no card to give them weight. */
+.dashboard-shell h1.apple-heading-md,
+.dashboard-shell h2.apple-heading-md {
+  font-size: 1.75rem;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.dashboard-shell .tx-button {
+  border-radius: 999px;
+}
+</style>

--- a/apps/nexus/app/pages/dashboard/assets.vue
+++ b/apps/nexus/app/pages/dashboard/assets.vue
@@ -391,6 +391,60 @@ const myPlugins = computed(() =>
   plugins.value.filter(p => p.userId === currentUserId.value),
 )
 
+/**
+ * The review queue used to sit stacked above the author's own list, so an admin
+ * scrolled past a moderation table to reach their own assets and the two tables'
+ * row actions read as interchangeable. They are separate views now.
+ *
+ * `pending` and `all` are admin-only: a normal account never renders the
+ * switcher and stays on `mine`, which is what it could already see.
+ */
+type AssetView = 'mine' | 'pending' | 'all'
+
+const assetView = ref<AssetView>('mine')
+
+const assetViews = computed(() => ([
+  {
+    id: 'mine' as const,
+    label: t('dashboard.sections.plugins.myPlugins'),
+    count: myPlugins.value.length,
+    adminOnly: false,
+  },
+  {
+    id: 'pending' as const,
+    label: t('dashboard.sections.plugins.pendingReviews'),
+    count: pendingReviewItems.value.length,
+    adminOnly: true,
+  },
+  {
+    id: 'all' as const,
+    label: t('dashboard.sections.plugins.allAssets', 'All Assets'),
+    count: plugins.value.length,
+    adminOnly: true,
+  },
+]).filter(view => isAdmin.value || !view.adminOnly))
+
+/**
+ * `isAdmin` resolves from the user payload after mount, so the first render is
+ * always non-admin. Without this an admin view selected before a role change —
+ * or restored on a re-render — would leave the page on a tab it may no longer
+ * render.
+ */
+watch(isAdmin, (admin) => {
+  if (!admin)
+    assetView.value = 'mine'
+}, { immediate: true })
+
+const visiblePlugins = computed(() =>
+  assetView.value === 'all' ? plugins.value : myPlugins.value,
+)
+
+const visiblePluginsTitle = computed(() =>
+  assetView.value === 'all'
+    ? t('dashboard.sections.plugins.allAssets', 'All Assets')
+    : t('dashboard.sections.plugins.myPlugins'),
+)
+
 const myPluginColumns = computed<DataTableColumn<DashboardPlugin>[]>(() => [
   { key: 'asset', title: isZh.value ? '发布物' : 'Asset', width: '34%' },
   { key: 'typeCategory', title: isZh.value ? '类型 / 分类' : 'Type / Category', width: 126 },
@@ -1120,8 +1174,36 @@ async function deletePluginVersion(plugin: DashboardPlugin, version: DashboardPl
       </p>
     </div>
 
+    <!-- View switcher: only an admin has more than one entry, so the whole row
+         collapses for a normal account rather than showing disabled tabs. -->
+    <div v-if="assetViews.length > 1" class="flex flex-wrap items-center justify-between gap-3">
+      <div
+        class="inline-flex items-center gap-1 rounded-2xl bg-black/[0.04] p-1 dark:bg-white/[0.06]"
+        role="tablist"
+        :aria-label="t('dashboard.sections.plugins.title')"
+      >
+        <button
+          v-for="view in assetViews"
+          :key="view.id"
+          type="button"
+          role="tab"
+          :aria-selected="assetView === view.id"
+          class="dashboard-asset-tab"
+          :class="assetView === view.id ? 'dashboard-asset-tab--active' : ''"
+          @click="assetView = view.id"
+        >
+          <span v-if="view.adminOnly" class="i-carbon-locked text-[11px] opacity-60" aria-hidden="true" />
+          <span>{{ view.label }}</span>
+          <span class="dashboard-asset-tab-count">{{ view.count }}</span>
+        </button>
+      </div>
+      <p class="text-xs text-black/40 dark:text-white/40">
+        {{ t('dashboard.sections.plugins.viewAdminOnly', '待处理审核与全部发布物仅管理员可见。') }}
+      </p>
+    </div>
+
     <!-- Admin: Pending Reviews -->
-    <div v-if="isAdmin" class="apple-card-lg p-6">
+    <div v-if="isAdmin && assetView === 'pending'" class="apple-card-lg p-6">
       <div class="mb-4 flex flex-wrap items-center justify-between gap-3 border-b border-black/[0.04] pb-4 dark:border-white/[0.06]">
         <div>
           <h3 class="apple-section-title">
@@ -1220,13 +1302,13 @@ async function deletePluginVersion(plugin: DashboardPlugin, version: DashboardPl
       </p>
     </div>
 
-    <!-- My Plugins Section -->
-    <div class="apple-card-lg p-6">
+    <!-- Owned assets (or every asset, for an admin on the `all` view) -->
+    <div v-if="assetView !== 'pending'" class="apple-card-lg p-6">
       <div class="mb-4 flex flex-wrap items-center justify-between gap-3 border-b border-black/[0.04] pb-4 dark:border-white/[0.06]">
         <div>
           <h3 class="apple-section-title">
-            {{ t('dashboard.sections.plugins.myPlugins') }}
-            <span class="ml-1 text-black/40 dark:text-white/40">({{ myPlugins.length }})</span>
+            {{ visiblePluginsTitle }}
+            <span class="ml-1 text-black/40 dark:text-white/40">({{ visiblePlugins.length }})</span>
           </h3>
           <p class="mt-1 text-xs text-black/45 dark:text-white/45">
             {{ isZh ? '统一管理发布物元数据、版本与审核状态。' : 'Manage asset metadata, versions, and review states in one table.' }}
@@ -1295,7 +1377,7 @@ async function deletePluginVersion(plugin: DashboardPlugin, version: DashboardPl
         </TxButton>
       </div>
 
-      <div v-else-if="!myPlugins.length" class="py-8 text-center text-sm text-black/40 dark:text-white/40">
+      <div v-else-if="!visiblePlugins.length" class="py-8 text-center text-sm text-black/40 dark:text-white/40">
         {{ t('dashboard.sections.plugins.empty') }}
       </div>
 
@@ -1307,7 +1389,7 @@ async function deletePluginVersion(plugin: DashboardPlugin, version: DashboardPl
         <div class="overflow-x-auto">
           <TxDataTable
             :columns="myPluginColumns"
-            :data="myPlugins"
+            :data="visiblePlugins"
             row-key="id"
             table-layout="fixed"
             interactive-rows
@@ -1540,5 +1622,48 @@ async function deletePluginVersion(plugin: DashboardPlugin, version: DashboardPl
   display: inline-block;
   white-space: normal;
   line-height: 1.45;
+}
+
+/**
+ * Segmented control for the asset views. Sized off the same 13px/pill rhythm as
+ * the dashboard's other tab strips so it does not read as a second control set.
+ */
+.dashboard-asset-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  font-size: 13px;
+  line-height: 1.2;
+  color: var(--tx-text-color-secondary, rgba(0, 0, 0, 0.5));
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease;
+}
+
+.dashboard-asset-tab:hover {
+  color: var(--tx-text-color-primary, #000);
+}
+
+.dashboard-asset-tab--active,
+.dashboard-asset-tab--active:hover {
+  background: rgb(255 255 255 / 90%);
+  color: var(--tx-text-color-primary, #000);
+  font-weight: 600;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 6%);
+}
+
+:root.dark .dashboard-asset-tab--active,
+:root.dark .dashboard-asset-tab--active:hover {
+  background: rgb(255 255 255 / 12%);
+  box-shadow: none;
+}
+
+.dashboard-asset-tab-count {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.55;
 }
 </style>

--- a/apps/nexus/i18n/locales/route/en/dashboard.ts
+++ b/apps/nexus/i18n/locales/route/en/dashboard.ts
@@ -1441,6 +1441,8 @@ Tuff may update this agreement at any time. Continued submission indicates accep
         rejectReason: 'Rejection reason',
         rejectReasonPlaceholder: 'Explain why this submission was rejected (optional)...',
         myPlugins: 'My Plugins',
+        allAssets: 'All Assets',
+        viewAdminOnly: 'Pending Reviews and All Assets are visible to administrators only.',
       },
       images: {
         title: 'Resource library',

--- a/apps/nexus/i18n/locales/route/zh/dashboard.ts
+++ b/apps/nexus/i18n/locales/route/zh/dashboard.ts
@@ -1437,6 +1437,8 @@ Tuff 可能随时更新本协议,继续提交表示接受变更。`,
         rejectReason: '驳回原因',
         rejectReasonPlaceholder: '请说明驳回此提交的原因（可选）...',
         myPlugins: '我的发布物',
+        allAssets: '全部发布物',
+        viewAdminOnly: '待处理审核与全部发布物仅管理员可见。',
       },
       images: {
         title: '资源库',


### PR DESCRIPTION
Two changes, both scoped to `/dashboard` routes.

## Surface

Dashboard panels drop the hairline border and lean on surface + shadow instead. With this many nested rows, a border on every card read as a grid of boxes rather than as grouping. The nav's active row loses its tinted fill for the same reason — it competed with the status colours in the panel beside it — so the accent survives on the icon alone, and the group labels lose the all-caps treatment.

Every rule is scoped under `.dashboard-shell` rather than rewritten in `uno.config.ts`: `apple-card` and `tx-button` are shared with the store, docs and marketing pages, which keep the bordered look.

## Assets

The admin review queue used to sit stacked above the author's own list, so an admin scrolled past a moderation table to reach their own assets and the two tables' row actions read as interchangeable. They are separate views now, behind a segmented control:

`My Plugins` · 🔒 `Pending Reviews` · 🔒 `All Assets`

`pending` and `all` are admin-only — a normal account renders no switcher at all and stays on the list it could already see. `watch(isAdmin)` pulls the view back to `mine` if the role goes away mid-session.

## Verification

Local run against a signed-in admin on all 18 dashboard routes: every route rendered, no redirects, no error states. Computed styles confirmed on-page (`border-radius: 22px`, `border-top-width: 0px`, `.tx-button` `border-radius: 999px`, section label `text-transform: none`).

Switcher behaviour, checked with two seeded accounts:

| Role | Switcher tabs | Cards rendered | Admin nav links |
|---|---|---|---|
| admin, `mine` | 3 | `MY PLUGINS` only | 8 |
| admin, `pending` | 3 | `PENDING REVIEWS` only | 8 |
| plain user | 0 (row not rendered) | `MY PLUGINS` only | 0 |

- dashboard suites: 24 files / 201 tests passed
- full `vitest run`: 227 files / 1421 tests passed
- `nuxt typecheck`: 0 errors
- eslint on the changed files: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dashboard asset views for owned, pending-review, and all assets, with administrator-only access to broader views.
  - Added localized labels and guidance for the new asset views in English and Chinese.

- **UI Improvements**
  - Updated dashboard navigation with neutral active-state styling and clearer section titles.
  - Refined dashboard layout styling with rounded cards, lighter shadows, improved dark-mode presentation, updated typography, and pill-shaped buttons.
  - Added segmented controls for switching between asset views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->