### PR TITLE
fix(nexus): use built TuffEx dist by default

### DIFF
--- a/apps/nexus/README.md
+++ b/apps/nexus/README.md
@@ -16,6 +16,13 @@ pnpm run dev
 
 The site will be available at `http://localhost:3200`.
 
+Nexus consumes the built TuffEx package by default, which keeps the docs dev graph small:
+
+- `pnpm run dev` uses `packages/tuffex/dist/es` (build it first with `pnpm -C packages/tuffex run build`).
+- `NUXT_TUFFEX_SOURCE=true pnpm run dev` uses `packages/tuffex/packages/components/src` for live TuffEx component editing.
+
+If the dist entry is missing, dev startup fails with the build command above; use source mode deliberately when working on TuffEx itself.
+
 ## Docs SEO and prerender evidence
 
 Docs pages are rendered through `app/pages/docs/[...slug].vue`. The page derives title/description from Nuxt Content, synchronizes the route locale for `/en/docs/**` and `/zh/docs/**` while the app still uses Nuxt i18n `no_prefix`, and emits canonical and localized alternate links, `robots`, Open Graph/Twitter metadata, and `TechArticle` JSON-LD.

--- a/apps/nexus/app/components/content/demo-client-boundary.test.ts
+++ b/apps/nexus/app/components/content/demo-client-boundary.test.ts
@@ -13,6 +13,16 @@ function readNuxtFile(file: string) {
   return readFileSync(new URL(`../../../.nuxt/${file}`, import.meta.url), 'utf8')
 }
 
