### PR TITLE
release: v2.4.14-beta.35

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/core-app",
-  "version": "2.4.14-beta.34",
+  "version": "2.4.14-beta.35",
   "private": true,
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@talex-touch/tuff",
   "homepage": "https://tuff.tagzxia.com",
   "type": "module",
-  "version": "2.4.14-beta.34",
+  "version": "2.4.14-beta.35",
   "packageManager": "pnpm@11.24.0",
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",


### PR DESCRIPTION
## 摘要

标准 `pnpm run version 2.4.14-beta.35` 生成的版本提交，仅同步根目录与 CoreApp 的 version 字段。搜索流修复、语音界面合并和双语说明已经通过 #1896 合入 master。

## 质量检查清单
- [x] 仅两个版本字段，无新增运行时变更
- [x] `release-notes-gateway.mjs verify`：版本、tag 名与双语正文契约均通过
- [x] Release acceptance：2 files / 11 tests passed
- [x] 标准脚本的 master 直推被 GH006 拒绝后改走本 PR，未使用管理员绕过
- [x] 目标发布 tag 尚未推送

## 发布与自动化需求

全部门禁通过并正常合入后，将尚未发布的本地 `v2.4.14-beta.35` annotated tag 重建到最终 master merge SHA，核验 HEAD/master/tag 一致后再推送。随后等待完整跨平台构建、签名、公证、Create Release 与 Sync Nexus Release，并独立核验公共产物。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application package version from `2.4.14-beta.34` to `2.4.14-beta.35`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->