### PR TITLE
fix(release): widen the post-publish registry read window

### DIFF
--- a/scripts/publish-package.mjs
+++ b/scripts/publish-package.mjs
@@ -180,7 +180,12 @@ function readRegistryField(packageName, version, field) {
  * `readField` is injectable so the failure path can be tested without a registry.
  */
 export function verifyRegistryManifest(packageInfo, version, readField = readRegistryField, options = {}) {
-  const { attempts = 6, delayMs = 5_000, sleep: sleepFn = sleep } = options
+  /*
+   * Waits double up to `maxDelayMs`, so the published version has roughly four
+   * minutes — 5 + 10 + 20 + 40 + 60 + 60 + 60 s — to become readable instead of
+   * the 30 s a fixed 6 × 5 s allowed.
+   */
+  const { attempts = 8, delayMs = 5_000, maxDelayMs = 60_000, sleep: sleepFn = sleep } = options
 
   // A non-positive `attempts` would skip the loop entirely, leaving `value`
   // undefined and `lastError` unset — and the regex below would then test the
@@ -197,10 +202,14 @@ export function verifyRegistryManifest(packageInfo, version, readField = readReg
      * Retried because this runs immediately after `npm publish` and the version
      * is not always queryable yet: tuffex@0.4.0 published correctly and then
      * failed here seconds later with `404 No match found for version 0.4.0`,
-     * marking a good release red. Retrying only widens the window — the throw
-     * below is unchanged and deliberate (#560): an unreadable manifest must
-     * never be reported as clean.
+     * marking a good release red, and tuffex@0.6.0 was still 404 five minutes
+     * after npm answered the publish with `+ @talex-touch/tuffex@0.6.0` — a
+     * fixed 6 × 5 s was still narrower than the registry's own
+     * "being processed and may take a few minutes". The waits therefore double.
+     * The throw below is unchanged and deliberate (#560): an unreadable
+     * manifest must never be reported as clean.
      */
+    let waitMs = delayMs
     for (let attempt = 1; attempt <= attempts; attempt += 1) {
       try {
         value = readField(packageInfo.name, version, field)
@@ -209,8 +218,10 @@ export function verifyRegistryManifest(packageInfo, version, readField = readReg
       }
       catch (error) {
         lastError = error
-        if (attempt < attempts)
-          sleepFn(delayMs)
+        if (attempt < attempts) {
+          sleepFn(waitMs)
+          waitMs = Math.min(waitMs * 2, maxDelayMs)
+        }
       }
     }
 

--- a/scripts/publish-package.mjs
+++ b/scripts/publish-package.mjs
@@ -209,7 +209,9 @@ export function verifyRegistryManifest(packageInfo, version, readField = readReg
      * The throw below is unchanged and deliberate (#560): an unreadable
      * manifest must never be reported as clean.
      */
-    let waitMs = delayMs
+    // Clamped up front too: maxDelayMs is a ceiling on every wait, including a
+    // caller that configures it below delayMs.
+    let waitMs = Math.min(delayMs, maxDelayMs)
     for (let attempt = 1; attempt <= attempts; attempt += 1) {
       try {
         value = readField(packageInfo.name, version, field)

--- a/scripts/publish-package.test.mjs
+++ b/scripts/publish-package.test.mjs
@@ -78,6 +78,30 @@ describe('verifyRegistryManifest', () => {
     assert.equal(calls, 6)
   })
 
+  it('clamps even the first wait when maxDelayMs is below delayMs', () => {
+    // `maxDelayMs` is a ceiling on every wait, not just on the doubled ones. If
+    // the first wait were initialized from `delayMs` alone, a caller that asked
+    // for 4 s max would still be put to sleep for the full 10 s before any
+    // retry — the cap would only start applying from the second wait on.
+    let calls = 0
+    const readField = () => {
+      calls += 1
+      throw new Error('npm error code E404 No match found for version 0.7.0')
+    }
+    const waits = []
+
+    assert.throws(() =>
+      verifyRegistryManifest(pkg, '0.7.0', readField, {
+        attempts: 4,
+        delayMs: 10_000,
+        maxDelayMs: 4_000,
+        sleep: ms => waits.push(ms),
+      }))
+
+    assert.deepEqual(waits, [4_000, 4_000, 4_000])
+    assert.equal(calls, 4)
+  })
+
   it('refuses a non-positive attempt count instead of passing without reading', () => {
     // With attempts <= 0 the loop never runs, so nothing is read and the
     // forbidden-protocol regex would test `undefined` and find it clean.

--- a/scripts/publish-package.test.mjs
+++ b/scripts/publish-package.test.mjs
@@ -51,6 +51,33 @@ describe('verifyRegistryManifest', () => {
     assert.ok(calls >= 3, 'expected the read to be retried')
   })
 
+  it('widens the wait between attempts and stops at the cap', () => {
+    // A fixed 6 x 5 s (30 s) was narrower than the registry's own "being
+    // processed and may take a few minutes", so the waits double. The schedule
+    // the caller observes is the whole point: a fixed delay or growth that
+    // ignores `maxDelayMs` gives a release less time than it was promised.
+    let calls = 0
+    const readField = () => {
+      calls += 1
+      throw new Error('npm error code E404 No match found for version 0.6.0')
+    }
+    const waits = []
+
+    assert.throws(
+      () =>
+        verifyRegistryManifest(pkg, '0.6.0', readField, {
+          attempts: 6,
+          delayMs: 5_000,
+          maxDelayMs: 60_000,
+          sleep: ms => waits.push(ms),
+        }),
+      /after 6 attempt\(s\)/,
+    )
+
+    assert.deepEqual(waits, [5_000, 10_000, 20_000, 40_000, 60_000])
+    assert.equal(calls, 6)
+  })
+
   it('refuses a non-positive attempt count instead of passing without reading', () => {
     // With attempts <= 0 the loop never runs, so nothing is read and the
     // forbidden-protocol regex would test `undefined` and find it clean.


### PR DESCRIPTION
## 摘要

发布 `@talex-touch/tuffex@0.6.0` 的那次运行被标记为红色，但包已经发出去了：npm 返回 `+ @talex-touch/tuffex@0.6.0`（tarball 1.2 MB / 解包 8.4 MB / 2286 文件），紧随其后的注册表校验在 27 秒内重试 6 次全部 404，随即抛出 `Could not read the published manifest ... (dependencies)` 并让整条流水线失败。

原因是重试窗口比 npm 自己的可用性延迟还窄。`verifyRegistryManifest` 用的是固定 `6 × 5s = 30s`，而 npm 在响应里明确写着 "Your package is being processed and may take a few minutes to become available"；本次实测 5 分钟后 `registry.npmjs.org` 仍未提供 `0.6.0`（`dist-tags.latest` 仍为 `0.5.0`）。同一类问题在 `tuffex@0.4.0` 已经出现过一次，当时的修复只是把 `attempts` 提到 6，窗口仍然不够。

现在等待时间改为**翻倍并封顶**：默认 `attempts = 8`、`delayMs = 5s`、`maxDelayMs = 60s` → `5 + 10 + 20 + 40 + 60 + 60 + 60 ≈ 4 分钟`。抛出条件、禁止协议扫描与「不可读的 manifest 绝不当作干净」的语义完全不变。

### 变更类型

- ☑ 缺陷修复
- ☑ 维护项（构建 / CI / 发布）

## 质量检查清单

- ☑ 代码符合项目的约定与规范
- ☑ 现有测试全部通过
- ☑ 需要时已补充或更新测试用例（新增 1 个契约测试）
- ☑ 必要的文档 / 注释已经同步更新（注释记录 0.4.0 与 0.6.0 两次实测）

## 测试情况

- ☑ 已在本地验证
- ☑ 已添加或更新自动化测试
- ☑ 影响发布流程，已进行相应验证

本地证据：

- `npx vitest run --config vitest.workspace-scripts.config.mjs scripts/publish-package.test.mjs` → `11 passed`（原 10 个用例未改动，新增 1 个）
- 新用例锁定调用方能观察到的等待序列：`{ attempts: 6, delayMs: 5000, maxDelayMs: 60000 }` → `[5000, 10000, 20000, 40000, 60000]`，且读取恰好 6 次。两次变异验证有效：去掉倍增（固定 5s）与去掉封顶（末次 80s）都会让该用例单独失败；还原后 11/11 通过。

## 发布与自动化需求

- ☐ 需要将此 PR 的提交包含进下一次 Release 更新日志
- ☐ 需要触发 AI 对此 PR 的自动分析

## 其他信息

- 本 PR 合并后 `Tuffex Package Publish` 会再次触发：版本未变且已在 npm 上，因此走「跳过发布」分支，正好用于把那次红色运行对应的流程补齐为绿色。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package publishing reliability by retrying registry reads with exponential backoff.
  * Registry checks now allow additional attempts and cap retry delays at 60 seconds.
  * Unreadable registry manifests continue to produce a clear error after retries are exhausted.

* **Tests**
  * Added coverage verifying increasing retry delays, the maximum delay cap, and final error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->