### PR TITLE
release: v2.4.14-beta.34

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/core-app",
-  "version": "2.4.14-beta.33",
+  "version": "2.4.14-beta.34",
   "private": true,
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@talex-touch/tuff",
   "homepage": "https://tuff.tagzxia.com",
   "type": "module",
-  "version": "2.4.14-beta.33",
+  "version": "2.4.14-beta.34",
   "packageManager": "pnpm@11.24.0",
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",


### PR DESCRIPTION
## Summary

- Bump root and CoreApp versions to 2.4.14-beta.34 using the repository version command.
- Bilingual notes and the settings relocation are already merged via #1894.
- Protected master rejected the direct version push; this PR preserves the required check boundary. The local tag is not published and will be recreated at the final master merge SHA.

## Validation

- pnpm release:notes:verify: passed for 2.4.14-beta.34.
- pnpm test:release-acceptance: 11 passed.
- Source candidate: all nine CI jobs and macOS/Windows/Linux native protocol checks passed.
- Audio Insights voice switch and simplified Assistant card verified in isolated Electron; toggle persisted across reload independently of Assistant and floating ball.

No dependency upgrades or user-profile changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Bumped the application version to `2.4.14-beta.34`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->