### PR TITLE
ref(nexus): extract the role checks into composables

### DIFF
--- a/apps/nexus/app/components/dashboard/DashboardNav.routing.test.ts
+++ b/apps/nexus/app/components/dashboard/DashboardNav.routing.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import { computed, ref } from 'vue'
 import { describe, expect, it } from 'vitest'
+import { isAdminAccountRole } from '~/utils/account-role'
 import { isFeatureFlagEnabled } from '#shared/utils/feature-flags'
 
 /**
@@ -100,7 +101,7 @@ function evaluateNav(state: NavState = {}): NavBindings {
   // eslint-disable-next-line no-new-func
   const factory = new Function(
     'deps',
-    `const { computed, t, route, mounted, user, runtimeConfig, isFeatureFlagEnabled, canManageOauthApps } = deps
+    `const { computed, t, route, mounted, user, isAccountAdmin, runtimeConfig, isFeatureFlagEnabled, canManageOauthApps } = deps
 ${body}
 return {
   sectionPaths,
@@ -113,6 +114,8 @@ return {
 }`,
   ) as (deps: Record<string, unknown>) => NavBindings
 
+  const user = ref(state.role === undefined ? { role: 'admin' } : state.role === null ? null : { role: state.role })
+
   return factory({
     computed,
     // Returning the key keeps assertions locale-independent; the locale files
@@ -120,7 +123,12 @@ return {
     t: (key: string) => key,
     route: { path: state.path ?? '/dashboard/overview' },
     mounted: ref(state.mounted ?? true),
-    user: ref(state.role === undefined ? { role: 'admin' } : state.role === null ? null : { role: state.role }),
+    user,
+    // The component resolves the role through useAccountRole(); injecting the
+    // flag keeps this test on the routing and menu tables it exists for, while
+    // still driving it from the same `role` fixture. The predicate has its own
+    // coverage in utils/account-role.test.ts.
+    isAccountAdmin: computed(() => isAdminAccountRole(user.value?.role)),
     runtimeConfig: { public: { riskControl: { enabled: state.riskFlag } } },
     isFeatureFlagEnabled,
     canManageOauthApps: computed(() => state.canManageOauthApps ?? true),

--- a/apps/nexus/app/components/dashboard/DashboardNav.vue
+++ b/apps/nexus/app/components/dashboard/DashboardNav.vue
@@ -91,15 +91,16 @@ watch(
   { immediate: true },
 )
 
-const isAdmin = computed(() => mounted.value && String(user.value?.role || '').toLowerCase() === 'admin')
-const isTeamAdmin = computed(() => {
-  if (!mounted.value)
-    return false
+/**
+ * Both gates wait for `mounted`: the admin sections are absent from the SSR
+ * markup (no user payload there), so rendering them on the first client tick
+ * would be a hydration mismatch.
+ */
+const { isAdmin: isAccountAdmin } = useAccountRole()
+const { isTeamAdmin: isTeamAdminRole } = useTeamRole(() => teamData.value?.team)
 
-  const team = teamData.value?.team
-  const role = String(team?.role || '').toLowerCase()
-  return team?.type === 'organization' && (role === 'owner' || role === 'admin')
-})
+const isAdmin = computed(() => mounted.value && isAccountAdmin.value)
+const isTeamAdmin = computed(() => mounted.value && isTeamAdminRole.value)
 const canManageOauthApps = computed(() => isAdmin.value || isTeamAdmin.value)
 const riskControlEnabled = computed(() => isFeatureFlagEnabled(runtimeConfig.public?.riskControl?.enabled))
 const notificationUnreadBadgeText = computed(() => notificationUnreadCount.value > 99 ? '99+' : String(notificationUnreadCount.value))

--- a/apps/nexus/app/components/dashboard/intelligence/IntelligenceAdminPanel.vue
+++ b/apps/nexus/app/components/dashboard/intelligence/IntelligenceAdminPanel.vue
@@ -13,9 +13,7 @@ const { user } = useAuthUser()
 const runtimeConfig = useRuntimeConfig()
 
 // Admin check - redirect if not admin