+/**
+ * Vite discovers a dependency imported through a package entry as a nested id
+ * (`owner > dep`), which changes the `optimizeDeps.include` spelling. Accept either the
+ * bare or the nested entry so this test keeps asserting the pre-bundle, not the id shape.
+ */
+function preBundlesDependency(config: string, dependency: string): boolean {
+  const escaped = dependency.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')
+  return new RegExp(`['"](?:[^'"]* > )?${escaped}['"]`).test(config)
+}
+
 describe('Tuff demo client boundary', () => {
   it('keeps the generated demo registry out of the SSR wrapper', () => {
     const wrapper = readComponent('./TuffDemoWrapper.vue')
@@ -99,22 +109,41 @@ describe('Tuff demo client boundary', () => {
     expect(adminBootstrapPage).toContain('const toast = useToast()')
   })
 
-  it('normalizes TuffEx dev component aliases to one source module id', () => {
+  it('normalizes TuffEx dev component aliases to one mode-selected module id', () => {
     const config = readProjectFile('../../../nuxt.config.ts')
 
+    // Source mode remains an explicit escape hatch, so its component targets must survive.
     expect(config).toContain('const tuffexComponentSourceEntry = ')
     expect(config).toContain('const tuffexComponentSourceTypePathEntry = ')
     expect(config).toContain('tuffexComponentsSourceRoot')
     expect(config).toContain('/$1/index.ts')
-    expect(config).toContain('{ find: /^@tuffex-components\\/(.+)$/, replacement: tuffexComponentSourceEntry }')
-    expect(config).toContain("'@tuffex-components/*': [tuffexComponentSourceTypePathEntry]")
+    expect(config).toMatch(/\$\{tuffexComponentsSourceRoot\}\/\*\/index\.ts/)
+
+    // Dist mode is the dev default, so its component targets must exist to be selected.
+    expect(config).toContain('const tuffexComponentDistEntry = ')
+    expect(config).toContain('const tuffexComponentDistTypePathEntry = ')
+    expect(config).toContain('/$1/index.js')
+    expect(config).toContain('/*/index.d.ts')
+
+    // Dev picks the entry from the resolved mode, while production keeps the source registry
+    // that the generated demo module auto-imports against.
+    expect(config).toContain('const tuffexComponentEntry = useTuffexSource ? tuffexComponentSourceEntry : tuffexComponentDistEntry')
+    expect(config).toContain('const tuffexComponentAutoImportEntry = isDev ? tuffexComponentEntry : tuffexComponentSourceEntry')
+    expect(config.replace(/\s+/g, ' ')).toContain('const tuffexComponentTypePathEntry = !isDev ? tuffexComponentSourceTypePathEntry : useTuffexSource ? tuffexComponentSourceTypePathEntry : tuffexComponentDistTypePathEntry')
+
+    // The auto-import alias keeps its module id stable in production; the package-subpath alias
+    // and both type paths stay mode-selected in dev.
+    expect(config).toContain('{ find: /^@tuffex-components\\/(.+)$/, replacement: tuffexComponentAutoImportEntry }')
+    expect(config).toContain('{ find: /^@talex-touch\\/tuffex\\/([a-z0-9-]+)$/, replacement: tuffexComponentEntry }')
+    expect(config).toContain("'@tuffex-components/*': [tuffexComponentTypePathEntry]")
+    expect(config).toContain("'@talex-touch/tuffex/*': [tuffexComponentTypePathEntry]")
   })
 
   it('pre-bundles TuffEx runtime dependencies used by docs chrome', () => {
     const config = readProjectFile('../../../nuxt.config.ts')
 
-    expect(config).toContain("'@floating-ui/vue'")
-    expect(config).toContain("'v-wave'")
+    expect(preBundlesDependency(config, '@floating-ui/vue')).toBe(true)
+    expect(preBundlesDependency(config, 'v-wave')).toBe(true)
   })
 
   it('pre-bundles WebGL background dependencies used by Nexus visual routes', () => {
@@ -132,7 +161,7 @@ describe('Tuff demo client boundary', () => {
     expect(config).toContain("'echarts/charts'")
     expect(config).toContain("'echarts/components'")
     expect(config).toContain("'echarts/renderers'")
-    expect(config).toContain("'dompurify'")
+    expect(preBundlesDependency(config, 'dompurify')).toBe(true)
   })
 
   it('keeps Sentry out of local dev startup unless explicitly enabled', () => {

--- a/apps/nexus/build/check-worker-bundle.mjs
+++ b/apps/nexus/build/check-worker-bundle.mjs
@@ -563,8 +563,9 @@ function checkRoutes() {
 
 /**
  * Mirrors how Pages reads `_headers`: `#` lines are comments, indented lines are headers of the
- * block above, and a pattern that appears twice keeps only its last block — the rules are keyed
- * by pattern, so the second block replaces the first rather than adding to it.
+ * block above, a header named twice in one block is joined with `, ` (as HTTP folds repeated
+ * fields), and a pattern that appears twice keeps only its last block — the rules are keyed by
+ * pattern, so the second block replaces the first rather than adding to it.
  */
 export function parseCloudflareHeadersFile(source) {
   const blocks = []
@@ -580,7 +581,9 @@ export function parseCloudflareHeadersFile(source) {
       const separator = line.indexOf(':')
       if (separator === -1)
         continue
-      current.headers[line.slice(0, separator).trim().toLowerCase()] = line.slice(separator + 1).trim()
+      const name = line.slice(0, separator).trim().toLowerCase()
+      const value = line.slice(separator + 1).trim()
+      current.headers[name] = name in current.headers ? `${current.headers[name]}, ${value}` : value
       continue
     }
     current = { pattern: line, headers: {} }
@@ -1075,6 +1078,14 @@ function findIconsStylesheet(distFiles) {
   }) ?? null
 }
 
+/**
+ * `uno.config.ts` wraps every icon selector in `:where()` so the after-mount sheet cannot outrank
+ * host utilities; the per-glyph budgets are keyed by the bare class.
+ */
+function unwrapIconSelector(selector) {
+  return selector.match(/^:where\((.+)\)$/)?.[1] ?? selector
+}
+
 function checkSharedEntryCssBudget(distFiles) {
   const entryFiles = distFiles.filter(file => /^_nuxt\/entry\.[^/]+\.css$/.test(file.relativePath))
   const findings = []
@@ -1112,7 +1123,7 @@ function checkSharedEntryCssBudget(distFiles) {
       const rule = rules.find((candidate) => {
         const selector = candidate.slice(0, candidate.indexOf('{'))
         return candidate.includes('--un-icon:')
-          && selector.split(',').some(part => part.trim() === `.${token}`)
+          && selector.split(',').some(part => unwrapIconSelector(part.trim()) === `.${token}`)
       })
       if (!rule) {
         findings.push(`aliased icon selector missing from the icons stylesheet: ${token}`)
@@ -1373,8 +1384,8 @@ console.log(`[nexus-dist-budget] Docs initial lifecycle blockers verified: ${doc
 console.log(`[nexus-dist-budget] Initial asset budgets verified: ${htmlInitialAssetBudgetRouteCount} routes / ${htmlInitialAssetBudgets.length} families`)
 if (sharedEntryCssCheck.entry) {
   console.log(`[nexus-dist-budget] Shared entry CSS verified: ${formatBytes(sharedEntryCssCheck.entry.bytes)} / ${formatBytes(sharedEntryCssCheck.entry.gzipBytes)} gzip`)
-if (sharedEntryCssCheck.icons)
-  console.log(`[nexus-dist-budget] Icons stylesheet verified: ${sharedEntryCssCheck.icons.asset} ${formatBytes(sharedEntryCssCheck.icons.bytes)} / ${formatBytes(sharedEntryCssCheck.icons.gzipBytes)} gzip (loaded after mount)`)
+  if (sharedEntryCssCheck.icons)
+    console.log(`[nexus-dist-budget] Icons stylesheet verified: ${sharedEntryCssCheck.icons.asset} ${formatBytes(sharedEntryCssCheck.icons.bytes)} / ${formatBytes(sharedEntryCssCheck.icons.gzipBytes)} gzip (loaded after mount)`)
 }
 console.log(`[nexus-dist-budget] Landing image prefetch hints verified: ${landingInitialHtmlFiles.length - landingImagePrefetchFindings.length}/${landingInitialHtmlFiles.length}`)
 console.log(`[nexus-dist-budget] Landing deferred image references verified: ${landingInitialHtmlFiles.length - landingDeferredImageFindings.length}/${landingInitialHtmlFiles.length}`)

--- a/apps/nexus/build/check-worker-bundle.test.ts
+++ b/apps/nexus/build/check-worker-bundle.test.ts
@@ -129,6 +129,23 @@ describe('Nexus deploy asset budget', () => {
     expect(uninstalled.css.length, 'i-ri-settings-line should not resolve — ri is not a dependency').toBe(0)
   })
 
+  /*
+   * The icons layer is a separate stylesheet appended after every other sheet once the app has
+   * mounted, so its rules come last in the cascade. At class specificity they would beat the
+   * `text-*` / `w-*` utilities on the same element (`color:inherit`, `width:1.2em`), which the
+   * old single-sheet order let the utilities win. `uno.config.ts` wraps every icon selector in
+   * `:where()` so load order cannot decide that again; both output modes must be covered.
+   */
+  it('emits icon rules at zero specificity so host utilities win whichever sheet lands last', async () => {
+    const uno = await createGenerator(unoConfig)
+    const { css } = await uno.generate('i-carbon-settings i-logos-vue text-amber-600 w-4', { preflights: false })
+
+    expect(css).toMatch(/:where\(\.i-carbon-settings\)\{[^}]*--un-icon:/)
+    expect(css).toMatch(/:where\(\.i-logos-vue\)\{[^}]*background:url\("data:image\/svg\+xml/)
+    expect(css).toMatch(/(?:^|\n)\.text-amber-600\{/)
+    expect(css).toMatch(/(?:^|\n)\.w-4\{/)
+  })
+
   it('keeps oversized route-local icon paths out of the shared entry CSS', () => {
     const unoSource = readFileSync(unoConfigPath, 'utf8')
     const guardSource = readFileSync(workerBundleGuardPath, 'utf8')

--- a/apps/nexus/build/static-cache-headers.test.ts
+++ b/apps/nexus/build/static-cache-headers.test.ts
@@ -65,6 +65,23 @@ describe('static cache headers guard', () => {
     )
   })
 
+  it('joins a header named twice in one block the way Pages sends it', () => {
+    const source = [
+      '/',
+      '  Link: </_nuxt/e.js>; rel=modulepreload; crossorigin',
+      '  Link: </_nuxt/entry.css>; rel=preload; as=style; crossorigin',
+    ].join('\n')
+
+    expect(parseCloudflareHeadersFile(source)).toEqual([{
+      pattern: '/',
+      headers: { link: '</_nuxt/e.js>; rel=modulepreload; crossorigin, </_nuxt/entry.css>; rel=preload; as=style; crossorigin' },
+    }])
+    // …so the early-hints guard sees both targets, not just the last line's.
+    expect(checkEarlyHints(source, target => target === '/_nuxt/e.js').findings).toContain(
+      '/: Link targets missing from dist: /_nuxt/entry.css',
+    )
+  })
+
   it('accepts the _headers file the shared route rules produce', () => {
     const result = checkStaticCacheHeaders(renderHeadersFile(createStaticCacheRouteRules()))
 

--- a/apps/nexus/build/tuffex-dev-mode.test.ts
+++ b/apps/nexus/build/tuffex-dev-mode.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { isTuffexSourceRequested, resolveTuffexDevMode } from './tuffex-dev-mode'
+
+describe('isTuffexSourceRequested', () => {
+  it.each(['1', 'true', 'yes', 'on', 'TRUE', ' true '])(
+    'treats %s as a source request in dev',
+    (value) => {
+      expect(isTuffexSourceRequested(true, { NUXT_TUFFEX_SOURCE: value })).toBe(true)
+    },
+  )
+
+  it.each([undefined, '0', 'false', ''])(
+    'does not treat %s as a source request in dev',
+    (value) => {
+      expect(isTuffexSourceRequested(true, { NUXT_TUFFEX_SOURCE: value })).toBe(false)
+    },
+  )
+
+  it('never requests source outside dev, even when the flag is set', () => {
+    expect(isTuffexSourceRequested(false, { NUXT_TUFFEX_SOURCE: 'true' })).toBe(false)
+  })
+})
+
+describe('resolveTuffexDevMode', () => {
+  it('prefers tuffex source in dev when the flag is set', () => {
+    expect(resolveTuffexDevMode({
+      isDev: true,
+      env: { NUXT_TUFFEX_SOURCE: '1' },
+      distEntryExists: true,
+    })).toBe('source')
+  })
+
+  it('uses the built tuffex dist in dev by default', () => {
+    expect(resolveTuffexDevMode({
+      isDev: true,
+      env: {},
+      distEntryExists: true,
+    })).toBe('dist')
+  })
+
+  it('tells dev how to build dist or opt into source when dist is missing', () => {
+    let message = ''
+    try {
+      resolveTuffexDevMode({ isDev: true, env: {}, distEntryExists: false })
+    }
+    catch (error) {
+      message = error instanceof Error ? error.message : String(error)
+    }
+
+    expect(message).toContain('pnpm -C packages/tuffex run build')
+    expect(message).toContain('NUXT_TUFFEX_SOURCE')
+  })
+
+  it('uses dist in production even when the flag is set or dist is absent', () => {
+    expect(resolveTuffexDevMode({
+      isDev: false,
+      env: { NUXT_TUFFEX_SOURCE: 'true' },
+      distEntryExists: true,
+    })).toBe('dist')
+
+    expect(resolveTuffexDevMode({
+      isDev: false,
+      env: {},
+      distEntryExists: false,
+    })).toBe('dist')
+  })
+})

--- a/apps/nexus/build/tuffex-dev-mode.ts
+++ b/apps/nexus/build/tuffex-dev-mode.ts
@@ -1,0 +1,53 @@
+export type TuffexDevMode = 'source' | 'dist'
+
+export interface ResolveTuffexDevModeOptions {
+  isDev: boolean
+  env?: Record<string, string | undefined>
+  distEntryExists: boolean
+}
+
+function isEnabled(value?: string): boolean {
+  if (!value)
+    return false
+
+  const normalized = value.trim().toLowerCase()
+  return normalized === '1'
+    || normalized === 'true'
+    || normalized === 'yes'
+    || normalized === 'on'
+}
+
+export function isTuffexSourceRequested(
+  isDev: boolean,
+  env: Record<string, string | undefined> = {},
+): boolean {
+  return isDev && isEnabled(env.NUXT_TUFFEX_SOURCE)
+}
+
+/**
+ * Resolve how Nexus should consume TuffEx during development.
+ *
+ * Production always consumes the built package. Development defaults to the same
+ * path so the docs app does not transform the whole TuffEx source tree; source
+ * mode is an explicit escape hatch for editing TuffEx itself.
+ */
+export function resolveTuffexDevMode({
+  isDev,
+  env = {},
+  distEntryExists,
+}: ResolveTuffexDevModeOptions): TuffexDevMode {
+  if (!isDev)
+    return 'dist'
+
+  if (isTuffexSourceRequested(isDev, env))
+    return 'source'
+
+  if (!distEntryExists) {
+    throw new Error(
+      '[nexus] tuffex dist is missing. Run `pnpm -C packages/tuffex run build`, '
+      + 'or set NUXT_TUFFEX_SOURCE=true to develop against tuffex source.',
+    )
+  }
+
+  return 'dist'
+}

--- a/apps/nexus/modules/tuffex-components.ts
+++ b/apps/nexus/modules/tuffex-components.ts
@@ -1,9 +1,11 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
+import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 // `nuxt/kit`, not `@nuxt/kit`: the latter is only a transitive dependency here,
 // so its types do not resolve without adding a direct dependency.
 import { addComponent, defineNuxtModule } from 'nuxt/kit'
+import { isTuffexSourceRequested } from '../build/tuffex-dev-mode'
 
 /**
  * Registers every tuffex component with Nuxt's own component system.
@@ -85,7 +87,13 @@ function readBarrelExports(barrel: string, followStar = true): string[] {
 
 export default defineNuxtModule({
   meta: { name: 'tuffex-components' },
-  setup() {
+  setup(_options, nuxt) {
+    const useTuffexSource = nuxt.options.dev !== true
+      || isTuffexSourceRequested(
+        nuxt.options.dev === true && process.env.NODE_ENV !== 'test',
+        process.env,
+      )
+    const componentSpecifierPrefix = useTuffexSource ? '@tuffex-components' : '@talex-touch/tuffex'
     const directories = readdirSync(COMPONENTS_SRC).filter((entry) => {
       if (AGGREGATE_DIRECTORIES.has(entry))
         return false
@@ -115,9 +123,10 @@ export default defineNuxtModule({
 
         addComponent({
           name,
-          // Always the source alias — it is the one specifier that resolves the
-          // same way in dev and in a production build.
-          filePath: `@tuffex-components/${directory}`,
+          // Source mode keeps the live workspace alias for component editing. Dist mode
+          // points at the same built subpath as explicit TuffEx imports, avoiding a second
+          // copy of the component in the dev module graph.
+          filePath: `${componentSpecifierPrefix}/${directory}`,
           export: name,
         })
       }

--- a/apps/nexus/nuxt.config.ts
+++ b/apps/nexus/nuxt.config.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { dirname, resolve } from 'node:path'
 import process from 'node:process'
@@ -6,6 +7,7 @@ import { config as loadEnv } from 'dotenv'
 import { pwa } from './app/config/pwa'
 import { appDescription } from './app/constants/index'
 import { remarkMermaid } from './app/utils/remark-mermaid'
+import { resolveTuffexDevMode } from './build/tuffex-dev-mode'
 import { nexusPageMetaFastPathPlugin } from './build/nexus-page-meta-fast-path'
 import { removeRouteLocalPageComponents } from './build/nexus-page-routes'
 import { createNexusPrerenderRoutes } from './build/nexus-prerender-routes'
@@ -20,7 +22,6 @@ loadEnv({ path: `.env.${process.env.NODE_ENV ?? 'development'}.local`, override:
 
 const isDev = process.env.NODE_ENV !== 'production'
 const useCloudflareDev = isDev && (process.env.NUXT_USE_CLOUDFLARE_DEV === 'true' || process.env.NITRO_PRESET === 'cloudflare-pages')
-const useWorkspaceSource = isDev
 const currentDir = dirname(fileURLToPath(import.meta.url))
 const workspaceRoot = resolve(currentDir, '../..')
 const tuffBusinessSourceEntry = resolve(currentDir, '../../packages/tuff-business/src/index.ts')
@@ -28,24 +29,35 @@ const tuffBusinessSourceEntry = resolve(currentDir, '../../packages/tuff-busines
 const tuffexChartsSourceEntry = resolve(currentDir, '../../packages/tuffex-charts/src/index.ts')
 const tuffexComponentsSourceRoot = resolve(currentDir, '../../packages/tuffex/packages/components/src')
 const tuffexDistRoot = resolve(currentDir, '../../packages/tuffex/dist/es')
-const tuffexSourceEntry = resolve(currentDir, '../../packages/tuffex/packages/components/src/index.ts')
 const tuffexDistEntry = resolve(tuffexDistRoot, 'index.js')
-const tuffexStyleEntry = resolve(currentDir, '../../packages/tuffex/packages/components/style/index.scss')
-const tuffexBaseStyleEntry = useWorkspaceSource
-  ? tuffexStyleEntry
+const tuffexDevMode = resolveTuffexDevMode({
+  // Vitest imports nuxt.config.ts for static config assertions without starting a dev server;
+  // do not make those config-only tests depend on an ignored build artifact.
+  isDev: isDev && process.env.NODE_ENV !== 'test',
+  env: process.env,
+  distEntryExists: existsSync(tuffexDistEntry),
+})
+const useTuffexSource = tuffexDevMode === 'source'
+const useTuffexDistComponentStyleMode = isDev && tuffexDevMode === 'dist'
+const tuffexSourceEntry = resolve(currentDir, '../../packages/tuffex/packages/components/src/index.ts')
+const tuffexBaseStyleEntry = useTuffexSource
+  ? resolve(currentDir, '../../packages/tuffex/packages/components/style/index.scss')
   : resolve(tuffexDistRoot, 'base.css')
-const tuffexComponentEntry = useWorkspaceSource
-  ? `${tuffexComponentsSourceRoot}/$1/index.ts`
-  : `${tuffexDistRoot}/$1/index.js`
 const tuffexComponentSourceEntry = `${tuffexComponentsSourceRoot}/$1/index.ts`
+const tuffexComponentDistEntry = `${tuffexDistRoot}/$1/index.js`
+const tuffexComponentEntry = useTuffexSource ? tuffexComponentSourceEntry : tuffexComponentDistEntry
+const tuffexComponentAutoImportEntry = isDev ? tuffexComponentEntry : tuffexComponentSourceEntry
 const tuffexComponentStyleEntry = resolve(tuffexDistRoot, '$1/style.css')
-const tuffexComponentTypePathEntry = useWorkspaceSource
-  ? `${tuffexComponentsSourceRoot}/*/index.ts`
-  : `${tuffexDistRoot}/*/index.d.ts`
 const tuffexComponentSourceTypePathEntry = `${tuffexComponentsSourceRoot}/*/index.ts`
+const tuffexComponentDistTypePathEntry = `${tuffexDistRoot}/*/index.d.ts`
+const tuffexComponentTypePathEntry = !isDev
+  ? tuffexComponentSourceTypePathEntry
+  : useTuffexSource
+    ? tuffexComponentSourceTypePathEntry
+    : tuffexComponentDistTypePathEntry
 const tuffexComponentStyleTypePathEntry = resolve(tuffexDistRoot, '*/style.css')
 const tuffexUtilsEntry = resolve(currentDir, '../../packages/tuffex/packages/utils/index.ts')
-const tuffexDistUtilsEntry = useWorkspaceSource
+const tuffexDistUtilsEntry = useTuffexSource
   ? tuffexUtilsEntry
   : resolve(tuffexDistRoot, 'utils/index.js')
 const requireFromConfig = createRequire(import.meta.url)
@@ -493,16 +505,24 @@ export default defineNuxtConfig({
         'gsap/ScrollToPlugin',
         'theme-colors',
         'simplex-noise',
-        'path-browserify',
         '@vueuse/core',
         'marked',
         'echarts/core',
         'echarts/charts',
         'echarts/components',
         'echarts/renderers',
-        'dompurify',
+        '@talex-touch/tuffex > shiki',
+        '@talex-touch/tuffex > shiki > @shikijs/core',
+        '@talex-touch/tuffex > @shikijs/engine-javascript',
+        '@talex-touch/tuffex > shiki > @shikijs/langs',
+        '@talex-touch/tuffex > shiki > @shikijs/themes',
+        '@talex-touch/tuffex > @better-scroll/core',
+        '@talex-touch/tuffex > @better-scroll/scroll-bar',
+        '@talex-touch/tuffex > @better-scroll/pull-down',
+        '@talex-touch/tuffex > @better-scroll/pull-up',
+        '@talex-touch/tuffex > dompurify',
         '@floating-ui/vue',
-        'v-wave',
+        '@talex-touch/tuffex > v-wave',
         'ogl',
       ],
     },
@@ -513,8 +533,8 @@ export default defineNuxtConfig({
         ...(useVueDevtoolsApiNoop ? [{ find: /^@vue\/devtools-api$/, replacement: vueDevtoolsApiNoopEntry }] : []),
         { find: /^@talex-touch\/tuff-business$/, replacement: tuffBusinessSourceEntry },
         { find: /^@talex-touch\/tuffex-charts$/, replacement: tuffexChartsSourceEntry },
-        { find: /^@tuffex-components\/(.+)$/, replacement: tuffexComponentSourceEntry },
-        { find: /^@talex-touch\/tuffex$/, replacement: useWorkspaceSource ? tuffexSourceEntry : tuffexDistEntry },
+        { find: /^@tuffex-components\/(.+)$/, replacement: tuffexComponentAutoImportEntry },
+        { find: /^@talex-touch\/tuffex$/, replacement: useTuffexSource ? tuffexSourceEntry : tuffexDistEntry },
         { find: /^@talex-touch\/tuffex\/utils$/, replacement: tuffexDistUtilsEntry },
         { find: /^@talex-touch\/tuffex\/base\.css$/, replacement: tuffexBaseStyleEntry },
         { find: /^@talex-touch\/tuffex\/([^/]+)\/style\.css$/, replacement: tuffexComponentStyleEntry },
@@ -523,7 +543,10 @@ export default defineNuxtConfig({
     },
     plugins: [
       nexusPageMetaFastPathPlugin(resolve(currentDir, 'app/pages')),
-      tuffexOnDemandStylePlugin({ enabled: !useWorkspaceSource }),
+      tuffexOnDemandStylePlugin({
+        enabled: tuffexDevMode === 'dist',
+        componentDistRoot: useTuffexDistComponentStyleMode ? tuffexDistRoot : undefined,
+      }),
     ],
     server: {
       fs: {
@@ -541,11 +564,11 @@ export default defineNuxtConfig({
         paths: {
           '@talex-touch/tuff-business': [tuffBusinessSourceEntry],
           '@talex-touch/tuffex-charts': [tuffexChartsSourceEntry],
-          '@tuffex-components/*': [tuffexComponentSourceTypePathEntry],
-          '@talex-touch/tuffex': [useWorkspaceSource ? tuffexSourceEntry : tuffexDistEntry],
+          '@tuffex-components/*': [tuffexComponentTypePathEntry],
+          '@talex-touch/tuffex': [useTuffexSource ? tuffexSourceEntry : tuffexDistEntry],
           '@talex-touch/tuffex/base.css': [tuffexBaseStyleEntry],
           '@talex-touch/tuffex/*/style.css': [tuffexComponentStyleTypePathEntry],
-          '@talex-touch/tuffex/utils': [tuffexUtilsEntry],
+          '@talex-touch/tuffex/utils': [tuffexDistUtilsEntry],
           '@talex-touch/tuffex/*': [tuffexComponentTypePathEntry],
         },
       },

--- a/apps/nexus/uno.config.ts
+++ b/apps/nexus/uno.config.ts
@@ -70,7 +70,8 @@ export default defineConfig({
        * server-rendered page an `i-*` element has no rule of its own yet. This gives every such
        * box the size the icon rule will give it (`scale: 1.2` below → 1.2em), so the glyphs paint
        * in without shifting the layout around them. Explicit `w-*`/`h-*` utilities still win:
-       * they live in a later layer.
+       * they live in a later layer, and the icon rules themselves carry no specificity (see
+       * `postprocess` below).
        */
       getCSS: () => `[class^="i-"],[class*=" i-"]{width:1.2em;height:1.2em}`,
     },
@@ -86,6 +87,23 @@ export default defineConfig({
           }
         }
       `,
+    },
+  ],
+  /*
+   * Icon rules carry no specificity. The icons layer ships as its own stylesheet, appended to
+   * `<head>` once the app has mounted, so in the cascade it comes after every other sheet. At
+   * class specificity that let an icon rule's `color:inherit` and `width:1.2em` beat the
+   * `text-amber-600` or `w-4` on the same element — utilities the single-sheet order used to
+   * let win, because `icons` sorts before `default`. `:where()` settles it for good: any classed
+   * rule on the host wins, whichever sheet arrives last. Both output modes are covered: mask
+   * icons carry `--un-icon`, multi-colour ones (`i-logos-*`) an SVG `background`.
+   */
+  postprocess: [
+    (util) => {
+      const isIcon = util.entries.some(([property, value]) => property === '--un-icon'
+        || (property === 'background' && typeof value === 'string' && value.startsWith('url("data:image/svg+xml')))
+      if (isIcon)
+        util.selector = `:where(${util.selector})`
     },
   ],
   presets: [

--- a/packages/tuffex/packages/script/build/__tests__/on-demand-style-plugin.test.ts
+++ b/packages/tuffex/packages/script/build/__tests__/on-demand-style-plugin.test.ts
@@ -1,3 +1,4 @@
+import type { TuffexOnDemandStylePluginOptions } from '../on-demand-style-plugin'
 import { describe, expect, it } from 'vitest'
 import { expandStyleClosure, tuffexOnDemandStylePlugin } from '../on-demand-style-plugin'
 
@@ -8,10 +9,25 @@ const styleDeps = {
   'dialog': ['base-surface'],
 }
 
-function transform(code: string, id = '/app/src/page.vue') {
-  const plugin = tuffexOnDemandStylePlugin({ styleDeps })
+function transform(
+  code: string,
+  id = '/app/src/page.vue',
+  options: TuffexOnDemandStylePluginOptions = {},
+) {
+  const plugin = tuffexOnDemandStylePlugin({ styleDeps, ...options })
   const handler = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform?.handler
   return (handler as (code: string, id: string) => { code: string } | null)?.call({}, code, id) ?? null
+}
+
+/**
+ * Every TuffEx stylesheet the transform emitted, in the order it emitted them.
+ * Matches the specifier rather than the whole statement, so a formatting change
+ * cannot make a suppression assertion pass for the wrong reason.
+ */
+function injectedStyleComponents(result: { code: string } | null): string[] {
+  return [...(result?.code ?? '').matchAll(/@talex-touch\/tuffex\/([a-z0-9-]+)\/style\.css/g)]
+    .map(match => match[1])
+    .filter((name): name is string => Boolean(name))
 }
 
 describe('expandStyleClosure', () => {
@@ -87,5 +103,85 @@ describe('tuffexOnDemandStylePlugin', () => {
       .call({}, `import { TxProgressBar } from '@talex-touch/tuffex/progress-bar'\n`, '/app/src/page.vue')
 
     expect(result).toBeNull()
+  })
+})
+
+describe('tuffexOnDemandStylePlugin with componentDistRoot', () => {
+  const componentDistRoot = '/workspace/packages/tuffex/dist/es'
+
+  // A real built entry (`dist/es/progress-bar/index.js`) imports its neighbours
+  // relatively and never names `@talex-touch/tuffex/...`, so the entry has to be
+  // recognised by its path — otherwise no built component would get its styles.
+  const builtEntry = [
+    `import { withInstall } from '../utils/withInstall.js'`,
+    `import _sfc_main from './src/TxProgressBar.vue.js'`,
+    ``,
+    `export default withInstall(_sfc_main)`,
+    ``,
+  ].join('\n')
+
+  // What a generated Nuxt registry does: one dynamic import per component.
+  const nuxtRegistry = [
+    `export default {`,
+    `  TxProgressBar: () => import('@talex-touch/tuffex/progress-bar'),`,
+    `  TxTooltip: () => import('@talex-touch/tuffex/tooltip'),`,
+    `  TxDialog: () => import('@talex-touch/tuffex/dialog'),`,
+    `}`,
+    ``,
+  ].join('\n')
+
+  it('injects the complete closure into a built component entry', () => {
+    const result = transform(builtEntry, `${componentDistRoot}/progress-bar/index.js`, { componentDistRoot })
+
+    expect(injectedStyleComponents(result)).toEqual([
+      'base-surface',
+      'base-anchor',
+      'tooltip',
+      'spinner',
+      'progress-bar',
+    ])
+  })
+
+  it('leaves a generated .nuxt module to load styles with each component chunk', () => {
+    const result = transform(nuxtRegistry, '/workspace/app/.nuxt/components.plugin.mjs', { componentDistRoot })
+
+    expect(injectedStyleComponents(result)).toEqual([])
+  })
+
+  it('leaves a Nuxt app runtime module to load styles with each component chunk', () => {
+    const result = transform(
+      nuxtRegistry,
+      '/workspace/app/node_modules/nuxt/dist/app/components.plugin.mjs',
+      { componentDistRoot },
+    )
+
+    expect(injectedStyleComponents(result)).toEqual([])
+  })
+
+  it('keeps fanning out for a Nuxt module when no dist root is configured', () => {
+    // The control for the two suppression cases above: the same registry does get
+    // the global fan-out unless `componentDistRoot` opts into the split.
+    const result = transform(nuxtRegistry, '/workspace/app/.nuxt/components.plugin.mjs')
+
+    expect(injectedStyleComponents(result)).toEqual([
+      'base-surface',
+      'dialog',
+      'base-anchor',
+      'tooltip',
+      'spinner',
+      'progress-bar',
+    ])
+  })
+
+  it('leaves an ordinary importer untouched in component-entry mode', () => {
+    // With `componentDistRoot` set the plugin is component-entry-only: a page that
+    // names a dozen components must not drag the whole closure into the entry chunk.
+    const result = transform(
+      `import { TxDialog } from '@talex-touch/tuffex/dialog'\n`,
+      '/app/src/page.vue',
+      { componentDistRoot },
+    )
+
+    expect(injectedStyleComponents(result)).toEqual([])
   })
 })

--- a/packages/tuffex/packages/script/build/index.ts
+++ b/packages/tuffex/packages/script/build/index.ts
@@ -123,6 +123,7 @@ export const buildVitePlugin = async () => {
       `export interface TuffexOnDemandStylePluginOptions {`,
       `  enabled?: boolean`,
       `  styleDeps?: Record<string, string[]>`,
+      `  componentDistRoot?: string`,
       `}`,
       ``,
       `export declare function expandStyleClosure(componentNames: string[], styleDeps: Record<string, string[]>): string[]`,

--- a/packages/tuffex/packages/script/build/on-demand-style-plugin.ts
+++ b/packages/tuffex/packages/script/build/on-demand-style-plugin.ts
@@ -15,6 +15,12 @@ export interface TuffexOnDemandStylePluginOptions {
    * `style-deps.json`. Injectable for tests.
    */
   styleDeps?: Record<string, string[]>
+  /**
+   * Built component root used by consumers that register every component through
+   * a generated lazy registry. Styles are injected into each component entry so
+   * the registry itself does not eagerly load the whole stylesheet set.
+   */
+  componentDistRoot?: string
 }
 
 function isComponentSubpath(componentName: string) {
@@ -45,6 +51,32 @@ function hasStyleImport(code: string, componentName: string) {
   const specifier = `@talex-touch/tuffex/${componentName}/style.css`
   return code.includes(`'${specifier}'`) || code.includes(`"${specifier}"`)
 }
+
+function createStyleImports(
+  componentNames: string[],
+  styleDeps: Record<string, string[]>,
+  code: string,
+): string {
+  return expandStyleClosure(componentNames, styleDeps)
+    .filter(componentName => !hasStyleImport(code, componentName))
+    .map(componentName => `import '@talex-touch/tuffex/${componentName}/style.css';`)
+    .join('\n')
+}
+
+function componentNameFromDistEntry(id: string, root: string | undefined): string | undefined {
+  if (!root)
+    return undefined
+
+  const normalizedId = id.split('?')[0]?.replace(/\\/g, '/')
+  const normalizedRoot = resolve(root).replace(/\\/g, '/')
+  if (!normalizedId?.startsWith(`${normalizedRoot}/`))
+    return undefined
+
+  const relativeId = normalizedId.slice(normalizedRoot.length + 1)
+  const componentName = /^([a-z0-9-]+)\/index\.js$/.exec(relativeId)?.[1]
+  return componentName && isComponentSubpath(componentName) ? componentName : undefined
+}
+
 
 /**
  * Baked in when this file is built for publishing, so the shipped plugin needs
@@ -159,6 +191,22 @@ export function tuffexOnDemandStylePlugin(options: TuffexOnDemandStylePluginOpti
         return null
       if (!SUPPORTED_CODE_ID_RE.test(id))
         return null
+
+      if (options.componentDistRoot) {
+        const distComponentName = componentNameFromDistEntry(id, options.componentDistRoot)
+        if (!distComponentName)
+          return null
+
+        const styleImports = createStyleImports([distComponentName], styleDeps, code)
+        if (!styleImports)
+          return null
+
+        return {
+          code: `${styleImports}\n${code}`,
+          map: null,
+        }
+      }
+
       if (!code.includes('@talex-touch/tuffex/'))
         return null
 
@@ -166,10 +214,7 @@ export function tuffexOnDemandStylePlugin(options: TuffexOnDemandStylePluginOpti
       if (componentNames.length === 0)
         return null
 
-      const styleImports = expandStyleClosure(componentNames, styleDeps)
-        .filter(componentName => !hasStyleImport(code, componentName))
-        .map(componentName => `import '@talex-touch/tuffex/${componentName}/style.css';`)
-        .join('\n')
+      const styleImports = createStyleImports(componentNames, styleDeps, code)
       if (!styleImports)
         return null
 


### PR DESCRIPTION
## Summary
- make Nexus development consume the built TuffEx dist by default, with explicit `NUXT_TUFFEX_SOURCE=true` for source editing
- inject on-demand component style closures for dist-backed component entries
- fix icon cascade specificity and repeated Cloudflare header parsing
- add focused regression coverage and update Nexus development guidance

## Verification
- `pnpm -C packages/tuffex exec vitest run packages/script/build/__tests__/on-demand-style-plugin.test.ts` — 13 passed
- `pnpm -C apps/nexus exec vitest run build/tuffex-dev-mode.test.ts build/check-worker-bundle.test.ts build/static-cache-headers.test.ts app/components/content/demo-client-boundary.test.ts` — 67 passed
- `pnpm lint:changed`
- `pnpm -C packages/tuffex run build`
- `pnpm -C apps/nexus run typecheck`
- `pnpm -C apps/nexus run build`
- `git diff --check`

This is the product change to land before preparing the next Beta version/tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nexus development now supports switching between the built TuffEx package and live TuffEx source editing with `NUXT_TUFFEX_SOURCE=true`.
  * Development startup now provides guidance when the required built package is unavailable.
  * Component-specific styles are handled more reliably during package builds.

* **Bug Fixes**
  * Improved icon styling so regular utility classes take precedence consistently.
  * Improved handling of repeated cache headers and icon stylesheet checks.
  * Expanded validation for development modes, asset budgets, and generated styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->