### PR TITLE
fix(i18n): resolve credit capability labels

### DIFF
--- a/apps/core-app/src/renderer/src/modules/lang/en-US.json
+++ b/apps/core-app/src/renderer/src/modules/lang/en-US.json
@@ -854,11 +854,13 @@
       "image": "credits / image"
     },
     "capabilities": {
-      "text.chat": "Text chat",
-      "vision.ocr": "Image text recognition",
-      "image.translate.e2e": "Image translation",
-      "audio.transcribe": "Speech transcription",
-      "audio.stt": "Speech transcription"
+      "text": { "chat": "Text chat" },
+      "vision": { "ocr": "Image text recognition" },
+      "image": { "translate": { "e2e": "Image translation" } },
+      "audio": {
+        "transcribe": "Speech transcription",
+        "stt": "Speech transcription"
+      }
     },
     "loginRequired": "Sign in to view remaining credits and usage.",
     "loading": "Loading credits information.",

--- a/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
+++ b/apps/core-app/src/renderer/src/modules/lang/zh-CN.json
@@ -854,11 +854,13 @@
       "image": "credits / 张"
     },
     "capabilities": {
-      "text.chat": "文本对话",
-      "vision.ocr": "图片文字识别",
-      "image.translate.e2e": "图片翻译",
-      "audio.transcribe": "语音转写",
-      "audio.stt": "语音转写"
+      "text": { "chat": "文本对话" },
+      "vision": { "ocr": "图片文字识别" },
+      "image": { "translate": { "e2e": "图片翻译" } },
+      "audio": {
+        "transcribe": "语音转写",
+        "stt": "语音转写"
+      }
     },
     "loginRequired": "登录后可查看 credits 剩余和消耗。",
     "loading": "正在获取 credits 信息。",


### PR DESCRIPTION
## Summary
- Publish existing local commit `309dc1f296ef82f5700e80fa167896cbd1a2a2ae`.
- Replace literal dotted capability keys with nested message objects in the English and Chinese credits translations so vue-i18n can resolve text, image, OCR, and speech capability labels.
- Preserve the existing translated text. Only the two locale JSON files are changed.

## Verification
- `pnpm -C apps/core-app exec vitest run src/renderer/src/modules/lang/translation-coverage.test.ts` — 4 tests passed.
- `pnpm -C apps/core-app run typecheck:node` — passed.
- `node scripts/docs/run-docs-verify.mjs` — passed.
- `node scripts/check-drizzle-snapshot-drift.mjs` — passed.

## Scope
This PR publishes an already-committed local fix; no new Trellis task was created. The untracked Comet migration task directory and local `build/` artifacts are not included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured capability translation data across English and Simplified Chinese locales into a nested hierarchy.
  * Preserved all existing translation text and supported capability labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->