-const isAdmin = computed(() => {
-  return user.value?.role === 'admin'
-})
+const { isAdmin } = useAccountRole()
 
 watch(isAdmin, (admin) => {
   if (user.value && !admin) {

--- a/apps/nexus/app/components/dashboard/intelligence/IntelligenceAgentWorkspace.vue
+++ b/apps/nexus/app/components/dashboard/intelligence/IntelligenceAgentWorkspace.vue
@@ -147,7 +147,7 @@ function labText(
   return applyTemplate(fallback, params)
 }
 
-const isAdmin = computed(() => user.value?.role === 'admin')
+const { isAdmin } = useAccountRole()
 watch(isAdmin, (admin) => {
   if (user.value && !admin) {
     navigateTo('/dashboard/overview')

--- a/apps/nexus/app/components/docs/DocsComments.vue
+++ b/apps/nexus/app/components/docs/DocsComments.vue
@@ -90,7 +90,7 @@ async function deleteComment(commentId: string) {
 function canDelete(comment: DocComment) {
   if (!user.value)
     return false
-  return user.value.id === comment.userId || user.value.role === 'admin'
+  return user.value.id === comment.userId || isAdminAccountRole(user.value.role)
 }
 
 function formatTimeAgo(timestamp: number) {

--- a/apps/nexus/app/composables/account-role-contract.test.ts
+++ b/apps/nexus/app/composables/account-role-contract.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * `computed(() => user.value?.role === 'admin')` had been copied into 20 pages
+ * and components. The copies had already drifted — some lower-cased first, some
+ * compared raw — and a reviewer suggesting a change to "the" admin check had no
+ * single place to point at. This keeps the check from being re-inlined.
+ *
+ * It matches only the *signed-in* user's role. Comparing some other row's role
+ * (the user table renders a badge from `entry.role`) is a different operation
+ * and stays allowed.
+ */
+const APP_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+const CURRENT_USER_ROLE_GATE = /\b(?:user|authUserState|currentUser)\b[^\n]{0,20}\.role\s*[=!]==\s*['"]admin['"]/
+
+/** The two files that define the check, and may therefore describe it. */
+const OWNS_THE_CHECK = new Set(['composables/useAccountRole.ts', 'utils/account-role.ts'])
+
+function sourceFiles(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules')
+      continue
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory())
+      sourceFiles(full, found)
+    else if ((full.endsWith('.vue') || full.endsWith('.ts')) && !full.endsWith('.test.ts'))
+      found.push(full)
+  }
+  return found
+}
+
+describe('account role check', () => {
+  it('is not re-inlined outside useAccountRole/isAdminAccountRole', () => {
+    const offenders = sourceFiles(APP_ROOT)
+      .map(file => path.relative(APP_ROOT, file))
+      .filter(file => !OWNS_THE_CHECK.has(file))
+      .filter(file => CURRENT_USER_ROLE_GATE.test(readFileSync(path.join(APP_ROOT, file), 'utf8')))
+
+    expect(
+      offenders,
+      'use `useAccountRole()` for a reactive gate, or `isAdminAccountRole(role)` inside a function',
+    ).toEqual([])
+  })
+
+  it('has no helper that folds the team owner role into the account role', () => {
+    const offenders = sourceFiles(APP_ROOT)
+      .map(file => path.relative(APP_ROOT, file))
+      .filter(file => !OWNS_THE_CHECK.has(file))
+      .filter(file => /['"]admin['"]\s*\|\|[^\n]{0,40}['"]owner['"]/.test(readFileSync(path.join(APP_ROOT, file), 'utf8')))
+
+    expect(
+      offenders,
+      '`owner` is a TeamMemberRole; requireAdmin only accepts `admin`. Use useTeamRole() instead.',
+    ).toEqual([])
+  })
+})

--- a/apps/nexus/app/composables/useAccountRole.ts
+++ b/apps/nexus/app/composables/useAccountRole.ts
@@ -1,0 +1,38 @@
+import { computed } from 'vue'
+import { isAdminAccountRole, normalizeAccountRole } from '~/utils/account-role'
+
+/**
+ * Reactive access to the signed-in account's platform role.
+ *
+ * Replaces the copy of `computed(() => user.value?.role === 'admin')` that had
+ * been written out in ~20 pages and components. The copies had already drifted:
+ * some lower-cased the value first and some compared it raw, so a stored role
+ * that differed only in case would have been admin on one page and not on the
+ * next.
+ *
+ * Reads the shared `auth-user` state directly instead of calling
+ * `useAuthUser()`. That composable installs a watcher on auth status and fires
+ * a profile request when authenticated — a graph the docs pages deliberately
+ * keep out of their setup (see `docs-page-performance.test.ts`). Whoever owns
+ * that fetch on a given route (useAuthUser on dashboard routes, app.vue
+ * elsewhere) writes into this same key, so reading it is all a gate needs, and
+ * this composable stays safe to call from anywhere.
+ *
+ * `isAdmin` is false while the payload is still loading, which is what every
+ * call site wants for gating UI. It is deliberately not a "still loading"
+ * signal — a component that must tell the two apart (the dashboard nav does,
+ * to avoid hydrating an admin section that was absent from the SSR markup)
+ * should pair this with its own mounted flag.
+ */
+interface AccountRoleState {
+  role?: string | null
+}
+
+export function useAccountRole() {
+  const userState = useState<AccountRoleState | null>('auth-user', () => null)
+
+  const role = computed(() => normalizeAccountRole(userState.value?.role))
+  const isAdmin = computed(() => isAdminAccountRole(userState.value?.role))
+
+  return { role, isAdmin }
+}

--- a/apps/nexus/app/composables/useProviderRegistryAdmin.test.ts
+++ b/apps/nexus/app/composables/useProviderRegistryAdmin.test.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Ref } from 'vue'
 import type { ProviderRegistryRecord, SceneRegistryRecord } from '~/utils/provider-registry-admin'
@@ -97,6 +97,7 @@ function installComposableRuntime(role: 'admin' | 'member' = 'admin') {
   lifecycle.mountedCallbacks.splice(0)
   vi.stubGlobal('navigateTo', navigateTo)
   vi.stubGlobal('useAuthUser', () => ({ user }))
+  vi.stubGlobal('useAccountRole', () => ({ isAdmin: computed(() => user.value?.role === 'admin') }))
   vi.stubGlobal('useI18n', () => ({
     t: (key: string, ...args: unknown[]) => {
       const fallback = args.at(-1)

--- a/apps/nexus/app/composables/useProviderRegistryAdmin.ts
+++ b/apps/nexus/app/composables/useProviderRegistryAdmin.ts
@@ -93,7 +93,7 @@ export function useProviderRegistryAdmin() {
   const providerService = createProviderRegistryCrudService()
   const sceneObservabilityService = createProviderRegistrySceneObservabilityService()
 
-  const isAdmin = computed(() => user.value?.role === 'admin')
+  const { isAdmin } = useAccountRole()
 
   watch(isAdmin, (admin) => {
     if (user.value && !admin) {

--- a/apps/nexus/app/composables/useTeamRole.test.ts
+++ b/apps/nexus/app/composables/useTeamRole.test.ts
@@ -1,0 +1,42 @@
+import { ref } from 'vue'
+import { describe, expect, it } from 'vitest'
+import { useTeamRole } from './useTeamRole'
+
+describe('useTeamRole', () => {
+  it('treats owner and admin alike, matching teamContext isAdminLike', () => {
+    for (const role of ['owner', 'admin']) {
+      const { isTeamAdmin } = useTeamRole({ type: 'organization', role })
+      expect(isTeamAdmin.value, role).toBe(true)
+    }
+  })
+
+  it('denies a plain member', () => {
+    const { isTeamAdmin } = useTeamRole({ type: 'organization', role: 'member' })
+    expect(isTeamAdmin.value).toBe(false)
+  })
+
+  /**
+   * Everyone has a personal team and is its owner, so without the organization
+   * check every account would pass as a team admin.
+   */
+  it('grants nothing on a personal team, whatever the role says', () => {
+    const { isTeamAdmin } = useTeamRole({ type: 'personal', role: 'owner' })
+    expect(isTeamAdmin.value).toBe(false)
+  })
+
+  it('is false while the team is still loading', () => {
+    expect(useTeamRole(null).isTeamAdmin.value).toBe(false)
+    expect(useTeamRole(undefined).isTeamAdmin.value).toBe(false)
+  })
+
+  it('tracks a ref and a getter, both of which call sites use', () => {
+    const team = ref<{ type?: string, role?: string } | null>(null)
+    const fromRef = useTeamRole(team)
+    const fromGetter = useTeamRole(() => team.value)
+
+    expect(fromRef.isTeamAdmin.value).toBe(false)
+    team.value = { type: 'organization', role: 'OWNER' }
+    expect(fromRef.isTeamAdmin.value).toBe(true)
+    expect(fromGetter.isTeamAdmin.value).toBe(true)
+  })
+})

--- a/apps/nexus/app/composables/useTeamRole.ts
+++ b/apps/nexus/app/composables/useTeamRole.ts
@@ -1,0 +1,37 @@
+import type { MaybeRefOrGetter } from 'vue'
+import { computed, toValue } from 'vue'
+
+/**
+ * Reactive access to a team membership role — `'owner' | 'admin' | 'member'`
+ * (`TeamMemberRole` in `server/utils/creditsStore.ts`).
+ *
+ * Separate namespace from the account role in `useAccountRole()`: a team owner
+ * is not a platform administrator and `requireAdmin` will refuse them. The
+ * only thing this currently unlocks is OAuth app management, which an
+ * organization's owner or admin may reach without being a platform admin.
+ *
+ * The team object is passed in rather than fetched here because both call
+ * sites already load `/api/dashboard/team` for their own reasons, and a second
+ * fetch inside the composable would double the request on every dashboard
+ * route.
+ */
+export interface TeamRoleSource {
+  type?: string | null
+  role?: string | null
+}
+
+export function useTeamRole(team: MaybeRefOrGetter<TeamRoleSource | null | undefined>) {
+  const role = computed(() => String(toValue(team)?.role ?? '').trim().toLowerCase())
+  const isOrganization = computed(() => toValue(team)?.type === 'organization')
+
+  /**
+   * Owner and admin are equivalent here, matching `teamContext.ts`'s
+   * `isAdminLike`. Membership in a personal team grants nothing, hence the
+   * organization check.
+   */
+  const isTeamAdmin = computed(() =>
+    isOrganization.value && (role.value === 'owner' || role.value === 'admin'),
+  )
+
+  return { role, isOrganization, isTeamAdmin }
+}

--- a/apps/nexus/app/pages/dashboard/admin/analytics-page-performance.test.ts
+++ b/apps/nexus/app/pages/dashboard/admin/analytics-page-performance.test.ts
@@ -132,6 +132,7 @@ interface AnalyticsExecutionDependencies {
     defineI18nRoute: () => void
     definePageMeta: () => void
     useAuthUser: () => { user: Ref<AnalyticsUser | null> }
+    useAccountRole: () => { isAdmin: ComputedRef<boolean> }
     useI18n: () => { t: (_key: string, fallback: string) => string, locale: Ref<string> }
     useRoute: () => AnalyticsRoute
     navigateTo: (path: string) => unknown
@@ -176,7 +177,7 @@ async function compileFacade(): Promise<AnalyticsFacadeSetup> {
   const executable = `
 export function setupAnalyticsFacade(dependencies) {
   const { ref, computed, watch, onMounted, onBeforeUnmount } = dependencies.vue
-  const { defineAsyncComponent, definePageMeta, defineI18nRoute, useI18n, useAuthUser, useRoute, navigateTo, requestJson } = dependencies.nuxt
+  const { defineAsyncComponent, definePageMeta, defineI18nRoute, useI18n, useAuthUser, useAccountRole, useRoute, navigateTo, requestJson } = dependencies.nuxt
   const { useAdminAnalyticsData, formatAnalyticsCategoryKey, formatAnalyticsCategoryLabel, formatAnalyticsDateTime, formatAnalyticsDuration, formatAnalyticsNumber, formatExchangeRate, formatPayloadPreview, toSortedAnalyticsList } = dependencies.analyticsDependencies
 ${scriptWithoutImports}
   return {
@@ -256,6 +257,7 @@ ${scriptWithoutImports}
       defineI18nRoute: () => undefined,
       definePageMeta: () => undefined,
       useAuthUser: () => ({ user: page.user }),
+      useAccountRole: () => ({ isAdmin: computed(() => page.user.value?.role === 'admin') }),
       useI18n: () => ({ t: (_key: string, fallback: string) => fallback, locale: page.locale }),
       useRoute: () => page.route,
       navigateTo: page.navigateTo,

--- a/apps/nexus/app/pages/dashboard/admin/analytics.vue
+++ b/apps/nexus/app/pages/dashboard/admin/analytics.vue
@@ -29,9 +29,7 @@ const { user } = useAuthUser()
 const route = useRoute()
 
 // Admin check - redirect if not admin
-const isAdmin = computed(() => {
-  return user.value?.role === 'admin'
-})
+const { isAdmin } = useAccountRole()
 
 watch(isAdmin, (admin) => {
   if (user.value && !admin) {

--- a/apps/nexus/app/pages/dashboard/admin/audits-page-behavior.test.ts
+++ b/apps/nexus/app/pages/dashboard/admin/audits-page-behavior.test.ts
@@ -87,7 +87,7 @@ beforeAll(async () => {
   const executable = `
 export function setupAuditsFacade(dependencies) {
   const { ref, reactive, computed, watch, onMounted, onBeforeUnmount } = dependencies.vue
-  const { definePageMeta, defineI18nRoute, useI18n, useAuthUser, navigateTo, requestJson, hasWindow } = dependencies.nuxt
+  const { definePageMeta, defineI18nRoute, useI18n, useAuthUser, useAccountRole, navigateTo, requestJson, hasWindow } = dependencies.nuxt
 ${scriptWithoutImports}
   return {
     audits, loading, error, pagination, filters, hasPrev, hasNext,
@@ -112,6 +112,7 @@ ${scriptWithoutImports}
         locale: dependencies.locale,
       }),
       useAuthUser: () => ({ user: ref({ role: dependencies.role ?? 'admin' }) }),
+      useAccountRole: () => ({ isAdmin: computed(() => (dependencies.role ?? 'admin') === 'admin') }),
       navigateTo: vi.fn(),
       requestJson: dependencies.requestJson,
       hasWindow: () => false,

--- a/apps/nexus/app/pages/dashboard/admin/audits.vue
+++ b/apps/nexus/app/pages/dashboard/admin/audits.vue
@@ -22,9 +22,7 @@ const { t } = useI18n()
 const { user } = useAuthUser()
 
 // Admin check - redirect if not admin
-const isAdmin = computed(() => {
-  return user.value?.role === 'admin'
-})
+const { isAdmin } = useAccountRole()
 
 watch(isAdmin, (admin) => {
   if (user.value && !admin) {

--- a/apps/nexus/app/pages/dashboard/admin/codes.vue
+++ b/apps/nexus/app/pages/dashboard/admin/codes.vue
@@ -16,7 +16,7 @@ watch(() => user.value, (current) => {
   // `replace` matters: this route only forwards, so leaving it in history means
   // Back lands here and is immediately forwarded again — the reader cannot get
   // out of the subscriptions page with the Back button.
-  if (current.role === 'admin') {
+  if (isAdminAccountRole(current.role)) {
     navigateTo('/dashboard/admin/subscriptions', { replace: true })
     return
   }

--- a/apps/nexus/app/pages/dashboard/admin/doc-comments.vue
+++ b/apps/nexus/app/pages/dashboard/admin/doc-comments.vue
@@ -21,7 +21,7 @@ const { user } = useAuthUser()
 const toast = useToast()
 const { deviceId } = useDeviceIdentity()
 
-const isAdmin = computed(() => user.value?.role === 'admin')
+const { isAdmin } = useAccountRole()
 
 watch(isAdmin, (admin) => {
   if (user.value && !admin) {

--- a/apps/nexus/app/pages/dashboard/admin/governance.runtime.test.ts
+++ b/apps/nexus/app/pages/dashboard/admin/governance.runtime.test.ts
@@ -79,7 +79,7 @@ async function compileGovernanceFacade(): Promise<GovernanceFacadeSetup> {
 export async function setupGovernanceFacade(dependencies) {
   const { computed, onMounted, reactive, ref, watch } = dependencies.vue
   const { createGovernanceFormatters } = dependencies.governance
-  const { defineI18nRoute, definePageMeta, navigateTo, useAuthUser, useAsyncData, useI18n } = dependencies.nuxt
+  const { defineI18nRoute, definePageMeta, navigateTo, useAuthUser, useAccountRole, useAsyncData, useI18n } = dependencies.nuxt
   const { requestJson } = dependencies.request
 ${governancePageScriptWithoutImports}
   return {
@@ -126,6 +126,7 @@ ${governancePageScriptWithoutImports}
       definePageMeta: () => undefined,
       navigateTo: page.navigateTo,
       useAuthUser: () => ({ user: page.user }),
+      useAccountRole: () => ({ isAdmin: computed(() => page.user.value?.role === 'admin') }),
       useAsyncData: page.useAsyncData,
       useI18n: () => ({ t: (_key: string, fallback: string) => fallback, te: () => false, locale: page.locale }),
     },

--- a/apps/nexus/app/pages/dashboard/admin/governance.vue
+++ b/apps/nexus/app/pages/dashboard/admin/governance.vue
@@ -39,7 +39,7 @@ onMounted(() => {
 })
 const { user } = useAuthUser()
 
-const isAdmin = computed(() => user.value?.role === 'admin')
+const { isAdmin } = useAccountRole()
 
 watch(isAdmin, (admin) => {
   if (user.value && !admin) {

--- a/apps/nexus/app/pages/dashboard/admin/intelligence-chat.vue
+++ b/apps/nexus/app/pages/dashboard/admin/intelligence-chat.vue
@@ -30,7 +30,7 @@ interface ChatStreamEvent {
 }
 
 const { user, pending, status } = useAuthUser()
-const isAdmin = computed(() => user.value?.role === 'admin')
+const { isAdmin } = useAccountRole()
 // `!isAdmin` is also true before the session resolves, so gating the template on it
 // alone told a signed-in admin they were not allowed in until the profile landed.
 const sessionResolving = computed(() => {

--- a/apps/nexus/app/pages/dashboard/admin/reviews.vue
+++ b/apps/nexus/app/pages/dashboard/admin/reviews.vue
@@ -22,7 +22,7 @@ const toast = useToast()
 const { formatDate } = useStoreFormatters()
 
 // Admin check - redirect if not admin
-const isAdmin = computed(() => user.value?.role === 'admin')
+const { isAdmin } = useAccountRole()
 
 watch(isAdmin, (admin) => {
   if (user.value && !admin) {

--- a/apps/nexus/app/pages/dashboard/admin/risk.vue
+++ b/apps/nexus/app/pages/dashboard/admin/risk.vue
@@ -17,7 +17,7 @@ defineI18nRoute(false)
 const { t } = useI18n()
 const { user } = useAuthUser()
 
-const isAdmin = computed(() => user.value?.role === 'admin')
+const { isAdmin } = useAccountRole()
 watch(isAdmin, (admin) => {
   if (user.value && !admin)
     navigateTo('/dashboard/overview')

--- a/apps/nexus/app/pages/dashboard/admin/subscriptions.vue
+++ b/apps/nexus/app/pages/dashboard/admin/subscriptions.vue
@@ -38,9 +38,7 @@ function resolveErrorMessage(err: unknown, fallback: string) {
 }
 
 // Admin check - redirect if not admin
-const isAdmin = computed(() => {
-  return user.value?.role === 'admin'
-})
+const { isAdmin } = useAccountRole()
 
 watch(isAdmin, (admin) => {
   if (user.value && !admin) {

--- a/apps/nexus/app/pages/dashboard/admin/users.vue
+++ b/apps/nexus/app/pages/dashboard/admin/users.vue
@@ -39,7 +39,7 @@ function resolveErrorMessage(err: unknown, fallback: string) {
   return typeof message === 'string' && message.trim() ? message.trim() : fallback
 }
 
-const isAdmin = computed(() => user.value?.role === 'admin')
+const { isAdmin } = useAccountRole()
 
 watch(isAdmin, (admin) => {
   if (user.value && !admin)

--- a/apps/nexus/app/pages/dashboard/api-keys.vue
+++ b/apps/nexus/app/pages/dashboard/api-keys.vue
@@ -15,7 +15,7 @@ definePageMeta({
 
 const { t } = useI18n()
 const { user, error: userError, refresh: refreshUser } = useAuthUser()
-const isAdmin = computed(() => user.value?.role === 'admin')
+const { isAdmin } = useAccountRole()
 
 interface ApiKey {
   id: string

--- a/apps/nexus/app/pages/dashboard/assets.vue
+++ b/apps/nexus/app/pages/dashboard/assets.vue
@@ -87,9 +87,7 @@ const toast = useToast()
 
 const { plugins, pending: pluginsPending, error: pluginsLoadError, refresh: refreshPlugins } = useDashboardPluginsData()
 
-const isAdmin = computed(() => {
-  return user.value?.role === 'admin'
-})
+const { isAdmin } = useAccountRole()
 
 const currentUserId = computed(() => user.value?.id ?? null)
 

--- a/apps/nexus/app/pages/dashboard/images.vue
+++ b/apps/nexus/app/pages/dashboard/images.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { FileUploaderFile } from '@talex-touch/tuffex/file-uploader'
-import { computed, ref, watchEffect } from 'vue'
+import { ref, watchEffect } from 'vue'
 import { useDashboardImagesData } from '~/composables/useDashboardData'
 import { requestJson } from '~/utils/request'
 
@@ -19,11 +19,8 @@ definePageMeta({
 defineI18nRoute(false)
 
 const { t } = useI18n()
-const { user } = useAuthUser()
 
-const isAdmin = computed(() => {
-  return user.value?.role === 'admin'
-})
+const { isAdmin } = useAccountRole()
 
 const {
   images,

--- a/apps/nexus/app/pages/dashboard/oauth.vue
+++ b/apps/nexus/app/pages/dashboard/oauth.vue
@@ -57,12 +57,8 @@ const { user } = useAuthUser()
 
 const { data: teamData, pending: teamPending } = useTypedFetch<TeamSummaryResponse>('/api/dashboard/team')
 
-const isNexusAdmin = computed(() => String(user.value?.role || '').toLowerCase() === 'admin')
-const isTeamAdmin = computed(() => {
-  const team = teamData.value?.team
-  const role = String(team?.role || '').toLowerCase()
-  return team?.type === 'organization' && (role === 'owner' || role === 'admin')
-})
+const { isAdmin: isNexusAdmin } = useAccountRole()
+const { isTeamAdmin } = useTeamRole(() => teamData.value?.team)
 const canManageOauth = computed(() => isNexusAdmin.value || isTeamAdmin.value)
 
 const scopeOptions = computed<Array<{ value: OauthScope, label: string }>>(() => {

--- a/apps/nexus/app/pages/dashboard/updates.vue
+++ b/apps/nexus/app/pages/dashboard/updates.vue
@@ -46,7 +46,7 @@ definePageMeta({
 defineI18nRoute(false)
 
 const { t, locale } = useI18n()
-const { user } = useAuthUser()
+
 const toast = useToast()
 
 const { updates, pending: updatesPending, error: updatesError, refresh: refreshUpdates } = useDashboardUpdatesData()
@@ -74,7 +74,7 @@ const selectedSource = ref<UpdateSourceFilter>('all')
 const selectedDateRange = ref<UpdateDateRangeFilter>('all')
 const currentUpdatePage = ref(1)
 
-const isAdmin = computed(() => user.value?.role === 'admin')
+const { isAdmin } = useAccountRole()
 
 const typeOptions = computed(() => [
   { value: 'all', label: isZh.value ? '全部类型' : 'All types' },

--- a/apps/nexus/app/pages/docs/[...slug].vue
+++ b/apps/nexus/app/pages/docs/[...slug].vue
@@ -79,8 +79,7 @@ watch(
   { immediate: import.meta.client },
 )
 
-const authUserState = useState<{ role?: string } | null>('auth-user', () => null)
-const isAdmin = computed(() => authUserState.value?.role === 'admin')
+const { isAdmin } = useAccountRole()
 
 const CJK_PATTERN = /[\u4e00-\u9fff\u3000-\u303f\uff00-\uffef]/g
 const docPath = computed(() => normalizeDocsPagePath(activeRoutePath.value))

--- a/apps/nexus/app/pages/docs/docs-page-performance.test.ts
+++ b/apps/nexus/app/pages/docs/docs-page-performance.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 const page = readFileSync(new URL('./[...slug].vue', import.meta.url), 'utf8')
 const docsOutline = readFileSync(new URL('../../components/DocsOutline.vue', import.meta.url), 'utf8')
+const accountRoleComposable = readFileSync(new URL('../../composables/useAccountRole.ts', import.meta.url), 'utf8')
 const docsSidebar = readFileSync(new URL('../../components/DocsSidebar.vue', import.meta.url), 'utf8')
 const docSection = readFileSync(new URL('../../components/docs/DocSection.vue', import.meta.url), 'utf8')
 const docsAsideCards = readFileSync(new URL('../../components/docs/DocsAsideCards.vue', import.meta.url), 'utf8')
@@ -142,10 +143,18 @@ describe('docs page performance boundaries', () => {
   })
 
   it('reads docs admin state without pulling auth composables into the docs setup graph', () => {
-    expect.soft(page).toContain("const authUserState = useState<{ role?: string } | null>('auth-user', () => null)")
-    expect.soft(page).toContain("const isAdmin = computed(() => authUserState.value?.role === 'admin')")
+    // The page reads the role through useAccountRole() now. The contract is
+    // unchanged — what must stay out of the docs setup graph is useAuthUser,
+    // which installs a status watcher and fires a profile request — so the
+    // composable is asserted to be a plain read of the same shared state.
+    expect.soft(page).toContain('const { isAdmin } = useAccountRole()')
     expect.soft(page).not.toContain('useAuthUser({ fetchOnAuth: false, server: false })')
     expect.soft(page).not.toContain('const { user } = useAuthUser')
+
+    expect.soft(accountRoleComposable).toContain("useState<AccountRoleState | null>('auth-user', () => null)")
+    expect.soft(accountRoleComposable).not.toMatch(/^\s*(?:const|await|void).*useAuthUser\(/m)
+    expect.soft(accountRoleComposable).not.toContain('useNexusAuth(')
+    expect.soft(accountRoleComposable).not.toContain('fetchCurrentUserProfile')
 
     expect.soft(appRoot).toContain("const authUserState = useState<AppAuthUserState | null>('auth-user', () => null)")
     expect.soft(appRoot).toContain("const authUserPending = useState<boolean>('auth-user-pending', () => false)")

--- a/apps/nexus/app/utils/account-role.test.ts
+++ b/apps/nexus/app/utils/account-role.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { isAdminAccountRole, normalizeAccountRole } from './account-role'
+
+describe('isAdminAccountRole', () => {
+  it('accepts the one value the server also accepts', () => {
+    expect(isAdminAccountRole('admin')).toBe(true)
+    expect(isAdminAccountRole('user')).toBe(false)
+  })
+
+  /**
+   * The predicate this replaced (`app/utils/role.ts`'s `isAdminRole`) returned
+   * true for 'owner'. 'owner' is a TeamMemberRole and never appears in
+   * `auth_users.role`, so that only ever meant one thing: had anything wired it
+   * up, a team owner would have been shown admin views whose every request
+   * `requireAdmin` then rejects with a 403.
+   */
+  it('does not treat the team owner role as a platform admin', () => {
+    expect(isAdminAccountRole('owner')).toBe(false)
+    expect(isAdminAccountRole('member')).toBe(false)
+  })
+
+  it('normalizes case and padding, since the copies it replaced disagreed', () => {
+    expect(isAdminAccountRole('ADMIN')).toBe(true)
+    expect(isAdminAccountRole(' Admin ')).toBe(true)
+  })
+
+  it('is false for an absent role rather than throwing', () => {
+    expect(isAdminAccountRole(undefined)).toBe(false)
+    expect(isAdminAccountRole(null)).toBe(false)
+    expect(isAdminAccountRole('')).toBe(false)
+    expect(normalizeAccountRole(undefined)).toBe('')
+  })
+})

--- a/apps/nexus/app/utils/account-role.ts
+++ b/apps/nexus/app/utils/account-role.ts
@@ -1,0 +1,24 @@
+/**
+ * The platform account role — the `role` column on `auth_users`.
+ *
+ * Only ever `admin` or `user`: the column defaults to `'user'`, and the one
+ * endpoint that writes it (`server/api/admin/users/index.get.ts`) validates
+ * against exactly that pair. The server gate is `requireAdmin`
+ * (`server/utils/auth.ts`), which rejects anything that is not `'admin'`, so a
+ * client check looser than this one renders a view whose own requests 403.
+ *
+ * This is NOT the team role. `owner` belongs to `TeamMemberRole`
+ * (`'owner' | 'admin' | 'member'`, see `server/utils/creditsStore.ts`) and
+ * lives in the team-membership table — a team owner has no platform
+ * privileges at all. Use `useTeamRole()` for that namespace; conflating the
+ * two is what the deleted `isAdminRole()` helper did.
+ */
+export type AccountRole = 'admin' | 'user'
+
+export function isAdminAccountRole(role?: string | null): boolean {
+  return normalizeAccountRole(role) === 'admin'
+}
+
+export function normalizeAccountRole(role?: string | null): string {
+  return String(role ?? '').trim().toLowerCase()
+}

--- a/apps/nexus/app/utils/role.ts
+++ b/apps/nexus/app/utils/role.ts
@@ -1,4 +1,0 @@
-export function isAdminRole(role?: string | null) {
-  const normalized = String(role || '').toLowerCase()
-  return normalized === 'admin' || normalized === 'owner'
-}


### PR DESCRIPTION
Stacked on #1892 — review that one first; this PR's diff is only the second commit.

## Why

`computed(() => user.value?.role === 'admin')` had been written out in **20** pages and components. The copies had already drifted — some lower-cased the value before comparing (`DashboardNav`, `oauth`) and some compared it raw (everywhere else) — so a stored role differing only in case would have been admin on one page and not on the next. There was also nowhere to point at when someone asked what *the* admin check is; a review bot on #1892 asked exactly that and picked the wrong answer.

## Two namespaces, kept apart

| | account role | team role |
|---|---|---|
| composable | `useAccountRole()` | `useTeamRole(team)` |
| predicate | `isAdminAccountRole(role)` | — |
| values | `admin` \| `user` | `owner` \| `admin` \| `member` |
| stored in | `auth_users.role` | team membership table |
| server gate | `requireAdmin` (`role !== 'admin'` → 403) | `teamContext` `isAdminLike` |
| unlocks | every `/dashboard/admin` route | OAuth app management |

## `app/utils/role.ts` is deleted

```ts
export function isAdminRole(role?: string | null) {
  return normalized === 'admin' || normalized === 'owner'
}
```

It folded the team role into the account role. Nothing imported it — that is the only reason it never caused an incident. Had anything wired it up, a team owner would have been shown admin views whose every request `requireAdmin` then rejects with a 403. A review bot suggested adopting it on #1892 for precisely that reason, so `account-role-contract.test.ts` now fails on any helper that folds the two together, and on any page that re-inlines the current-user role check.

## One thing this refactor nearly broke

`docs-page-performance.test.ts` asserts the docs page reads the role **without pulling auth composables into its setup graph** — `useAuthUser()` installs a status watcher and fires a profile request. The first version of `useAccountRole()` called `useAuthUser()`, and that test caught it. The composable now reads the shared `auth-user` state directly, which is where `useAuthUser` and `app.vue` both write anyway, so it is side-effect free and safe to call from any route. The docs contract is updated rather than relaxed: it now also asserts the composable performs no fetch of its own.

## Verification

- full `vitest run`: **230 files / 1432 tests passed** (was 227/1421 — the 11 new tests are this PR's)
- `nuxt typecheck`: 0 errors
- eslint on `app/`: clean
- net **−58 / +63** across 34 files, most of it comments and tests

Five sandbox-style test harnesses inject auto-imports by hand and needed the new composable added next to `useAuthUser`; each still drives off the same `role` fixture it always did.