### PR TITLE
release: v2.4.14-beta.38

### DIFF
--- a/apps/core-app/package.json
+++ b/apps/core-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talex-touch/core-app",
-  "version": "2.4.14-beta.37",
+  "version": "2.4.14-beta.38",
   "private": true,
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@talex-touch/tuff",
   "homepage": "https://tuff.tagzxia.com",
   "type": "module",
-  "version": "2.4.14-beta.37",
+  "version": "2.4.14-beta.38",
   "packageManager": "pnpm@11.24.0",
   "description": "A strong adaptation more platform all-tool program.",
   "author": "TalexDreamSoul <TalexDreamSoul@Gmail.com>",


### PR DESCRIPTION
## Summary
Bump the root and CoreApp package versions to `2.4.14-beta.38` after the Beta 38 notes PR landed.

## Verification
- `node scripts/release-notes-gateway.mjs verify --version 2.4.14-beta.38 --tag v2.4.14-beta.38` — valid
- bilingual Beta release notes contract — valid
- `git diff --check` — passed

After this PR merges, the annotated tag will be created from the resulting `master` merge commit, then the Build and Release workflow will be watched through Nexus sync.